### PR TITLE
TokenService.cs: Check if key exists before deleting it

### DIFF
--- a/src/App/Services/TokenService.cs
+++ b/src/App/Services/TokenService.cs
@@ -150,7 +150,7 @@ namespace Bit.App.Services
                 var tokenBytes = Encoding.UTF8.GetBytes(token);
                 _secureStorage.Store(key, tokenBytes);
             }
-            else
+            else if(_secureStorage.Contains(key))
             {
                 _secureStorage.Delete(key);
             }


### PR DESCRIPTION
To avoid errors in Task<ApiResult<TokenResponse>> when logging in on
UWP apps ensure that we check that they key exists before we delete the
2FA key token.

Signed-off-by: Alistair Francis <alistair@alistair23.me>