### PR TITLE
Login page fixes

### DIFF
--- a/src/App/Pages/LoginPage.cs
+++ b/src/App/Pages/LoginPage.cs
@@ -48,9 +48,9 @@ namespace Bit.App.Pages
                 Windows: new Thickness(10, 8));
 
             PasswordCell = new FormEntryCell(AppResources.MasterPassword, isPassword: true,
-                useLabelAsPlaceholder: true, imageSource: "lock", containerPadding: padding);
+                useLabelAsPlaceholder: true, imageSource: "lock.png", containerPadding: padding);
             EmailCell = new FormEntryCell(AppResources.EmailAddress, nextElement: PasswordCell.Entry,
-                entryKeyboard: Keyboard.Email, useLabelAsPlaceholder: true, imageSource: "envelope",
+                entryKeyboard: Keyboard.Email, useLabelAsPlaceholder: true, imageSource: "envelope.png",
                 containerPadding: padding);
 
             var lastLoginEmail = _settings.GetValueOrDefault(Constants.LastLoginEmail, string.Empty);

--- a/src/App/Pages/LoginPage.cs
+++ b/src/App/Pages/LoginPage.cs
@@ -45,7 +45,7 @@ namespace Bit.App.Pages
             var padding = Helpers.OnPlatform(
                 iOS: new Thickness(15, 20),
                 Android: new Thickness(15, 8),
-                WinPhone: new Thickness(15, 20));
+                Windows: new Thickness(10, 8));
 
             PasswordCell = new FormEntryCell(AppResources.MasterPassword, isPassword: true,
                 useLabelAsPlaceholder: true, imageSource: "lock", containerPadding: padding);
@@ -97,7 +97,7 @@ namespace Bit.App.Pages
             var layout = new StackLayout
             {
                 Children = { table, forgotPasswordButton },
-                Spacing = Helpers.OnPlatform(iOS: 0, Android: 10, WinPhone: 0)
+                Spacing = Helpers.OnPlatform(iOS: 0, Android: 10, Windows: 0)
             };
 
             var scrollView = new ScrollView { Content = layout };


### PR DESCRIPTION
This series provides a lot of fixes for Windows 10 and Windows Phone 10 UWP platforms.

This sets the toolbar options to have images (otherwise they look blank on the default view). See https://github.com/bitwarden/mobile/pull/188 for what the difference is.

This also fixes up the layout to correctly separate the login boxes (they used to be touching) and ensures that the reset password link can be seen by the user.

It fixes up some missing images.

Finally it allows the back button to appear when running on Windows 10. Previously it would not appear and there would be no obvious way to progress backwards. This allows us to remove the cancel button.

I'm getting the hang of this now, so if this is merged I can keep working on the other pages.

This is what it looks like now:
Phone
![windowsphone-uwp-login](https://user-images.githubusercontent.com/171674/33519805-34e44b22-d763-11e7-9642-66cd56f2d964.PNG)
Desktop
<img width="610" alt="windows10-uwp-login" src="https://user-images.githubusercontent.com/171674/33519806-34fd7ad4-d763-11e7-8051-c8b6a07c4c43.PNG">
