### PR TITLE
App: LoginPage.cs: Use a logo for the login button

### DIFF
--- a/src/App/Pages/EnvironmentPage.cs
+++ b/src/App/Pages/EnvironmentPage.cs
@@ -2,6 +2,7 @@
 using Bit.App.Abstractions;
 using Bit.App.Controls;
 using Bit.App.Resources;
+using Bit.App.Utilities;
 using Xamarin.Forms;
 using XLabs.Ioc;
 using Acr.UserDialogs;
@@ -111,7 +112,7 @@ namespace Bit.App.Pages
                 Content = StackLayout
             };
 
-            var toolbarItem = new ToolbarItem(AppResources.Save, null, async () => await SaveAsync(),
+            var toolbarItem = new ToolbarItem(AppResources.Save, Helpers.ToolbarImage("envelope.png"), async () => await SaveAsync(),
                 ToolbarItemOrder.Default, 0);
 
             if(Device.RuntimePlatform == Device.iOS || Device.RuntimePlatform == Device.Windows)

--- a/src/App/Pages/Lock/LockPasswordPage.cs
+++ b/src/App/Pages/Lock/LockPasswordPage.cs
@@ -81,7 +81,7 @@ namespace Bit.App.Pages
                 table.EstimatedRowHeight = 70;
             }
 
-            var loginToolbarItem = new ToolbarItem(AppResources.Submit, null, async () =>
+            var loginToolbarItem = new ToolbarItem(AppResources.Submit, Helpers.ToolbarImage("login.png"), async () =>
             {
                 await CheckPasswordAsync();
             }, ToolbarItemOrder.Default, 0);

--- a/src/App/Pages/LoginPage.cs
+++ b/src/App/Pages/LoginPage.cs
@@ -112,7 +112,7 @@ namespace Bit.App.Pages
                 }));
             }
 
-            var loginToolbarItem = new ToolbarItem(AppResources.LogIn, null, async () =>
+            var loginToolbarItem = new ToolbarItem(AppResources.LogIn, Helpers.ToolbarImage("login.png"), async () =>
             {
                 await LogIn();
             }, ToolbarItemOrder.Default, 0);

--- a/src/App/Pages/LoginTwoFactorPage.cs
+++ b/src/App/Pages/LoginTwoFactorPage.cs
@@ -114,7 +114,7 @@ namespace Bit.App.Pages
             else if(_providerType.Value == TwoFactorProviderType.Authenticator ||
                 _providerType.Value == TwoFactorProviderType.Email)
             {
-                var continueToolbarItem = new ToolbarItem(AppResources.Continue, null, async () =>
+                var continueToolbarItem = new ToolbarItem(AppResources.Continue, Helpers.ToolbarImage("login.png"), async () =>
                 {
                     var token = TokenCell?.Entry.Text.Trim().Replace(" ", "");
                     await LogInAsync(token);

--- a/src/App/Pages/PasswordHintPage.cs
+++ b/src/App/Pages/PasswordHintPage.cs
@@ -80,7 +80,7 @@ namespace Bit.App.Pages
                 table.EstimatedRowHeight = 70;
             }
 
-            var submitToolbarItem = new ToolbarItem(AppResources.Submit, null, async () =>
+            var submitToolbarItem = new ToolbarItem(AppResources.Submit, Helpers.ToolbarImage("ion_chevron_right.png"), async () =>
             {
                 await SubmitAsync();
             }, ToolbarItemOrder.Default, 0);

--- a/src/App/Pages/RegisterPage.cs
+++ b/src/App/Pages/RegisterPage.cs
@@ -117,7 +117,7 @@ namespace Bit.App.Pages
                 Content = StackLayout
             };
 
-            var loginToolbarItem = new ToolbarItem(AppResources.Submit, null, async () =>
+            var loginToolbarItem = new ToolbarItem(AppResources.Submit, Helpers.ToolbarImage("ion_chevron_right.png"), async () =>
             {
                 await Register();
             }, ToolbarItemOrder.Default, 0);

--- a/src/App/Pages/Settings/SettingsAddFolderPage.cs
+++ b/src/App/Pages/Settings/SettingsAddFolderPage.cs
@@ -56,7 +56,7 @@ namespace Bit.App.Pages
                 table.EstimatedRowHeight = 70;
             }
 
-            var saveToolBarItem = new ToolbarItem(AppResources.Save, null, async () =>
+            var saveToolBarItem = new ToolbarItem(AppResources.Save, Helpers.ToolbarImage("envelope.png"), async () =>
             {
                 if(_lastAction.LastActionWasRecent())
                 {

--- a/src/App/Pages/Settings/SettingsEditFolderPage.cs
+++ b/src/App/Pages/Settings/SettingsEditFolderPage.cs
@@ -73,7 +73,7 @@ namespace Bit.App.Pages
                 mainTable.EstimatedRowHeight = 70;
             }
 
-            var saveToolBarItem = new ToolbarItem(AppResources.Save, null, async () =>
+            var saveToolBarItem = new ToolbarItem(AppResources.Save, Helpers.ToolbarImage("envelope.png"), async () =>
             {
                 if(_lastAction.LastActionWasRecent())
                 {

--- a/src/App/Pages/Tools/ToolsPasswordGeneratorPage.cs
+++ b/src/App/Pages/Tools/ToolsPasswordGeneratorPage.cs
@@ -112,7 +112,7 @@ namespace Bit.App.Pages
 
             if(_passwordValueAction != null)
             {
-                var selectToolBarItem = new ToolbarItem(AppResources.Select, null, async () =>
+                var selectToolBarItem = new ToolbarItem(AppResources.Select, Helpers.ToolbarImage("ion_chevron_right.png"), async () =>
                 {
                     if(_fromAutofill)
                     {

--- a/src/App/Pages/Vault/VaultAddCipherPage.cs
+++ b/src/App/Pages/Vault/VaultAddCipherPage.cs
@@ -572,7 +572,7 @@ namespace Bit.App.Pages
 
         private void InitSave()
         {
-            var saveToolBarItem = new ToolbarItem(AppResources.Save, null, async () =>
+            var saveToolBarItem = new ToolbarItem(AppResources.Save, Helpers.ToolbarImage("envelope.png"), async () =>
             {
                 if(_lastAction.LastActionWasRecent())
                 {

--- a/src/App/Pages/Vault/VaultAttachmentsPage.cs
+++ b/src/App/Pages/Vault/VaultAttachmentsPage.cs
@@ -132,7 +132,7 @@ namespace Bit.App.Pages
                 Margin = new Thickness(0, 40, 0, 0)
             };
 
-            var saveToolBarItem = new ToolbarItem(AppResources.Save, null, async () =>
+            var saveToolBarItem = new ToolbarItem(AppResources.Save, Helpers.ToolbarImage("envelope.png"), async () =>
             {
                 if(_lastAction.LastActionWasRecent() || _cipher == null)
                 {

--- a/src/App/Pages/Vault/VaultCustomFieldsPage.cs
+++ b/src/App/Pages/Vault/VaultCustomFieldsPage.cs
@@ -64,7 +64,7 @@ namespace Bit.App.Pages
                 Margin = new Thickness(10, 40, 10, 0)
             };
 
-            SaveToolbarItem = new ToolbarItem(AppResources.Save, null, async () =>
+            SaveToolbarItem = new ToolbarItem(AppResources.Save, Helpers.ToolbarImage("envelope.png"), async () =>
             {
                 if(_lastAction.LastActionWasRecent() || _cipher == null)
                 {

--- a/src/App/Pages/Vault/VaultEditCipherPage.cs
+++ b/src/App/Pages/Vault/VaultEditCipherPage.cs
@@ -438,7 +438,7 @@ namespace Bit.App.Pages
 
         private void InitSave()
         {
-            var saveToolBarItem = new ToolbarItem(AppResources.Save, null, async () =>
+            var saveToolBarItem = new ToolbarItem(AppResources.Save, Helpers.ToolbarImage("envelope.png"), async () =>
             {
                 if(_lastAction.LastActionWasRecent())
                 {

--- a/src/App/Pages/Vault/VaultViewCipherPage.cs
+++ b/src/App/Pages/Vault/VaultViewCipherPage.cs
@@ -500,6 +500,7 @@ namespace Bit.App.Pages
                 _page = page;
                 _cipherId = cipherId;
                 Text = AppResources.Edit;
+                Icon = Helpers.ToolbarImage("cog.png");
                 ClickAction = async () => await ClickedItem();
             }
 

--- a/src/App/Utilities/Helpers.cs
+++ b/src/App/Utilities/Helpers.cs
@@ -73,6 +73,17 @@ namespace Bit.App.Utilities
 
             return " ";
         }
+
+        public static string ToolbarImage(string image)
+        {
+            if (Device.RuntimePlatform == Device.iOS || Device.RuntimePlatform == Device.Android)
+            {
+                return null;
+            }
+
+            return image;
+        }
+
         public static async void CipherMoreClickedAsync(Page page, VaultListPageModel.Cipher cipher, bool autofill)
         {
             var buttons = new List<string> { AppResources.View, AppResources.Edit };


### PR DESCRIPTION
This adds a helper function which we can use to set logos for Windows
platforms to ensure the user can see the UWP toolbar actions. This won't
have an effect on non-Windows platforms.

Signed-off-by: Alistair Francis <alistair@alistair23.me>