### PR TITLE
Pages: Settings: Disable fingerprint on Windows

### DIFF
--- a/src/App/Pages/Settings/SettingsPage.cs
+++ b/src/App/Pages/Settings/SettingsPage.cs
@@ -91,7 +91,8 @@ namespace Bit.App.Pages
                 TwoStepCell
             };
 
-            if((await _fingerprint.GetAvailabilityAsync()) == FingerprintAvailability.Available)
+            if ((await _fingerprint.GetAvailabilityAsync()) == FingerprintAvailability.Available &&
+                Device.RuntimePlatform != Device.Windows)
             {
                 var fingerprintName = Helpers.OnPlatform(
                     iOS: _deviceInfoService.HasFaceIdSupport ? AppResources.FaceID : AppResources.TouchID,


### PR DESCRIPTION
Looking at the documentation here:
https://github.com/smstuebe/xamarin-fingerprint/blob/master/README.md
the GetAvailabilityAsync() and IsAvailableAsync() don't work on Windows.
To avoid always seeing the fingerprint option just diable it on Windows
as at the moment it's untested.

Signed-off-by: Alistair Francis <alistair@alistair23.me>