### PR TITLE
Add support for Windows Hello

### DIFF
--- a/src/App/Pages/Lock/LockFingerprintPage.cs
+++ b/src/App/Pages/Lock/LockFingerprintPage.cs
@@ -7,6 +7,7 @@ using XLabs.Ioc;
 using Plugin.Fingerprint.Abstractions;
 using Plugin.Settings.Abstractions;
 using Bit.App.Abstractions;
+using Bit.App.Utilities;
 
 namespace Bit.App.Pages
 {
@@ -32,9 +33,23 @@ namespace Bit.App.Pages
 
         public void Init()
         {
+            var biometricIcon = Helpers.OnPlatform(
+                        iOS: _deviceInfoService.HasFaceIdSupport ? "smile.png" : "fingerprint.png",
+                        Android: "fingerprint.png",
+                        Windows: "smile.png");
+            var biometricText = Helpers.OnPlatform(
+                        iOS: _deviceInfoService.HasFaceIdSupport ? AppResources.UseFaceIDToUnlock : AppResources.UseFingerprintToUnlock,
+                        Android: AppResources.UseFingerprintToUnlock,
+                        Windows: AppResources.UseWindowsHelloToUnlock);
+            var biometricTitle = Helpers.OnPlatform(
+                        iOS: _deviceInfoService.HasFaceIdSupport ? AppResources.VerifyFaceID : AppResources.VerifyFingerprint,
+                        Android: AppResources.VerifyFingerprint,
+                        Windows: AppResources.VerifyWindowsHello);
+
+
             var fingerprintIcon = new ExtendedButton
             {
-                Image = _deviceInfoService.HasFaceIdSupport ? "smile.png" : "fingerprint.png",
+                Image = biometricIcon,
                 BackgroundColor = Color.Transparent,
                 Command = new Command(async () => await CheckFingerprintAsync()),
                 VerticalOptions = LayoutOptions.CenterAndExpand,
@@ -43,8 +58,7 @@ namespace Bit.App.Pages
 
             var fingerprintButton = new ExtendedButton
             {
-                Text = _deviceInfoService.HasFaceIdSupport ? AppResources.UseFaceIDToUnlock :
-                    AppResources.UseFingerprintToUnlock,
+                Text = biometricText,
                 Command = new Command(async () => await CheckFingerprintAsync()),
                 VerticalOptions = LayoutOptions.EndAndExpand,
                 Style = (Style)Application.Current.Resources["btn-primary"]
@@ -67,7 +81,7 @@ namespace Bit.App.Pages
                 Children = { fingerprintIcon, fingerprintButton, logoutButton }
             };
 
-            Title = _deviceInfoService.HasFaceIdSupport ? AppResources.VerifyFaceID : AppResources.VerifyFingerprint;
+            Title = biometricTitle;
             Content = stackLayout;
         }
 

--- a/src/App/Pages/Settings/SettingsPage.cs
+++ b/src/App/Pages/Settings/SettingsPage.cs
@@ -95,7 +95,8 @@ namespace Bit.App.Pages
             {
                 var fingerprintName = Helpers.OnPlatform(
                     iOS: _deviceInfoService.HasFaceIdSupport ? AppResources.FaceID : AppResources.TouchID,
-                    Android: AppResources.Fingerprint, Windows: AppResources.Fingerprint);
+                    Android: AppResources.Fingerprint,
+                    Windows: AppResources.WindowsHello);
                 FingerprintCell = new ExtendedSwitchCell
                 {
                     Text = string.Format(AppResources.UnlockWith, fingerprintName),

--- a/src/App/Resources/AppResources.Designer.cs
+++ b/src/App/Resources/AppResources.Designer.cs
@@ -2950,6 +2950,15 @@ namespace Bit.App.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Unlock with Windows Hello.
+        /// </summary>
+        public static string UseWindowsHelloToUnlock {
+            get {
+                return ResourceManager.GetString("UseWindowsHelloToUnlock", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Validating.
         /// </summary>
         public static string Validating {
@@ -3058,6 +3067,15 @@ namespace Bit.App.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Verify with Windows Hello.
+        /// </summary>
+        public static string VerifyWindowsHello {
+            get {
+                return ResourceManager.GetString("VerifyWindowsHello", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Version.
         /// </summary>
         public static string Version {
@@ -3135,6 +3153,15 @@ namespace Bit.App.Resources {
         public static string WebVaultUrl {
             get {
                 return ResourceManager.GetString("WebVaultUrl", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Windows Hello.
+        /// </summary>
+        public static string WindowsHello {
+            get {
+                return ResourceManager.GetString("WindowsHello", resourceCulture);
             }
         }
         

--- a/src/App/Resources/AppResources.resx
+++ b/src/App/Resources/AppResources.resx
@@ -1231,4 +1231,13 @@
   <data name="VerifyFaceID" xml:space="preserve">
     <value>Verify Face ID</value>
   </data>
+  <data name="UseWindowsHelloToUnlock" xml:space="preserve">
+    <value>Unlock with Windows Hello</value>
+  </data>
+  <data name="VerifyWindowsHello" xml:space="preserve">
+    <value>Verify with Windows Hello</value>
+  </data>
+  <data name="WindowsHello" xml:space="preserve">
+    <value>Windows Hello</value>
+  </data>
 </root>

--- a/src/UWP.Images/UWP.Images.projitems
+++ b/src/UWP.Images/UWP.Images.projitems
@@ -47,6 +47,7 @@
     <Content Include="$(MSBuildThisFileDirectory)search.png" />
     <Content Include="$(MSBuildThisFileDirectory)share.png" />
     <Content Include="$(MSBuildThisFileDirectory)share_tools.png" />
+    <Content Include="$(MSBuildThisFileDirectory)smile.png" />
     <Content Include="$(MSBuildThisFileDirectory)star.png" />
     <Content Include="$(MSBuildThisFileDirectory)star_selected.png" />
     <Content Include="$(MSBuildThisFileDirectory)tools.png" />


### PR DESCRIPTION
Windows Hello is currently supported in the UWP app, but all of the
strings just point to using fingerprint. Windows Hello instead will
adjust based on what the user has avaliable and registered with the
Windows OS. To reflect that it isn't just fingerprints update the
strings when on UWP.

Signed-off-by: Alistair Francis <alistair@alistair23.me>