### PR TITLE
Vault: Don't specify page options for ActivityLoading

### DIFF
--- a/src/App/Pages/Vault/VaultAutofillListCiphersPage.cs
+++ b/src/App/Pages/Vault/VaultAutofillListCiphersPage.cs
@@ -115,9 +115,7 @@ namespace Bit.App.Pages
 
             LoadingIndicator = new ActivityIndicator
             {
-                IsRunning = true,
-                VerticalOptions = LayoutOptions.CenterAndExpand,
-                HorizontalOptions = LayoutOptions.Center
+                IsRunning = true
             };
 
             Content = LoadingIndicator;

--- a/src/App/Pages/Vault/VaultListCiphersPage.cs
+++ b/src/App/Pages/Vault/VaultListCiphersPage.cs
@@ -164,9 +164,7 @@ namespace Bit.App.Pages
 
             LoadingIndicator = new ActivityIndicator
             {
-                IsRunning = true,
-                VerticalOptions = LayoutOptions.CenterAndExpand,
-                HorizontalOptions = LayoutOptions.Center
+                IsRunning = true
             };
 
             Content = LoadingIndicator;

--- a/src/App/Pages/Vault/VaultListGroupingsPage.cs
+++ b/src/App/Pages/Vault/VaultListGroupingsPage.cs
@@ -106,9 +106,7 @@ namespace Bit.App.Pages
 
             LoadingIndicator = new ActivityIndicator
             {
-                IsRunning = true,
-                VerticalOptions = LayoutOptions.CenterAndExpand,
-                HorizontalOptions = LayoutOptions.Center
+                IsRunning = true
             };
 
             Content = LoadingIndicator;


### PR DESCRIPTION
When specifying page options the loader doesn't appear properly on UWP
applications. I also couldn't see the options documented here:
https://developer.xamarin.com/api/type/Xamarin.Forms.ActivityIndicator/

Signed-off-by: Alistair Francis <alistair@alistair23.me>