### PR TITLE
UWP: Fix images when compiling with .NET Native Toolchain

### DIFF
--- a/src/UWP/App.xaml.cs
+++ b/src/UWP/App.xaml.cs
@@ -9,6 +9,8 @@ using Plugin.Fingerprint;
 using Plugin.Settings.Abstractions;
 using SimpleInjector;
 using System;
+using System.Collections.Generic;
+using System.Reflection;
 using Windows.ApplicationModel;
 using Windows.ApplicationModel.Activation;
 using Windows.UI.Xaml;
@@ -16,6 +18,7 @@ using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Navigation;
 using XLabs.Ioc;
 using XLabs.Ioc.SimpleInjectorContainer;
+using FFImageLoading.Forms;
 
 namespace Bit.UWP
 {
@@ -42,7 +45,13 @@ namespace Bit.UWP
             {
                 rootFrame = new Frame();
                 rootFrame.NavigationFailed += OnNavigationFailed;
-                Xamarin.Forms.Forms.Init(e);
+
+                var assembliesToInclude = new List<Assembly>()
+                {
+                    typeof(CachedImage).GetTypeInfo().Assembly,
+                    typeof(CachedImageRenderer).GetTypeInfo().Assembly
+                };
+                Xamarin.Forms.Forms.Init(e, assembliesToInclude);
 
                 ((Style)Resources["TabbedPageStyle"]).Setters[0] = ((Style)Resources["TabbedPageStyle2"]).Setters[0];
 


### PR DESCRIPTION
Following the instructions here:
https://github.com/luberda-molinet/FFImageLoading/wiki/Xamarin.Forms-API#windows-uwp---compile-with-net-native-tool-chain-note
fix the UWP App.xaml.cs to ensure images are loaded when building UWP
apps for release.

Signed-off-by: Alistair Francis <alistair@alistair23.me>