### PR TITLE
App: Pages: Add a null check in OnSelectTemplate()

### DIFF
--- a/src/App/Pages/Vault/VaultListGroupingsPage.cs
+++ b/src/App/Pages/Vault/VaultListGroupingsPage.cs
@@ -350,6 +350,10 @@ namespace Bit.App.Pages
 
             protected override DataTemplate OnSelectTemplate(object item, BindableObject container)
             {
+                if(item == null)
+                {
+                    return null;
+                }
                 return ((GroupingOrCipher)item).Cipher == null ? GroupingTemplate : CipherTemplate;
             }
         }


### PR DESCRIPTION
To avoid accessing a null poiter add a null check in OnSelectTemplate().

Signed-off-by: Alistair Francis <alistair@alistair23.me>