### PR TITLE
UWP: Add a ExtendedTableViewRenderer

### DIFF
--- a/src/UWP/App.xaml.cs
+++ b/src/UWP/App.xaml.cs
@@ -49,7 +49,8 @@ namespace Bit.UWP
                 var assembliesToInclude = new List<Assembly>()
                 {
                     typeof(CachedImage).GetTypeInfo().Assembly,
-                    typeof(CachedImageRenderer).GetTypeInfo().Assembly
+                    typeof(CachedImageRenderer).GetTypeInfo().Assembly,
+                    typeof(Controls.ExtendedTableViewRenderer).GetTypeInfo().Assembly
                 };
                 Xamarin.Forms.Forms.Init(e, assembliesToInclude);
 

--- a/src/UWP/Controls/ExtendedTableViewRenderer.cs
+++ b/src/UWP/Controls/ExtendedTableViewRenderer.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.ComponentModel;
+using Bit.App.Controls;
+using Bit.UWP.Controls;
+using Xamarin.Forms;
+using Xamarin.Forms.Platform.UWP;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+
+
+[assembly: ExportRenderer(typeof(ExtendedTableView), typeof(ExtendedTableViewRenderer))]
+namespace Bit.UWP.Controls
+{
+    public class ExtendedTableViewRenderer : TableViewRenderer
+    {
+        public override SizeRequest GetDesiredSize(double widthConstraint, double heightConstraint)
+        {
+            var baseSize = new Size(Control.Width, Control.Height);
+
+            return new SizeRequest(new Size(baseSize.Width, baseSize.Height));
+        }
+
+        protected override void OnElementChanged(ElementChangedEventArgs<TableView> e)
+        {
+            base.OnElementChanged(e);
+        }
+    }
+}

--- a/src/UWP/UWP.csproj
+++ b/src/UWP/UWP.csproj
@@ -95,6 +95,7 @@
     <Compile Include="App.xaml.cs">
       <DependentUpon>App.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Controls\ExtendedTableViewRenderer.cs" />
     <Compile Include="IconConverter.cs" />
     <Compile Include="MainPage.xaml.cs">
       <DependentUpon>MainPage.xaml</DependentUpon>


### PR DESCRIPTION
Add a base ExtendedTableViewRenderer we can use.

This is part of the work to fix the vertical layout issues, not there yet, but I think this is moving in the right direction.

Signed-off-by: Alistair Francis <alistair@alistair23.me>