### PR TITLE
Don't leak password length through mask

### DIFF
--- a/src/App/Models/Page/VaultViewCipherPageModel.cs
+++ b/src/App/Models/Page/VaultViewCipherPageModel.cs
@@ -114,7 +114,7 @@ namespace Bit.App.Models.Page
             }
         }
         public string MaskedLoginPassword => RevealLoginPassword ?
-            LoginPassword : LoginPassword == null ? null : new string('•', LoginPassword.Length);
+            LoginPassword : LoginPassword == null ? null : new string('•', 8);
         public ImageSource LoginShowHideImage => RevealLoginPassword ?
             ImageSource.FromFile("eye_slash.png") : ImageSource.FromFile("eye.png");
 
@@ -622,7 +622,7 @@ namespace Bit.App.Models.Page
                 {
                     if(_maskedValue == null && Value != null)
                     {
-                        _maskedValue = new string('•', Value.Length);
+                        _maskedValue = new string('•', 8);
                     }
 
                     return _maskedValue;


### PR DESCRIPTION
This is a pretty simple PR. I'm migrating from 1Password to Bitwarden, and I noticed that while 1Password has a constant-length password mask, Bitwarden's leaks the length of the password even when it's masked. This commit simply changes to a constant-length mask.