### PR TITLE
Use BaseUrl when opening web vault if defined

### DIFF
--- a/src/App/Pages/Tools/ToolsPage.cs
+++ b/src/App/Pages/Tools/ToolsPage.cs
@@ -158,7 +158,15 @@ namespace Bit.App.Pages
         private void WebCell_Tapped(object sender, EventArgs e)
         {
             _googleAnalyticsService.TrackAppEvent("OpenedTool", "Web");
-            Device.OpenUri(new Uri("https://vault.bitwarden.com"));
+            var appSettings = Resolver.Resolve<IAppSettingsService>();
+            if (!string.IsNullOrWhiteSpace(appSettings.BaseUrl))
+            {
+                Device.OpenUri(new Uri(appSettings.BaseUrl));
+            }
+            else
+            {
+                Device.OpenUri(new Uri("https://vault.bitwarden.com"));
+            }
         }
 
         private void ShareCell_Tapped(object sender, EventArgs e)


### PR DESCRIPTION
In the tab tools when you have a self hosted bitwarden environment and click on the web vault.
The application open the link "https://vault.bitwarden.com" instead of the defined BaseUrl.

This commit fix the link if a BaseUrl is defined.