### PR TITLE
Honor user CA store when targeting Android Nougat SDK and later

### DIFF
--- a/src/Android/Android.csproj
+++ b/src/Android/Android.csproj
@@ -1021,5 +1021,8 @@
   <ItemGroup>
     <AndroidResource Include="Resources\drawable-xxxhdpi\upload2.png" />
   </ItemGroup>
+  <ItemGroup>
+    <AndroidResource Include="Resources\xml\network_security_config.xml" />
+  </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.CSharp.targets" />
 </Project>

--- a/src/Android/Properties/AndroidManifest.xml
+++ b/src/Android/Properties/AndroidManifest.xml
@@ -13,7 +13,8 @@
   <uses-feature android:name="android.hardware.camera.autofocus" android:required="false" />
 
   <application android:label="Bitwarden" android:theme="@style/BitwardenTheme" android:allowBackup="false"
-               android:icon="@mipmap/ic_launcher" android:roundIcon="@mipmap/ic_launcher_round">
+               android:icon="@mipmap/ic_launcher" android:roundIcon="@mipmap/ic_launcher_round"
+               android:networkSecurityConfig="@xml/network_security_config">
     <provider
         android:name="android.support.v4.content.FileProvider"
         android:authorities="com.x8bit.bitwarden.fileprovider"

--- a/src/Android/Resources/Resource.Designer.cs
+++ b/src/Android/Resources/Resource.Designer.cs
@@ -8565,6 +8565,9 @@ namespace Bit.Android
 			// aapt resource value: 0x7f080002
 			public const int filepaths = 2131230722;
 			
+			// aapt resource value: 0x7f080003
+			public const int network_security_config = 2131230723;
+			
 			static Xml()
 			{
 				global::Android.Runtime.ResourceIdManager.UpdateIdValues();

--- a/src/Android/Resources/xml/network_security_config.xml
+++ b/src/Android/Resources/xml/network_security_config.xml
@@ -1,5 +1,5 @@
 ﻿<network-security-config>
-  <base-config>
+  <base-config cleartextTrafficPermitted="false">
     <trust-anchors>
       <!-- Trust pre-installed CAs -->
       <certificates src="system" />
@@ -7,7 +7,7 @@
       <certificates src="user" />
     </trust-anchors>
   </base-config>
-  <domain-config>
+  <domain-config cleartextTrafficPermitted="false">
     <domain includeSubdomains="true">bitwarden.com</domain>
     <trust-anchors>
       <!-- Only trust pre-installed CAs for

--- a/src/Android/Resources/xml/network_security_config.xml
+++ b/src/Android/Resources/xml/network_security_config.xml
@@ -1,0 +1,8 @@
+﻿<network-security-config>
+  <base-config>
+    <trust-anchors>
+      <certificates src="system" />
+      <certificates src="user" />
+    </trust-anchors>
+  </base-config>
+</network-security-config>

--- a/src/Android/Resources/xml/network_security_config.xml
+++ b/src/Android/Resources/xml/network_security_config.xml
@@ -1,8 +1,18 @@
 ﻿<network-security-config>
   <base-config>
     <trust-anchors>
+      <!-- Trust pre-installed CAs -->
       <certificates src="system" />
+      <!-- Additionally trust user added CAs -->
       <certificates src="user" />
     </trust-anchors>
   </base-config>
+  <domain-config>
+    <domain includeSubdomains="true">bitwarden.com</domain>
+    <trust-anchors>
+      <!-- Only trust pre-installed CAs for
+           Bitwarden.com and all subdomains -->
+      <certificates src="system" />
+    </trust-anchors>
+  </domain-config>
 </network-security-config>


### PR DESCRIPTION
See: https://android-developers.googleblog.com/2016/07/changes-to-trusted-certificate.html

Fixes: #346 