### PR TITLE
Handle exception when adding attachment that does not exist on file system.

### DIFF
--- a/src/Android/MainActivity.cs
+++ b/src/Android/MainActivity.cs
@@ -203,12 +203,19 @@ namespace Bit.Android
                     return;
                 }
 
-                using(var stream = ContentResolver.OpenInputStream(uri))
-                using(var memoryStream = new MemoryStream())
+                try
                 {
-                    stream.CopyTo(memoryStream);
-                    MessagingCenter.Send(Xamarin.Forms.Application.Current, "SelectFileResult",
-                        new Tuple<byte[], string>(memoryStream.ToArray(), fileName ?? "unknown_file_name"));
+                    using(var stream = ContentResolver.OpenInputStream(uri))
+                    using(var memoryStream = new MemoryStream())
+                    {
+                        stream.CopyTo(memoryStream);
+                        MessagingCenter.Send(Xamarin.Forms.Application.Current, "SelectFileResult",
+                            new Tuple<byte[], string>(memoryStream.ToArray(), fileName ?? "unknown_file_name"));
+                    }
+                }
+                catch (Java.IO.FileNotFoundException)
+                {
+                    return;
                 }
             }
         }


### PR DESCRIPTION
Bitwarden crashes when trying to add a file that does not exist on the filesystem as an attachment.

The Android 'Documents' app seems to keep a cache of downloaded files despite those files having been deleted off of the file system. This causes Bitwarden to crash when the user selects them.

I figure that presenting some error to the user when this happens makes sense, but beyond the generic "An error has occurred" message, I couldn't find a suitable resource.