### PR TITLE
Set Android InputType directly for the pin lock screen to force numeric-only keyboard layout.

### DIFF
--- a/src/Android/Controls/ExtendedEntryRenderer.cs
+++ b/src/Android/Controls/ExtendedEntryRenderer.cs
@@ -66,7 +66,7 @@ namespace Bit.Android.Controls
                 Control.SetRawInputType(InputTypes.TextFlagNoSuggestions | InputTypes.TextVariationVisiblePassword);
             }
 
-            if(_view.IsPin)
+            if(_view.NumbersOnly)
             {
                 Control.SetRawInputType(InputTypes.ClassNumber | InputTypes.NumberVariationPassword);
             }

--- a/src/Android/Controls/ExtendedEntryRenderer.cs
+++ b/src/Android/Controls/ExtendedEntryRenderer.cs
@@ -66,6 +66,11 @@ namespace Bit.Android.Controls
                 Control.SetRawInputType(InputTypes.TextFlagNoSuggestions | InputTypes.TextVariationVisiblePassword);
             }
 
+            if(_view.IsPin)
+            {
+                Control.SetRawInputType(InputTypes.ClassNumber | InputTypes.NumberVariationPassword);
+            }
+
             _view.ToggleIsPassword += ToggleIsPassword;
 
             if(_view.FontFamily == "monospace")

--- a/src/App/Controls/ExtendedEntry.cs
+++ b/src/App/Controls/ExtendedEntry.cs
@@ -12,7 +12,7 @@ namespace Bit.App.Controls
             {
                 PlaceholderColor = Color.FromHex("c7c7cd");
             }
-
+            
             IsPasswordFromToggled = IsPassword;
         }
 
@@ -57,6 +57,7 @@ namespace Bit.App.Controls
         public bool DisableAutocapitalize { get; set; }
         public bool AllowClear { get; set; }
         public bool HideCursor { get; set; }
+        public bool IsPin { get; set; }
 
         // Need to overwrite default handler because we cant Invoke otherwise
         public new event EventHandler Completed;

--- a/src/App/Controls/ExtendedEntry.cs
+++ b/src/App/Controls/ExtendedEntry.cs
@@ -57,7 +57,7 @@ namespace Bit.App.Controls
         public bool DisableAutocapitalize { get; set; }
         public bool AllowClear { get; set; }
         public bool HideCursor { get; set; }
-        public bool IsPin { get; set; }
+        public bool NumbersOnly { get; set; }
 
         // Need to overwrite default handler because we cant Invoke otherwise
         public new event EventHandler Completed;

--- a/src/App/Controls/PinControl.cs
+++ b/src/App/Controls/PinControl.cs
@@ -21,7 +21,8 @@ namespace Bit.App.Controls
             {
                 Keyboard = Keyboard.Numeric,
                 TargetMaxLength = 4,
-                HideCursor = true
+                HideCursor = true,
+                IsPin = true
             };
 
             Entry.BackgroundColor = Entry.TextColor = Color.Transparent;

--- a/src/App/Controls/PinControl.cs
+++ b/src/App/Controls/PinControl.cs
@@ -22,7 +22,7 @@ namespace Bit.App.Controls
                 Keyboard = Keyboard.Numeric,
                 TargetMaxLength = 4,
                 HideCursor = true,
-                IsPin = true
+                NumbersOnly = true
             };
 
             Entry.BackgroundColor = Entry.TextColor = Color.Transparent;


### PR DESCRIPTION
See issue #446 