### PR TITLE
Android: Support autofill in Fennec F-Droid

### DIFF
--- a/src/Android/Autofill/AutofillHelpers.cs
+++ b/src/Android/Autofill/AutofillHelpers.cs
@@ -32,8 +32,9 @@ namespace Bit.Android.Autofill
             "com.google.android.apps.chrome","com.google.android.apps.chrome_dev","com.yandex.browser",
             "com.sec.android.app.sbrowser","com.sec.android.app.sbrowser.beta","org.codeaurora.swe.browser",
             "com.amazon.cloud9","mark.via.gp","org.bromite.bromite","org.chromium.chrome","com.kiwibrowser.browser",
-            "com.ecosia.android","com.opera.mini.native.beta","org.mozilla.fennec_aurora","com.qwant.liberty",
-            "com.opera.touch","org.mozilla.fenix","org.mozilla.reference.browser","org.mozilla.rocket"
+            "com.ecosia.android","com.opera.mini.native.beta","org.mozilla.fennec_aurora","org.mozilla.fennec_fdroid",
+	    "com.qwant.liberty", "com.opera.touch","org.mozilla.fenix","org.mozilla.reference.browser",
+	    "org.mozilla.rocket"
         };
 
         // The URLs are blacklisted from autofilling

--- a/src/Android/AutofillService.cs
+++ b/src/Android/AutofillService.cs
@@ -49,6 +49,7 @@ namespace Bit.Android
             new Browser("org.mozilla.firefox", "url_bar_title"),
             new Browser("org.mozilla.firefox_beta", "url_bar_title"),
             new Browser("org.mozilla.fennec_aurora", "url_bar_title"),
+            new Browser("org.mozilla.fennec_fdroid", "url_bar_title"),
             new Browser("org.mozilla.focus", "display_url"),
             new Browser("org.mozilla.klar", "display_url"),
             new Browser("org.mozilla.fenix", "mozac_browser_toolbar_url_view"),

--- a/src/Android/Resources/xml/autofillservice.xml
+++ b/src/Android/Resources/xml/autofillservice.xml
@@ -37,6 +37,9 @@
     android:name="org.mozilla.fennec_aurora"
     android:maxLongVersionCode="10000000000"/>
   <compatibility-package
+    android:name="org.mozilla.fennec_fdroid"
+    android:maxLongVersionCode="10000000000"/>
+  <compatibility-package
     android:name="org.mozilla.firefox"
     android:maxLongVersionCode="10000000000"/>
   <compatibility-package


### PR DESCRIPTION
The F-Droid build of Firefox (Fennec) has a different package name.
This name needs to be explicitly listed in order for autofill support to
work correctly.