### PR TITLE
Change password generator to use ColoredPassword

### DIFF
--- a/src/App/Pages/Generator/GeneratorHistoryPage.xaml
+++ b/src/App/Pages/Generator/GeneratorHistoryPage.xaml
@@ -19,6 +19,7 @@
         <ResourceDictionary>
             <u:InverseBoolConverter x:Key="inverseBool" />
             <u:DateTimeConverter x:Key="dateTime" />
+            <u:ColoredPasswordConverter x:Key="coloredPassword" />
             <ToolbarItem Text="{u:I18n Close}" Clicked="Close_Clicked" Order="Primary" Priority="-1"
                          x:Name="_closeItem" x:Key="closeItem" />
             <ToolbarItem Text="{u:I18n Clear}"
@@ -71,7 +72,8 @@
                                 Grid.Column="0"
                                 Grid.Row="0"
                                 StyleClass="list-title, list-title-platform"
-                                Text="{Binding Password, Mode=OneWay}" />
+                                TextType="Html"
+                                Text="{Binding Password, Mode=OneWay, Converter={StaticResource coloredPassword}}" />
                             <Label LineBreakMode="TailTruncation"
                                 Grid.Column="0"
                                 Grid.Row="1"

--- a/src/App/Pages/Generator/GeneratorPage.xaml
+++ b/src/App/Pages/Generator/GeneratorPage.xaml
@@ -40,7 +40,8 @@
         <StackLayout Spacing="0" Padding="0">
             <StackLayout StyleClass="box">
                 <controls:MonoLabel
-                    FormattedText="{Binding ColoredPassword, Mode=OneWay}"
+                    Text="{Binding ColoredPassword, Mode=OneWay}"
+                    TextType="Html"
                     Margin="0, 20"
                     StyleClass="text-lg"
                     HorizontalTextAlignment="Center"

--- a/src/App/Pages/Generator/GeneratorPage.xaml
+++ b/src/App/Pages/Generator/GeneratorPage.xaml
@@ -40,7 +40,7 @@
         <StackLayout Spacing="0" Padding="0">
             <StackLayout StyleClass="box">
                 <controls:MonoLabel
-                    Text="{Binding Password}"
+                    FormattedText="{Binding ColoredPassword, Mode=OneWay}"
                     Margin="0, 20"
                     StyleClass="text-lg"
                     HorizontalTextAlignment="Center"

--- a/src/App/Pages/Generator/GeneratorPageViewModel.cs
+++ b/src/App/Pages/Generator/GeneratorPageViewModel.cs
@@ -53,7 +53,7 @@ namespace Bit.App.Pages
                 });
         }
 
-        public FormattedString ColoredPassword => PasswordFormatter.FormatPassword(Password);
+        public string ColoredPassword => PasswordFormatter.FormatPassword(Password);
 
         public bool IsPassword
         {

--- a/src/App/Pages/Vault/PasswordHistoryPage.xaml
+++ b/src/App/Pages/Vault/PasswordHistoryPage.xaml
@@ -23,6 +23,7 @@
         <ResourceDictionary>
             <u:InverseBoolConverter x:Key="inverseBool" />
             <u:DateTimeConverter x:Key="dateTime" />
+            <u:ColoredPasswordConverter x:Key="coloredPassword" />
         </ResourceDictionary>
     </ContentPage.Resources>
 
@@ -62,7 +63,8 @@
                                Grid.Column="0"
                                Grid.Row="0"
                                StyleClass="list-title, list-title-platform"
-                               Text="{Binding Password, Mode=OneWay}" />
+                               TextType="Html"
+                               Text="{Binding Password, Mode=OneWay, Converter={StaticResource coloredPassword}}" />
                             <Label LineBreakMode="TailTruncation"
                                Grid.Column="0"
                                Grid.Row="1"

--- a/src/App/Pages/Vault/ViewPage.xaml
+++ b/src/App/Pages/Vault/ViewPage.xaml
@@ -118,7 +118,8 @@
                                     Grid.Column="0"
                                     IsVisible="{Binding ShowPassword, Converter={StaticResource inverseBool}}" />
                                 <controls:MonoLabel
-                                    FormattedText="{Binding ColoredPassword, Mode=OneWay}"
+                                    Text="{Binding ColoredPassword, Mode=OneWay}"
+                                    TextType="Html"
                                     StyleClass="box-value"
                                     Grid.Row="1"
                                     Grid.Column="0"

--- a/src/App/Utilities/ColoredPasswordConverter.cs
+++ b/src/App/Utilities/ColoredPasswordConverter.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using Xamarin.Forms;
+
+namespace Bit.App.Utilities
+{
+    public class ColoredPasswordConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter,
+            System.Globalization.CultureInfo culture)
+        {
+            if(targetType != typeof(string))
+            {
+                throw new InvalidOperationException("The target must be a string.");
+            }
+            if(value == null)
+            {
+                return string.Empty;
+            }
+            return PasswordFormatter.FormatPassword((string)value);
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter,
+            System.Globalization.CultureInfo culture)
+        {
+            throw new NotSupportedException();
+        }
+    }
+}

--- a/src/App/Utilities/PasswordFormatter.cs
+++ b/src/App/Utilities/PasswordFormatter.cs
@@ -25,10 +25,14 @@ namespace Bit.App.Utilities
         {
             if(password == null)
             {
-                return "";
+                return string.Empty;
             }
 
-            var result = "";
+            // First two digits of returned hex code contains the alpha,
+            // which is not supported in HTML color, so we need to cut those out.
+            var numberColor = $"<span style=\"color:#{((Color)Application.Current.Resources["PasswordNumberColor"]).ToHex().Substring(2)}\">";
+            var specialColor = $"<span style=\"color:#{((Color)Application.Current.Resources["PasswordSpecialColor"]).ToHex().Substring(2)}\">";
+            var result = string.Empty;
 
             // Start with an otherwise uncovered case so we will definitely enter the "something changed"
             // state.
@@ -55,7 +59,7 @@ namespace Bit.App.Utilities
                 if(charType != currentType)
                 {
                     // Close off previous span.
-                    if (currentType != CharType.None)
+                    if (currentType != CharType.None || currentType != CharType.Normal)
                     {
                         result += "</span>";
                     }
@@ -67,14 +71,11 @@ namespace Bit.App.Utilities
                     switch(currentType)
                     {
                         // Apply color style to span.
-                        // First two digits of returned hex code contains the alpha,
-                        // which is not supported in HTML color,
-                        // so we need to cut those out.
                         case CharType.Number:
-                            result += $"<span style=\"color:#{((Color)Application.Current.Resources["PasswordNumberColor"]).ToHex().Substring(2)}\">";
+                            result += numberColor;
                             break;
                         case CharType.Special:
-                            result += $"<span style=\"color:#{((Color)Application.Current.Resources["PasswordSpecialColor"]).ToHex().Substring(2)}\">";
+                            result += specialColor;
                             break;
                     }
                 }
@@ -82,7 +83,7 @@ namespace Bit.App.Utilities
             }
 
             // Close off last span.
-            if (currentType != CharType.Normal)
+            if (currentType != CharType.None || currentType != CharType.Normal)
             {
                 result += "</span>";
             }

--- a/src/App/Utilities/PasswordFormatter.cs
+++ b/src/App/Utilities/PasswordFormatter.cs
@@ -21,17 +21,15 @@ namespace Bit.App.Utilities
             Special
         }
 
-        public static FormattedString FormatPassword(string password)
+        public static string FormatPassword(string password)
         {
             if(password == null)
             {
-                return new FormattedString();
+                return "";
             }
 
-            var result = new FormattedString();
-            // Start off with an empty span to prevent possible NPEs. Due to the way the state machine
-            // works, this will actually always be replaced by a new span anyway.
-            var currentSpan = new Span();
+            var result = "";
+
             // Start with an otherwise uncovered case so we will definitely enter the "something changed"
             // state.
             var currentType = CharType.None;
@@ -56,24 +54,39 @@ namespace Bit.App.Utilities
                 // If the char type changed, build a new span to append the text to.
                 if(charType != currentType)
                 {
-                    currentSpan = new Span();
-                    result.Spans.Add(currentSpan);
+                    // Close off previous span.
+                    if (currentType != CharType.None)
+                    {
+                        result += "</span>";
+                    }
+                    
                     currentType = charType;
 
                     // Switch the color if it is not a normal text. Otherwise leave the
                     // default value.
                     switch(currentType)
                     {
+                        // Apply color style to span.
+                        // First two digits of returned hex code contains the alpha,
+                        // which is not supported in HTML color,
+                        // so we need to cut those out.
                         case CharType.Number:
-                            currentSpan.TextColor = (Color)Application.Current.Resources["PasswordNumberColor"];
+                            result += $"<span style=\"color:#{((Color)Application.Current.Resources["PasswordNumberColor"]).ToHex().Substring(2)}\">";
                             break;
                         case CharType.Special:
-                            currentSpan.TextColor = (Color)Application.Current.Resources["PasswordSpecialColor"];
+                            result += $"<span style=\"color:#{((Color)Application.Current.Resources["PasswordSpecialColor"]).ToHex().Substring(2)}\">";
                             break;
                     }
                 }
-                currentSpan.Text += c;
+                result += c;
             }
+
+            // Close off last span.
+            if (currentType != CharType.Normal)
+            {
+                result += "</span>";
+            }
+
             return result;
         }
     }

--- a/src/App/Utilities/PasswordFormatter.cs
+++ b/src/App/Utilities/PasswordFormatter.cs
@@ -59,7 +59,7 @@ namespace Bit.App.Utilities
                 if(charType != currentType)
                 {
                     // Close off previous span.
-                    if (currentType != CharType.None || currentType != CharType.Normal)
+                    if (currentType != CharType.None && currentType != CharType.Normal)
                     {
                         result += "</span>";
                     }
@@ -83,7 +83,7 @@ namespace Bit.App.Utilities
             }
 
             // Close off last span.
-            if (currentType != CharType.None || currentType != CharType.Normal)
+            if (currentType != CharType.None && currentType != CharType.Normal)
             {
                 result += "</span>";
             }


### PR DESCRIPTION
Passwords displayed in the password generator are not colour coded like they are on other platforms. This pull request changes the password generator password to be colour coded.

https://community.bitwarden.com/t/color-coded-password-not-working-on-android/9594