### PR TITLE
Fix for notification pendingIntent uri being set to browser package name

### DIFF
--- a/src/Android/Accessibility/AccessibilityHelpers.cs
+++ b/src/Android/Accessibility/AccessibilityHelpers.cs
@@ -114,6 +114,12 @@ namespace Bit.Droid.Accessibility
                     uri = ExtractUri(uri, addressNode, browser);
                     addressNode.Dispose();
                 }
+                else
+                {
+                    // Return null to prevent overwriting notification pendingIntent uri with browser packageName
+                    // (we login to pages, not browsers)
+                    return null;
+                }
             }
             return uri;
         }

--- a/src/Android/Accessibility/AccessibilityService.cs
+++ b/src/Android/Accessibility/AccessibilityService.cs
@@ -100,11 +100,11 @@ namespace Bit.Droid.Accessibility
                                 break;
                             }
                             var uri = AccessibilityHelpers.GetUri(root);
-                            if(uri != _lastNotificationUri)
+                            if(uri != null && uri != _lastNotificationUri)
                             {
                                 CancelNotification(notificationManager);
                             }
-                            else if(uri.StartsWith(Constants.AndroidAppProtocol))
+                            else if(uri != null && uri.StartsWith(Constants.AndroidAppProtocol))
                             {
                                 CancelNotification(notificationManager, 30000);
                             }


### PR DESCRIPTION
  * AccessibilityHelpers.cs:  If AccessibilityNodeInfo.FindAccessibilityNodeInfosByViewId(..) returns null when the source package is a supported browser, return a null uri to prevent overwriting the existing notification's pendingIntent uri extra with the brower's packageName.

* AccessibilityService.cs: Added null uri checks as it is now possible for AccessibilityHelpers.getUri(..) to return a null uri when the Accessibility Service is misbehaving.