### PR TITLE
Removal of double-event block for known browsers

### DIFF
--- a/src/Android/Accessibility/AccessibilityService.cs
+++ b/src/Android/Accessibility/AccessibilityService.cs
@@ -85,11 +85,6 @@ namespace Bit.Droid.Accessibility
                             break;
                         }
 
-                        var isKnownBroswer = AccessibilityHelpers.SupportedBrowsers.ContainsKey(root.PackageName);
-                        if(e.EventType == EventTypes.ViewClicked && isKnownBroswer)
-                        {
-                            break;
-                        }
                         if(!(e.Source?.Password ?? false) && !AccessibilityHelpers.IsUsernameEditText(root, e))
                         {
                             CancelOverlayPrompt();


### PR DESCRIPTION
Removal of double-event block for known browsers since it's no longer necessary and was preventing the overlay from working with some browsers