### PR TITLE
Migrate EnvironmentUrls to pref storage

### DIFF
--- a/src/App/Services/PreferencesStorageService.cs
+++ b/src/App/Services/PreferencesStorageService.cs
@@ -13,7 +13,8 @@ namespace Bit.App.Services
         private readonly string _sharedName;
         private readonly JsonSerializerSettings _jsonSettings = new JsonSerializerSettings
         {
-            ContractResolver = new CamelCasePropertyNamesContractResolver()
+            ContractResolver = new CamelCasePropertyNamesContractResolver(),
+            NullValueHandling = NullValueHandling.Ignore
         };
 
         public PreferencesStorageService(string sharedName)


### PR DESCRIPTION
Currently, we store environment URLs in our LiteDB JSON database. Enterprise customers have expressed a desire to pre-configure the environment URL of the app for their employees using app installation tools like https://www.appconfig.org/. These tools can generally only pre-configure app values that are stored in `NSUserDefaults` (iOS) or `SharedPreferences` (Android). See https://www.appconfig.org/www/appconfig-content/uploads/2015/08/ImplementingAppConfigwithXamarin.pdf

To support this, we need to move environment URLs to be stored in our `PreferencesStorageService`. Existing users with configured environment URLs need to have their values migrated from `LiteDbStorage` to `PreferencesStorageService`.