### PR TITLE
Fix runtime exception.

### DIFF
--- a/src/App/Pages/Accounts/TwoFactorPageViewModel.cs
+++ b/src/App/Pages/Accounts/TwoFactorPageViewModel.cs
@@ -208,7 +208,7 @@ namespace Bit.App.Pages
                 _broadcasterService.Unsubscribe(nameof(TwoFactorPage));
                 var disableFavicon = await _storageService.GetAsync<bool?>(Constants.DisableFaviconKey);
                 await _stateService.SaveAsync(Constants.DisableFaviconKey, disableFavicon.GetValueOrDefault());
-                Application.Current.MainPage = new TabsPage();
+                Device.BeginInvokeOnMainThread(() => { Application.Current.MainPage = new TabsPage(); });
             }
             catch(ApiException e)
             {


### PR DESCRIPTION
In the callback the processing does not go in the main UI thread, so we
need to switch there. Otherwise on Android this throws
Android.Util.AndroidRuntimeException with detail “Only the original thread
that created a view hierarchy can touch its views”.

Discovered by trying to login with Duo as a two-factor login type.