### PR TITLE
Fixed password color and alignment on iOS password generator

### DIFF
--- a/src/App/Pages/Generator/GeneratorPage.xaml
+++ b/src/App/Pages/Generator/GeneratorPage.xaml
@@ -45,6 +45,7 @@
                     Margin="0, 20"
                     StyleClass="text-lg"
                     HorizontalTextAlignment="Center"
+                    HorizontalOptions="CenterAndExpand"
                     LineBreakMode="CharacterWrap" />
                 <Button Text="{u:I18n RegeneratePassword}"
                         HorizontalOptions="FillAndExpand"

--- a/src/App/Utilities/PasswordFormatter.cs
+++ b/src/App/Utilities/PasswordFormatter.cs
@@ -30,8 +30,9 @@ namespace Bit.App.Utilities
 
             // First two digits of returned hex code contains the alpha,
             // which is not supported in HTML color, so we need to cut those out.
-            var numberColor = $"<span style=\"color:#{((Color)Application.Current.Resources["PasswordNumberColor"]).ToHex().Substring(2)}\">";
-            var specialColor = $"<span style=\"color:#{((Color)Application.Current.Resources["PasswordSpecialColor"]).ToHex().Substring(2)}\">";
+            var normalColor = $"<span style=\"color:#{((Color)Application.Current.Resources["TextColor"]).ToHex().Substring(3)}\">";
+            var numberColor = $"<span style=\"color:#{((Color)Application.Current.Resources["PasswordNumberColor"]).ToHex().Substring(3)}\">";
+            var specialColor = $"<span style=\"color:#{((Color)Application.Current.Resources["PasswordSpecialColor"]).ToHex().Substring(3)}\">";
             var result = string.Empty;
 
             // Start with an otherwise uncovered case so we will definitely enter the "something changed"
@@ -59,7 +60,7 @@ namespace Bit.App.Utilities
                 if(charType != currentType)
                 {
                     // Close off previous span.
-                    if (currentType != CharType.None && currentType != CharType.Normal)
+                    if (currentType != CharType.None)
                     {
                         result += "</span>";
                     }
@@ -71,6 +72,9 @@ namespace Bit.App.Utilities
                     switch(currentType)
                     {
                         // Apply color style to span.
+                        case CharType.Normal:
+                            result += normalColor;
+                            break;
                         case CharType.Number:
                             result += numberColor;
                             break;
@@ -83,7 +87,7 @@ namespace Bit.App.Utilities
             }
 
             // Close off last span.
-            if (currentType != CharType.None && currentType != CharType.Normal)
+            if (currentType != CharType.None)
             {
                 result += "</span>";
             }


### PR DESCRIPTION
Some key takeaways:

- One character of the alpha hex code was still in the hex color.  Android ignored the invalid char and was able to establish the intended hex color, whereas iOS threw the whole thing out as invalid, hence the color-less passwords.  Also had to add another span for the "normal" color so it respects what "normal" is based on the selected app theme.  I actually can't figure out how Android is doing this automatically.

- Changing the label to `HorizontalOptions="CenterAndExpand"` mimics the behavior of `wrap_content` in Android, so the label itself is only as wide as the text within.  This "fixes" the issue of iOS ignoring `HorizontalTextAlignment="Center"` when `TextType="Html"` is used, but only if the password is on a single line.  Once the password starts wrapping, the left-justification is visible again.

- Another issue that I haven't figured out how to solve:  `LineBreakMode="CharacterWrap"` is not working as expected with `TextType="Html"`.  It seems to be wrapping on "words" resulting in violent shifting of the screen controls as the wrapping index is re-evaluated for each new password.  (This is extra apparent when you download the app store version of bitwarden which properly wraps on characters, resulting in a much smoother experience when adjusting the length slider)