### PR TITLE
New Android attachment handling to support saving or opening attachments

### DIFF
--- a/src/Android/Services/DeviceActionService.cs
+++ b/src/Android/Services/DeviceActionService.cs
@@ -230,15 +230,8 @@ namespace Bit.Droid.Services
                 string mimeType = MimeTypeMap.Singleton.GetMimeTypeFromExtension(extension);
                 if(mimeType == null)
                 {
-                    if(extension == "json")
-                    {
-                        // Explicit support for json since older versions of Android don't recognize the extension
-                        mimeType = "text/json";
-                    }
-                    else
-                    {
-                        return false; 
-                    }
+                    // Unable to identify so fall back to generic "any" type
+                    mimeType = "*/*";
                 }
 
                 var intent = new Intent(Intent.ActionCreateDocument);

--- a/src/App/Pages/Vault/ViewPage.xaml.cs
+++ b/src/App/Pages/Vault/ViewPage.xaml.cs
@@ -1,4 +1,5 @@
-﻿using Bit.App.Resources;
+﻿using System;
+using Bit.App.Resources;
 using Bit.Core.Abstractions;
 using Bit.Core.Utilities;
 using System.Collections.Generic;
@@ -74,6 +75,18 @@ namespace Bit.App.Pages
                                 var task = _vm.LoadAsync(() => AdjustToolbar());
                             }
                         }
+                    });
+                }
+                else if(message.Command == "selectSaveFileResult")
+                {
+                    Device.BeginInvokeOnMainThread(() =>
+                    {
+                        var data = message.Data as Tuple<string, string>;
+                        if(data == null)
+                        {
+                            return;
+                        }
+                        _vm.SaveFileSelected(data.Item1, data.Item2);
                     });
                 }
             });

--- a/src/App/Pages/Vault/ViewPageViewModel.cs
+++ b/src/App/Pages/Vault/ViewPageViewModel.cs
@@ -459,25 +459,15 @@ namespace Bit.App.Pages
 
         public async void PromptOpenOrSave(byte[] data, AttachmentView attachment)
         {
-            var options = new List<KeyValuePair<string, string>>
-            {
-                new KeyValuePair<string, string>("open", AppResources.Open),
-                new KeyValuePair<string, string>("save", AppResources.Save)
-            };
             var selection = await Page.DisplayActionSheet(attachment.FileName, AppResources.Cancel, null,
-                options.Select(o => o.Value).ToArray());
-            if(selection != null && selection != AppResources.Cancel)
+                AppResources.Open, AppResources.Save);
+            if(selection == AppResources.Open)
             {
-                switch(options.FirstOrDefault(f => f.Value == selection).Key)
-                {
-                    case "open":
-                        OpenAttachment(data, attachment);
-                        break;
-
-                    case "save":
-                        SaveAttachment(data, attachment);
-                        break;
-                }
+                OpenAttachment(data, attachment);
+            }
+            else if(selection == AppResources.Save)
+            {
+                SaveAttachment(data, attachment);
             }
         }
 

--- a/src/App/Pages/Vault/ViewPageViewModel.cs
+++ b/src/App/Pages/Vault/ViewPageViewModel.cs
@@ -34,6 +34,8 @@ namespace Bit.App.Pages
         private bool _totpLow;
         private DateTime? _totpInterval = null;
         private string _previousCipherId;
+        private byte[] _attachmentData;
+        private string _attachmentFilename;
 
         public ViewPageViewModel()
         {
@@ -405,10 +407,19 @@ namespace Bit.App.Pages
                     return;
                 }
             }
+
+            var canOpenFile = true;
             if(!_deviceActionService.CanOpenFile(attachment.FileName))
             {
-                await _platformUtilsService.ShowDialogAsync(AppResources.UnableToOpenFile);
-                return;
+                if(Device.RuntimePlatform == Device.iOS)
+                {
+                    // iOS is currently hardcoded to always return CanOpenFile == true, but should it ever return false
+                    // for any reason we want to be sure to catch it here.
+                    await _platformUtilsService.ShowDialogAsync(AppResources.UnableToOpenFile);
+                    return;
+                }
+
+                canOpenFile = false;
             }
 
             await _deviceActionService.ShowLoadingAsync(AppResources.Downloading);
@@ -421,10 +432,23 @@ namespace Bit.App.Pages
                     await _platformUtilsService.ShowDialogAsync(AppResources.UnableToDownloadFile);
                     return;
                 }
-                if(!_deviceActionService.OpenFile(data, attachment.Id, attachment.FileName))
+
+                if(Device.RuntimePlatform == Device.Android)
                 {
-                    await _platformUtilsService.ShowDialogAsync(AppResources.UnableToOpenFile);
-                    return;
+                    if(canOpenFile)
+                    {
+                        // We can open this attachment directly, so give the user the option to open or save
+                        PromptOpenOrSave(data, attachment);
+                    }
+                    else
+                    {
+                        // We can't open this attachment so go directly to save
+                        SaveAttachment(data, attachment);
+                    }
+                }
+                else
+                {
+                    OpenAttachment(data, attachment);
                 }
             }
             catch
@@ -433,6 +457,69 @@ namespace Bit.App.Pages
             }
         }
 
+        public async void PromptOpenOrSave(byte[] data, AttachmentView attachment)
+        {
+            var options = new List<KeyValuePair<string, string>>
+            {
+                new KeyValuePair<string, string>("open", AppResources.Open),
+                new KeyValuePair<string, string>("save", AppResources.Save)
+            };
+            var selection = await Page.DisplayActionSheet(attachment.FileName, AppResources.Cancel, null,
+                options.Select(o => o.Value).ToArray());
+            if(selection != null && selection != AppResources.Cancel)
+            {
+                switch(options.FirstOrDefault(f => f.Value == selection).Key)
+                {
+                    case "open":
+                        OpenAttachment(data, attachment);
+                        break;
+
+                    case "save":
+                        SaveAttachment(data, attachment);
+                        break;
+                }
+            }
+        }
+
+        public async void OpenAttachment(byte[] data, AttachmentView attachment)
+        {
+            if(!_deviceActionService.OpenFile(data, attachment.Id, attachment.FileName))
+            {
+                await _platformUtilsService.ShowDialogAsync(AppResources.UnableToOpenFile);
+                return;
+            }
+        }
+
+        public async void SaveAttachment(byte[] data, AttachmentView attachment)
+        {
+            _attachmentData = data;
+            _attachmentFilename = attachment.FileName;
+            if(!_deviceActionService.SaveFile(_attachmentData, null, _attachmentFilename, null))
+            {
+                ClearAttachmentData();
+                await _platformUtilsService.ShowDialogAsync(AppResources.UnableToSaveAttachment);
+            }
+        }
+
+        public async void SaveFileSelected(string contentUri, string filename)
+        {
+            if(_deviceActionService.SaveFile(_attachmentData, null, filename ?? _attachmentFilename, contentUri))
+            {
+                ClearAttachmentData();
+                _platformUtilsService.ShowToast("success", null, AppResources.SaveAttachmentSuccess);
+                return;
+            }
+
+            ClearAttachmentData();
+            await _platformUtilsService.ShowDialogAsync(AppResources.UnableToSaveAttachment);
+        }
+
+        private void ClearAttachmentData()
+        {
+            _attachmentData = null;
+            _attachmentFilename = null;
+        }
+        
         private async void CopyAsync(string id, string text = null)
         {
             string name = null;

--- a/src/App/Resources/AppResources.Designer.cs
+++ b/src/App/Resources/AppResources.Designer.cs
@@ -2841,5 +2841,23 @@ namespace Bit.App.Resources {
                 return ResourceManager.GetString("PasswordGeneratorPolicyInEffect", resourceCulture);
             }
         }
+        
+        public static string Open {
+            get {
+                return ResourceManager.GetString("Open", resourceCulture);
+            }
+        }
+        
+        public static string UnableToSaveAttachment {
+            get {
+                return ResourceManager.GetString("UnableToSaveAttachment", resourceCulture);
+            }
+        }
+        
+        public static string SaveAttachmentSuccess {
+            get {
+                return ResourceManager.GetString("SaveAttachmentSuccess", resourceCulture);
+            }
+        }
     }
 }

--- a/src/App/Resources/AppResources.resx
+++ b/src/App/Resources/AppResources.resx
@@ -1615,4 +1615,14 @@
   <data name="PasswordGeneratorPolicyInEffect" xml:space="preserve">
     <value>One or more organization policies are affecting your generator settings</value>
   </data>
+  <data name="Open" xml:space="preserve">
+    <value>Open</value>
+    <comment>Button text for an open operation (verb).</comment>
+  </data>
+  <data name="UnableToSaveAttachment" xml:space="preserve">
+    <value>There was a problem saving this attachment.  If the problem persists, you'll need to save it from the web vault.</value>
+  </data>
+  <data name="SaveAttachmentSuccess" xml:space="preserve">
+    <value>Attachment saved successfully</value>
+  </data>
 </root>

--- a/src/App/Resources/AppResources.resx
+++ b/src/App/Resources/AppResources.resx
@@ -1620,7 +1620,7 @@
     <comment>Button text for an open operation (verb).</comment>
   </data>
   <data name="UnableToSaveAttachment" xml:space="preserve">
-    <value>There was a problem saving this attachment.  If the problem persists, you'll need to save it from the web vault.</value>
+    <value>There was a problem saving this attachment. If the problem persists, you can save it from the web vault.</value>
   </data>
   <data name="SaveAttachmentSuccess" xml:space="preserve">
     <value>Attachment saved successfully</value>


### PR DESCRIPTION
Introduced new attachment handling flow for Android:  Click download icon -> perform download -> If the file can be opened by the system, present user with "open or save" prompt -> If the file can't be opened by the system, go directly into the save flow.  This effectively means we can save any type of attachment + optionally open/view directly if supported.