### PR TITLE
Wait for app to resume before attempting to set Application.Current.MainPage

### DIFF
--- a/src/App/Pages/Accounts/TwoFactorPageViewModel.cs
+++ b/src/App/Pages/Accounts/TwoFactorPageViewModel.cs
@@ -141,6 +141,7 @@ namespace Bit.App.Pages
                     page.DuoWebView.RegisterAction(sig =>
                     {
                         Token = sig;
+                        App.WaitForResume();
                         Device.BeginInvokeOnMainThread(async () => await SubmitAsync());
                     });
                     break;


### PR DESCRIPTION
Workaround for older bug in Xamarin.Forms by waiting for app to resume before attempting to set Application.Current.MainPage.  Fixed in latest Xamarin.Forms 4.4.0.x but it's too dangerous to swap that out so close to a release.

This fixes the issue with Duo that only occurs when you leave the Bitwarden app completely to acknowledge the push (in recent versions of Android you can ack the push directly from the Duo notification, never leaving the Bitwarden app)