### PR TITLE
Fixed issue where multiple threads were attempting to modify search result list

### DIFF
--- a/src/App/Pages/Vault/CiphersPage.xaml.cs
+++ b/src/App/Pages/Vault/CiphersPage.xaml.cs
@@ -75,7 +75,7 @@ namespace Bit.App.Pages
             {
                 return;
             }
-            _vm.Search(e.NewTextValue, 500);
+            _vm.Search(e.NewTextValue, 200);
         }
 
         private void SearchBar_SearchButtonPressed(object sender, EventArgs e)

--- a/src/App/Pages/Vault/CiphersPageViewModel.cs
+++ b/src/App/Pages/Vault/CiphersPageViewModel.cs
@@ -77,7 +77,7 @@ namespace Bit.App.Pages
                 .GetValueOrDefault();
             if(!string.IsNullOrWhiteSpace((Page as CiphersPage).SearchBar.Text))
             {
-                Search((Page as CiphersPage).SearchBar.Text, 500);
+                Search((Page as CiphersPage).SearchBar.Text, 200);
             }
         }
 
@@ -117,9 +117,12 @@ namespace Bit.App.Pages
                 {
                     ciphers = new List<CipherView>();
                 }
-                Ciphers.ResetWithRange(ciphers);
-                ShowNoData = searchable && Ciphers.Count == 0;
-                ShowList = searchable && !ShowNoData;
+                Device.BeginInvokeOnMainThread(() =>
+                {
+                    Ciphers.ResetWithRange(ciphers);
+                    ShowNoData = searchable && Ciphers.Count == 0;
+                    ShowList = searchable && !ShowNoData;
+                });
             }, cts.Token);
             _searchCancellationTokenSource = cts;
         }

--- a/src/App/Pages/Vault/CiphersPageViewModel.cs
+++ b/src/App/Pages/Vault/CiphersPageViewModel.cs
@@ -110,7 +110,7 @@ namespace Bit.App.Pages
                     }
                     catch(OperationCanceledException)
                     {
-                        ciphers = new List<CipherView>();
+                        return;
                     }
                 }
                 if(ciphers == null)


### PR DESCRIPTION
- Perform search result list update on main thread to force thread safety on the underlying ObservableCollection.  This fixes the occasional `ArgumentOutOfRangeException` as well as the strange behavior where hitting the IME "enter" key after entering text would clear the results and state none were found even though they exist.

- Changed existing search execution delay for keystrokes to 200ms to match web

- Fixed race condition where non-delayed search (keyboard "enter") jumped the queue and the prior delayed search (text change) would still modify the search results, contributing to the "no results found" problem (we're now returning when `OperationCanceledException` is thrown)