### PR TITLE
Move tab bar colors to styles

### DIFF
--- a/src/App/Pages/TabsPage.cs
+++ b/src/App/Pages/TabsPage.cs
@@ -15,21 +15,21 @@ namespace Bit.App.Pages
             _groupingsPage = new NavigationPage(new GroupingsPage(true, previousPage: previousPage))
             {
                 Title = AppResources.MyVault,
-                Icon = "lock.png"
+                IconImageSource = "lock.png"
             };
             Children.Add(_groupingsPage);
 
             _generatorPage = new NavigationPage(new GeneratorPage(true, null, this))
             {
                 Title = AppResources.Generator,
-                Icon = "refresh.png"
+                IconImageSource = "refresh.png"
             };
             Children.Add(_generatorPage);
 
             var settingsPage = new NavigationPage(new SettingsPage(this))
             {
                 Title = AppResources.Settings,
-                Icon = "cog.png"
+                IconImageSource = "cog.png"
             };
             Children.Add(settingsPage);
 
@@ -41,10 +41,6 @@ namespace Bit.App.Pages
                     Xamarin.Forms.PlatformConfiguration.AndroidSpecific.ToolbarPlacement.Bottom);
                 Xamarin.Forms.PlatformConfiguration.AndroidSpecific.TabbedPage.SetIsSwipePagingEnabled(this, false);
                 Xamarin.Forms.PlatformConfiguration.AndroidSpecific.TabbedPage.SetIsSmoothScrollEnabled(this, false);
-                Xamarin.Forms.PlatformConfiguration.AndroidSpecific.TabbedPage.SetBarSelectedItemColor(this,
-                    (Color)Application.Current.Resources["TabBarSelectedItemColor"]);
-                Xamarin.Forms.PlatformConfiguration.AndroidSpecific.TabbedPage.SetBarItemColor(this,
-                    (Color)Application.Current.Resources["TabBarItemColor"]);
             }
 
             if(appOptions?.GeneratorTile ?? false)

--- a/src/App/Styles/Base.xaml
+++ b/src/App/Styles/Base.xaml
@@ -65,6 +65,10 @@
            ApplyToDerivedTypes="True">
         <Setter Property="BarBackgroundColor"
                 Value="{StaticResource TabBarBackgroundColor}" />
+        <Setter Property="SelectedTabColor"
+                Value="{StaticResource TabBarSelectedItemColor}" />
+        <Setter Property="UnselectedTabColor"
+                Value="{StaticResource TabBarItemColor}" />
     </Style>
   <Style TargetType="NavigationPage"
          ApplyToDerivedTypes="True">

--- a/src/iOS/Renderers/CustomTabbedRenderer.cs
+++ b/src/iOS/Renderers/CustomTabbedRenderer.cs
@@ -12,10 +12,6 @@ namespace Bit.iOS.Renderers
             base.OnElementChanged(e);
             TabBar.Translucent = false;
             TabBar.Opaque = true;
-            TabBar.SelectedImageTintColor =
-                ((Color)Xamarin.Forms.Application.Current.Resources["TabBarSelectedItemColor"]).ToUIColor();
-            TabBar.UnselectedItemTintColor =
-                ((Color)Xamarin.Forms.Application.Current.Resources["TabBarItemColor"]).ToUIColor();
         }
     }
 }


### PR DESCRIPTION
Looks like the platform-specific property for tab colors was deprecated in Xamarin.Forms 4, so moved this to proper styling (new way) and removed the custom renderer hack on iOS.

Also changed Icon to IconImageSource since apparently that was deprecated now too.