### PR TITLE
Null check policies from SyncResponse before parsing

### DIFF
--- a/src/Core/Services/SyncService.cs
+++ b/src/Core/Services/SyncService.cs
@@ -366,7 +366,7 @@ namespace Bit.Core.Services
         private async Task SyncPolicies(List<PolicyResponse> response)
         {
             var policies = response?.ToDictionary(p => p.Id, p => new PolicyData(p)) ??
-                           new Dictionary<string, PolicyData>();
+                new Dictionary<string, PolicyData>();
             await _policyService.Replace(policies);
         }
     }

--- a/src/Core/Services/SyncService.cs
+++ b/src/Core/Services/SyncService.cs
@@ -365,7 +365,8 @@ namespace Bit.Core.Services
 
         private async Task SyncPolicies(List<PolicyResponse> response)
         {
-            var policies = response.ToDictionary(p => p.Id, p => new PolicyData(p));
+            var policies = response?.ToDictionary(p => p.Id, p => new PolicyData(p)) ??
+                           new Dictionary<string, PolicyData>();
             await _policyService.Replace(policies);
         }
     }


### PR DESCRIPTION
Fixes sync issue introduced with policies combined with org-less accounts