### PR TITLE
Bumped csvHelper to 15.0.1 and added missing error dialog in export failure flow

### DIFF
--- a/src/App/Pages/Settings/ExportVaultPageViewModel.cs
+++ b/src/App/Pages/Settings/ExportVaultPageViewModel.cs
@@ -111,6 +111,7 @@ namespace Bit.App.Pages
                 catch(Exception ex)
                 {
                     ClearResult();
+                    await _platformUtilsService.ShowDialogAsync(_i18nService.T("ExportVaultFailure"));
                     System.Diagnostics.Debug.WriteLine(">>> {0}: {1}", ex.GetType(), ex.StackTrace);
                 }
             }

--- a/src/Core/Core.csproj
+++ b/src/Core/Core.csproj
@@ -23,7 +23,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="CsvHelper" Version="15.0.0" />
+    <PackageReference Include="CsvHelper" Version="15.0.1" />
     <PackageReference Include="LiteDB" Version="4.1.4" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="PCLCrypto" Version="2.0.147" />


### PR DESCRIPTION
- Bumped CsvHelper to 15.0.1
- Added missing error dialog in export failure catch block