### PR TITLE
Enforce Passphrase Policy

### DIFF
--- a/src/App/Pages/Generator/GeneratorPage.xaml
+++ b/src/App/Pages/Generator/GeneratorPage.xaml
@@ -132,6 +132,8 @@
                             HorizontalOptions="StartAndExpand" />
                         <Switch
                             IsToggled="{Binding Capitalize}"
+                            IsEnabled="{Binding EnforcedPolicyOptions.Capitalize,
+                                Converter={StaticResource inverseBool}}"
                             StyleClass="box-value"
                             HorizontalOptions="End" />
                     </StackLayout>
@@ -143,6 +145,8 @@
                             HorizontalOptions="StartAndExpand" />
                         <Switch
                             IsToggled="{Binding IncludeNumber}"
+                            IsEnabled="{Binding EnforcedPolicyOptions.IncludeNumber,
+                                Converter={StaticResource inverseBool}}"
                             StyleClass="box-value"
                             HorizontalOptions="End" />
                     </StackLayout>

--- a/src/App/Pages/Generator/GeneratorPageViewModel.cs
+++ b/src/App/Pages/Generator/GeneratorPageViewModel.cs
@@ -233,10 +233,7 @@ namespace Bit.App.Pages
                 });
         }
 
-        public bool IsPolicyInEffect => _enforcedPolicyOptions.MinLength > 0 || _enforcedPolicyOptions.UseUppercase ||
-                                        _enforcedPolicyOptions.UseLowercase || _enforcedPolicyOptions.UseNumbers ||
-                                        _enforcedPolicyOptions.NumberCount > 0 || _enforcedPolicyOptions.UseSpecial ||
-                                        _enforcedPolicyOptions.SpecialCount > 0;
+        public bool IsPolicyInEffect => _enforcedPolicyOptions.InEffect();
 
         public int TypeSelectedIndex
         {

--- a/src/Core/Models/Domain/PasswordGeneratorPolicyOptions.cs
+++ b/src/Core/Models/Domain/PasswordGeneratorPolicyOptions.cs
@@ -16,17 +16,17 @@
         
         public bool InEffect()
         {
-            return DefaultType != ""
-                   || MinLength > 0
-                   || NumberCount > 0
-                   || SpecialCount > 0
-                   || UseUppercase
-                   || UseLowercase
-                   || UseNumbers
-                   || UseSpecial
-                   || MinNumberOfWords > 0
-                   || Capitalize
-                   || IncludeNumber;
+            return DefaultType != "" || 
+                   MinLength > 0 ||
+                   NumberCount > 0 ||
+                   SpecialCount > 0 ||
+                   UseUppercase ||
+                   UseLowercase ||
+                   UseNumbers ||
+                   UseSpecial ||
+                   MinNumberOfWords > 0 ||
+                   Capitalize ||
+                   IncludeNumber;
         }
     }
 }

--- a/src/Core/Models/Domain/PasswordGeneratorPolicyOptions.cs
+++ b/src/Core/Models/Domain/PasswordGeneratorPolicyOptions.cs
@@ -2,6 +2,7 @@
 {
     public class PasswordGeneratorPolicyOptions
     {
+        public string DefaultType { get; set; }
         public int MinLength { get; set; }
         public bool UseUppercase { get; set; }
         public bool UseLowercase { get; set; }
@@ -9,5 +10,23 @@
         public int NumberCount { get; set; }
         public bool UseSpecial { get; set; }
         public int SpecialCount { get; set; }
+        public int MinNumberOfWords { get; set; }
+        public bool Capitalize { get; set; }
+        public bool IncludeNumber { get; set; }
+        
+        public bool InEffect()
+        {
+            return DefaultType != ""
+                   || MinLength > 0
+                   || NumberCount > 0
+                   || SpecialCount > 0
+                   || UseUppercase
+                   || UseLowercase
+                   || UseNumbers
+                   || UseSpecial
+                   || MinNumberOfWords > 0
+                   || Capitalize
+                   || IncludeNumber;
+        }
     }
 }

--- a/src/Core/Models/Domain/PasswordGeneratorPolicyOptions.cs
+++ b/src/Core/Models/Domain/PasswordGeneratorPolicyOptions.cs
@@ -16,17 +16,17 @@
         
         public bool InEffect()
         {
-            return DefaultType != "" || 
-                   MinLength > 0 ||
-                   NumberCount > 0 ||
-                   SpecialCount > 0 ||
-                   UseUppercase ||
-                   UseLowercase ||
-                   UseNumbers ||
-                   UseSpecial ||
-                   MinNumberOfWords > 0 ||
-                   Capitalize ||
-                   IncludeNumber;
+            return DefaultType != "" ||
+                MinLength > 0 || 
+                NumberCount > 0 || 
+                SpecialCount > 0 || 
+                UseUppercase ||
+                UseLowercase ||
+                UseNumbers ||
+                UseSpecial ||
+                MinNumberOfWords > 0 ||
+                Capitalize ||
+                IncludeNumber;
         }
     }
 }

--- a/src/Core/Services/PasswordGenerationService.cs
+++ b/src/Core/Services/PasswordGenerationService.cs
@@ -312,6 +312,27 @@ namespace Bit.Core.Services
                 {
                     options.MinSpecial = options.Length - options.MinNumber;
                 }
+
+                if(options.NumWords < enforcedPolicyOptions.MinNumberOfWords)
+                {
+                    options.NumWords = enforcedPolicyOptions.MinNumberOfWords;
+                }
+
+                if(enforcedPolicyOptions.Capitalize)
+                {
+                    options.Capitalize = true;
+                }
+
+                if(enforcedPolicyOptions.IncludeNumber)
+                {
+                    options.IncludeNumber = true;
+                }
+
+                // Force default type if password/passphrase selected via policy
+                if(enforcedPolicyOptions.DefaultType == "password" || enforcedPolicyOptions.DefaultType == "passphrase")
+                {
+                    options.Type = enforcedPolicyOptions.DefaultType;
+                }
             }
             else
             {
@@ -342,6 +363,12 @@ namespace Bit.Core.Services
                 if(enforcedOptions == null)
                 {
                     enforcedOptions = new PasswordGeneratorPolicyOptions();
+                }
+
+                var defaultType = GetPolicyString(currentPolicy, "defaultType");
+                if(defaultType != null && enforcedOptions.DefaultType != "password")
+                {
+                    enforcedOptions.DefaultType = defaultType;
                 }
 
                 var minLength = GetPolicyInt(currentPolicy, "minLength");
@@ -385,6 +412,24 @@ namespace Bit.Core.Services
                 {
                     enforcedOptions.SpecialCount = (int)(long)minSpecial;
                 }
+
+                var minNumberWords = GetPolicyInt(currentPolicy, "minNumberWords");
+                if(minNumberWords != null && (int)(long)minNumberWords > enforcedOptions.MinNumberOfWords)
+                {
+                    enforcedOptions.MinNumberOfWords = (int)(long)minNumberWords;
+                }
+
+                var capitalize = GetPolicyBool(currentPolicy, "capitalize");
+                if(capitalize != null && (bool)capitalize)
+                {
+                    enforcedOptions.Capitalize = true;
+                }
+                
+                var includeNumber = GetPolicyBool(currentPolicy, "includeNumber");
+                if(includeNumber != null && (bool)includeNumber)
+                {
+                    enforcedOptions.IncludeNumber = true;
+                }
             }
 
             return enforcedOptions;
@@ -411,6 +456,19 @@ namespace Bit.Core.Services
                 if(value != null)
                 {
                     return (bool)value;
+                }
+            }
+            return null;
+        }
+        
+        private string GetPolicyString(Policy policy, string key)
+        {
+            if(policy.Data.ContainsKey(key))
+            {
+                var value = policy.Data[key];
+                if(value != null)
+                {
+                    return (string)value;
                 }
             }
             return null;
@@ -548,6 +606,11 @@ namespace Bit.Core.Services
             else if(options.NumWords > 20)
             {
                 options.NumWords = 20;
+            }
+
+            if(options.NumWords < enforcedPolicyOptions.MinNumberOfWords)
+            {
+                options.NumWords = enforcedPolicyOptions.MinNumberOfWords;
             }
 
             if(options.WordSeparator != null && options.WordSeparator.Length > 1)


### PR DESCRIPTION
## Objective
> Add missing components for passphrase policy. Use existing data structures/patterns to implement a shared password generator (password/passphrase) for both Android and iOS.

## Code Changes
- **GeneratorPage.xaml**: Added `IsEnabled` values for `Capitalize` and `IncludeNumber` switches depending on the `EnforcedPolicyOptions` returned
- **GeneratorPageViewModel.cs**: Updated boolean property to use newly added `InEffect()` function
- **PasswordGeneratorPolicyOptions.cs**: Added new fields for tracking the passphrase policy. Created helper method to clear up a long conditional in the view model.
- **PasswordGenerationService.cs**: Passphrase options are now enforced during `PasswordGeneratorPolicyOptions` objection creation.  User options are now updated with passphrase options during retrieval. Normalize options will make sure the floor is set with `MinNumberWords` variable.

## Screenshots
### Android
![0-android-passphrase-enforced](https://user-images.githubusercontent.com/26154748/76647764-6aeae700-652b-11ea-9a92-c684db784641.png)
### iOS
![0-ios-passphrase-enforced](https://user-images.githubusercontent.com/26154748/76647782-73432200-652b-11ea-96b6-6c0cf43e665d.png)

