### PR TITLE
Fix bug with policy banner visibility

### DIFF
--- a/src/Core/Models/Domain/PasswordGeneratorPolicyOptions.cs
+++ b/src/Core/Models/Domain/PasswordGeneratorPolicyOptions.cs
@@ -2,7 +2,7 @@
 {
     public class PasswordGeneratorPolicyOptions
     {
-        public string DefaultType { get; set; }
+        public string DefaultType { get; set; } = "";
         public int MinLength { get; set; }
         public bool UseUppercase { get; set; }
         public bool UseLowercase { get; set; }


### PR DESCRIPTION
## Objective
> Policy In Effect banner is showing up for users not in an organization [Reddit](https://www.reddit.com/r/Bitwarden/comments/fjfies/one_or_more_organization_policies_are_affecting/)

## Failure Point
- Downstream code was expecting the `PasswordGeneratorPolicyOptions` object to have a default `DefaultType` of an empty string. This was not being set, causing the conditional `DefaultType != ""` to return true.

## Code Changes
- **PasswordGeneratorPolicyOptions.cs**: Added default value for `DefaultType` property. This now mimics the js codebase.