### PR TITLE
Add support for inverse data matrix QR codes

### DIFF
--- a/src/App/Pages/Vault/ScanPage.xaml.cs
+++ b/src/App/Pages/Vault/ScanPage.xaml.cs
@@ -20,6 +20,7 @@ namespace Bit.App.Pages
                 UseNativeScanning = true,
                 PossibleFormats = new List<ZXing.BarcodeFormat> { ZXing.BarcodeFormat.QR_CODE },
                 AutoRotate = false,
+                TryInverted = true
             };
             if(Device.RuntimePlatform == Device.Android)
             {


### PR DESCRIPTION
The QR code in the attached issue is inverted.  Adding `TryInverted` to the scan options makes ZXing aware of it.  