### PR TITLE
Added Quick Settings tile for triggering accessibility autofill

### DIFF
--- a/src/Android/Accessibility/AccessibilityActivity.cs
+++ b/src/Android/Accessibility/AccessibilityActivity.cs
@@ -82,7 +82,7 @@ namespace Bit.Droid.Accessibility
 
         private void HandleIntent(Intent callingIntent, int requestCode)
         {
-            if(callingIntent?.GetBooleanExtra("autofillTileClicked", false) == true)
+            if(callingIntent?.GetBooleanExtra("autofillTileClicked", false) ?? false)
             {
                 Intent.RemoveExtra("autofillTileClicked");
                 var messagingService = ServiceContainer.Resolve<IMessagingService>("messagingService");

--- a/src/Android/Accessibility/AccessibilityActivity.cs
+++ b/src/Android/Accessibility/AccessibilityActivity.cs
@@ -4,6 +4,8 @@ using Android.OS;
 using Android.Runtime;
 using Android.Views;
 using System;
+using Bit.Core.Abstractions;
+using Bit.Core.Utilities;
 
 namespace Bit.Droid.Accessibility
 {
@@ -16,13 +18,13 @@ namespace Bit.Droid.Accessibility
         protected override void OnCreate(Bundle bundle)
         {
             base.OnCreate(bundle);
-            LaunchMainActivity(Intent, 932473);
+            HandleIntent(Intent, 932473);
         }
 
         protected override void OnNewIntent(Intent intent)
         {
             base.OnNewIntent(intent);
-            LaunchMainActivity(intent, 489729);
+            HandleIntent(intent, 489729);
         }
 
         protected override void OnDestroy()
@@ -76,6 +78,21 @@ namespace Bit.Droid.Accessibility
                 }
             }
             Finish();
+        }
+
+        private void HandleIntent(Intent callingIntent, int requestCode)
+        {
+            if(callingIntent?.GetBooleanExtra("autofillTileClicked", false) == true)
+            {
+                Intent.RemoveExtra("autofillTileClicked");
+                var messagingService = ServiceContainer.Resolve<IMessagingService>("messagingService");
+                messagingService.Send("OnAutofillTileClick");
+                Finish();
+            }
+            else
+            {
+                LaunchMainActivity(callingIntent, requestCode);
+            }
         }
 
         private void LaunchMainActivity(Intent callingIntent, int requestCode)

--- a/src/Android/Accessibility/AccessibilityHelpers.cs
+++ b/src/Android/Accessibility/AccessibilityHelpers.cs
@@ -20,6 +20,8 @@ namespace Bit.Droid.Accessibility
         public static Credentials LastCredentials = null;
         public static string SystemUiPackage = "com.android.systemui";
         public static string BitwardenTag = "bw_access";
+        public static bool IsAutofillTileAdded = false;
+        public static bool IsAccessibilityBroadcastReady = false;
 
         public static Dictionary<string, Browser> SupportedBrowsers => new List<Browser>
         {

--- a/src/Android/Accessibility/AccessibilityService.cs
+++ b/src/Android/Accessibility/AccessibilityService.cs
@@ -226,8 +226,12 @@ namespace Bit.Droid.Accessibility
 
             if(_windowManager != null && _overlayView != null)
             {
-                _windowManager.RemoveViewImmediate(_overlayView);
-                System.Diagnostics.Debug.WriteLine(">>> Accessibility Overlay View Removed");
+                try
+                {
+                    _windowManager.RemoveViewImmediate(_overlayView);
+                    System.Diagnostics.Debug.WriteLine(">>> Accessibility Overlay View Removed");
+                }
+                catch { }
             }
 
             _overlayView = null;

--- a/src/Android/Android.csproj
+++ b/src/Android/Android.csproj
@@ -136,6 +136,7 @@
     <Compile Include="Services\CryptoPrimitiveService.cs" />
     <Compile Include="Services\DeviceActionService.cs" />
     <Compile Include="Services\LocalizeService.cs" />
+    <Compile Include="Tiles\AutofillTileService.cs" />
     <Compile Include="Tiles\GeneratorTileService.cs" />
     <Compile Include="Tiles\MyVaultTileService.cs" />
     <Compile Include="Utilities\AndroidHelpers.cs" />

--- a/src/Android/Resources/values/strings.xml
+++ b/src/Android/Resources/values/strings.xml
@@ -16,6 +16,9 @@
   <string name="PasswordGenerator">
     Password Generator
   </string>
+  <string name="ScanAndFill">
+    Scan &amp; Fill
+  </string>
   <string name="SelfHostedServerUrl">
     Self-hosted server URL
   </string>

--- a/src/Android/Tiles/AutofillTileService.cs
+++ b/src/Android/Tiles/AutofillTileService.cs
@@ -1,0 +1,80 @@
+﻿using Android.App;
+using Android.Content;
+using Android.OS;
+using Android.Runtime;
+using Android.Service.QuickSettings;
+using Bit.App.Resources;
+using Bit.Droid.Accessibility;
+using Java.Lang;
+
+namespace Bit.Droid.Tile
+{
+    [Service(Permission = Android.Manifest.Permission.BindQuickSettingsTile, Label = "@string/ScanAndFill",
+        Icon = "@drawable/shield")]
+    [IntentFilter(new string[] { ActionQsTile })]
+    [Register("com.x8bit.bitwarden.AutofillTileService")]
+    public class AutofillTileService : TileService
+    {
+        public override void OnTileAdded()
+        {
+            base.OnTileAdded();
+            AccessibilityHelpers.IsAutofillTileAdded = true;
+        }
+
+        public override void OnStartListening()
+        {
+            base.OnStartListening();
+        }
+
+        public override void OnStopListening()
+        {
+            base.OnStopListening();
+        }
+
+        public override void OnTileRemoved()
+        {
+            base.OnTileRemoved();
+            AccessibilityHelpers.IsAutofillTileAdded = false;
+        }
+
+        public override void OnClick()
+        {
+            base.OnClick();
+            
+            if(IsLocked)
+            {
+                UnlockAndRun(new Runnable(ScanAndFill));
+            }
+            else
+            {
+                ScanAndFill();
+            }
+        }
+
+        private void ScanAndFill()
+        {
+            if(!AccessibilityHelpers.IsAccessibilityBroadcastReady)
+            {
+                ShowConfigErrorDialog();
+                return;
+            }
+            
+            var intent = new Intent(this, typeof(AccessibilityActivity));
+            intent.SetFlags(ActivityFlags.NewTask | ActivityFlags.SingleTop | ActivityFlags.ClearTop);
+            intent.PutExtra("autofillTileClicked", true);
+            StartActivityAndCollapse(intent);
+        }
+
+        private void ShowConfigErrorDialog()
+        {
+            var alertBuilder = new AlertDialog.Builder(this);
+            alertBuilder.SetMessage(AppResources.AutofillTileAccessibilityRequired);
+            alertBuilder.SetCancelable(true);
+            alertBuilder.SetPositiveButton(AppResources.Ok, (sender, args) =>
+            {
+                (sender as AlertDialog)?.Cancel();
+            });
+            ShowDialog(alertBuilder.Create());
+        }
+    }
+}

--- a/src/Android/Tiles/AutofillTileService.cs
+++ b/src/Android/Tiles/AutofillTileService.cs
@@ -1,24 +1,29 @@
-﻿using Android.App;
+﻿using Android;
+using Android.App;
 using Android.Content;
-using Android.OS;
 using Android.Runtime;
 using Android.Service.QuickSettings;
 using Bit.App.Resources;
+using Bit.Core;
+using Bit.Core.Abstractions;
+using Bit.Core.Utilities;
 using Bit.Droid.Accessibility;
 using Java.Lang;
 
 namespace Bit.Droid.Tile
 {
-    [Service(Permission = Android.Manifest.Permission.BindQuickSettingsTile, Label = "@string/ScanAndFill",
+    [Service(Permission = Manifest.Permission.BindQuickSettingsTile, Label = "@string/ScanAndFill",
         Icon = "@drawable/shield")]
     [IntentFilter(new string[] { ActionQsTile })]
     [Register("com.x8bit.bitwarden.AutofillTileService")]
     public class AutofillTileService : TileService
     {
+        private IStorageService _storageService;
+        
         public override void OnTileAdded()
         {
             base.OnTileAdded();
-            AccessibilityHelpers.IsAutofillTileAdded = true;
+            SetTileAdded(true);
         }
 
         public override void OnStartListening()
@@ -34,7 +39,7 @@ namespace Bit.Droid.Tile
         public override void OnTileRemoved()
         {
             base.OnTileRemoved();
-            AccessibilityHelpers.IsAutofillTileAdded = false;
+            SetTileAdded(false);
         }
 
         public override void OnClick()
@@ -49,6 +54,16 @@ namespace Bit.Droid.Tile
             {
                 ScanAndFill();
             }
+        }
+
+        private void SetTileAdded(bool isAdded)
+        {
+            AccessibilityHelpers.IsAutofillTileAdded = isAdded;
+            if(_storageService == null)
+            {
+                _storageService = ServiceContainer.Resolve<IStorageService>("storageService");
+            }
+            _storageService.SaveAsync(Constants.AutofillTileAdded, isAdded);
         }
 
         private void ScanAndFill()

--- a/src/App/Resources/AppResources.Designer.cs
+++ b/src/App/Resources/AppResources.Designer.cs
@@ -2859,5 +2859,17 @@ namespace Bit.App.Resources {
                 return ResourceManager.GetString("SaveAttachmentSuccess", resourceCulture);
             }
         }
+        
+        public static string AutofillTileAccessibilityRequired {
+            get {
+                return ResourceManager.GetString("AutofillTileAccessibilityRequired", resourceCulture);
+            }
+        }
+        
+        public static string AutofillTileUriNotFound {
+            get {
+                return ResourceManager.GetString("AutofillTileUriNotFound", resourceCulture);
+            }
+        }
     }
 }

--- a/src/App/Resources/AppResources.resx
+++ b/src/App/Resources/AppResources.resx
@@ -1625,4 +1625,10 @@
   <data name="SaveAttachmentSuccess" xml:space="preserve">
     <value>Attachment saved successfully</value>
   </data>
+  <data name="AutofillTileAccessibilityRequired" xml:space="preserve">
+    <value>Please enable "Auto-fill Accessibility Service" from Bitwarden Settings to use the Scan &amp; Fill tile.</value>
+  </data>
+  <data name="AutofillTileUriNotFound" xml:space="preserve">
+    <value>No password fields detected</value>
+  </data>
 </root>

--- a/src/Core/Constants.cs
+++ b/src/Core/Constants.cs
@@ -15,6 +15,7 @@
         public static string LastFileCacheClearKey = "lastFileCacheClear";
         public static string AutofillDisableSavePromptKey = "autofillDisableSavePrompt";
         public static string AutofillBlacklistedUrisKey = "autofillBlacklistedUris";
+        public static string AutofillTileAdded = "autofillTileAdded";
         public static string DisableFaviconKey = "disableFavicon";
         public static string PushRegisteredTokenKey = "pushRegisteredToken";
         public static string PushCurrentTokenKey = "pushCurrentToken";


### PR DESCRIPTION
The user can now add a "scan & fill" quick setting tile on Android 7.0+ via the Android's tile edit/config mechanism.  It uses accessibility to perform the autofill and can be used in addition to, or in lieu of, the accessibility overlay (by leaving the overlay permission disabled they can safely use the tile only - the missing-overlay-permission toast only appears if the tile isn't enabled).

Fun stuff:

- You can only collapse the quick settings dropdown by launching an activity or opening a dialog.  Once I accepted defeat here I resorted to using a dialog for the "you need to enable accessibility" error, and an activity to trigger the broadcast message to the accessibility service to perform a field search.
- Without waiting 250ms after receiving the trigger message, the window parser would routinely only see the system UI which we ignore by default.  Can't beat a good nap.