### PR TITLE
Tweaks to autofill tile naming & fixed missing plus icon

### DIFF
--- a/src/Android/Resources/values/strings.xml
+++ b/src/Android/Resources/values/strings.xml
@@ -16,8 +16,8 @@
   <string name="PasswordGenerator">
     Password Generator
   </string>
-  <string name="ScanAndFill">
-    Scan &amp; Fill
+  <string name="AutoFillTile">
+    Auto-fill
   </string>
   <string name="SelfHostedServerUrl">
     Self-hosted server URL

--- a/src/Android/Tiles/AutofillTileService.cs
+++ b/src/Android/Tiles/AutofillTileService.cs
@@ -12,7 +12,7 @@ using Java.Lang;
 
 namespace Bit.Droid.Tile
 {
-    [Service(Permission = Manifest.Permission.BindQuickSettingsTile, Label = "@string/ScanAndFill",
+    [Service(Permission = Manifest.Permission.BindQuickSettingsTile, Label = "@string/AutoFillTile",
         Icon = "@drawable/shield")]
     [IntentFilter(new string[] { ActionQsTile })]
     [Register("com.x8bit.bitwarden.AutofillTileService")]

--- a/src/App/Pages/Vault/AutofillCiphersPage.xaml
+++ b/src/App/Pages/Vault/AutofillCiphersPage.xaml
@@ -96,6 +96,7 @@
         </ContentView>
         <Button
             x:Name="_fab"
+            Image="plus.png"
             Clicked="AddButton_Clicked"
             Style="{StaticResource btn-fab}"
             AbsoluteLayout.LayoutFlags="PositionProportional"

--- a/src/App/Resources/AppResources.resx
+++ b/src/App/Resources/AppResources.resx
@@ -1626,7 +1626,7 @@
     <value>Attachment saved successfully</value>
   </data>
   <data name="AutofillTileAccessibilityRequired" xml:space="preserve">
-    <value>Please enable "Auto-fill Accessibility Service" from Bitwarden Settings to use the Scan &amp; Fill tile.</value>
+    <value>Please enable "Auto-fill Accessibility Service" from Bitwarden Settings to use the Auto-fill tile.</value>
   </data>
   <data name="AutofillTileUriNotFound" xml:space="preserve">
     <value>No password fields detected</value>


### PR DESCRIPTION
- Changed wording of autofill tile from "Scan & Fill" to "Auto-fill" for consistency throughout the app
- Fixed missing "+" icon in FAB when attempting to autofill something that doesn't exist in your vault

![device-2020-04-03-095255](https://user-images.githubusercontent.com/59324545/78368015-f981df80-7590-11ea-86e5-1a3e99149197.png)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1169444489336079/1169794380212370) by [Unito](https://www.unito.io/learn-more)
