### PR TITLE
Additional accessibility tweaks

### DIFF
--- a/src/Android/Accessibility/AccessibilityHelpers.cs
+++ b/src/Android/Accessibility/AccessibilityHelpers.cs
@@ -504,17 +504,7 @@ namespace Bit.Droid.Accessibility
         
         public static bool IsAutofillServicePromptVisible(IEnumerable<AccessibilityWindowInfo> windows)
         {
-            if (windows != null)
-            {
-                foreach (var window in windows)
-                {
-                    if (window.Title?.ToLower().Contains("autofill") ?? false)
-                    {
-                        return true;
-                    }
-                }
-            }
-            return false;
+            return windows?.Any(w => w.Title?.ToLower().Contains("autofill") ?? false) ?? false;
         }
 
         public static int GetNodeHeight(AccessibilityNodeInfo node)
@@ -542,13 +532,12 @@ namespace Bit.Droid.Accessibility
 
         private static int GetSystemResourceDimenPx(AccessibilityService service, string resName)
         {
-            var barHeight = 0;
             var resourceId = service.Resources.GetIdentifier(resName, "dimen", "android");
             if (resourceId > 0)
             {
-                barHeight = service.Resources.GetDimensionPixelSize(resourceId);
+                return service.Resources.GetDimensionPixelSize(resourceId);
             }
-            return barHeight;
+            return 0;
         }
     }
 }


### PR DESCRIPTION
- Removed dependency on MainActivity for acquiring resource context from the `GetSystemResourceDimenPx` helper method as the "current" activity may not be ours (confirmed via invalid cast exceptions in crash logs).  Now using the resource context from our own service.
- Added some smarts to detect the presence of the autofill service prompt and back off if it's visible (we want the autofill service to take priority over accessibility - in most cases this happens automatically but in situations where it doesn't, this should help).
- Moved time-based overload protection (as well as new autofill detection) in front of overlay permission warning toast.  I believe the false positives (negatives?) returned by `Settings.CanDrawOverlays(...)` may be caused by excessive pounding on the method by accessibility events.  This appears to have stopped the erroneous toasts in places I was able to reproduce it, but additional user feedback is needed as I can't reproduce it in all the places reported.