### PR TITLE
[Autofill] Apply locked autofill flow to logged out state

### DIFF
--- a/src/App/App.csproj
+++ b/src/App/App.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="Plugin.Fingerprint" Version="2.1.1" />
     <PackageReference Include="Xamarin.Essentials" Version="1.5.2" />
     <PackageReference Include="Xamarin.FFImageLoading.Forms" Version="2.4.11.982" />
-    <PackageReference Include="Xamarin.Forms" Version="4.5.0.530" />
+    <PackageReference Include="Xamarin.Forms" Version="4.5.0.617" />
     <PackageReference Include="ZXing.Net.Mobile" Version="2.4.1" />
     <PackageReference Include="ZXing.Net.Mobile.Forms" Version="2.4.1" />
   </ItemGroup>

--- a/src/App/App.xaml.cs
+++ b/src/App/App.xaml.cs
@@ -304,7 +304,7 @@ namespace Bit.App
             }
             else
             {
-                Current.MainPage = new HomePage();
+                Current.MainPage = new HomePage(_appOptions);
             }
         }
 

--- a/src/App/Pages/Accounts/HomePage.xaml.cs
+++ b/src/App/Pages/Accounts/HomePage.xaml.cs
@@ -3,6 +3,7 @@ using Bit.Core.Abstractions;
 using Bit.Core.Utilities;
 using System;
 using System.Threading.Tasks;
+using Bit.App.Models;
 using Xamarin.Forms;
 
 namespace Bit.App.Pages
@@ -10,11 +11,13 @@ namespace Bit.App.Pages
     public partial class HomePage : BaseContentPage
     {
         private IMessagingService _messagingService;
+        private readonly AppOptions _appOptions;
 
-        public HomePage()
+        public HomePage(AppOptions appOptions = null)
         {
             _messagingService = ServiceContainer.Resolve<IMessagingService>("messagingService");
             _messagingService.Send("showStatusBar", false);
+            _appOptions = appOptions;
             InitializeComponent();
             _logo.Source = !ThemeManager.UsingLightTheme ? "logo_white.png" : "logo.png";
         }
@@ -22,7 +25,7 @@ namespace Bit.App.Pages
         public async Task DismissRegisterPageAndLogInAsync(string email)
         {
             await Navigation.PopModalAsync();
-            await Navigation.PushModalAsync(new NavigationPage(new LoginPage(email)));
+            await Navigation.PushModalAsync(new NavigationPage(new LoginPage(email, _appOptions)));
         }
 
         protected override void OnAppearing()
@@ -35,7 +38,7 @@ namespace Bit.App.Pages
         {
             if (DoOnce())
             {
-                Navigation.PushModalAsync(new NavigationPage(new LoginPage()));
+                Navigation.PushModalAsync(new NavigationPage(new LoginPage(null, _appOptions)));
             }
         }
 

--- a/src/App/Pages/Accounts/HomePage.xaml.cs
+++ b/src/App/Pages/Accounts/HomePage.xaml.cs
@@ -1,9 +1,9 @@
-﻿using Bit.App.Utilities;
+﻿using Bit.App.Models;
+using Bit.App.Utilities;
 using Bit.Core.Abstractions;
 using Bit.Core.Utilities;
 using System;
 using System.Threading.Tasks;
-using Bit.App.Models;
 using Xamarin.Forms;
 
 namespace Bit.App.Pages

--- a/src/App/Pages/Accounts/HomePage.xaml.cs
+++ b/src/App/Pages/Accounts/HomePage.xaml.cs
@@ -10,8 +10,8 @@ namespace Bit.App.Pages
 {
     public partial class HomePage : BaseContentPage
     {
-        private IMessagingService _messagingService;
         private readonly AppOptions _appOptions;
+        private IMessagingService _messagingService;
 
         public HomePage(AppOptions appOptions = null)
         {

--- a/src/App/Pages/Accounts/LockPage.xaml.cs
+++ b/src/App/Pages/Accounts/LockPage.xaml.cs
@@ -106,7 +106,7 @@ namespace Bit.App.Pages
                     Application.Current.MainPage = new NavigationPage(new AddEditPage(appOptions: _appOptions));
                     return;
                 }
-                else if (_appOptions.Uri != null)
+                if (_appOptions.Uri != null)
                 {
                     Application.Current.MainPage = new NavigationPage(new AutofillCiphersPage(_appOptions));
                     return;

--- a/src/App/Pages/Accounts/LoginPage.xaml.cs
+++ b/src/App/Pages/Accounts/LoginPage.xaml.cs
@@ -93,7 +93,7 @@ namespace Bit.App.Pages
                     Application.Current.MainPage = new NavigationPage(new AddEditPage(appOptions: _appOptions));
                     return;
                 }
-                else if (_appOptions.Uri != null)
+                if (_appOptions.Uri != null)
                 {
                     Application.Current.MainPage = new NavigationPage(new AutofillCiphersPage(_appOptions));
                     return;

--- a/src/App/Pages/Accounts/LoginPage.xaml.cs
+++ b/src/App/Pages/Accounts/LoginPage.xaml.cs
@@ -1,9 +1,9 @@
-﻿using Bit.Core.Abstractions;
+﻿using Bit.App.Models;
+using Bit.Core;
+using Bit.Core.Abstractions;
 using Bit.Core.Utilities;
 using System;
-using Bit.App.Models;
 using System.Threading.Tasks;
-using Bit.Core;
 using Xamarin.Forms;
 
 namespace Bit.App.Pages

--- a/src/App/Pages/Accounts/LoginPage.xaml.cs
+++ b/src/App/Pages/Accounts/LoginPage.xaml.cs
@@ -1,6 +1,9 @@
 ﻿using Bit.Core.Abstractions;
 using Bit.Core.Utilities;
 using System;
+using Bit.App.Models;
+using System.Threading.Tasks;
+using Bit.Core;
 using Xamarin.Forms;
 
 namespace Bit.App.Pages
@@ -8,15 +11,21 @@ namespace Bit.App.Pages
     public partial class LoginPage : BaseContentPage
     {
         private readonly IMessagingService _messagingService;
+        private readonly IStorageService _storageService;
         private readonly LoginPageViewModel _vm;
+        private readonly AppOptions _appOptions;
 
-        public LoginPage(string email = null)
+        public LoginPage(string email = null, AppOptions appOptions = null)
         {
+            _storageService = ServiceContainer.Resolve<IStorageService>("storageService");
             _messagingService = ServiceContainer.Resolve<IMessagingService>("messagingService");
             _messagingService.Send("showStatusBar", true);
+            _appOptions = appOptions;
             InitializeComponent();
             _vm = BindingContext as LoginPageViewModel;
             _vm.Page = this;
+            _vm.StartTwoFactorAction = () => Device.BeginInvokeOnMainThread(async () => await StartTwoFactorAsync());
+            _vm.LoggedInAction = () => Device.BeginInvokeOnMainThread(async () => await LoggedInAsync());
             _vm.Email = email;
             MasterPasswordEntry = _masterPassword;
             if (Device.RuntimePlatform == Device.Android)
@@ -67,6 +76,35 @@ namespace Bit.App.Pages
                 _messagingService.Send("showStatusBar", false);
                 await Navigation.PopModalAsync();
             }
+        }
+
+        private async Task StartTwoFactorAsync()
+        {
+            var page = new TwoFactorPage();
+            await Navigation.PushModalAsync(new NavigationPage(page));
+        }
+        
+        private async Task LoggedInAsync()
+        {
+            if (_appOptions != null)
+            {
+                if (_appOptions.FromAutofillFramework && _appOptions.SaveType.HasValue)
+                {
+                    Application.Current.MainPage = new NavigationPage(new AddEditPage(appOptions: _appOptions));
+                    return;
+                }
+                else if (_appOptions.Uri != null)
+                {
+                    Application.Current.MainPage = new NavigationPage(new AutofillCiphersPage(_appOptions));
+                    return;
+                }
+            }
+            var previousPage = await _storageService.GetAsync<PreviousPageInfo>(Constants.PreviousPageKey);
+            if (previousPage != null)
+            {
+                await _storageService.RemoveAsync(Constants.PreviousPageKey);
+            }
+            Application.Current.MainPage = new TabsPage(_appOptions, previousPage);
         }
     }
 }

--- a/src/App/Pages/Accounts/LoginPageViewModel.cs
+++ b/src/App/Pages/Accounts/LoginPageViewModel.cs
@@ -4,6 +4,7 @@ using Bit.Core;
 using Bit.Core.Abstractions;
 using Bit.Core.Exceptions;
 using Bit.Core.Utilities;
+using System;
 using System.Threading.Tasks;
 using Xamarin.Forms;
 
@@ -65,6 +66,8 @@ namespace Bit.App.Pages
         public Command TogglePasswordCommand { get; }
         public string ShowPasswordIcon => ShowPassword ? "" : "";
         public bool RememberEmail { get; set; }
+        public Action StartTwoFactorAction { get; set; }
+        public Action LoggedInAction { get; set; }
 
         public async Task InitAsync()
         {
@@ -121,15 +124,14 @@ namespace Bit.App.Pages
                 await _deviceActionService.HideLoadingAsync();
                 if (response.TwoFactor)
                 {
-                    var page = new TwoFactorPage();
-                    await Page.Navigation.PushModalAsync(new NavigationPage(page));
+                    StartTwoFactorAction?.Invoke();
                 }
                 else
                 {
                     var disableFavicon = await _storageService.GetAsync<bool?>(Constants.DisableFaviconKey);
                     await _stateService.SaveAsync(Constants.DisableFaviconKey, disableFavicon.GetValueOrDefault());
                     var task = Task.Run(async () => await _syncService.FullSyncAsync(true));
-                    Application.Current.MainPage = new TabsPage();
+                    LoggedInAction?.Invoke();
                 }
             }
             catch (ApiException e)

--- a/src/App/Pages/Accounts/TwoFactorPage.xaml.cs
+++ b/src/App/Pages/Accounts/TwoFactorPage.xaml.cs
@@ -168,7 +168,7 @@ namespace Bit.App.Pages
                     Application.Current.MainPage = new NavigationPage(new AddEditPage(appOptions: _appOptions));
                     return;
                 }
-                else if (_appOptions.Uri != null)
+                if (_appOptions.Uri != null)
                 {
                     Application.Current.MainPage = new NavigationPage(new AutofillCiphersPage(_appOptions));
                     return;

--- a/src/App/Pages/Accounts/TwoFactorPage.xaml.cs
+++ b/src/App/Pages/Accounts/TwoFactorPage.xaml.cs
@@ -3,6 +3,8 @@ using Bit.Core.Abstractions;
 using Bit.Core.Utilities;
 using System;
 using System.Threading.Tasks;
+using Bit.App.Models;
+using Bit.Core;
 using Xamarin.Forms;
 
 namespace Bit.App.Pages
@@ -11,18 +13,23 @@ namespace Bit.App.Pages
     {
         private readonly IBroadcasterService _broadcasterService;
         private readonly IMessagingService _messagingService;
+        private readonly IStorageService _storageService;
+        private readonly AppOptions _appOptions;
 
         private TwoFactorPageViewModel _vm;
         private bool _inited;
 
-        public TwoFactorPage()
+        public TwoFactorPage(AppOptions appOptions = null)
         {
             InitializeComponent();
             SetActivityIndicator();
+            _appOptions = appOptions;
+            _storageService = ServiceContainer.Resolve<IStorageService>("storageService");
             _broadcasterService = ServiceContainer.Resolve<IBroadcasterService>("broadcasterService");
             _messagingService = ServiceContainer.Resolve<IMessagingService>("messagingService");
             _vm = BindingContext as TwoFactorPageViewModel;
             _vm.Page = this;
+            _vm.TwoFactorAction = () => Device.BeginInvokeOnMainThread(async () => await TwoFactorAuthAsync());
             DuoWebView = _duoWebView;
             if (Device.RuntimePlatform == Device.Android)
             {
@@ -150,6 +157,29 @@ namespace Bit.App.Pages
                     _messagingService.Send("listenYubiKeyOTP", true);
                 }
             }
+        }
+        
+        private async Task TwoFactorAuthAsync()
+        {
+            if (_appOptions != null)
+            {
+                if (_appOptions.FromAutofillFramework && _appOptions.SaveType.HasValue)
+                {
+                    Application.Current.MainPage = new NavigationPage(new AddEditPage(appOptions: _appOptions));
+                    return;
+                }
+                else if (_appOptions.Uri != null)
+                {
+                    Application.Current.MainPage = new NavigationPage(new AutofillCiphersPage(_appOptions));
+                    return;
+                }
+            }
+            var previousPage = await _storageService.GetAsync<PreviousPageInfo>(Constants.PreviousPageKey);
+            if (previousPage != null)
+            {
+                await _storageService.RemoveAsync(Constants.PreviousPageKey);
+            }
+            Application.Current.MainPage = new TabsPage(_appOptions, previousPage);
         }
     }
 }

--- a/src/App/Pages/Accounts/TwoFactorPage.xaml.cs
+++ b/src/App/Pages/Accounts/TwoFactorPage.xaml.cs
@@ -1,10 +1,10 @@
 ﻿using Bit.App.Controls;
+using Bit.App.Models;
+using Bit.Core;
 using Bit.Core.Abstractions;
 using Bit.Core.Utilities;
 using System;
 using System.Threading.Tasks;
-using Bit.App.Models;
-using Bit.Core;
 using Xamarin.Forms;
 
 namespace Bit.App.Pages

--- a/src/App/Pages/Accounts/TwoFactorPageViewModel.cs
+++ b/src/App/Pages/Accounts/TwoFactorPageViewModel.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Bit.App.Abstractions;
+﻿using Bit.App.Abstractions;
 using Bit.App.Resources;
 using Bit.Core;
 using Bit.Core.Abstractions;
@@ -7,6 +6,7 @@ using Bit.Core.Enums;
 using Bit.Core.Exceptions;
 using Bit.Core.Models.Request;
 using Bit.Core.Utilities;
+using System;
 using System.Linq;
 using System.Net;
 using System.Threading.Tasks;

--- a/src/App/Pages/Accounts/TwoFactorPageViewModel.cs
+++ b/src/App/Pages/Accounts/TwoFactorPageViewModel.cs
@@ -1,4 +1,5 @@
-﻿using Bit.App.Abstractions;
+﻿using System;
+using Bit.App.Abstractions;
 using Bit.App.Resources;
 using Bit.Core;
 using Bit.Core.Abstractions;
@@ -88,6 +89,7 @@ namespace Bit.App.Pages
             });
         }
         public Command SubmitCommand { get; }
+        public Action TwoFactorAction { get; set; }
 
         public void Init()
         {
@@ -209,7 +211,7 @@ namespace Bit.App.Pages
                 _broadcasterService.Unsubscribe(nameof(TwoFactorPage));
                 var disableFavicon = await _storageService.GetAsync<bool?>(Constants.DisableFaviconKey);
                 await _stateService.SaveAsync(Constants.DisableFaviconKey, disableFavicon.GetValueOrDefault());
-                Application.Current.MainPage = new TabsPage();
+                TwoFactorAction?.Invoke();
             }
             catch (ApiException e)
             {

--- a/src/App/Pages/Generator/GeneratorPage.xaml
+++ b/src/App/Pages/Generator/GeneratorPage.xaml
@@ -166,6 +166,7 @@
                         <controls:ExtendedSlider
                             DragCompleted="LengthSlider_DragCompleted"
                             Value="{Binding Length}"
+                            AutomationProperties.HelpText="{Binding Length}"
                             StyleClass="box-value"
                             VerticalOptions="CenterAndExpand"
                             HorizontalOptions="FillAndExpand"


### PR DESCRIPTION
## Objective
> Allow logged out applications to be aware of auto-fill flow. This closes a gap between being locked vs logged out from timeout/restart.

## Code Changes
- **App.xaml.cs**: Passed `appOptions` into `HomePage` constructor
- **HomePage.xaml.cs**: Updated constructor to accept `appOptions`. Passed `appOptions` into `LoginPage`
- **LoginPage.xaml.cs**: Updated constructor to accept `appOptions`. Passed `appOptions` into `TwoFactorPage` and added two helpers for moving to next page.
- **LoginPageViewModel.cs**: Added `StartTwoFactorAction` and `LoggedInAction` properties and invoked during page change.
- **TwoFactorPage.xaml.cs**: Updated constructor to accept `appOptions` and init `storageService`. Added helper for moving to next page.
- **TwoFactorPageViewModel.cs**: Added `TwoFactorAction` property and invoked during page change.