### PR TITLE
Fix for talkback slider control

### DIFF
--- a/src/App/App.csproj
+++ b/src/App/App.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="Plugin.Fingerprint" Version="2.1.1" />
     <PackageReference Include="Xamarin.Essentials" Version="1.5.2" />
     <PackageReference Include="Xamarin.FFImageLoading.Forms" Version="2.4.11.982" />
-    <PackageReference Include="Xamarin.Forms" Version="4.5.0.530" />
+    <PackageReference Include="Xamarin.Forms" Version="4.5.0.617" />
     <PackageReference Include="ZXing.Net.Mobile" Version="2.4.1" />
     <PackageReference Include="ZXing.Net.Mobile.Forms" Version="2.4.1" />
   </ItemGroup>

--- a/src/App/Pages/Generator/GeneratorPage.xaml
+++ b/src/App/Pages/Generator/GeneratorPage.xaml
@@ -166,6 +166,7 @@
                         <controls:ExtendedSlider
                             DragCompleted="LengthSlider_DragCompleted"
                             Value="{Binding Length}"
+                            AutomationProperties.HelpText="{Binding Length}"
                             StyleClass="box-value"
                             VerticalOptions="CenterAndExpand"
                             HorizontalOptions="FillAndExpand"


### PR DESCRIPTION
Updated to Xamarin.Forms `4.5.0.617` which fixes slider binding when operating via TalkBack on Android.  Also added `AutomationProperties.HelpText` to read length aloud while adjusting.