### PR TITLE
[FIX] Consider default URI match type on filtering

### DIFF
--- a/src/Core/Services/CipherService.cs
+++ b/src/Core/Services/CipherService.cs
@@ -342,7 +342,12 @@ namespace Bit.Core.Services
                         continue;
                     }
                     var match = false;
-                    switch (u.Match)
+                    var toMatch = defaultMatch;
+                    if (u.Match != null)
+                    {
+                        toMatch = u.Match;
+                    }
+                    switch (toMatch)
                     {
                         case null:
                         case UriMatchType.Domain:


### PR DESCRIPTION
Consider default URI match type selected on settings when filtering the entries to show on autofill.