### PR TITLE
[Auto-Logout] Update Service layer logic

### DIFF
--- a/src/Android/Receivers/LockAlarmReceiver.cs
+++ b/src/Android/Receivers/LockAlarmReceiver.cs
@@ -10,7 +10,7 @@ namespace Bit.Droid.Receivers
         public async override void OnReceive(Context context, Intent intent)
         {
             var vaultTimeoutService = ServiceContainer.Resolve<IVaultTimeoutService>("vaultTimeoutService");
-            await vaultTimeoutService.CheckLockAsync();
+            await vaultTimeoutService.CheckVaultTimeoutAsync();
         }
     }
 }

--- a/src/App/App.xaml.cs
+++ b/src/App/App.xaml.cs
@@ -322,7 +322,7 @@ namespace Bit.App
             var lockOption = _platformUtilsService.LockTimeout();
             if (lockOption == null)
             {
-                lockOption = await _storageService.GetAsync<int?>(Constants.LockOptionKey);
+                lockOption = await _storageService.GetAsync<int?>(Constants.VaultTimeoutKey);
             }
             lockOption = lockOption.GetValueOrDefault(-1);
             if (lockOption > 0)
@@ -422,7 +422,7 @@ namespace Bit.App
             await _stateService.PurgeAsync();
             if (autoPromptFingerprint && Device.RuntimePlatform == Device.iOS)
             {
-                var lockOptions = await _storageService.GetAsync<int?>(Constants.LockOptionKey);
+                var lockOptions = await _storageService.GetAsync<int?>(Constants.VaultTimeoutKey);
                 if (lockOptions == 0)
                 {
                     autoPromptFingerprint = false;

--- a/src/App/Pages/Settings/SettingsPage/SettingsPageViewModel.cs
+++ b/src/App/Pages/Settings/SettingsPage/SettingsPageViewModel.cs
@@ -70,7 +70,7 @@ namespace Bit.App.Pages
                 _lastSyncDate = string.Format("{0} {1}", lastSync.Value.ToShortDateString(),
                     lastSync.Value.ToShortTimeString());
             }
-            var option = await _storageService.GetAsync<int?>(Constants.LockOptionKey);
+            var option = await _storageService.GetAsync<int?>(Constants.VaultTimeoutKey);
             _lockOptionValue = _lockOptions.FirstOrDefault(o => o.Value == option).Key;
             var pinSet = await _vaultTimeoutService.IsPinLockSetAsync();
             _pin = pinSet.Item1 || pinSet.Item2;
@@ -193,7 +193,8 @@ namespace Bit.App.Pages
             var cleanSelection = selection.Replace("✓ ", string.Empty);
             var selectionOption = _lockOptions.FirstOrDefault(o => o.Key == cleanSelection);
             _lockOptionValue = selectionOption.Key;
-            await _vaultTimeoutService.SetLockOptionAsync(selectionOption.Value);
+            // TODO Save Action instead of null
+            await _vaultTimeoutService.SetVaultTimeoutOptionsAsync(selectionOption.Value, null);
             BuildList();
         }
 

--- a/src/App/Services/MobileStorageService.cs
+++ b/src/App/Services/MobileStorageService.cs
@@ -12,7 +12,8 @@ namespace Bit.App.Services
 
         private readonly HashSet<string> _preferenceStorageKeys = new HashSet<string>
         {
-            Constants.LockOptionKey,
+            Constants.VaultTimeoutKey,
+            Constants.VaultTimeoutActionKey,
             Constants.ThemeKey,
             Constants.DefaultUriMatch,
             Constants.DisableAutoTotpCopyKey,

--- a/src/App/Utilities/AppHelpers.cs
+++ b/src/App/Utilities/AppHelpers.cs
@@ -128,12 +128,17 @@ namespace Bit.App.Utilities
             if (lastBuild == null)
             {
                 // Installed
-                var currentLock = await storageService.GetAsync<int?>(Constants.VaultTimeoutKey);
-                if (currentLock == null)
+                var currentTimeout = await storageService.GetAsync<int?>(Constants.VaultTimeoutKey);
+                if (currentTimeout == null)
                 {
                     await storageService.SaveAsync(Constants.VaultTimeoutKey, 15);
                 }
-                // TODO Save Default Action 
+                
+                var currentAction = await storageService.GetAsync<int?>(Constants.VaultTimeoutActionKey);
+                if (currentAction == null)
+                {
+                    await storageService.SaveAsync(Constants.VaultTimeoutActionKey, "lock");
+                }
             }
             else if (lastBuild != currentBuild)
             {

--- a/src/App/Utilities/AppHelpers.cs
+++ b/src/App/Utilities/AppHelpers.cs
@@ -128,11 +128,12 @@ namespace Bit.App.Utilities
             if (lastBuild == null)
             {
                 // Installed
-                var currentLock = await storageService.GetAsync<int?>(Constants.LockOptionKey);
+                var currentLock = await storageService.GetAsync<int?>(Constants.VaultTimeoutKey);
                 if (currentLock == null)
                 {
-                    await storageService.SaveAsync(Constants.LockOptionKey, 15);
+                    await storageService.SaveAsync(Constants.VaultTimeoutKey, 15);
                 }
+                // TODO Save Default Action 
             }
             else if (lastBuild != currentBuild)
             {

--- a/src/Core/Abstractions/ITokenService.cs
+++ b/src/Core/Abstractions/ITokenService.cs
@@ -16,6 +16,7 @@ namespace Bit.Core.Abstractions
         bool GetPremium();
         Task<string> GetRefreshTokenAsync();
         Task<string> GetTokenAsync();
+        Task ToggleTokensAsync();
         DateTime? GetTokenExpirationDate();
         Task<string> GetTwoFactorTokenAsync(string email);
         string GetUserId();

--- a/src/Core/Abstractions/IVaultTimeoutService.cs
+++ b/src/Core/Abstractions/IVaultTimeoutService.cs
@@ -9,12 +9,13 @@ namespace Bit.Core.Abstractions
         CipherString PinProtectedKey { get; set; }
         bool FingerprintLocked { get; set; }
 
-        Task CheckLockAsync();
+        Task CheckVaultTimeoutAsync();
         Task ClearAsync();
         Task<bool> IsLockedAsync();
         Task<Tuple<bool, bool>> IsPinLockSetAsync();
         Task<bool> IsFingerprintLockSetAsync();
         Task LockAsync(bool allowSoftLock = false, bool userInitiated = false);
-        Task SetLockOptionAsync(int? lockOption);
+        Task LogOutAsync();
+        Task SetVaultTimeoutOptionsAsync(int? timeout, string action);
     }
 }

--- a/src/Core/Constants.cs
+++ b/src/Core/Constants.cs
@@ -4,7 +4,8 @@
     {
         public const string AndroidAppProtocol = "androidapp://";
         public const string iOSAppProtocol = "iosapp://";
-        public static string LockOptionKey = "lockOption";
+        public static string VaultTimeoutKey = "lockOption";
+        public static string VaultTimeoutActionKey = "vaultTimeoutAction";
         public static string LastActiveKey = "lastActive";
         public static string FingerprintUnlockKey = "fingerprintUnlock";
         public static string ProtectedPin = "protectedPin";

--- a/src/Core/Services/CryptoService.cs
+++ b/src/Core/Services/CryptoService.cs
@@ -47,7 +47,7 @@ namespace Bit.Core.Services
         public async Task SetKeyAsync(SymmetricCryptoKey key)
         {
             _key = key;
-            var option = await _storageService.GetAsync<int?>(Constants.LockOptionKey);
+            var option = await _storageService.GetAsync<int?>(Constants.VaultTimeoutKey);
             var fingerprint = await _storageService.GetAsync<bool?>(Constants.FingerprintUnlockKey);
             if (option.HasValue && !fingerprint.GetValueOrDefault())
             {
@@ -353,7 +353,7 @@ namespace Bit.Core.Services
         public async Task ToggleKeyAsync()
         {
             var key = await GetKeyAsync();
-            var option = await _storageService.GetAsync<int?>(Constants.LockOptionKey);
+            var option = await _storageService.GetAsync<int?>(Constants.VaultTimeoutKey);
             var fingerprint = await _storageService.GetAsync<bool?>(Constants.FingerprintUnlockKey);
             if (!fingerprint.GetValueOrDefault() && (option != null || option == 0))
             {

--- a/src/Core/Services/TokenService.cs
+++ b/src/Core/Services/TokenService.cs
@@ -84,7 +84,7 @@ namespace Bit.Core.Services
             var refreshToken = await GetRefreshTokenAsync();
             var timeout = await _storageService.GetAsync<int?>(Constants.VaultTimeoutKey);
             var action = await _storageService.GetAsync<string>(Constants.VaultTimeoutActionKey);
-            if ((timeout != null || timeout == 0) && action == "logOut")
+            if (await SkipTokenStorage())
             {
                 await ClearTokenAsync();
                 _token = token;

--- a/src/Core/Services/TokenService.cs
+++ b/src/Core/Services/TokenService.cs
@@ -82,8 +82,6 @@ namespace Bit.Core.Services
         {
             var token = await GetTokenAsync();
             var refreshToken = await GetRefreshTokenAsync();
-            var timeout = await _storageService.GetAsync<int?>(Constants.VaultTimeoutKey);
-            var action = await _storageService.GetAsync<string>(Constants.VaultTimeoutActionKey);
             if (await SkipTokenStorage())
             {
                 await ClearTokenAsync();

--- a/src/Core/Services/VaultTimeoutService.cs
+++ b/src/Core/Services/VaultTimeoutService.cs
@@ -100,14 +100,13 @@ namespace Bit.Core.Services
             {
                 // Pivot based on saved action
                 var action = await _storageService.GetAsync<string>(Constants.VaultTimeoutActionKey);
-                switch(action)
+                if (action == "lock")
                 {
-                    case "lock":
-                        await LockAsync(true);
-                        break;
-                    case "logOut":
-                        await LogOutAsync();
-                        break;
+                    await LockAsync(true);
+                }
+                else
+                {
+                    await LogOutAsync();
                 }
             }
         }

--- a/src/Core/Services/VaultTimeoutService.cs
+++ b/src/Core/Services/VaultTimeoutService.cs
@@ -16,7 +16,9 @@ namespace Bit.Core.Services
         private readonly ICollectionService _collectionService;
         private readonly ISearchService _searchService;
         private readonly IMessagingService _messagingService;
+        private readonly ITokenService _tokenService;
         private readonly Action<bool> _lockedCallback;
+        private readonly Func<bool, Task> _loggedOutCallback;
 
         public VaultTimeoutService(
             ICryptoService cryptoService,
@@ -28,7 +30,9 @@ namespace Bit.Core.Services
             ICollectionService collectionService,
             ISearchService searchService,
             IMessagingService messagingService,
-            Action<bool> lockedCallback)
+            ITokenService tokenService,
+            Action<bool> lockedCallback,
+            Func<bool, Task> loggedOutCallback)
         {
             _cryptoService = cryptoService;
             _userService = userService;
@@ -39,7 +43,9 @@ namespace Bit.Core.Services
             _collectionService = collectionService;
             _searchService = searchService;
             _messagingService = messagingService;
+            _tokenService = tokenService;
             _lockedCallback = lockedCallback;
+            _loggedOutCallback = loggedOutCallback;
         }
 
         public CipherString PinProtectedKey { get; set; } = null;
@@ -59,7 +65,7 @@ namespace Bit.Core.Services
             return !hasKey;
         }
 
-        public async Task CheckLockAsync()
+        public async Task CheckVaultTimeoutAsync()
         {
             if (_platformUtilsService.IsViewOpen())
             {
@@ -74,12 +80,13 @@ namespace Bit.Core.Services
             {
                 return;
             }
-            var lockOption = _platformUtilsService.LockTimeout();
-            if (lockOption == null)
+            // This only returns null
+            var vaultTimeout = _platformUtilsService.LockTimeout();
+            if (vaultTimeout == null)
             {
-                lockOption = await _storageService.GetAsync<int?>(Constants.LockOptionKey);
+                vaultTimeout = await _storageService.GetAsync<int?>(Constants.VaultTimeoutKey);
             }
-            if (lockOption.GetValueOrDefault(-1) < 0)
+            if (vaultTimeout.GetValueOrDefault(-1) < 0)
             {
                 return;
             }
@@ -89,10 +96,19 @@ namespace Bit.Core.Services
                 return;
             }
             var diff = DateTime.UtcNow - lastActive.Value;
-            if (diff.TotalSeconds >= lockOption.Value)
+            if (diff.TotalSeconds >= vaultTimeout.Value)
             {
-                // need to lock now
-                await LockAsync(true);
+                // Pivot based on saved action
+                var action = await _storageService.GetAsync<string>(Constants.VaultTimeoutActionKey);
+                switch(action)
+                {
+                    case "lock":
+                        await LockAsync(true);
+                        break;
+                    case "logOut":
+                        await LogOutAsync();
+                        break;
+                }
             }
         }
 
@@ -126,11 +142,21 @@ namespace Bit.Core.Services
             _messagingService.Send("locked", userInitiated);
             _lockedCallback?.Invoke(userInitiated);
         }
-
-        public async Task SetLockOptionAsync(int? lockOption)
+        
+        public async Task LogOutAsync()
         {
-            await _storageService.SaveAsync(Constants.LockOptionKey, lockOption);
+            if(_loggedOutCallback != null)
+            {
+                await _loggedOutCallback.Invoke(false);
+            }
+        }
+
+        public async Task SetVaultTimeoutOptionsAsync(int? timeout, string action)
+        {
+            await _storageService.SaveAsync(Constants.VaultTimeoutKey, timeout);
+            await _storageService.SaveAsync(Constants.VaultTimeoutActionKey, action);
             await _cryptoService.ToggleKeyAsync();
+            await _tokenService.ToggleTokensAsync();
         }
 
         public async Task<Tuple<bool, bool>> IsPinLockSetAsync()

--- a/src/Core/Utilities/ServiceContainer.cs
+++ b/src/Core/Utilities/ServiceContainer.cs
@@ -46,7 +46,12 @@ namespace Bit.Core.Utilities
             var collectionService = new CollectionService(cryptoService, userService, storageService, i18nService);
             searchService = new SearchService(cipherService);
             var vaultTimeoutService = new VaultTimeoutService(cryptoService, userService, platformUtilsService, 
-                storageService, folderService, cipherService, collectionService, searchService, messagingService, null);
+                storageService, folderService, cipherService, collectionService, searchService, messagingService, tokenService,
+                null, (expired) =>
+                {
+                    messagingService.Send("logout", expired);
+                    return Task.FromResult(0);
+                });
             var policyService = new PolicyService(storageService, userService);
             var syncService = new SyncService(userService, apiService, settingsService, folderService,
                 cipherService, cryptoService, collectionService, storageService, messagingService, policyService,

--- a/src/iOS/AppDelegate.cs
+++ b/src/iOS/AppDelegate.cs
@@ -336,7 +336,7 @@ namespace Bit.iOS
                 {
                     Device.BeginInvokeOnMainThread(() =>
                     {
-                        _vaultTimeoutService.CheckLockAsync();
+                        _vaultTimeoutService.CheckVaultTimeoutAsync();
                         _lockTimer?.Invalidate();
                         _lockTimer?.Dispose();
                         _lockTimer = null;


### PR DESCRIPTION
## Objective
> Prepare the service/dependent application layers for using new `VaultTimeout` logic to include logging out during timeout.

## Code Changes
- **LockAlarmReceiver.cs**: Updated call to use refactored name `CheckVaultTimeoutAsync`
- **App.xaml.cs**: Updated Constants key reference to `VaultTimeoutKey`
- **SettingsPageViewModel.cs**: Updated Constants key reference to `VaultTimeoutKey`.  Added placeholder for new `SetVaultTimeoutOptionsAsync` method.
- **MobileStorageService.cs**: Added new action key to `preferenceStorageKeys`.
- **AppHelper.cs**: Updated Constants key reference to `VaultTimeoutKey`.  Added default value for `VaultTimeoutActionKey` and set it to `lock`
- **ITokenService.cs**: Added `ToggleTokensAsync` method reference
- **IVaultTimeoutService.cs**: Name refactors `CheckVaultTimeoutAsync` and `SetVaultTimeoutActionsAsync`. Added `LogOutAsync`.
- **Constants.cs**: Refactored `LockOptionKey` to `VaultTimeoutKey`. Added `VaultTimeoutActionKey`
- **CryptoService.cs**: Updated Constants key reference to `VaultTimeoutKey`
- **TokenService.cs**: Updated logic for whether or not to save token/refresh token based on the vault timeout and action saved. Added `ToggleTokensAsync` method which will properly clear out the tokens if necessary.
- **VaultTimeoutService.cs**: Added `TokenService` dependency.  Added `loggedOutCallback` dependency. Added logic for log out actions.
- **ServiceContainer.cs**: Updated init for `VaultTimeoutService`. Added log out actions through `messengerService`.
- **AppDelegate.cs**: Updated call to use refactored name `CheckVaultTimeoutAsync`