### PR TITLE
Add support for Vivaldi Sopranos browser. Closes #673

### DIFF
--- a/src/Android/Accessibility/AccessibilityHelpers.cs
+++ b/src/Android/Accessibility/AccessibilityHelpers.cs
@@ -76,6 +76,7 @@ namespace Bit.Droid.Accessibility
             new Browser("jp.co.fenrir.android.sleipnir_test", "url_text"),
             new Browser("com.vivaldi.browser", "url_bar"),
             new Browser("com.vivaldi.browser.snapshot", "url_bar"),
+            new Browser("com.vivaldi.browser.sopranos", "url_bar"),
             new Browser("com.feedback.browser.wjbrowser", "addressbar_url"),
             new Browser("com.naver.whale", "url_bar"),
         }.ToDictionary(n => n.PackageName);

--- a/src/Android/Autofill/AutofillHelpers.cs
+++ b/src/Android/Autofill/AutofillHelpers.cs
@@ -64,6 +64,7 @@ namespace Bit.Droid.Autofill
             "org.torproject.torbrowser",
             "com.vivaldi.browser",
             "com.vivaldi.browser.snapshot",
+            "com.vivaldi.browser.sopranos",
             "com.naver.whale",
         };
 

--- a/src/Android/Resources/xml/autofillservice.xml
+++ b/src/Android/Resources/xml/autofillservice.xml
@@ -110,6 +110,9 @@
     android:name="com.vivaldi.browser.snapshot"
     android:maxLongVersionCode="10000000000"/>
   <compatibility-package
+    android:name="com.vivaldi.browser.sopranos"
+    android:maxLongVersionCode="10000000000"/>
+  <compatibility-package
     android:name="com.naver.whale"
     android:maxLongVersionCode="10000000000"/>
 </autofill-service>


### PR DESCRIPTION
This adds compatibility for Vivaldi Sopranos browser (following user request).
This one being pre-snapshot build for translators and Vivaldi team members.

Closes #673