### PR TITLE
Allow a BiometricPrompt to succeed after an initial failure

### DIFF
--- a/src/Android/Services/DeviceActionService.cs
+++ b/src/Android/Services/DeviceActionService.cs
@@ -446,7 +446,8 @@ namespace Bit.Droid.Services
                     new BiometricAuthenticationCallback
                     {
                         Success = authResult => result.TrySetResult(true),
-                        Failed = () => result.TrySetResult(false),
+                        Error = () => result.TrySetResult(false),
+                        Failed = () => { },
                         Help = (helpCode, helpString) => { }
                     });
                 return result.Task;
@@ -866,6 +867,7 @@ namespace Bit.Droid.Services
         private class BiometricAuthenticationCallback : BiometricPrompt.AuthenticationCallback
         {
             public Action<BiometricPrompt.AuthenticationResult> Success { get; set; }
+            public Action Error { get; set; }
             public Action Failed { get; set; }
             public Action<BiometricAcquiredStatus, Java.Lang.ICharSequence> Help { get; set; }
 
@@ -873,6 +875,12 @@ namespace Bit.Droid.Services
             {
                 base.OnAuthenticationSucceeded(authResult);
                 Success?.Invoke(authResult);
+            }
+
+            public override void OnAuthenticationError([GeneratedEnum] BiometricErrorCode errorCode, Java.Lang.ICharSequence errString)
+            {
+                base.OnAuthenticationError(errorCode, errString);
+                Error?.Invoke();
             }
 
             public override void OnAuthenticationFailed()


### PR DESCRIPTION
Previously a call to BiometricPrompt.AuthenticationCallback#OnAuthenticationFailed()
was treated as though an unrecoverable failure had occurred. However this is called on
each failed fingerprint match, for example, and is not a terminal failure. Now these
intermittent failures are ignored and a call to #OnAuthenticationError() is recognised
as an unrecoverable failure instead.

Fixes #791