### PR TITLE
Set Google publisher upload timeout to 3 minutes

### DIFF
--- a/store/google/Publisher/Program.cs
+++ b/store/google/Publisher/Program.cs
@@ -77,6 +77,7 @@ namespace Bit.Publisher
             {
                 HttpClientInitializer = creds
             });
+            service.HttpClient.Timeout = TimeSpan.FromMinutes(3);
 
             var editRequest = service.Edits.Insert(null, Package);
             var edit = await editRequest.ExecuteAsync();


### PR DESCRIPTION
Per Google's recommendation, pad the HTTP request timeout when uploading APK/bundles to Play Store.  (Previous attempt to publish was met with `TaskCanceledException` - apparently the client defaults to 20 seconds)