### PR TITLE
[Soft Delete] Added trash folder to mobile

### DIFF
--- a/src/App/Pages/Vault/AddEditPage.xaml
+++ b/src/App/Pages/Vault/AddEditPage.xaml
@@ -44,7 +44,7 @@
                          Order="Secondary"
                          x:Name="_attachmentsItem"
                          x:Key="attachmentsItem" />
-            <ToolbarItem Text="{u:I18n Delete}"
+            <ToolbarItem Text="{u:I18n SoftDelete}"
                          Clicked="Delete_Clicked"
                          Order="Secondary"
                          IsDestructive="True"

--- a/src/App/Pages/Vault/AddEditPage.xaml
+++ b/src/App/Pages/Vault/AddEditPage.xaml
@@ -44,7 +44,7 @@
                          Order="Secondary"
                          x:Name="_attachmentsItem"
                          x:Key="attachmentsItem" />
-            <ToolbarItem Text="{u:I18n SoftDelete}"
+            <ToolbarItem Text="{u:I18n Delete}"
                          Clicked="Delete_Clicked"
                          Order="Secondary"
                          IsDestructive="True"

--- a/src/App/Pages/Vault/AddEditPage.xaml.cs
+++ b/src/App/Pages/Vault/AddEditPage.xaml.cs
@@ -267,8 +267,8 @@ namespace Bit.App.Pages
                 options.Add(_vm.Cipher.OrganizationId == null ? AppResources.Share : AppResources.Collections);
             }
             var selection = await DisplayActionSheet(AppResources.Options, AppResources.Cancel,
-                (_vm.EditMode && !_vm.CloneMode) ? AppResources.SoftDelete : null, options.ToArray());
-            if (selection == AppResources.SoftDelete)
+                (_vm.EditMode && !_vm.CloneMode) ? AppResources.Delete : null, options.ToArray());
+            if (selection == AppResources.Delete)
             {
                 if (await _vm.DeleteAsync())
                 {

--- a/src/App/Pages/Vault/AddEditPage.xaml.cs
+++ b/src/App/Pages/Vault/AddEditPage.xaml.cs
@@ -267,8 +267,8 @@ namespace Bit.App.Pages
                 options.Add(_vm.Cipher.OrganizationId == null ? AppResources.Share : AppResources.Collections);
             }
             var selection = await DisplayActionSheet(AppResources.Options, AppResources.Cancel,
-                (_vm.EditMode && !_vm.CloneMode) ? AppResources.Delete : null, options.ToArray());
-            if (selection == AppResources.Delete)
+                (_vm.EditMode && !_vm.CloneMode) ? AppResources.SoftDelete : null, options.ToArray());
+            if (selection == AppResources.SoftDelete)
             {
                 if (await _vm.DeleteAsync())
                 {

--- a/src/App/Pages/Vault/AddEditPageViewModel.cs
+++ b/src/App/Pages/Vault/AddEditPageViewModel.cs
@@ -489,7 +489,8 @@ namespace Bit.App.Pages
                     AppResources.InternetConnectionRequiredTitle);
                 return false;
             }
-            var confirmed = await _platformUtilsService.ShowDialogAsync(AppResources.DoYouReallyWantToDelete,
+            var confirmed = await _platformUtilsService.ShowDialogAsync(
+                AppResources.DoYouReallyWantToSoftDeleteCipher,
                 null, AppResources.Yes, AppResources.Cancel);
             if (!confirmed)
             {
@@ -497,11 +498,11 @@ namespace Bit.App.Pages
             }
             try
             {
-                await _deviceActionService.ShowLoadingAsync(AppResources.Deleting);
-                await _cipherService.DeleteWithServerAsync(Cipher.Id);
+                await _deviceActionService.ShowLoadingAsync(AppResources.SoftDeleting);
+                await _cipherService.SoftDeleteWithServerAsync(Cipher.Id);
                 await _deviceActionService.HideLoadingAsync();
-                _platformUtilsService.ShowToast("success", null, AppResources.ItemDeleted);
-                _messagingService.Send("deletedCipher", Cipher);
+                _platformUtilsService.ShowToast("success", null, AppResources.ItemSoftDeleted);
+                _messagingService.Send("softDeletedCipher", Cipher);
                 return true;
             }
             catch (ApiException e)

--- a/src/App/Pages/Vault/CiphersPage.xaml.cs
+++ b/src/App/Pages/Vault/CiphersPage.xaml.cs
@@ -16,14 +16,19 @@ namespace Bit.App.Pages
         private bool _hasFocused;
 
         public CiphersPage(Func<CipherView, bool> filter, bool folder = false, bool collection = false,
-            bool type = false, string autofillUrl = null)
+            bool type = false, string autofillUrl = null, bool deleted = false)
         {
             InitializeComponent();
             _vm = BindingContext as CiphersPageViewModel;
             _vm.Page = this;
             _vm.Filter = filter;
             _vm.AutofillUrl = _autofillUrl = autofillUrl;
-            if (folder)
+            _vm.Deleted = deleted;
+            if (deleted)
+            {
+                _vm.PageTitle = AppResources.SearchTrash;
+            }
+            else if (folder)
             {
                 _vm.PageTitle = AppResources.SearchFolder;
             }

--- a/src/App/Pages/Vault/CiphersPageViewModel.cs
+++ b/src/App/Pages/Vault/CiphersPageViewModel.cs
@@ -44,6 +44,7 @@ namespace Bit.App.Pages
         public ExtendedObservableCollection<CipherView> Ciphers { get; set; }
         public Func<CipherView, bool> Filter { get; set; }
         public string AutofillUrl { get; set; }
+        public bool Deleted { get; set; }
 
         public bool ShowNoData
         {
@@ -105,7 +106,8 @@ namespace Bit.App.Pages
                     }
                     try
                     {
-                        ciphers = await _searchService.SearchCiphersAsync(searchText, Filter, null, cts.Token);
+                        ciphers = await _searchService.SearchCiphersAsync(searchText, 
+                            Filter ?? (c => c.IsDeleted == Deleted), null, cts.Token);
                         cts.Token.ThrowIfCancellationRequested();
                     }
                     catch (OperationCanceledException)

--- a/src/App/Pages/Vault/GroupingsPage/GroupingsPageListItem.cs
+++ b/src/App/Pages/Vault/GroupingsPage/GroupingsPageListItem.cs
@@ -15,6 +15,7 @@ namespace Bit.App.Pages
         public CipherType? Type { get; set; }
         public string ItemCount { get; set; }
         public bool FuzzyAutofill { get; set; }
+        public bool IsTrash { get; set; }
 
         public string Name
         {
@@ -24,7 +25,11 @@ namespace Bit.App.Pages
                 {
                     return _name;
                 }
-                if (Folder != null)
+                if (IsTrash)
+                {
+                    _name = AppResources.Trash;
+                }
+                else if (Folder != null)
                 {
                     _name = Folder.Name;
                 }
@@ -64,7 +69,11 @@ namespace Bit.App.Pages
                 {
                     return _icon;
                 }
-                if (Folder != null)
+                if (IsTrash)
+                {
+                    _icon = "\uf014"; // fa-trash-o
+                }
+                else if (Folder != null)
                 {
                     _icon = Folder.Id == null ? "" : "";
                 }

--- a/src/App/Pages/Vault/ViewPage.xaml
+++ b/src/App/Pages/Vault/ViewPage.xaml
@@ -32,7 +32,7 @@
                      Order="Secondary" />
             <ToolbarItem Text="{u:I18n Close}" Clicked="Close_Clicked" Order="Primary" Priority="-1"
                          x:Name="_closeItem" x:Key="closeItem" />
-            <ToolbarItem Text="{u:I18n Edit}" Clicked="EditToolbarItem_Clicked" Order="Primary"
+            <ToolbarItem Text="" Clicked="EditToolbarItem_Clicked" Order="Primary"
                          x:Name="_editItem" x:Key="editItem" />
             <ToolbarItem Icon="more_vert.png" Clicked="More_Clicked" Order="Primary"
                          x:Name="_moreItem" x:Key="moreItem"
@@ -40,7 +40,7 @@
                          AutomationProperties.Name="{u:I18n Options}" />
             <ToolbarItem Text="{u:I18n Attachments}" Clicked="Attachments_Clicked" Order="Secondary"
                          x:Name="_attachmentsItem" x:Key="attachmentsItem" />
-            <ToolbarItem Text="{u:I18n Delete}" Clicked="Delete_Clicked" Order="Secondary" IsDestructive="True"
+            <ToolbarItem Text="{u:I18n SoftDelete}" Clicked="Delete_Clicked" Order="Secondary" IsDestructive="True"
                          x:Name="_deleteItem" x:Key="deleteItem" />
             <ToolbarItem Text="{u:I18n Clone}" Clicked="Clone_Clicked" Order="Secondary"
                          x:Name="_cloneItem" x:Key="cloneItem" />
@@ -670,7 +670,8 @@
             AbsoluteLayout.LayoutFlags="PositionProportional"
             AbsoluteLayout.LayoutBounds="1, 1, AutoSize, AutoSize"
             AutomationProperties.IsInAccessibleTree="True"
-            AutomationProperties.Name="{u:I18n EditItem}">
+            AutomationProperties.Name="{u:I18n EditItem}"
+            IsVisible="{Binding CanEdit}">
             <Button.Effects>
                 <effects:FabShadowEffect />
             </Button.Effects>

--- a/src/App/Pages/Vault/ViewPage.xaml
+++ b/src/App/Pages/Vault/ViewPage.xaml
@@ -32,7 +32,7 @@
                      Order="Secondary" />
             <ToolbarItem Text="{u:I18n Close}" Clicked="Close_Clicked" Order="Primary" Priority="-1"
                          x:Name="_closeItem" x:Key="closeItem" />
-            <ToolbarItem Text="" Clicked="EditToolbarItem_Clicked" Order="Primary"
+            <ToolbarItem Clicked="EditToolbarItem_Clicked" Order="Primary"
                          x:Name="_editItem" x:Key="editItem" />
             <ToolbarItem Icon="more_vert.png" Clicked="More_Clicked" Order="Primary"
                          x:Name="_moreItem" x:Key="moreItem"
@@ -40,7 +40,7 @@
                          AutomationProperties.Name="{u:I18n Options}" />
             <ToolbarItem Text="{u:I18n Attachments}" Clicked="Attachments_Clicked" Order="Secondary"
                          x:Name="_attachmentsItem" x:Key="attachmentsItem" />
-            <ToolbarItem Text="{u:I18n SoftDelete}" Clicked="Delete_Clicked" Order="Secondary" IsDestructive="True"
+            <ToolbarItem Text="{u:I18n Delete}" Clicked="Delete_Clicked" Order="Secondary" IsDestructive="True"
                          x:Name="_deleteItem" x:Key="deleteItem" />
             <ToolbarItem Text="{u:I18n Clone}" Clicked="Clone_Clicked" Order="Secondary"
                          x:Name="_cloneItem" x:Key="cloneItem" />

--- a/src/App/Pages/Vault/ViewPage.xaml.cs
+++ b/src/App/Pages/Vault/ViewPage.xaml.cs
@@ -204,9 +204,8 @@ namespace Bit.App.Pages
             }
 
             var selection = await DisplayActionSheet(AppResources.Options, AppResources.Cancel,
-                _vm.IsDeleted ? AppResources.Delete : AppResources.SoftDelete,
-                options.ToArray());
-            if (selection == AppResources.Delete || selection == AppResources.SoftDelete)
+                AppResources.Delete, options.ToArray());
+            if (selection == AppResources.Delete)
             {
                 if (await _vm.DeleteAsync())
                 {
@@ -251,8 +250,6 @@ namespace Bit.App.Pages
             }
             _editItem.Text = _vm.Cipher.IsDeleted ? AppResources.Restore :
                 AppResources.Edit;
-            _deleteItem.Text = _vm.Cipher.IsDeleted ? AppResources.Delete :
-                AppResources.SoftDelete;
             if (_vm.Cipher.IsDeleted)
             {
                 _absLayout.Children.Remove(_fab);

--- a/src/App/Pages/Vault/ViewPageViewModel.cs
+++ b/src/App/Pages/Vault/ViewPageViewModel.cs
@@ -86,6 +86,8 @@ namespace Bit.App.Pages
                     nameof(PasswordUpdatedText),
                     nameof(PasswordHistoryText),
                     nameof(ShowIdentityAddress),
+                    nameof(IsDeleted),
+                    nameof(CanEdit),
                 });
         }
         public List<ViewPageFieldViewModel> Fields
@@ -210,6 +212,8 @@ namespace Bit.App.Pages
                 Page.Resources["textTotp"] = Application.Current.Resources[value ? "text-danger" : "text-default"];
             }
         }
+        public bool IsDeleted => Cipher.IsDeleted;
+        public bool CanEdit => !Cipher.IsDeleted;
 
         public async Task<bool> LoadAsync(Action finishedLoadingAction = null)
         {
@@ -282,7 +286,8 @@ namespace Bit.App.Pages
                     AppResources.InternetConnectionRequiredTitle);
                 return false;
             }
-            var confirmed = await _platformUtilsService.ShowDialogAsync(AppResources.DoYouReallyWantToDelete,
+            var confirmed = await _platformUtilsService.ShowDialogAsync(
+                Cipher.IsDeleted ? AppResources.DoYouReallyWantToPermanentlyDeleteCipher : AppResources.DoYouReallyWantToSoftDeleteCipher,
                 null, AppResources.Yes, AppResources.Cancel);
             if (!confirmed)
             {
@@ -290,11 +295,58 @@ namespace Bit.App.Pages
             }
             try
             {
-                await _deviceActionService.ShowLoadingAsync(AppResources.Deleting);
-                await _cipherService.DeleteWithServerAsync(Cipher.Id);
+                await _deviceActionService.ShowLoadingAsync(Cipher.IsDeleted ? AppResources.Deleting : AppResources.SoftDeleting);
+                if (Cipher.IsDeleted)
+                {
+                    await _cipherService.DeleteWithServerAsync(Cipher.Id);
+                }
+                else
+                {
+                    await _cipherService.SoftDeleteWithServerAsync(Cipher.Id);
+                }
                 await _deviceActionService.HideLoadingAsync();
-                _platformUtilsService.ShowToast("success", null, AppResources.ItemDeleted);
-                _messagingService.Send("deletedCipher", Cipher);
+                _platformUtilsService.ShowToast("success", null,
+                    Cipher.IsDeleted ? AppResources.ItemDeleted : AppResources.ItemSoftDeleted);
+                _messagingService.Send(Cipher.IsDeleted ? "deletedCipher" : "softDeletedCipher", Cipher);
+                return true;
+            }
+            catch (ApiException e)
+            {
+                await _deviceActionService.HideLoadingAsync();
+                if (e?.Error != null)
+                {
+                    await _platformUtilsService.ShowDialogAsync(e.Error.GetSingleMessage(),
+                        AppResources.AnErrorHasOccurred);
+                }
+            }
+            return false;
+        }
+
+        public async Task<bool> RestoreAsync()
+        {
+            if (!IsDeleted)
+            {
+                return false;
+            }
+            if (Xamarin.Essentials.Connectivity.NetworkAccess == Xamarin.Essentials.NetworkAccess.None)
+            {
+                await _platformUtilsService.ShowDialogAsync(AppResources.InternetConnectionRequiredMessage,
+                    AppResources.InternetConnectionRequiredTitle);
+                return false;
+            }
+            var confirmed = await _platformUtilsService.ShowDialogAsync(AppResources.DoYouReallyWantToRestoreCipher,
+                null, AppResources.Yes, AppResources.Cancel);
+            if (!confirmed)
+            {
+                return false;
+            }
+            try
+            {
+                await _deviceActionService.ShowLoadingAsync(AppResources.Restoring);
+                await _cipherService.RestoreWithServerAsync(Cipher.Id);
+                await _deviceActionService.HideLoadingAsync();
+                _platformUtilsService.ShowToast("success", null, AppResources.ItemRestored);
+                _messagingService.Send("restoredCipher", Cipher);
                 return true;
             }
             catch (ApiException e)

--- a/src/App/Resources/AppResources.Designer.cs
+++ b/src/App/Resources/AppResources.Designer.cs
@@ -10,6 +10,7 @@
 
 namespace Bit.App.Resources {
     using System;
+    using System.Reflection;
     
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
@@ -1924,6 +1925,12 @@ namespace Bit.App.Resources {
             }
         }
         
+        public static string NoItemsTrash {
+            get {
+                return ResourceManager.GetString("NoItemsTrash", resourceCulture);
+            }
+        }
+        
         public static string AutofillAccessibilityService {
             get {
                 return ResourceManager.GetString("AutofillAccessibilityService", resourceCulture);
@@ -2869,6 +2876,72 @@ namespace Bit.App.Resources {
         public static string AutofillTileUriNotFound {
             get {
                 return ResourceManager.GetString("AutofillTileUriNotFound", resourceCulture);
+            }
+        }
+        
+        public static string SoftDelete {
+            get {
+                return ResourceManager.GetString("SoftDelete", resourceCulture);
+            }
+        }
+        
+        public static string SoftDeleting {
+            get {
+                return ResourceManager.GetString("SoftDeleting", resourceCulture);
+            }
+        }
+        
+        public static string ItemSoftDeleted {
+            get {
+                return ResourceManager.GetString("ItemSoftDeleted", resourceCulture);
+            }
+        }
+        
+        public static string Restore {
+            get {
+                return ResourceManager.GetString("Restore", resourceCulture);
+            }
+        }
+        
+        public static string Restoring {
+            get {
+                return ResourceManager.GetString("Restoring", resourceCulture);
+            }
+        }
+        
+        public static string ItemRestored {
+            get {
+                return ResourceManager.GetString("ItemRestored", resourceCulture);
+            }
+        }
+        
+        public static string Trash {
+            get {
+                return ResourceManager.GetString("Trash", resourceCulture);
+            }
+        }
+        
+        public static string SearchTrash {
+            get {
+                return ResourceManager.GetString("SearchTrash", resourceCulture);
+            }
+        }
+        
+        public static string DoYouReallyWantToPermanentlyDeleteCipher {
+            get {
+                return ResourceManager.GetString("DoYouReallyWantToPermanentlyDeleteCipher", resourceCulture);
+            }
+        }
+        
+        public static string DoYouReallyWantToRestoreCipher {
+            get {
+                return ResourceManager.GetString("DoYouReallyWantToRestoreCipher", resourceCulture);
+            }
+        }
+        
+        public static string DoYouReallyWantToSoftDeleteCipher {
+            get {
+                return ResourceManager.GetString("DoYouReallyWantToSoftDeleteCipher", resourceCulture);
             }
         }
     }

--- a/src/App/Resources/AppResources.Designer.cs
+++ b/src/App/Resources/AppResources.Designer.cs
@@ -2879,12 +2879,6 @@ namespace Bit.App.Resources {
             }
         }
         
-        public static string SoftDelete {
-            get {
-                return ResourceManager.GetString("SoftDelete", resourceCulture);
-            }
-        }
-        
         public static string SoftDeleting {
             get {
                 return ResourceManager.GetString("SoftDeleting", resourceCulture);

--- a/src/App/Resources/AppResources.resx
+++ b/src/App/Resources/AppResources.resx
@@ -1634,10 +1634,6 @@
   <data name="AutofillTileUriNotFound" xml:space="preserve">
     <value>No password fields detected</value>
   </data>
-  <data name="SoftDelete" xml:space="preserve">
-    <value>Send to trash</value>
-    <comment>Soft-Deletes an entity (verb).</comment>
-  </data>
   <data name="SoftDeleting" xml:space="preserve">
     <value>Sending to trash...</value>
     <comment>Message shown when interacting with the server</comment>

--- a/src/App/Resources/AppResources.resx
+++ b/src/App/Resources/AppResources.resx
@@ -1131,6 +1131,9 @@
   <data name="NoItemsFolder" xml:space="preserve">
     <value>There are no items in this folder.</value>
   </data>
+  <data name="NoItemsTrash" xml:space="preserve">
+    <value>There are no items in the trash.</value>
+  </data>
   <data name="AutofillAccessibilityService" xml:space="preserve">
     <value>Auto-fill Accessibility Service</value>
   </data>
@@ -1630,5 +1633,49 @@
   </data>
   <data name="AutofillTileUriNotFound" xml:space="preserve">
     <value>No password fields detected</value>
+  </data>
+  <data name="SoftDelete" xml:space="preserve">
+    <value>Send to trash</value>
+    <comment>Soft-Deletes an entity (verb).</comment>
+  </data>
+  <data name="SoftDeleting" xml:space="preserve">
+    <value>Sending to trash...</value>
+    <comment>Message shown when interacting with the server</comment>
+  </data>
+  <data name="ItemSoftDeleted" xml:space="preserve">
+    <value>Item has been sent to trash.</value>
+    <comment>Confirmation message after successfully soft-deleting a login</comment>
+  </data>
+  <data name="Restore" xml:space="preserve">
+    <value>Restore</value>
+    <comment>Restores an entity (verb).</comment>
+  </data>
+  <data name="Restoring" xml:space="preserve">
+    <value>Restoring...</value>
+    <comment>Message shown when interacting with the server</comment>
+  </data>
+  <data name="ItemRestored" xml:space="preserve">
+    <value>Item has been restored.</value>
+    <comment>Confirmation message after successfully restoring a soft-deleted item</comment>
+  </data>
+  <data name="Trash" xml:space="preserve">
+    <value>Trash</value>
+    <comment>(noun) Location of deleted items which have not yet been permanently deleted</comment>
+  </data>
+  <data name="SearchTrash" xml:space="preserve">
+    <value>Search trash</value>
+    <comment>(action prompt) Label for the search text field when viewing the trash folder</comment>
+  </data>
+  <data name="DoYouReallyWantToPermanentlyDeleteCipher" xml:space="preserve">
+    <value>Do you really want to permanently delete? This cannot be undone.</value>
+    <comment>Confirmation alert message when permanently deleteing a cipher.</comment>
+  </data>
+  <data name="DoYouReallyWantToRestoreCipher" xml:space="preserve">
+    <value>Do you really want to restore this item?</value>
+    <comment>Confirmation alert message when restoring a soft-deleted cipher.</comment>
+  </data>
+  <data name="DoYouReallyWantToSoftDeleteCipher" xml:space="preserve">
+    <value>Do you really want to send to the trash?</value>
+    <comment>Confirmation alert message when soft-deleting a cipher.</comment>
   </data>
 </root>

--- a/src/App/Utilities/AppHelpers.cs
+++ b/src/App/Utilities/AppHelpers.cs
@@ -18,7 +18,11 @@ namespace Bit.App.Utilities
         {
             var platformUtilsService = ServiceContainer.Resolve<IPlatformUtilsService>("platformUtilsService");
             var eventService = ServiceContainer.Resolve<IEventService>("eventService");
-            var options = new List<string> { AppResources.View, AppResources.Edit };
+            var options = new List<string> { AppResources.View };
+            if (!cipher.IsDeleted)
+            {
+                options.Add(AppResources.Edit);
+            }
             if (cipher.Type == Core.Enums.CipherType.Login)
             {
                 if (!string.IsNullOrWhiteSpace(cipher.Login.Username))

--- a/src/Core/Abstractions/IApiService.cs
+++ b/src/Core/Abstractions/IApiService.cs
@@ -37,6 +37,8 @@ namespace Bit.Core.Abstractions
         Task PutCipherCollectionsAsync(string id, CipherCollectionsRequest request);
         Task<FolderResponse> PutFolderAsync(string id, FolderRequest request);
         Task<CipherResponse> PutShareCipherAsync(string id, CipherShareRequest request);
+        Task PutDeleteCipherAsync(string id);
+        Task PutRestoreCipherAsync(string id);
         Task RefreshIdentityTokenAsync();
         Task<TResponse> SendAsync<TRequest, TResponse>(HttpMethod method, string path,
             TRequest body, bool authed, bool hasResponse);

--- a/src/Core/Abstractions/ICipherService.cs
+++ b/src/Core/Abstractions/ICipherService.cs
@@ -36,5 +36,7 @@ namespace Bit.Core.Abstractions
         Task UpsertAsync(CipherData cipher);
         Task UpsertAsync(List<CipherData> cipher);
         Task<byte[]> DownloadAndDecryptAttachmentAsync(AttachmentView attachment, string organizationId);
+        Task SoftDeleteWithServerAsync(string id);
+        Task RestoreWithServerAsync(string id);
     }
 }

--- a/src/Core/Abstractions/ISearchService.cs
+++ b/src/Core/Abstractions/ISearchService.cs
@@ -12,8 +12,8 @@ namespace Bit.Core.Abstractions
         Task IndexCiphersAsync();
         bool IsSearchable(string query);
         Task<List<CipherView>> SearchCiphersAsync(string query, Func<CipherView, bool> filter = null,
-            List<CipherView> ciphers = null, CancellationToken ct = default(CancellationToken));
+            List<CipherView> ciphers = null, CancellationToken ct = default);
         List<CipherView> SearchCiphersBasic(List<CipherView> ciphers, string query,
-            CancellationToken ct = default(CancellationToken));
+            CancellationToken ct = default, bool deleted = false);
     }
 }

--- a/src/Core/Enums/EventType.cs
+++ b/src/Core/Enums/EventType.cs
@@ -26,6 +26,8 @@
         Cipher_ClientCopiedHiddenField = 1112,
         Cipher_ClientCopiedCardCode = 1113,
         Cipher_ClientAutofilled = 1114,
+        Cipher_SoftDeleted = 1115,
+        Cipher_Restored = 1116,
 
         Collection_Created = 1300,
         Collection_Updated = 1301,

--- a/src/Core/Models/Data/CipherData.cs
+++ b/src/Core/Models/Data/CipherData.cs
@@ -45,6 +45,7 @@ namespace Bit.Core.Models.Data
             Fields = response.Fields?.Select(f => new FieldData(f)).ToList();
             Attachments = response.Attachments?.Select(a => new AttachmentData(a)).ToList();
             PasswordHistory = response.PasswordHistory?.Select(ph => new PasswordHistoryData(ph)).ToList();
+            DeletedDate = response.DeletedDate;
         }
 
         public string Id { get; set; }
@@ -66,5 +67,6 @@ namespace Bit.Core.Models.Data
         public List<AttachmentData> Attachments { get; set; }
         public List<PasswordHistoryData> PasswordHistory { get; set; }
         public List<string> CollectionIds { get; set; }
+        public DateTime? DeletedDate { get; set; }
     }
 }

--- a/src/Core/Models/Domain/Cipher.cs
+++ b/src/Core/Models/Domain/Cipher.cs
@@ -51,6 +51,7 @@ namespace Bit.Core.Models.Domain
             Attachments = obj.Attachments?.Select(a => new Attachment(a, alreadyEncrypted)).ToList();
             Fields = obj.Fields?.Select(f => new Field(f, alreadyEncrypted)).ToList();
             PasswordHistory = obj.PasswordHistory?.Select(ph => new PasswordHistory(ph, alreadyEncrypted)).ToList();
+            DeletedDate = obj.DeletedDate;
         }
 
         public string Id { get; set; }
@@ -72,6 +73,8 @@ namespace Bit.Core.Models.Domain
         public List<Field> Fields { get; set; }
         public List<PasswordHistory> PasswordHistory { get; set; }
         public HashSet<string> CollectionIds { get; set; }
+
+        public DateTime? DeletedDate { get; set; }
 
         public async Task<CipherView> DecryptAsync()
         {
@@ -161,7 +164,8 @@ namespace Bit.Core.Models.Domain
                 Favorite = Favorite,
                 RevisionDate = RevisionDate,
                 Type = Type,
-                CollectionIds = CollectionIds.ToList()
+                CollectionIds = CollectionIds.ToList(),
+                DeletedDate = DeletedDate
             };
             BuildDataModel(this, c, new HashSet<string>
             {

--- a/src/Core/Models/Response/CipherResponse.cs
+++ b/src/Core/Models/Response/CipherResponse.cs
@@ -24,5 +24,6 @@ namespace Bit.Core.Models.Response
         public List<AttachmentResponse> Attachments { get; set; }
         public List<PasswordHistoryResponse> PasswordHistory { get; set; }
         public List<string> CollectionIds { get; set; }
+        public DateTime? DeletedDate { get; set; }
     }
 }

--- a/src/Core/Models/View/CipherView.cs
+++ b/src/Core/Models/View/CipherView.cs
@@ -22,6 +22,7 @@ namespace Bit.Core.Models.View
             LocalData = c.LocalData;
             CollectionIds = c.CollectionIds;
             RevisionDate = c.RevisionDate;
+            DeletedDate = c.DeletedDate;
         }
 
         public string Id { get; set; }
@@ -43,6 +44,7 @@ namespace Bit.Core.Models.View
         public List<PasswordHistoryView> PasswordHistory { get; set; }
         public HashSet<string> CollectionIds { get; set; }
         public DateTime RevisionDate { get; set; }
+        public DateTime? DeletedDate { get; set; }
 
 
         public string SubTitle
@@ -96,5 +98,6 @@ namespace Bit.Core.Models.View
                 return Login.PasswordRevisionDate;
             }
         }
+        public bool IsDeleted => DeletedDate.HasValue;
     }
 }

--- a/src/Core/Services/ApiService.cs
+++ b/src/Core/Services/ApiService.cs
@@ -245,6 +245,16 @@ namespace Bit.Core.Services
             return SendAsync<object, object>(HttpMethod.Delete, string.Concat("/ciphers/", id), null, true, false);
         }
 
+        public Task PutDeleteCipherAsync(string id)
+        {
+            return SendAsync<object, object>(HttpMethod.Put, string.Concat("/ciphers/", id, "/delete"), null, true, false);
+        }
+
+        public Task PutRestoreCipherAsync(string id)
+        {
+            return SendAsync<object, object>(HttpMethod.Put, string.Concat("/ciphers/", id, "/restore"), null, true, false);
+        }
+
         #endregion
 
         #region Attachments APIs

--- a/src/Core/Services/SearchService.cs
+++ b/src/Core/Services/SearchService.cs
@@ -35,7 +35,7 @@ namespace Bit.Core.Services
         }
 
         public async Task<List<CipherView>> SearchCiphersAsync(string query, Func<CipherView, bool> filter = null,
-            List<CipherView> ciphers = null, CancellationToken ct = default(CancellationToken))
+            List<CipherView> ciphers = null, CancellationToken ct = default)
         {
             var results = new List<CipherView>();
             if (query != null)
@@ -68,7 +68,7 @@ namespace Bit.Core.Services
         }
 
         public List<CipherView> SearchCiphersBasic(List<CipherView> ciphers, string query,
-            CancellationToken ct = default(CancellationToken))
+            CancellationToken ct = default, bool deleted = false)
         {
             ct.ThrowIfCancellationRequested();
             query = query.Trim().ToLower();

--- a/src/iOS.Core/Views/ExtensionTableSource.cs
+++ b/src/iOS.Core/Views/ExtensionTableSource.cs
@@ -63,7 +63,7 @@ namespace Bit.iOS.Core.Views
             }
 
             _allItems = combinedLogins
-                .Where(c => c.Type == Bit.Core.Enums.CipherType.Login)
+                .Where(c => c.Type == Bit.Core.Enums.CipherType.Login && !c.IsDeleted)
                 .Select(s => new CipherViewModel(s))
                 .ToList() ?? new List<CipherViewModel>();
             FilterResults(searchFilter, new CancellationToken());

--- a/src/iOS/AppDelegate.cs
+++ b/src/iOS/AppDelegate.cs
@@ -168,6 +168,11 @@ namespace Bit.iOS
                         await ASCredentialIdentityStore.SharedStore?.RemoveAllCredentialIdentitiesAsync();
                     }
                 }
+                else if ((message.Command == "softDeletedCipher" || message.Command == "restoredCipher")
+                    && _deviceActionService.SystemMajorVersion() >= 12)
+                {
+                    await ASHelpers.ReplaceAllIdentities();
+                }
             });
 
             return base.FinishedLaunching(app, options);


### PR DESCRIPTION
## Objective
> Similar changes as the other clients, added Trash bin support, soft-delete and restore functions to the mobile app. Tested in iOS and Android emulators.

Sorry for the size of this one. PR from `soft-delete-init` to `soft-delete`.

## Code Changes
- **/App/Pages/Vault/AddEditPage.xaml**:  When editing an item, only provide "soft-delete", relabeled as "Send to trash"
- **/App/Pages/Vault/AddEditPage.xaml.cs**:  See "AddEditPage.xaml" above
- **/App/Pages/Vault/AddEditPageViewModel.cs**:  Text changes for the prompt, "Send to trash" vs. "Delete"
- **/App/Pages/Vault/CiphersPage.xaml.cs**:  Treatment for handling the display of the trash bin vs. other normal folders/views including messaging
- **/App/Pages/Vault/CiphersPageViewModel.cs**:  See "CiphersPage.xaml.cs" above
- **/App/Pages/Vault/GroupingsPage/GroupingsPage.xaml.cs**:  Handle view of trash bin folder, remove add menu option and add button (android) from view, etc.
- **/App/Pages/Vault/GroupingsPage/GroupingsPageListItem.cs**:  Added trash item grouping with appropriate icon (from font-store)
- **/App/Pages/Vault/GroupingsPage/GroupingsPageViewModel.cs**:  Count and management of the trash item, filter and visibility of the add cipher button
- **/App/Pages/Vault/ViewPage.xaml**:  Default soft delete from menu and whether or not an item is editable
- **/App/Pages/Vault/ViewPage.xaml.cs**:  Edit toolbar action either Edits or "Restores" a soft-deleted item, handle soft-delete and delete from the same command and adjust toolbar item visibility based on whether a cipher is soft-deleted or not
- **/App/Pages/Vault/ViewPageViewModel.cs**:  Added actions for restoring and modified the action for delete to prompt and handle either soft or permanently deleting an item based on it's current deleted state
- **/App/Resources/AppResources.resx**:  New text, labels and messaging regarding soft-delete, permanently delete and restore actions and trash label
- **/App/Utilities/AppHelpers.cs**:  Only allow the Edit menu option if not soft-deleted
- **/Core/Abstractions/IApiService.cs**:  Update the API abstraction for putDelete and putRestore endpoints
- **/Core/Abstractions/ICipherService.cs**:  Added to abstraction definition methods for soft delete and restore with server
- **/Core/Abstractions/ISearchService.cs**:  Added deleted flags for search service abstraction to match other clients'. Cleaned up syntax for `default(T)` to `default` where type is known/inferred
- **/Core/Enums/EventType.cs**:  Keeping the Event Type enum in sync with the server code
- **/Core/Models/Data/CipherData.cs**:  Tracking the new DeletedDate property
- **/Core/Models/Domain/Cipher.cs**:  "
- **/Core/Models/Response/CipherResponse.cs**:  "
- **/Core/Models/View/CipherView.cs**:  Added DeletedDate and IsDeleted derived properties
- **/Core/Services/ApiService.cs**:  Implementation for new putDelete and putRestore methods
- **/Core/Services/CipherService.cs **:  Implementation for soft delete and restore functions as well as preventing `IsDeleted` ciphers for auto-fill functions
- **/Core/Services/SearchService.cs**:  Mirror other clients' search service interface, applied Is Deleted filter explicitly unless searching in trash
- **/iOS.Core/Views/ExtensionTableSource.cs**:  Prevent deleted items from showing up in auto-fill service for iOS
- **/iOS/AppDelegate.cs**:  Handle event delegates for soft delete and restore actions

## Screenshots
![image](https://user-images.githubusercontent.com/3904944/80407962-76546080-8894-11ea-8cf2-eccb335b5d10.png)

![image](https://user-images.githubusercontent.com/3904944/80408019-89ffc700-8894-11ea-84f1-9bd61e50984f.png)

![image](https://user-images.githubusercontent.com/3904944/80408037-908e3e80-8894-11ea-8742-1ec2542397f7.png)

![image](https://user-images.githubusercontent.com/3904944/80408060-98e67980-8894-11ea-8d9c-da0c2bfe10fd.png)

![image](https://user-images.githubusercontent.com/3904944/80408081-9f74f100-8894-11ea-86b6-4d6ab96afab5.png)

![image](https://user-images.githubusercontent.com/3904944/80408099-a7cd2c00-8894-11ea-88eb-6ee08910dfcc.png)

![image](https://user-images.githubusercontent.com/3904944/80408125-ae5ba380-8894-11ea-9316-4ccefaaddf29.png)

![image](https://user-images.githubusercontent.com/3904944/80408151-b87da200-8894-11ea-9b96-03f6e8f529ca.png)
