### PR TITLE
Additional URI parsing fix

### DIFF
--- a/src/Android/Accessibility/AccessibilityHelpers.cs
+++ b/src/Android/Accessibility/AccessibilityHelpers.cs
@@ -161,10 +161,6 @@ namespace Bit.Droid.Accessibility
             uri = browser.GetUriFunction(addressNode.Text)?.Trim();
             if (uri != null && uri.Contains("."))
             {
-                if (Uri.TryCreate(uri, UriKind.Absolute, out var uri2))
-                {
-                    return uri;
-                }
                 var hasHttpProtocol = uri.StartsWith("http://") || uri.StartsWith("https://");
                 if (!hasHttpProtocol && uri.Contains("."))
                 {
@@ -172,6 +168,10 @@ namespace Bit.Droid.Accessibility
                     {
                         return string.Concat("http://", uri);
                     }
+                }
+                if (Uri.TryCreate(uri, UriKind.Absolute, out var uri2))
+                {
+                    return uri;
                 }
             }
             return uri;

--- a/src/Android/Accessibility/AccessibilityHelpers.cs
+++ b/src/Android/Accessibility/AccessibilityHelpers.cs
@@ -164,12 +164,12 @@ namespace Bit.Droid.Accessibility
                 var hasHttpProtocol = uri.StartsWith("http://") || uri.StartsWith("https://");
                 if (!hasHttpProtocol && uri.Contains("."))
                 {
-                    if (Uri.TryCreate("http://" + uri, UriKind.Absolute, out var uri3))
+                    if (Uri.TryCreate("http://" + uri, UriKind.Absolute, out var uri2))
                     {
                         return string.Concat("http://", uri);
                     }
                 }
-                if (Uri.TryCreate(uri, UriKind.Absolute, out var uri2))
+                if (Uri.TryCreate(uri, UriKind.Absolute, out var uri3))
                 {
                     return uri;
                 }

--- a/src/Core/Utilities/CoreHelpers.cs
+++ b/src/Core/Utilities/CoreHelpers.cs
@@ -88,14 +88,14 @@ namespace Bit.Core.Utilities
             var hasHttpProtocol = uriString.StartsWith("http://") || uriString.StartsWith("https://");
             if (!hasHttpProtocol && uriString.Contains("."))
             {
-                if (Uri.TryCreate("http://" + uriString, UriKind.Absolute, out var uri2))
+                if (Uri.TryCreate("http://" + uriString, UriKind.Absolute, out var uri))
                 {
-                    return uri2;
+                    return uri;
                 }
             }
-            if (Uri.TryCreate(uriString, UriKind.Absolute, out var uri))
+            if (Uri.TryCreate(uriString, UriKind.Absolute, out var uri2))
             {
-                return uri;
+                return uri2;
             }
             return null;
         }

--- a/src/Core/Utilities/CoreHelpers.cs
+++ b/src/Core/Utilities/CoreHelpers.cs
@@ -85,10 +85,6 @@ namespace Bit.Core.Utilities
             {
                 return null;
             }
-            if (Uri.TryCreate(uriString, UriKind.Absolute, out var uri))
-            {
-                return uri;
-            }
             var hasHttpProtocol = uriString.StartsWith("http://") || uriString.StartsWith("https://");
             if (!hasHttpProtocol && uriString.Contains("."))
             {
@@ -96,6 +92,10 @@ namespace Bit.Core.Utilities
                 {
                     return uri2;
                 }
+            }
+            if (Uri.TryCreate(uriString, UriKind.Absolute, out var uri))
+            {
+                return uri;
             }
             return null;
         }


### PR DESCRIPTION
Ran across an issue introduced by recent modifications where an expected failure did in fact, not fail, resulting in a 'no matches found' condition (calling `Uri.TryCreate` on a URL without a scheme worked, and passed along a scheme-less URI until it was rejected by subsequent code).

The solution (which lines up better with previous code) is to perform the http(s) scheme check / prefix creation _first_, and if not necessary _then_ fall back to attempting to create the URI with the string as-is.  This results in the scheme-less URI being properly prefixed with `http://`.  Also tested with the URLs fixed by our recent changes, and they still work properly.

I'm unsure why we didn't see this while testing the recent changes.  For reference, the uriString that exposed this was `rqpc45.synology.me:5000`