### PR TITLE
[Autofill - Browser lists] Accessibility Service: add Tor Browser, Firefox Lite and Opera Mini Beta

### DIFF
--- a/src/Android/Accessibility/AccessibilityHelpers.cs
+++ b/src/Android/Accessibility/AccessibilityHelpers.cs
@@ -55,6 +55,7 @@ namespace Bit.Droid.Accessibility
             new Browser("com.opera.browser", "url_field"),
             new Browser("com.opera.browser.beta", "url_field"),
             new Browser("com.opera.mini.native", "url_field"),
+            new Browser("com.opera.mini.native.beta", "url_field"),
             new Browser("com.opera.touch", "addressbarEdit"),
             new Browser("com.qwant.liberty", "url_bar_title"),
             new Browser("com.sec.android.app.sbrowser", "location_bar_edit_text"),
@@ -83,6 +84,8 @@ namespace Bit.Droid.Accessibility
             new Browser("org.mozilla.focus", "display_url"),
             new Browser("org.mozilla.klar", "display_url"),
             new Browser("org.mozilla.reference.browser", "mozac_browser_toolbar_url_view"),
+            new Browser("org.mozilla.rocket", "display_url"),
+            new Browser("org.torproject.torbrowser", "url_bar_title"),
         }.ToDictionary(n => n.PackageName);
 
         // Known packages to skip


### PR DESCRIPTION
This adds **[Tor Browser](https://play.google.com/store/apps/details?id=org.torproject.torbrowser)**, **[Firefox Lite](https://play.google.com/store/apps/details?id=org.mozilla.rocket)** ¹ and **[Opera Mini Beta](https://play.google.com/store/apps/details?id=com.opera.mini.native.beta)** browsers to `AccessibilityHelpers.SupportedBrowsers`.

The resource-id value of these has been checked.

These three browser entries were missing there, see screenshot below:
![browser_lists_comparison_A-Z](https://user-images.githubusercontent.com/4764956/80758841-92772c80-8b36-11ea-8861-5892afc57aa8.png)
_(**left:** `AutofillHelpers.{TrustedBrowsers+CompatBrowsers}` combined and sorted alphabetically **/** 
**right:** `AccessibilityHelpers.SupportedBrowsers` sorted alphabetically)_

___
¹ Formerly known as _Firefox Rocket_, this browser launched a few years ago, is the lite version of Firefox (approx. 6 MB), based on the Android WebView system component and intended for the following markets at the time of writing: China, Indonesia, India, The Philippines, Thailand and Vietnam. See [this page](https://support.mozilla.org/en-US/kb/get-started-firefox-lite).

<details>
  <summary>More details (screenshot) ...</summary>

![Firefox_Lite_resource-id](https://user-images.githubusercontent.com/4764956/80759072-fd286800-8b36-11ea-8fe3-4361db2254b4.png)
_(I needed to download the APK via [APKMirror](https://www.apkmirror.com/apk/mozilla/firefox-rocket-fast-and-lightweight-web-browser/) for this test therefore, since restricted to these countries on the Play Store. Note that the APK file can also be downloaded from [their GitHub](https://github.com/mozilla-tw/FirefoxLite/releases). Can be compiled from [source](https://github.com/mozilla-tw/FirefoxLite) too; confirming this [resource-id value](https://github.com/mozilla-tw/FirefoxLite/search?l=XML&q=display_url) is therefore easy.)_

</details>