### PR TITLE
Add support for Tor Browser (Alpha)

### DIFF
--- a/src/Android/Accessibility/AccessibilityHelpers.cs
+++ b/src/Android/Accessibility/AccessibilityHelpers.cs
@@ -86,6 +86,7 @@ namespace Bit.Droid.Accessibility
             new Browser("org.mozilla.reference.browser", "mozac_browser_toolbar_url_view"),
             new Browser("org.mozilla.rocket", "display_url"),
             new Browser("org.torproject.torbrowser", "url_bar_title"),
+            new Browser("org.torproject.torbrowser_alpha", "url_bar_title"),
         }.ToDictionary(n => n.PackageName);
 
         // Known packages to skip

--- a/src/Android/Autofill/AutofillHelpers.cs
+++ b/src/Android/Autofill/AutofillHelpers.cs
@@ -70,6 +70,7 @@ namespace Bit.Droid.Autofill
             "org.mozilla.reference.browser",
             "org.mozilla.rocket",
             "org.torproject.torbrowser",
+            "org.torproject.torbrowser_alpha",
         };
 
         // The URLs are blacklisted from autofilling

--- a/src/Android/Resources/xml/autofillservice.xml
+++ b/src/Android/Resources/xml/autofillservice.xml
@@ -122,4 +122,7 @@
   <compatibility-package
     android:name="org.torproject.torbrowser"
     android:maxLongVersionCode="10000000000"/>
+  <compatibility-package
+    android:name="org.torproject.torbrowser_alpha"
+    android:maxLongVersionCode="10000000000"/>
 </autofill-service>


### PR DESCRIPTION
![Tor_Browser_logo](https://user-images.githubusercontent.com/4764956/80911128-b1dba880-8d34-11ea-9f37-048aa1fc772d.png)
___

This adds compatibility for **[Tor Browser (Alpha)](https://play.google.com/store/apps/details?id=org.torproject.torbrowser_alpha)** (`org.torproject.torbrowser_alpha`).

:heavy_check_mark: The resource-id value (`url_bar_title`) has been checked.