### PR TITLE
Add support for GNU IceCat

### DIFF
--- a/src/Android/Accessibility/AccessibilityHelpers.cs
+++ b/src/Android/Accessibility/AccessibilityHelpers.cs
@@ -74,6 +74,7 @@ namespace Bit.Droid.Accessibility
             new Browser("org.bromite.bromite", "url_bar"),
             new Browser("org.chromium.chrome", "url_bar"),
             new Browser("org.codeaurora.swe.browser", "url_bar"),
+            new Browser("org.gnu.icecat", "url_bar_title"),
             new Browser("org.iron.srware", "url_bar"),
             new Browser("org.mozilla.fenix", "mozac_browser_toolbar_url_view"),
             new Browser("org.mozilla.fenix.nightly", "mozac_browser_toolbar_url_view"),

--- a/src/Android/Autofill/AutofillHelpers.cs
+++ b/src/Android/Autofill/AutofillHelpers.cs
@@ -61,6 +61,7 @@ namespace Bit.Droid.Autofill
             "org.bromite.bromite",
             "org.chromium.chrome",
             "org.codeaurora.swe.browser",
+            "org.gnu.icecat",
             "org.mozilla.fenix",
             "org.mozilla.fenix.nightly",
             "org.mozilla.fennec_aurora",

--- a/src/Android/Resources/xml/autofillservice.xml
+++ b/src/Android/Resources/xml/autofillservice.xml
@@ -96,6 +96,9 @@
     android:name="org.codeaurora.swe.browser"
     android:maxLongVersionCode="10000000000"/>
   <compatibility-package
+    android:name="org.gnu.icecat"
+    android:maxLongVersionCode="10000000000"/>
+  <compatibility-package
     android:name="org.mozilla.fenix"
     android:maxLongVersionCode="10000000000"/>
   <compatibility-package


### PR DESCRIPTION
![GNU_IceCat_logo](https://user-images.githubusercontent.com/4764956/80912244-e868f180-8d3b-11ea-816a-6eafd57f9847.png)
___

This adds compatibility for **[GNU IceCat](https://f-droid.org/en/packages/org.gnu.icecat/)** (`org.gnu.icecat`), the [GNU version of the Firefox ESR browser](https://en.wikipedia.org/wiki/GNU_IceCat).

:heavy_check_mark: The resource-id value (`url_bar_title`) has been checked.

<details>
  <summary>Read more ...</summary>

### Screenshot (for _resource-id_ value)
![GNU_IceCat_resource-id](https://user-images.githubusercontent.com/4764956/80912141-3c270b00-8d3b-11ea-8c8a-c9fa26078a66.png)
:arrow_right: `org.gnu.icecat:id/` **`url_bar_title`**

</details>