### PR TITLE
Add support for Avast Secure Browser

### DIFF
--- a/src/Android/Accessibility/AccessibilityHelpers.cs
+++ b/src/Android/Accessibility/AccessibilityHelpers.cs
@@ -31,6 +31,7 @@ namespace Bit.Droid.Accessibility
             new Browser("com.amazon.cloud9", "url"),
             new Browser("com.android.browser", "url"),
             new Browser("com.android.chrome", "url_bar"),
+            new Browser("com.avast.android.secure.browser", "editor"),
             new Browser("com.brave.browser", "url_bar"),
             new Browser("com.brave.browser_beta", "url_bar"),
             new Browser("com.chrome.beta", "url_bar"),

--- a/src/Android/Autofill/AutofillHelpers.cs
+++ b/src/Android/Autofill/AutofillHelpers.cs
@@ -34,6 +34,7 @@ namespace Bit.Droid.Autofill
             "com.amazon.cloud9",
             "com.android.browser",
             "com.android.chrome",
+            "com.avast.android.secure.browser",
             "com.brave.browser",
             "com.brave.browser_beta",
             "com.chrome.beta",

--- a/src/Android/Resources/xml/autofillservice.xml
+++ b/src/Android/Resources/xml/autofillservice.xml
@@ -15,6 +15,9 @@
     android:name="com.android.chrome"
     android:maxLongVersionCode="10000000000"/>
   <compatibility-package
+    android:name="com.avast.android.secure.browser"
+    android:maxLongVersionCode="10000000000"/>
+  <compatibility-package
     android:name="com.brave.browser"
     android:maxLongVersionCode="10000000000"/>
   <compatibility-package


### PR DESCRIPTION
![Avast_Secure_Browser_logo](https://user-images.githubusercontent.com/4764956/80912452-3e8a6480-8d3d-11ea-8e9f-4595aa577a03.png)
___

This adds compatibility for **[Avast Secure Browser](https://play.google.com/store/apps/details?id=com.avast.android.secure.browser)** (`com.avast.android.secure.browser`).
More info about it on [its Wikipedia page](https://en.wikipedia.org/wiki/Avast_Secure_Browser).

:heavy_check_mark: The resource-id value (`editor`) has been checked.

<details>
  <summary>Read more ...</summary>

### Screenshot (for _resource-id_ value)
![Avast_Secure_Browser_resource-id](https://user-images.githubusercontent.com/4764956/80912479-7ee9e280-8d3d-11ea-8593-150dd4c11d4c.png)
:arrow_right: `com.avast.android.secure.browser:id/` **`editor`**

</details>