### PR TITLE
Add support for Samsung "Multi Window" mode (Android < 7.0 users)

### DIFF
--- a/src/Android/Properties/AndroidManifest.xml
+++ b/src/Android/Properties/AndroidManifest.xml
@@ -55,5 +55,9 @@
 
     <meta-data android:name="android.max_aspect" android:value="2.1" />
     <meta-data android:name="android.content.APP_RESTRICTIONS" android:resource="@xml/app_restrictions" />
+
+    <!-- Support for Samsung "Multi Window" mode (for Android < 7.0 users) -->
+    <meta-data android:name="com.samsung.android.sdk.multiwindow.enable" android:value="true" />
+    <meta-data android:name="com.samsung.android.sdk.multiwindow.penwindow.enable" android:value="true" />
   </application>
 </manifest>


### PR DESCRIPTION
_... including "Pen Window" support, too._ :relaxed:

# Samsung "Multi Window" mode
![Samsung_Galaxy_Tab_S_10 5_inches](https://user-images.githubusercontent.com/4764956/81015799-98834b00-8e5f-11ea-8516-d22f415d9e74.png)

## Context
Long before Android natively supported multi-window management with Android 7.0, Samsung had launched its system. This PR allows Bitwarden to be compatible with this system, which can be used on some tablets but also on some large screen smartphones from the Samsung brand.

## So, what is Multi Window?
<details>
  <summary>Read me ...</summary>

### **On tablet**
![Samsung_Multi_Window_on_tablet](https://user-images.githubusercontent.com/4764956/81015437-00856180-8e5f-11ea-9e3d-c07298993d37.jpg)

### **On smartphone**
![Samsung_Multi_Window_on_smartphone](https://user-images.githubusercontent.com/4764956/81001406-f6a43400-8e47-11ea-91e2-4f3ceb301af5.png)

:arrow_right: This PR adds Bitwarden to this list (of compatible apps), allowing it to be used in split-screen mode. That is, typically, _left or right_ for **tablet**, _top or bottom_ for **smartphone**. But the very large tablets, typically 12" and more, allow the use of 4 simultaneous apps in the form of a 2x2 grid!

:arrow_right: **See these two official videos for use:** :clapper:
  - [Samsung Galaxy Tab 4 | How To: Multiwindow](https://www.youtube.com/watch?v=XEDEQc1WMig) (2m45s) :point_left:
  - [Galaxy Tab S 10.5 - How-To-Video - Using Multi Window](https://www.youtube.com/watch?v=RLVx4CRfaJ0) (1m46s)

</details>

## What about Pen Window? _(on few models only)_
<details>
  <summary>Read me ...</summary>

### **On tablet**
![Samsung_Multi_Window_mode_Pen_Window_0](https://user-images.githubusercontent.com/4764956/81002302-4cc5a700-8e49-11ea-911d-f7f34bb8b5fa.jpg)
![Samsung_Multi_Window_mode_Pen_Window_1](https://user-images.githubusercontent.com/4764956/81002109-0112fd80-8e49-11ea-9ecf-2da054fe98fd.jpg)
![Samsung_Multi_Window_mode_Pen_Window_2](https://user-images.githubusercontent.com/4764956/81002112-02dcc100-8e49-11ea-9894-e596d11e675b.jpg)
![Samsung_Multi_Window_mode_Pen_Window_3](https://user-images.githubusercontent.com/4764956/81002119-04a68480-8e49-11ea-82e6-bb4076853420.jpg)

> You can draw a window in any size, anywhere on the screen just as you feel appropriate and select an app to launch within that window box.
>
> **Source:** [Samsung](https://www.samsung.com/in/support/mobile-devices/how-to-use-pen-window-in-samsung-galaxy-note-10-1/)

:arrow_right: This PR adds Bitwarden to this list (of compatible apps), allowing it to be used in windowed mode.

:arrow_right: Watch [this video](https://www.youtube.com/watch?v=VUo9WG_7xQ8) (up to 1 minute and 40 seconds). :clapper:

</details>

## In action with Bitwarden!
<details>
  <summary>Read me ...</summary>

### Basic use
![01 Screenshot_2020-05-04-16-16-42](https://user-images.githubusercontent.com/4764956/81014589-6cff6100-8e5d-11ea-9c8b-0f56cd54edf7.png)
_**Before this PR:** no Bitwarden icon present in the sidebar of the OS (Android 6.0 Marshmallow in this case)._

![02 Screenshot_2020-05-04-16-21-21](https://user-images.githubusercontent.com/4764956/81014595-6f61bb00-8e5d-11ea-8dd2-b8b5f0d9bb53.png)
_**After this PR:** the Bitwarden icon is now present in the list._

![03 Screenshot_2020-05-04-21-42-16](https://user-images.githubusercontent.com/4764956/81014604-712b7e80-8e5d-11ea-9b56-931a77681340.png)
_Just press and hold the app icon and drag and drop it to the desired side of the screen (here the left)._

![04 Screenshot_2020-05-04-16-25-08](https://user-images.githubusercontent.com/4764956/81014609-738dd880-8e5d-11ea-95b9-49d64bb7cddf.png)
_The Bitwarden app now appears in split-screen mode._

### Below are some ideas for use (sign in) ...
![05 Screenshot_2020-05-04-16-45-22](https://user-images.githubusercontent.com/4764956/81014616-77215f80-8e5d-11ea-9ab3-f1aec30874f7.png)
:warning: Please note that on these versions of Android (< 10), other apps can monitor the contents of your clipboard, however.

![06 Screenshot_2020-05-04-16-48-25](https://user-images.githubusercontent.com/4764956/81018260-79d38300-8e64-11ea-82b8-9b02d77733fe.png)
:bulb: But if the autofill system has a problem for example, why not just display the password*, select all its characters except the last 4, and paste it then manually type these 4 characters?

(*) _Bitwarden prevents any screen capture attempts by default, so this is secure._

### Below are some ideas for use (sign up) ...
![07 Screenshot_2020-05-04-17-04-37](https://user-images.githubusercontent.com/4764956/81018267-7d670a00-8e64-11ea-88bf-fc4401a2e276.png)

![08 Screenshot_2020-05-04-17-06-47](https://user-images.githubusercontent.com/4764956/81018274-7fc96400-8e64-11ea-9980-e624234a9f15.png)

![09 Screenshot_2020-05-04-17-12-43](https://user-images.githubusercontent.com/4764956/81018281-82c45480-8e64-11ea-934d-e64c8d9e230e.png)

![10 Screenshot_2020-05-04-17-14-12](https://user-images.githubusercontent.com/4764956/81018288-848e1800-8e64-11ea-9c7e-714a1c741d81.png)

![11 Screenshot_2020-05-04-17-11-52](https://user-images.githubusercontent.com/4764956/81018290-8657db80-8e64-11ea-94b4-421b8e0c00d9.png)

### Below are a few more ideas ...
![12 Screenshot_2020-05-04-17-21-22](https://user-images.githubusercontent.com/4764956/81018296-88ba3580-8e64-11ea-8808-14806061b487.png)
_Use of secure notes (SSH keys, whatever) for your terminal (1/2)._

![13 Screenshot_2020-05-04-17-21-42](https://user-images.githubusercontent.com/4764956/81018300-8a83f900-8e64-11ea-8298-fd875779af0c.png)
_Use of secure notes (SSH keys, whatever) for your terminal (2/2)._

![14 Screenshot_2020-05-04-17-25-05](https://user-images.githubusercontent.com/4764956/81018306-8ce65300-8e64-11ea-9677-32804535043c.png)
_Use of notes for writing your email (1/2) — in this example, not logged however._

![15 Screenshot_2020-05-04-17-26-13](https://user-images.githubusercontent.com/4764956/81018314-8eb01680-8e64-11ea-8578-c566a9baffb6.png)
_Use of notes for writing your email (2/2) — in this example, not logged however._

</details>