### PR TITLE
Add support for LG "Dual Window" mode (Android < 7.0 users)

### DIFF
--- a/src/Android/Properties/AndroidManifest.xml
+++ b/src/Android/Properties/AndroidManifest.xml
@@ -59,5 +59,8 @@
     <!-- Support for Samsung "Multi Window" mode (for Android < 7.0 users) -->
     <meta-data android:name="com.samsung.android.sdk.multiwindow.enable" android:value="true" />
     <meta-data android:name="com.samsung.android.sdk.multiwindow.penwindow.enable" android:value="true" />
+
+    <!-- Support for LG "Dual Window" mode (for Android < 7.0 users) -->
+    <meta-data android:name="com.lge.support.SPLIT_WINDOW" android:value="true" />
   </application>
 </manifest>


### PR DESCRIPTION
# LG "Dual Window" mode
![LG_Dual_Window_on_smartphone](https://user-images.githubusercontent.com/4764956/81095884-ea7eac00-8f05-11ea-9839-9efec586cbe3.jpg)

In the same vein as the support for [Samsung "Multi Window" mode](https://github.com/bitwarden/mobile/pull/877), this adds support for **LG "Dual Window" mode** (for Android < 7.0 users).

<details>
  <summary>Read more ...</summary>

## Context
Long before Android natively supported multi-window management with Android 7.0, LG had launched its system. This PR allows Bitwarden to be compatible with this system, which can be used on some tablets but also on some large screen smartphones from the LG brand.

## About it
This PR adds Bitwarden to the list of compatible apps, allowing it to be used in split-screen mode. That is, typically, _left or right_ for **tablet**, _top or bottom_ for **smartphone**. Just press and hold the Bitwarden icon (located in the dedicated area) and drag and drop it to the desired side of the screen.

:clapper: **See these two videos from AT&T for use:**
  - [Dual Window on the LG G Pad X 10.1 | AT&T Wireless](https://www.youtube.com/watch?v=vcNV_cadP44) (1m32s) :point_left:
  - [LG G Pad F™ 8.0 : Dual Window](https://www.youtube.com/watch?v=fY4g0yia1A8) (1m07s)

## Remark
:point_right: Having neither LG tablet nor LG smartphone compatible with "Dual Window" mode allowing me to test this, any feedback is welcome. Although LG has made it as simple as possible to implement (only one line of code to add).

</details>