### PR TITLE
Support for establishing a username field without a password field

### DIFF
--- a/src/Android/Accessibility/AccessibilityHelpers.cs
+++ b/src/Android/Accessibility/AccessibilityHelpers.cs
@@ -123,6 +123,7 @@ namespace Bit.Droid.Accessibility
             new KnownUsernameField("amazon.com","signin", "ap_email_login"),
             new KnownUsernameField("github.com", "", "user[login]-footer"),
             new KnownUsernameField("paypal.com","signin", "email"),
+            new KnownUsernameField("signin.aws.amazon.com","signin", "resolving_input"),
             new KnownUsernameField("signin.ebay.com","eBayISAPI.dll", "userid"),
           
         }.ToDictionary(n => n.UriAuthority);

--- a/src/Android/Accessibility/KnownUsernameField.cs
+++ b/src/Android/Accessibility/KnownUsernameField.cs
@@ -1,0 +1,16 @@
+﻿namespace Bit.Droid.Accessibility
+{
+    public class KnownUsernameField
+    {
+        public KnownUsernameField(string uriAuthority, string uriPathEnd, string usernameViewId)
+        {
+            UriAuthority = uriAuthority;
+            UriPathEnd = uriPathEnd;
+            UsernameViewId = usernameViewId;
+        }
+
+        public string UriAuthority { get; set; }
+        public string UriPathEnd { get; set; }
+        public string UsernameViewId { get; set; }
+    }
+}

--- a/src/Android/Android.csproj
+++ b/src/Android/Android.csproj
@@ -100,6 +100,7 @@
     <Compile Include="Accessibility\AccessibilityService.cs" />
     <Compile Include="Accessibility\Browser.cs" />
     <Compile Include="Accessibility\NodeList.cs" />
+    <Compile Include="Accessibility\KnownUsernameField.cs" />
     <Compile Include="Autofill\AutofillHelpers.cs" />
     <Compile Include="Autofill\AutofillService.cs" />
     <Compile Include="Autofill\Field.cs" />


### PR DESCRIPTION
Accessibility:  Added support for establishing a username field without the presence of a password field, or for overriding a username field with a different one (think github homepage user/email/pass form).  As there doesn't appear to be a reliable way to make this work automagically, this takes the manual route where we simply maintain a list of sites and their corresponding username field IDs.

I opted not to use the entire URI as some of the variations were endless depending on locale, continuation path args, etc.  So we're keying off the authority and the end of the path to establish a site & page match, then on the view ID for a username field match.

Additional data was needed earlier in the process to establish the username field, so some operations were shuffled around to prevent them from running twice.

![device-2020-05-05-175044](https://user-images.githubusercontent.com/59324545/81120654-2bbd8e80-8efb-11ea-9691-f3d7336feb37.png)

![device-2020-05-05-181429](https://user-images.githubusercontent.com/59324545/81121276-565c1700-8efc-11ea-8f11-d2614f39c583.png)
