### PR TITLE
Add support for AVG Browser

### DIFF
--- a/src/Android/Accessibility/AccessibilityHelpers.cs
+++ b/src/Android/Accessibility/AccessibilityHelpers.cs
@@ -35,6 +35,7 @@ namespace Bit.Droid.Accessibility
             new Browser("com.android.browser", "url"),
             new Browser("com.android.chrome", "url_bar"),
             new Browser("com.avast.android.secure.browser", "editor"),
+            new Browser("com.avg.android.secure.browser", "editor"),
             new Browser("com.brave.browser", "url_bar"),
             new Browser("com.brave.browser_beta", "url_bar"),
             new Browser("com.brave.browser_default", "url_bar"),

--- a/src/Android/Autofill/AutofillHelpers.cs
+++ b/src/Android/Autofill/AutofillHelpers.cs
@@ -42,6 +42,7 @@ namespace Bit.Droid.Autofill
             "com.android.browser",
             "com.android.chrome",
             "com.avast.android.secure.browser",
+            "com.avg.android.secure.browser",
             "com.brave.browser",
             "com.brave.browser_beta",
             "com.brave.browser_default",

--- a/src/Android/Resources/xml/autofillservice.xml
+++ b/src/Android/Resources/xml/autofillservice.xml
@@ -23,6 +23,9 @@
     android:name="com.avast.android.secure.browser"
     android:maxLongVersionCode="10000000000"/>
   <compatibility-package
+    android:name="com.avg.android.secure.browser"
+    android:maxLongVersionCode="10000000000"/>
+  <compatibility-package
     android:name="com.brave.browser"
     android:maxLongVersionCode="10000000000"/>
   <compatibility-package


### PR DESCRIPTION
![AVG_Browser_logo](https://user-images.githubusercontent.com/4764956/81216490-45360780-8fdb-11ea-9d9a-cb64c455928d.png)
___

This adds compatibility for **[AVG Browser](https://play.google.com/store/apps/details?id=com.avg.android.secure.browser)** (`com.avg.android.secure.browser`).

:heavy_check_mark: The resource-id value (`editor`) has been checked.

<details>
  <summary>Read more ...</summary>

## Screenshot (for _resource-id_ value)
![AVG_Browser_resource-id](https://user-images.githubusercontent.com/4764956/81216673-93e3a180-8fdb-11ea-83c9-e003eb873bef.png)
:arrow_right: `com.avg.android.secure.browser:id/` **`editor`**

## Remark
Very similar to [Avast Secure Browser](https://play.google.com/store/apps/details?id=com.avast.android.secure.browser) (recently committed from [this PR](https://github.com/bitwarden/mobile/pull/874)).

This is because **AVG** has been a subsidiary of **Avast** since [its acquisition](https://press.avast.com/avast-closes-acquisition-of-avg-technologies) by the latter in 2016. For information, the two browsers were released the same day on the Play Store (March 23, 2020).

![Avast_Secure_Browser_logo_only](https://user-images.githubusercontent.com/4764956/81218445-7f54d880-8fde-11ea-8cea-81bf58cbc72c.png) ![AVG_Browser_logo_only](https://user-images.githubusercontent.com/4764956/81218452-81b73280-8fde-11ea-92b6-e723071261c6.png)
:arrow_right: **Avast Secure Browser** logo at left (`com.avast.android.secure.browser`)
:arrow_right: **AVG Browser** logo at right (`com.avg.android.secure.browser`)

</details>