### PR TITLE
Usability improvements to accessibility settings

### DIFF
--- a/src/App/Pages/Settings/AccessibilityServicePage.xaml
+++ b/src/App/Pages/Settings/AccessibilityServicePage.xaml
@@ -25,40 +25,18 @@
                    VerticalOptions="Start"
                    HorizontalTextAlignment="Center"
                    LineBreakMode="WordWrap" />
-            <StackLayout VerticalOptions="CenterAndExpand"
+            <StackLayout IsVisible="{Binding Enabled, Converter={StaticResource inverseBool}}"
+                         VerticalOptions="CenterAndExpand"
                          HorizontalOptions="Center"
-                         Spacing="10">
-                <StackLayout IsVisible="{Binding Enabled, Converter={StaticResource inverseBool}}"
-                             Orientation="Horizontal" HorizontalOptions="Center">
+                         Spacing="20">
+                <StackLayout Orientation="Horizontal" HorizontalOptions="Center">
                     <Label Text="{u:I18n Status}" />
                     <Label Text="{u:I18n Disabled}"
                            StyleClass="text-danger, text-bold" />
                 </StackLayout>
-                <StackLayout IsVisible="{Binding Enabled}"
-                             Orientation="Horizontal" HorizontalOptions="Center">
-                    <Label Text="{u:I18n Status}" />
-                    <Label Text="{u:I18n Enabled}"
-                           StyleClass="text-success, text-bold" />
-                </StackLayout>
-                <StackLayout IsVisible="{Binding Permitted, Converter={StaticResource inverseBool}}"
-                             Orientation="Horizontal" HorizontalOptions="Center">
-                    <Label Text="{u:I18n OverlayPermission}" />
-                    <Label Text="{u:I18n Denied}"
-                           StyleClass="text-danger, text-bold" />
-                </StackLayout>
-                <StackLayout IsVisible="{Binding Permitted}"
-                             Orientation="Horizontal" HorizontalOptions="Center">
-                    <Label Text="{u:I18n OverlayPermission}" />
-                    <Label Text="{u:I18n Granted}"
-                           StyleClass="text-success, text-bold" />
-                </StackLayout>
-            </StackLayout>
-            <StackLayout IsVisible="{Binding Enabled, Converter={StaticResource inverseBool}}"
-                         VerticalOptions="CenterAndExpand"
-                         HorizontalOptions="Center"
-                         Spacing="10">
                 <Image Source="accessibility_step1.png"
                        HorizontalOptions="Center"
+                       Margin="0, 20, 0, 0"
                        WidthRequest="300"
                        HeightRequest="98" />
                 <Label Text="{u:I18n BitwardenAutofillServiceStep1}"
@@ -78,9 +56,15 @@
             <StackLayout IsVisible="{Binding EnabledWithoutPermission}"
                          VerticalOptions="CenterAndExpand"
                          HorizontalOptions="Center"
-                         Spacing="10">
+                         Spacing="20">
+                <StackLayout Orientation="Horizontal" HorizontalOptions="Center">
+                    <Label Text="{u:I18n Status}" />
+                    <Label Text="{u:I18n Disabled}"
+                           StyleClass="text-danger, text-bold" />
+                </StackLayout>
                 <Image Source="accessibility_permission.png"
                        HorizontalOptions="Center"
+                       Margin="0, 20, 0, 0"
                        WidthRequest="300"
                        HeightRequest="142" />
                 <Label Text="{u:I18n BitwardenAutofillServiceStep3}"
@@ -91,9 +75,15 @@
             <StackLayout IsVisible="{Binding EnabledAndPermitted}"
                          VerticalOptions="CenterAndExpand"
                          HorizontalOptions="Center"
-                         Spacing="10">
+                         Spacing="20">
+                <StackLayout Orientation="Horizontal" HorizontalOptions="Center">
+                    <Label Text="{u:I18n Status}" />
+                    <Label Text="{u:I18n Enabled}"
+                           StyleClass="text-success, text-bold" />
+                </StackLayout>
                 <Image Source="accessibility_overlay.png"
                        HorizontalOptions="Center"
+                       Margin="0, 20, 0, 0"
                        WidthRequest="300"
                        HeightRequest="172" />
                 <Label Text="{u:I18n BitwardenAutofillServiceOverlay}"
@@ -105,11 +95,13 @@
                 <Button Text="{u:I18n BitwardenAutofillServiceOpenAccessibilitySettings}"
                     Clicked="Settings_Clicked"
                     HorizontalOptions="Fill"
-                    VerticalOptions="End"></Button>
+                    VerticalOptions="End"
+                    IsVisible="{Binding Enabled, Converter={StaticResource inverseBool}}"></Button>
                 <Button Text="{u:I18n BitwardenAutofillServiceOpenOverlayPermissionSettings}"
                     Clicked="OverlayPermissionSettings_Clicked"
                     HorizontalOptions="Fill"
-                    VerticalOptions="End"></Button>
+                    VerticalOptions="End"
+                    IsVisible="{Binding Permitted, Converter={StaticResource inverseBool}}"></Button>
             </StackLayout>
         </StackLayout>
     </ScrollView>


### PR DESCRIPTION
Adjusted layout and logic of accessibility settings to better match the cleaner autofill service settings.  Screenshots from Nexus 5X to demonstrate with space restrictions:

<br>

### Screen 1: Both accessibility and the draw-over permission are disabled:

<br>

![01-all_off](https://user-images.githubusercontent.com/59324545/81340745-5ab03d80-907e-11ea-8ab4-79f2da5a81d3.png)

<br>

### Screen 2: Accessibility is enabled but the draw-over permission isn't:

<br>

![02-acc_on_drawover_off](https://user-images.githubusercontent.com/59324545/81340793-7287c180-907e-11ea-88c0-758ec1bbe9b0.png)

<br>

### Screen 3: Accessibility isn't enabled but the draw-over permission is (this is what most users will see if/when we're granted automatic draw-over permission from the play store):

<br>

![03-acc_off_drawover_on](https://user-images.githubusercontent.com/59324545/81340934-a8c54100-907e-11ea-8897-c5f4eb4d7d35.png)

<br>

### Screen 4: Both accessibility and draw-over permission are enabled:

<br>

![04-all_on](https://user-images.githubusercontent.com/59324545/81340957-bf6b9800-907e-11ea-8d23-997b0fe7739f.png)
