### PR TITLE
[WIP] Ability to create and display xamarin forms page in an ios extension

### DIFF
--- a/src/App/Pages/TestPage.xaml
+++ b/src/App/Pages/TestPage.xaml
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="UTF-8" ?>
+<pages:BaseContentPage
+    x:Class="Bit.App.Pages.TestPage"
+    xmlns="http://xamarin.com/schemas/2014/forms"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:pages="clr-namespace:Bit.App.Pages"
+    BackgroundColor="Orange">
+    <StackLayout HorizontalOptions="Center" VerticalOptions="Center">
+        <Label Text="{Binding TestProp}" />
+    </StackLayout>
+</pages:BaseContentPage>

--- a/src/App/Pages/TestPage.xaml.cs
+++ b/src/App/Pages/TestPage.xaml.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+
+using Xamarin.Forms;
+
+namespace Bit.App.Pages
+{
+    public partial class TestPage : BaseContentPage
+    {
+        public TestPage()
+        {
+            InitializeComponent();
+            BindingContext = new TestPageViewModel();
+        }
+    }
+}

--- a/src/App/Pages/TestPageViewModel.cs
+++ b/src/App/Pages/TestPageViewModel.cs
@@ -1,0 +1,7 @@
+﻿namespace Bit.App.Pages
+{
+    public class TestPageViewModel : BaseViewModel
+    {
+        public string TestProp { get; set; } = "Test Value From Xamarin.Forms View Model";
+    }
+}

--- a/src/iOS.Extension/LoadingViewController.cs
+++ b/src/iOS.Extension/LoadingViewController.cs
@@ -13,6 +13,8 @@ using Bit.iOS.Core.Models;
 using Bit.Core.Utilities;
 using Bit.Core.Abstractions;
 using Bit.App.Abstractions;
+using Bit.App.Pages;
+using Xamarin.Forms;
 
 namespace Bit.iOS.Extension
 {
@@ -59,6 +61,21 @@ namespace Bit.iOS.Extension
         public override void ViewDidAppear(bool animated)
         {
             base.ViewDidAppear(animated);
+
+            // Apply business logic and nativage to a XF page/flow
+            // Initialize Xamarin Forms
+            Xamarin.Forms.Forms.Init();
+            // Do NOT load application, because the flow was already activated natively
+            // Create pages, VMs, initialize data, services and the rest if needed
+            var testPage = new TestPage();
+            // The main trick is to convert XF page to a native view controller by calling CreateViewController method
+            var testController = testPage.CreateViewController();
+            // The rest is the same as with regular page
+            testController.ModalPresentationStyle = UIModalPresentationStyle.FullScreen;
+            testController.View.BackgroundColor = UIColor.Yellow;
+            PresentViewController(testController, false, null);
+            return;
+
             if (!IsAuthed())
             {
                 var alert = Dialogs.CreateAlert(null, AppResources.MustLogInMainApp, AppResources.Ok, (a) =>

--- a/src/iOS.Extension/iOS.Extension.csproj
+++ b/src/iOS.Extension/iOS.Extension.csproj
@@ -230,6 +230,9 @@
     <PackageReference Include="Microsoft.AppCenter.Crashes">
       <Version>3.2.1</Version>
     </PackageReference>
+    <PackageReference Include="Xamarin.Forms">
+      <Version>4.6.0.726</Version>
+    </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.AppExtension.CSharp.targets" />
 </Project>


### PR DESCRIPTION
This PR shows how to use Xamarin.Forms pages in an iOS extensions. This will allow to move all the native iOS controllers to the shared XF core and implement them with Xaml, MVVM and hot reload. 

The key steps are:

1. Add XF NuGet reference
1. initialize XF
2. Do NOT load XF app
3. Create XF pages and convert them to view controller with `CreateViewController` method
4. Stay alert on memory usage by your extension as XF will add memory pressure and extensions are strict on that.

I've tested on sim and device, in release configuration with enabled linker (SDK Only or All) the extension performs well, no issues found with this approach. 

![bitwarden-x](https://user-images.githubusercontent.com/3697084/81462328-9c1c1800-9166-11ea-8b5b-de2752e963b8.gif)
