### PR TITLE
fix typo in PINRequireMasterPasswordRestart

### DIFF
--- a/src/App/Resources/AppResources.af.resx
+++ b/src/App/Resources/AppResources.af.resx
@@ -1514,7 +1514,7 @@
     <value>Are you sure you want to exit Bitwarden?</value>
   </data>
   <data name="PINRequireMasterPasswordRestart" xml:space="preserve">
-    <value>You you want to require unlocking with your master password when the application is restarted?</value>
+    <value>Do you want to require unlocking with your master password when the application is restarted?</value>
   </data>
   <data name="Black" xml:space="preserve">
     <value>Black</value>

--- a/src/App/Resources/AppResources.de.resx
+++ b/src/App/Resources/AppResources.de.resx
@@ -1514,7 +1514,7 @@
     <value>Sind Sie sicher, dass Sie Bitwarden verlassen möchten?</value>
   </data>
   <data name="PINRequireMasterPasswordRestart" xml:space="preserve">
-    <value>You you want to require unlocking with your master password when the application is restarted?</value>
+    <value>Do you want to require unlocking with your master password when the application is restarted?</value>
   </data>
   <data name="Black" xml:space="preserve">
     <value>Schwarz</value>

--- a/src/App/Resources/AppResources.es.resx
+++ b/src/App/Resources/AppResources.es.resx
@@ -1514,7 +1514,7 @@
     <value>¿Estás seguro de que deseas salir de Bitwarden?</value>
   </data>
   <data name="PINRequireMasterPasswordRestart" xml:space="preserve">
-    <value>You you want to require unlocking with your master password when the application is restarted?</value>
+    <value>Do you want to require unlocking with your master password when the application is restarted?</value>
   </data>
   <data name="Black" xml:space="preserve">
     <value>Negro</value>

--- a/src/App/Resources/AppResources.et.resx
+++ b/src/App/Resources/AppResources.et.resx
@@ -1514,7 +1514,7 @@
     <value>Kas soovid tõesti Bitwardeni sulgeda?</value>
   </data>
   <data name="PINRequireMasterPasswordRestart" xml:space="preserve">
-    <value>You you want to require unlocking with your master password when the application is restarted?</value>
+    <value>Do you want to require unlocking with your master password when the application is restarted?</value>
   </data>
   <data name="Black" xml:space="preserve">
     <value>Must</value>

--- a/src/App/Resources/AppResources.fa.resx
+++ b/src/App/Resources/AppResources.fa.resx
@@ -1514,7 +1514,7 @@
     <value>آیا مطمئنید که می‌خواهید از Bitwarden خارج شوید؟</value>
   </data>
   <data name="PINRequireMasterPasswordRestart" xml:space="preserve">
-    <value>You you want to require unlocking with your master password when the application is restarted?</value>
+    <value>Do you want to require unlocking with your master password when the application is restarted?</value>
   </data>
   <data name="Black" xml:space="preserve">
     <value>سیاه</value>

--- a/src/App/Resources/AppResources.fi.resx
+++ b/src/App/Resources/AppResources.fi.resx
@@ -1514,7 +1514,7 @@
     <value>Oletko varma, että haluat poistua Bitwardenista?</value>
   </data>
   <data name="PINRequireMasterPasswordRestart" xml:space="preserve">
-    <value>You you want to require unlocking with your master password when the application is restarted?</value>
+    <value>Do you want to require unlocking with your master password when the application is restarted?</value>
   </data>
   <data name="Black" xml:space="preserve">
     <value>Musta</value>

--- a/src/App/Resources/AppResources.hu.resx
+++ b/src/App/Resources/AppResources.hu.resx
@@ -1514,7 +1514,7 @@
     <value>Biztos vagy benne, hogy kilépsz?</value>
   </data>
   <data name="PINRequireMasterPasswordRestart" xml:space="preserve">
-    <value>You you want to require unlocking with your master password when the application is restarted?</value>
+    <value>Do you want to require unlocking with your master password when the application is restarted?</value>
   </data>
   <data name="Black" xml:space="preserve">
     <value>Fekete</value>

--- a/src/App/Resources/AppResources.id.resx
+++ b/src/App/Resources/AppResources.id.resx
@@ -1514,7 +1514,7 @@
     <value>Apakah anda yakin ingin keluar dari Bitwarden?</value>
   </data>
   <data name="PINRequireMasterPasswordRestart" xml:space="preserve">
-    <value>You you want to require unlocking with your master password when the application is restarted?</value>
+    <value>Do you want to require unlocking with your master password when the application is restarted?</value>
   </data>
   <data name="Black" xml:space="preserve">
     <value>Hitam</value>

--- a/src/App/Resources/AppResources.it.resx
+++ b/src/App/Resources/AppResources.it.resx
@@ -1514,7 +1514,7 @@
     <value>Sei sicuro di voler uscire da Bitwarden?</value>
   </data>
   <data name="PINRequireMasterPasswordRestart" xml:space="preserve">
-    <value>You you want to require unlocking with your master password when the application is restarted?</value>
+    <value>Do you want to require unlocking with your master password when the application is restarted?</value>
   </data>
   <data name="Black" xml:space="preserve">
     <value>Nero</value>

--- a/src/App/Resources/AppResources.ko.resx
+++ b/src/App/Resources/AppResources.ko.resx
@@ -1514,7 +1514,7 @@
     <value>정말로 Bitwarden에서 나가시려는 건가요?</value>
   </data>
   <data name="PINRequireMasterPasswordRestart" xml:space="preserve">
-    <value>You you want to require unlocking with your master password when the application is restarted?</value>
+    <value>Do you want to require unlocking with your master password when the application is restarted?</value>
   </data>
   <data name="Black" xml:space="preserve">
     <value>검은 테마</value>

--- a/src/App/Resources/AppResources.nb.resx
+++ b/src/App/Resources/AppResources.nb.resx
@@ -1514,7 +1514,7 @@
     <value>Er du sikker på at du vil lukke Bitwarden?</value>
   </data>
   <data name="PINRequireMasterPasswordRestart" xml:space="preserve">
-    <value>You you want to require unlocking with your master password when the application is restarted?</value>
+    <value>Do you want to require unlocking with your master password when the application is restarted?</value>
   </data>
   <data name="Black" xml:space="preserve">
     <value>Svart</value>

--- a/src/App/Resources/AppResources.ro.resx
+++ b/src/App/Resources/AppResources.ro.resx
@@ -1514,7 +1514,7 @@
     <value>Sunteți sigur că doriți să ieșiți?</value>
   </data>
   <data name="PINRequireMasterPasswordRestart" xml:space="preserve">
-    <value>You you want to require unlocking with your master password when the application is restarted?</value>
+    <value>Do you want to require unlocking with your master password when the application is restarted?</value>
   </data>
   <data name="Black" xml:space="preserve">
     <value>Neagră</value>

--- a/src/App/Resources/AppResources.sk.resx
+++ b/src/App/Resources/AppResources.sk.resx
@@ -1514,7 +1514,7 @@
     <value>Naozaj chcete ukončiť Bitwarden?</value>
   </data>
   <data name="PINRequireMasterPasswordRestart" xml:space="preserve">
-    <value>You you want to require unlocking with your master password when the application is restarted?</value>
+    <value>Do you want to require unlocking with your master password when the application is restarted?</value>
   </data>
   <data name="Black" xml:space="preserve">
     <value>Čierna</value>

--- a/src/App/Resources/AppResources.th.resx
+++ b/src/App/Resources/AppResources.th.resx
@@ -1514,7 +1514,7 @@
     <value>Are you sure you want to exit Bitwarden?</value>
   </data>
   <data name="PINRequireMasterPasswordRestart" xml:space="preserve">
-    <value>You you want to require unlocking with your master password when the application is restarted?</value>
+    <value>Do you want to require unlocking with your master password when the application is restarted?</value>
   </data>
   <data name="Black" xml:space="preserve">
     <value>Black</value>

--- a/src/App/Resources/AppResources.vi.resx
+++ b/src/App/Resources/AppResources.vi.resx
@@ -1514,7 +1514,7 @@
     <value>Are you sure you want to exit Bitwarden?</value>
   </data>
   <data name="PINRequireMasterPasswordRestart" xml:space="preserve">
-    <value>You you want to require unlocking with your master password when the application is restarted?</value>
+    <value>Do you want to require unlocking with your master password when the application is restarted?</value>
   </data>
   <data name="Black" xml:space="preserve">
     <value>Black</value>

--- a/src/App/Resources/AppResources.zh-Hans.resx
+++ b/src/App/Resources/AppResources.zh-Hans.resx
@@ -1514,7 +1514,7 @@
     <value>您确定要退出 Bitwarden？</value>
   </data>
   <data name="PINRequireMasterPasswordRestart" xml:space="preserve">
-    <value>You you want to require unlocking with your master password when the application is restarted?</value>
+    <value>Do you want to require unlocking with your master password when the application is restarted?</value>
   </data>
   <data name="Black" xml:space="preserve">
     <value>黑色</value>


### PR DESCRIPTION
I fixed a typo in the `PINRequireMasterPasswordRestart` popup message. It was present in all languages.