### PR TITLE
lock screen drawing & 2FA entry bugfixes

### DIFF
--- a/src/App/App.xaml.cs
+++ b/src/App/App.xaml.cs
@@ -234,13 +234,6 @@ namespace Bit.App
             SyncIfNeeded();
             if (Current.MainPage is NavigationPage navPage && navPage.CurrentPage is LockPage lockPage)
             {
-                if (Device.RuntimePlatform == Device.Android)
-                {
-                    // Workaround for https://github.com/xamarin/Xamarin.Forms/issues/7478
-                    await Task.Delay(100);
-                    Current.MainPage = new NavigationPage(lockPage);
-                    // End workaround
-                }
                 await lockPage.PromptFingerprintAfterResumeAsync();
             }
         }

--- a/src/App/Pages/Accounts/TwoFactorPage.xaml.cs
+++ b/src/App/Pages/Accounts/TwoFactorPage.xaml.cs
@@ -81,7 +81,7 @@ namespace Bit.App.Pages
                     }
                 }
             });
-            
+
             await LoadOnAppearedAsync(_scrollView, true, () =>
             {
                 if (!_inited)

--- a/src/App/Pages/Accounts/TwoFactorPage.xaml.cs
+++ b/src/App/Pages/Accounts/TwoFactorPage.xaml.cs
@@ -81,20 +81,20 @@ namespace Bit.App.Pages
                     }
                 }
             });
-
-            if (!_inited)
+            
+            await LoadOnAppearedAsync(_scrollView, true, () =>
             {
-                _inited = true;
-                await LoadOnAppearedAsync(_scrollView, true, () =>
+                if (!_inited)
                 {
+                    _inited = true;
                     _vm.Init();
-                    if (_vm.TotpMethod)
-                    {
-                        RequestFocus(_totpEntry);
-                    }
-                    return Task.FromResult(0);
-                });
-            }
+                }
+                if (_vm.TotpMethod)
+                {
+                    RequestFocus(_totpEntry);
+                }
+                return Task.FromResult(0);
+            });
         }
 
         protected override void OnDisappearing()


### PR DESCRIPTION
**TwoFactorPage.xaml.cs** - The focus request would only ever happen once since it was behind the `!_inited` condition.  Changed this to always perform the focus request in `OnAppearing()` while only restricting `_vm.Init()` to the `!_inited` condition.  Fixes #905 

**App.xaml.cs** - removed the workaround added mid-December.  The Xamarin.Forms issue linked was closed on Feb 11, and the Forms updates since then were no longer reacting well to the workaround, resulting in what appeared to be an empty instance of the lockPage instead of the one already available.  Fixes #906 