### PR TITLE
Removal of lifecycle hack for 2FA resume flow

### DIFF
--- a/src/App/App.xaml.cs
+++ b/src/App/App.xaml.cs
@@ -153,27 +153,6 @@ namespace Bit.App
             });
         }
         
-        // Workaround for https://github.com/xamarin/Xamarin.Forms/issues/7478
-        // Fixed in last Xamarin.Forms 4.4.0.x - remove this hack after updating
-        public static void WaitForResume()
-        {
-            var checkFrequencyInMillis = 100;
-            var maxTimeInMillis = 5000;
-            
-            var count = 0;
-            while (!_isResumed)
-            {
-                Task.Delay(checkFrequencyInMillis).Wait();
-                count += checkFrequencyInMillis;
-                
-                // don't let this run forever
-                if (count >= maxTimeInMillis)
-                {
-                    break;
-                }
-            }
-        }
-
         protected async override void OnStart()
         {
             System.Diagnostics.Debug.WriteLine("XF App: OnStart");

--- a/src/App/Pages/Accounts/TwoFactorPageViewModel.cs
+++ b/src/App/Pages/Accounts/TwoFactorPageViewModel.cs
@@ -143,7 +143,6 @@ namespace Bit.App.Pages
                     page.DuoWebView.RegisterAction(sig =>
                     {
                         Token = sig;
-                        App.WaitForResume();
                         Device.BeginInvokeOnMainThread(async () => await SubmitAsync());
                     });
                     break;


### PR DESCRIPTION
Confirmed this is no longer necessary with the version of Forms we're using.  (Flow is also snappier without the hack, making for an improved experience)