### PR TITLE
Workaround for pasting into editor within scrollview

### DIFF
--- a/src/Android/Renderers/CustomEditorRenderer.cs
+++ b/src/Android/Renderers/CustomEditorRenderer.cs
@@ -12,6 +12,15 @@ namespace Bit.Droid.Renderers
         public CustomEditorRenderer(Context context)
             : base(context)
         { }
+        
+        // Workaround for issue described here:
+        // https://github.com/xamarin/Xamarin.Forms/issues/8291#issuecomment-617456651
+        protected override void OnAttachedToWindow()
+        {
+            base.OnAttachedToWindow();
+            EditText.Enabled = false;
+            EditText.Enabled = true;
+        }
 
         protected override void OnElementChanged(ElementChangedEventArgs<Editor> e)
         {


### PR DESCRIPTION
Workaround provided by Xamarin team for allowing long-press-in-editor-within-scrollview system prompts to appear (copy/paste/etc).  Fixes #747 
