### PR TITLE
Add support for Privacy Browser (Free/Standard). Closes #407

### DIFF
--- a/src/Android/Accessibility/AccessibilityHelpers.cs
+++ b/src/Android/Accessibility/AccessibilityHelpers.cs
@@ -59,6 +59,8 @@ namespace Bit.Droid.Accessibility
             new Browser("com.qwant.liberty", "url_bar_title"),
             new Browser("com.sec.android.app.sbrowser", "location_bar_edit_text"),
             new Browser("com.sec.android.app.sbrowser.beta", "location_bar_edit_text"),
+            new Browser("com.stoutner.privacybrowser.free", "url_edittext"),
+            new Browser("com.stoutner.privacybrowser.standard", "url_edittext"),
             new Browser("com.vivaldi.browser", "url_bar"),
             new Browser("com.vivaldi.browser.snapshot", "url_bar"),
             new Browser("com.vivaldi.browser.sopranos", "url_bar"),

--- a/src/Android/Autofill/AutofillHelpers.cs
+++ b/src/Android/Autofill/AutofillHelpers.cs
@@ -65,6 +65,8 @@ namespace Bit.Droid.Autofill
             "com.qwant.liberty",
             "com.sec.android.app.sbrowser",
             "com.sec.android.app.sbrowser.beta",
+            "com.stoutner.privacybrowser.free",
+            "com.stoutner.privacybrowser.standard",
             "com.vivaldi.browser",
             "com.vivaldi.browser.snapshot",
             "com.vivaldi.browser.sopranos",

--- a/src/Android/Resources/xml/autofillservice.xml
+++ b/src/Android/Resources/xml/autofillservice.xml
@@ -92,6 +92,12 @@
     android:name="com.sec.android.app.sbrowser.beta"
     android:maxLongVersionCode="10000000000"/>
   <compatibility-package
+    android:name="com.stoutner.privacybrowser.free"
+    android:maxLongVersionCode="10000000000"/>
+  <compatibility-package
+    android:name="com.stoutner.privacybrowser.standard"
+    android:maxLongVersionCode="10000000000"/>
+  <compatibility-package
     android:name="com.vivaldi.browser"
     android:maxLongVersionCode="10000000000"/>
   <compatibility-package


### PR DESCRIPTION
![Privacy_Browser_logo](https://user-images.githubusercontent.com/4764956/82714498-2bf5b200-9c8f-11ea-9061-71ceea87ce71.png)
___

### This:
- adds compatibility for **[Privacy Browser (Free)](https://play.google.com/store/apps/details?id=com.stoutner.privacybrowser.free)** (`com.stoutner.privacybrowser.free`) and
- adds compatibility for **[Privacy Browser (Standard)](https://play.google.com/store/apps/details?id=com.stoutner.privacybrowser.standard)** (`com.stoutner.privacybrowser.standard`).
&nbsp;

:heavy_check_mark: The resource-id value (`url_edittext`) has been checked.

:arrow_right: Only on the **Free** version though.
:arrow_right_hook: But is more than certainly the same on the **Standard** version, the latter being mainly a paid ad-free version. See the `Privacy Browser Free Advertisements` section of their [Privacy Policy](https://www.stoutner.com/privacy-browser/privacy-policy/) page.
&nbsp;

<details>
  <summary>Read more ...</summary>

### Screenshot (for _resource-id_ value)
![Privacy_Browser_Free_resource-id](https://user-images.githubusercontent.com/4764956/82714268-1af87100-9c8e-11ea-8ad0-50e6848f53d3.png)
:arrow_right: `com.stoutner.privacybrowser.free:id/` **`url_edittext`**

### Remark
Note that, on this browser, like many alternative browsers (even from big names like **Avast**), there is a known problem (which you know well). Namely, if you scroll a long page, the URL bar hides but does not reappear when you click in a password field. This poses a problem for password managers to detect the URL of the web page (for users using the accessibility service). Fortunately, most websites put their login fields at the top of the page, especially on the pages dedicated to logging in. Allowing users not to be confronted with this problem.

### Remark (demo)
:arrow_double_down: To simulate the problem on a website yet correctly coded concerning this, I zoomed the page and scrolled it slightly, to hide the URL bar _(screenshot 1)_. Then clicked in the password field _(screenshot 2)_.

#### On Google Chrome (handling this correctly) :+1:
<details>
  <summary>View me ...</summary>

&nbsp;
![Screenshot_1589904732](https://user-images.githubusercontent.com/4764956/82715145-22217e00-9c92-11ea-9bbe-a635e46caa3f.png)

![Screenshot_1589904752](https://user-images.githubusercontent.com/4764956/82715148-2352ab00-9c92-11ea-9601-4530c5034419.png)

</details>

#### On Mozilla Firefox (handling this correctly) :+1:
<details>
  <summary>View me ...</summary>

&nbsp;
![Screenshot_1589905587](https://user-images.githubusercontent.com/4764956/82716808-ab887e80-9c99-11ea-8468-11f5bd62c405.png)

![Screenshot_1589905593](https://user-images.githubusercontent.com/4764956/82716810-ad524200-9c99-11ea-8da8-179cb97a5992.png)

</details>

#### On Privacy Browser (not handling this correctly) :octocat:
<details>
  <summary>View me ...</summary>

&nbsp;
![1-Screenshot_1589905800](https://user-images.githubusercontent.com/4764956/82715167-3cf3f280-9c92-11ea-97ff-cd5d37918574.png)

![2-Screenshot_1589905805](https://user-images.githubusercontent.com/4764956/82715170-3f564c80-9c92-11ea-9393-847965db6a90.png)

</details>

</details>

___
Closes #407