### PR TITLE
Adblock Browser: clarification

### DIFF
--- a/src/Android/Accessibility/AccessibilityHelpers.cs
+++ b/src/Android/Accessibility/AccessibilityHelpers.cs
@@ -67,8 +67,8 @@ namespace Bit.Droid.Accessibility
             new Browser("com.yandex.browser", "bro_omnibar_address_title_text,bro_omnibox_collapsed_title",
                 (s) => s.Split(new char[]{' ', ' '}).FirstOrDefault()), // 0 = Regular Space, 1 = No-break space (00A0)
             new Browser("mark.via.gp", "aw"),
-            new Browser("org.adblockplus.browser", "url_bar,url_bar_title"),
-            new Browser("org.adblockplus.browser.beta", "url_bar,url_bar_title"),
+            new Browser("org.adblockplus.browser", "url_bar,url_bar_title"), // 2nd = Legacy (before v2)
+            new Browser("org.adblockplus.browser.beta", "url_bar,url_bar_title"), // 2nd = Legacy (before v2)
             new Browser("org.bromite.bromite", "url_bar"),
             new Browser("org.chromium.chrome", "url_bar"),
             new Browser("org.codeaurora.swe.browser", "url_bar"),


### PR DESCRIPTION
This adds a comment clarifying that the second entry of the resource-id value for "Adblock Browser" is not another current possibility, but an entry kept for reasons of compatibility with the previous versions (those before version 2 — _which were based on Firefox for Android_).

:arrow_right: This entry can therefore be safely withdrawn in the future. :heavy_check_mark: