### PR TITLE
Fix support for Firefox Nightly for Developers

### DIFF
--- a/src/Android/Accessibility/AccessibilityHelpers.cs
+++ b/src/Android/Accessibility/AccessibilityHelpers.cs
@@ -75,8 +75,8 @@ namespace Bit.Droid.Accessibility
             new Browser("org.gnu.icecat", "url_bar_title"),
             new Browser("org.mozilla.fenix", "mozac_browser_toolbar_url_view"),
             new Browser("org.mozilla.fenix.nightly", "mozac_browser_toolbar_url_view"),
-            new Browser("org.mozilla.fennec_aurora", "url_bar_title"),
-            new Browser("org.mozilla.fennec_fdroid", "url_bar_title"),
+            new Browser("org.mozilla.fennec_aurora", "mozac_browser_toolbar_url_view,url_bar_title"), // 2nd = Legacy
+            new Browser("org.mozilla.fennec_fdroid", "mozac_browser_toolbar_url_view,url_bar_title"), // 2nd = Legacy
             new Browser("org.mozilla.firefox", "url_bar_title"),
             new Browser("org.mozilla.firefox_beta", "url_bar_title"),
             new Browser("org.mozilla.focus", "display_url"),


### PR DESCRIPTION
This fixes support for (new versions of) **Firefox Nightly for Developers** (see [here](https://play.google.com/store/apps/details?id=org.mozilla.fennec_aurora&hl=en) ~~and [here](https://f-droid.org/en/packages/org.mozilla.fennec_fdroid/)~~). :heavy_check_mark:

:arrow_right_hook: **UPDATE:** See PR https://github.com/bitwarden/mobile-maui/pull/919 (Partial revert of "Fix support for Firefox Nightly for Developers").

## Screenshot (for _resource-id_ value)
<details>
  <summary>View me ...</summary>

&nbsp;
![Firefox_Nightly_for_Developers_resource-id_update](https://user-images.githubusercontent.com/4764956/82720536-ca483e80-9cb4-11ea-8fe0-ae1a8a586471.png)
:arrow_right: `org.mozilla.fennec_aurora:id/` **`mozac_browser_toolbar_url_view`**

</details>

## Screenshots (tested version, installed a few days ago)
<details>
  <summary>View me ...</summary>

### Screenshot 1 of 3
![1-Screenshot_1589898028](https://user-images.githubusercontent.com/4764956/82720593-214e1380-9cb5-11ea-8dca-7fe12b3b1688.png)

### Screenshot 2 of 3
![2-Screenshot_1589898922](https://user-images.githubusercontent.com/4764956/82720594-2317d700-9cb5-11ea-99af-357a35e1ee0b.png)

### Screenshot 3 of 3
![3-Screenshot_1589898037](https://user-images.githubusercontent.com/4764956/82720595-24e19a80-9cb5-11ea-9a54-94d41c1b4f84.png)

</details>