### PR TITLE
Fix support for Firefox Beta

### DIFF
--- a/src/Android/Accessibility/AccessibilityHelpers.cs
+++ b/src/Android/Accessibility/AccessibilityHelpers.cs
@@ -78,7 +78,7 @@ namespace Bit.Droid.Accessibility
             new Browser("org.mozilla.fennec_aurora", "mozac_browser_toolbar_url_view,url_bar_title"), // 2nd = Legacy
             new Browser("org.mozilla.fennec_fdroid", "mozac_browser_toolbar_url_view,url_bar_title"), // 2nd = Legacy
             new Browser("org.mozilla.firefox", "url_bar_title"),
-            new Browser("org.mozilla.firefox_beta", "url_bar_title"),
+            new Browser("org.mozilla.firefox_beta", "mozac_browser_toolbar_url_view,url_bar_title"), // 2nd = Legacy
             new Browser("org.mozilla.focus", "display_url"),
             new Browser("org.mozilla.klar", "display_url"),
             new Browser("org.mozilla.reference.browser", "mozac_browser_toolbar_url_view"),


### PR DESCRIPTION
This fixes support for (new versions of) [Firefox Beta](https://play.google.com/store/apps/details?id=org.mozilla.firefox_beta). :heavy_check_mark:

## Screenshot (for _resource-id_ value)
<details>
  <summary>View me ...</summary>

&nbsp;
![Firefox_Beta_resource-id_update](https://user-images.githubusercontent.com/4764956/82721376-ebad2880-9cbc-11ea-9287-159051426e6a.png)
:arrow_right: `org.mozilla.firefox_beta:id/` **`mozac_browser_toolbar_url_view`**

</details>

## Screenshots (tested version, installed a few days ago)
<details>
  <summary>View me ...</summary>

### Screenshot 1 of 3
![1-Screenshot_1589899968](https://user-images.githubusercontent.com/4764956/82721390-fff12580-9cbc-11ea-8e5f-a05de7a91854.png)

### Screenshot 2 of 3
![2-Screenshot_1589899982](https://user-images.githubusercontent.com/4764956/82721393-04b5d980-9cbd-11ea-8d06-18154fda4ccf.png)

### Screenshot 3 of 3
![3-Screenshot_1589899995](https://user-images.githubusercontent.com/4764956/82721398-0a132400-9cbd-11ea-8502-c564a1d9fff7.png)

</details>