### PR TITLE
Early support for future versions of Firefox (+ some forks)

### DIFF
--- a/src/Android/Accessibility/AccessibilityHelpers.cs
+++ b/src/Android/Accessibility/AccessibilityHelpers.cs
@@ -77,7 +77,7 @@ namespace Bit.Droid.Accessibility
             new Browser("org.mozilla.fenix.nightly", "mozac_browser_toolbar_url_view"),
             new Browser("org.mozilla.fennec_aurora", "mozac_browser_toolbar_url_view,url_bar_title"), // 2nd = Legacy
             new Browser("org.mozilla.fennec_fdroid", "url_bar_title"),
-            new Browser("org.mozilla.firefox", "url_bar_title"),
+            new Browser("org.mozilla.firefox", "url_bar_title,mozac_browser_toolbar_url_view"), // 2nd = Anticipation
             new Browser("org.mozilla.firefox_beta", "mozac_browser_toolbar_url_view,url_bar_title"), // 2nd = Legacy
             new Browser("org.mozilla.focus", "display_url"),
             new Browser("org.mozilla.klar", "display_url"),

--- a/src/Android/Accessibility/AccessibilityHelpers.cs
+++ b/src/Android/Accessibility/AccessibilityHelpers.cs
@@ -56,7 +56,7 @@ namespace Bit.Droid.Accessibility
             new Browser("com.opera.mini.native", "url_field"),
             new Browser("com.opera.mini.native.beta", "url_field"),
             new Browser("com.opera.touch", "addressbarEdit"),
-            new Browser("com.qwant.liberty", "url_bar_title"),
+            new Browser("com.qwant.liberty", "url_bar_title,mozac_browser_toolbar_url_view"), // 2nd = Anticipation
             new Browser("com.sec.android.app.sbrowser", "location_bar_edit_text"),
             new Browser("com.sec.android.app.sbrowser.beta", "location_bar_edit_text"),
             new Browser("com.stoutner.privacybrowser.free", "url_edittext"),
@@ -72,19 +72,19 @@ namespace Bit.Droid.Accessibility
             new Browser("org.bromite.bromite", "url_bar"),
             new Browser("org.chromium.chrome", "url_bar"),
             new Browser("org.codeaurora.swe.browser", "url_bar"),
-            new Browser("org.gnu.icecat", "url_bar_title"),
+            new Browser("org.gnu.icecat", "url_bar_title,mozac_browser_toolbar_url_view"), // 2nd = Anticipation
             new Browser("org.mozilla.fenix", "mozac_browser_toolbar_url_view"),
             new Browser("org.mozilla.fenix.nightly", "mozac_browser_toolbar_url_view"),
             new Browser("org.mozilla.fennec_aurora", "mozac_browser_toolbar_url_view,url_bar_title"), // 2nd = Legacy
-            new Browser("org.mozilla.fennec_fdroid", "url_bar_title"),
+            new Browser("org.mozilla.fennec_fdroid", "url_bar_title,mozac_browser_toolbar_url_view"), // 2nd = Anticipation
             new Browser("org.mozilla.firefox", "url_bar_title,mozac_browser_toolbar_url_view"), // 2nd = Anticipation
             new Browser("org.mozilla.firefox_beta", "mozac_browser_toolbar_url_view,url_bar_title"), // 2nd = Legacy
             new Browser("org.mozilla.focus", "display_url"),
             new Browser("org.mozilla.klar", "display_url"),
             new Browser("org.mozilla.reference.browser", "mozac_browser_toolbar_url_view"),
             new Browser("org.mozilla.rocket", "display_url"),
-            new Browser("org.torproject.torbrowser", "url_bar_title"),
-            new Browser("org.torproject.torbrowser_alpha", "url_bar_title"),
+            new Browser("org.torproject.torbrowser", "url_bar_title,mozac_browser_toolbar_url_view"), // 2nd = Anticipation
+            new Browser("org.torproject.torbrowser_alpha", "url_bar_title,mozac_browser_toolbar_url_view"), // 2nd = Anticipation
 
             // [Section B] Entries only present here
             //


### PR DESCRIPTION
## Observation / Deduction
The resource-id value progressively goes from `url_bar_title` to `mozac_browser_toolbar_url_view` in Firefox browsers.

In the order of their appearance, it seems to be: `org.mozilla.fenix.nightly` **->** `org.mozilla.fenix` and then `org.mozilla.fennec_aurora` **->** `org.mozilla.firefox_beta`.

:arrow_right_hook: We can therefore easily deduce that the next on the list will be `org.mozilla.firefox` very soon<sup>*</sup>.

###### <sup>*</sup> Recently tested and this is not yet the case, for information.

## Therefore ...
This PR adds this new resource-id value:
  - for `org.mozilla.firefox` _in anticipation_ (this is specified) and
  - for some Firefox forks<sup>*</sup> _in anticipation_ (also specified).

###### <sup>*</sup> Those that use the same resource-id value as the one used by Firefox, i.e. `url_bar_title`.

## Additional information
Ideally, a swapping of the two entries of these resource-id values will be done when the time comes; `url_bar_title` becoming Legacy.