### PR TITLE
Dispose of LiteDatabase instance

### DIFF
--- a/src/App/Services/MobileStorageService.cs
+++ b/src/App/Services/MobileStorageService.cs
@@ -1,11 +1,12 @@
 ﻿using Bit.Core;
 using Bit.Core.Abstractions;
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace Bit.App.Services
 {
-    public class MobileStorageService : IStorageService
+    public class MobileStorageService : IStorageService, IDisposable
     {
         private readonly IStorageService _preferencesStorageService;
         private readonly IStorageService _liteDbStorageService;
@@ -87,6 +88,18 @@ namespace Bit.App.Services
                 return _preferencesStorageService.RemoveAsync(key);
             }
             return _liteDbStorageService.RemoveAsync(key);
+        }
+
+        public void Dispose()
+        {
+            if (_liteDbStorageService is IDisposable disposableLiteDbService)
+            {
+                disposableLiteDbService.Dispose();
+            }
+            if (_preferencesStorageService is IDisposable disposablePrefService)
+            {
+                disposablePrefService.Dispose();
+            }
         }
     }
 }

--- a/src/Core/Utilities/ServiceContainer.cs
+++ b/src/Core/Utilities/ServiceContainer.cs
@@ -113,6 +113,13 @@ namespace Bit.Core.Utilities
 
         public static void Reset()
         {
+            foreach (var service in RegisteredServices)
+            {
+                if (service.Value != null && service.Value is IDisposable disposableService)
+                {
+                    disposableService.Dispose();
+                }
+            }
             Inited = false;
             RegisteredServices.Clear();
             RegisteredServices = new Dictionary<string, object>();


### PR DESCRIPTION
LiteDB broke something in latest update. We now need to properly dispose of the database object or we get exceptions on file locking when trying to re-construct.