### PR TITLE
[Auto Logout] Update lock option to be default value

### DIFF
--- a/src/App/App.xaml.cs
+++ b/src/App/App.xaml.cs
@@ -339,13 +339,13 @@ namespace Bit.App
             else if (vaultTimeout == 0)
             {
                 var action = await _storageService.GetAsync<string>(Constants.VaultTimeoutActionKey);
-                if (action == "lock")
+                if (action == "logOut")
                 {
-                    await _vaultTimeoutService.LockAsync(true);
+                    await _vaultTimeoutService.LogOutAsync();
                 }
                 else
                 {
-                    await _vaultTimeoutService.LogOutAsync();
+                    await _vaultTimeoutService.LockAsync(true);   
                 }
             }
         }

--- a/src/App/App.xaml.cs
+++ b/src/App/App.xaml.cs
@@ -345,7 +345,7 @@ namespace Bit.App
                 }
                 else
                 {
-                    await _vaultTimeoutService.LockAsync(true);   
+                    await _vaultTimeoutService.LockAsync(true);
                 }
             }
         }

--- a/src/App/Pages/Settings/SettingsPage/SettingsPageViewModel.cs
+++ b/src/App/Pages/Settings/SettingsPage/SettingsPageViewModel.cs
@@ -79,7 +79,7 @@ namespace Bit.App.Pages
             }
             var timeout = await _storageService.GetAsync<int?>(Constants.VaultTimeoutKey);
             _vaultTimeoutDisplayValue = _vaultTimeouts.FirstOrDefault(o => o.Value == timeout).Key;
-            var action = await _storageService.GetAsync<string>(Constants.VaultTimeoutActionKey);
+            var action = await _storageService.GetAsync<string>(Constants.VaultTimeoutActionKey) ?? "lock";
             _vaultTimeoutActionDisplayValue = _vaultTimeoutActions.FirstOrDefault(o => o.Value == action).Key;
             var pinSet = await _vaultTimeoutService.IsPinLockSetAsync();
             _pin = pinSet.Item1 || pinSet.Item2;

--- a/src/Core/Services/VaultTimeoutService.cs
+++ b/src/Core/Services/VaultTimeoutService.cs
@@ -100,13 +100,13 @@ namespace Bit.Core.Services
             {
                 // Pivot based on saved action
                 var action = await _storageService.GetAsync<string>(Constants.VaultTimeoutActionKey);
-                if (action == "lock")
+                if (action == "logOut")
                 {
-                    await LockAsync(true);
+                    await LogOutAsync();
                 }
                 else
                 {
-                    await LogOutAsync();
+                    await LockAsync(true);
                 }
             }
         }


### PR DESCRIPTION
## Objective
> Make sure that the `lock` option is the default value even if the setting has not been explicitly set and/or the app is updated instead of cleanly installed.

## Code Changes
- **App.xaml.cs**: Changed conditional logic to make lock option the default action
- **SettingsPageViewModel.cs**: Added default for `lock` if saved action was null
- **VaultTimeoutService.cs**: Changed conditional logic to make lock option the default action