### PR TITLE
Avoid Task.Result usage

### DIFF
--- a/src/App/Pages/Settings/ExportVaultPageViewModel.cs
+++ b/src/App/Pages/Settings/ExportVaultPageViewModel.cs
@@ -100,10 +100,10 @@ namespace Bit.App.Pages
             {
                 try
                 {
-                    var data = _exportService.GetExport(FileFormatOptions[FileFormatSelectedIndex].Key);
+                    var data = await _exportService.GetExport(FileFormatOptions[FileFormatSelectedIndex].Key);
                     var fileFormat = FileFormatOptions[FileFormatSelectedIndex].Key;
                     _defaultFilename = _exportService.GetFileName(null, fileFormat);
-                    _exportResult = Encoding.ASCII.GetBytes(data.Result);
+                    _exportResult = Encoding.ASCII.GetBytes(data);
 
                     if (!_deviceActionService.SaveFile(_exportResult, null, _defaultFilename, null))
                     {


### PR DESCRIPTION
Avoid Task.Result usage in application in apps with the UI thread, this can cause deadlocks, await a task instead.