### PR TITLE
check app options ios extension on nfc check

### DIFF
--- a/src/App/App.xaml.cs
+++ b/src/App/App.xaml.cs
@@ -43,7 +43,7 @@ namespace Bit.App
         public App(AppOptions appOptions)
         {
             Options = appOptions ?? new AppOptions();
-            if (Options.EmptyApp)
+            if (Options.IosExtension)
             {
                 Current = this;
                 return;

--- a/src/App/Models/AppOptions.cs
+++ b/src/App/Models/AppOptions.cs
@@ -18,6 +18,6 @@ namespace Bit.App.Models
         public string SaveCardExpMonth { get; set; }
         public string SaveCardExpYear { get; set; }
         public string SaveCardCode { get; set; }
-        public bool EmptyApp { get; set; }
+        public bool IosExtension { get; set; }
     }
 }

--- a/src/iOS.Autofill/CredentialProviderViewController.cs
+++ b/src/iOS.Autofill/CredentialProviderViewController.cs
@@ -291,7 +291,7 @@ namespace Bit.iOS.Autofill
         private void LaunchLoginFlow()
         {
             var loginPage = new LoginPage();
-            var app = new App.App(new AppOptions { EmptyApp = true });
+            var app = new App.App(new AppOptions { IosExtension = true });
             ThemeManager.SetTheme(false, app.Resources);
             ThemeManager.ApplyResourcesToPage(loginPage);
             if (loginPage.BindingContext is LoginPageViewModel vm)
@@ -311,7 +311,7 @@ namespace Bit.iOS.Autofill
         private void LaunchTwoFactorFlow()
         {
             var twoFactorPage = new TwoFactorPage();
-            var app = new App.App(new AppOptions { EmptyApp = true });
+            var app = new App.App(new AppOptions { IosExtension = true });
             ThemeManager.SetTheme(false, app.Resources);
             ThemeManager.ApplyResourcesToPage(twoFactorPage);
             if (twoFactorPage.BindingContext is TwoFactorPageViewModel vm)

--- a/src/iOS.Core/Services/DeviceActionService.cs
+++ b/src/iOS.Core/Services/DeviceActionService.cs
@@ -295,7 +295,11 @@ namespace Bit.iOS.Core.Services
 
         public bool SupportsNfc()
         {
-            return CoreNFC.NFCNdefReaderSession.ReadingAvailable;
+            if(Application.Current is App.App currentApp && !currentApp.Options.IosExtension)
+            {
+                return CoreNFC.NFCNdefReaderSession.ReadingAvailable;
+            }
+            return false;
         }
 
         public bool SupportsCamera()
@@ -350,7 +354,7 @@ namespace Bit.iOS.Core.Services
         public Task<string> DisplayActionSheetAsync(string title, string cancel, string destruction,
             params string[] buttons)
         {
-            if (Application.Current is App.App app && app.Options != null && !app.Options.EmptyApp)
+            if (Application.Current is App.App app && app.Options != null && !app.Options.IosExtension)
             {
                 return app.MainPage.DisplayActionSheet(title, cancel, destruction, buttons);
             }

--- a/src/iOS.Extension/LoadingViewController.cs
+++ b/src/iOS.Extension/LoadingViewController.cs
@@ -423,7 +423,7 @@ namespace Bit.iOS.Extension
         private void LaunchLoginFlow()
         {
             var loginPage = new LoginPage();
-            var app = new App.App(new AppOptions { EmptyApp = true });
+            var app = new App.App(new AppOptions { IosExtension = true });
             ThemeManager.SetTheme(false, app.Resources);
             ThemeManager.ApplyResourcesToPage(loginPage);
             if (loginPage.BindingContext is LoginPageViewModel vm)
@@ -443,7 +443,7 @@ namespace Bit.iOS.Extension
         private void LaunchTwoFactorFlow()
         {
             var twoFactorPage = new TwoFactorPage();
-            var app = new App.App(new AppOptions { EmptyApp = true });
+            var app = new App.App(new AppOptions { IosExtension = true });
             ThemeManager.SetTheme(false, app.Resources);
             ThemeManager.ApplyResourcesToPage(twoFactorPage);
             if (twoFactorPage.BindingContext is TwoFactorPageViewModel vm)


### PR DESCRIPTION
- Rename EmptyApp option to IosExtension since that's what it's really for
- Add IosExtension check to SupportsNfc checks