### PR TITLE
Don't build the keyboard index for autofill if using logout action

### DIFF
--- a/src/App/Pages/Settings/SettingsPage/SettingsPageViewModel.cs
+++ b/src/App/Pages/Settings/SettingsPage/SettingsPageViewModel.cs
@@ -112,7 +112,7 @@ namespace Bit.App.Pages
             {
                 fingerprint = await _cryptoService.GetFingerprintAsync(await _userService.GetUserIdAsync());
             }
-            catch (Exception e) when(e.Message == "No public key available.")
+            catch (Exception e) when (e.Message == "No public key available.")
             {
                 return;
             }
@@ -193,8 +193,10 @@ namespace Bit.App.Pages
 
         public async Task VaultTimeoutAsync()
         {
-            var options = _vaultTimeouts.Select(o => o.Key == _vaultTimeoutDisplayValue ? $"✓ {o.Key}" : o.Key).ToArray();
-            var selection = await Page.DisplayActionSheet(AppResources.VaultTimeout, AppResources.Cancel, null, options);
+            var options = _vaultTimeouts.Select(
+                o => o.Key == _vaultTimeoutDisplayValue ? $"✓ {o.Key}" : o.Key).ToArray();
+            var selection = await Page.DisplayActionSheet(AppResources.VaultTimeout,
+                AppResources.Cancel, null, options);
             if (selection == null || selection == AppResources.Cancel)
             {
                 return;
@@ -206,11 +208,13 @@ namespace Bit.App.Pages
                 GetVaultTimeoutActionFromKey(_vaultTimeoutActionDisplayValue));
             BuildList();
         }
-        
+
         public async Task VaultTimeoutActionAsync()
         {
-            var options = _vaultTimeoutActions.Select(o => o.Key == _vaultTimeoutActionDisplayValue ? $"✓ {o.Key}" : o.Key).ToArray();
-            var selection = await Page.DisplayActionSheet(AppResources.VaultTimeoutAction, AppResources.Cancel, null, options);
+            var options = _vaultTimeoutActions.Select(o =>
+                o.Key == _vaultTimeoutActionDisplayValue ? $"✓ {o.Key}" : o.Key).ToArray();
+            var selection = await Page.DisplayActionSheet(AppResources.VaultTimeoutAction,
+                AppResources.Cancel, null, options);
             if (selection == null || selection == AppResources.Cancel)
             {
                 return;
@@ -227,6 +231,10 @@ namespace Bit.App.Pages
                 }
             }
             var selectionOption = _vaultTimeoutActions.FirstOrDefault(o => o.Key == cleanSelection);
+            if(_vaultTimeoutActionDisplayValue != selectionOption.Key)
+            {
+                _messagingService.Send("vaultTimeoutActionChanged");
+            }
             _vaultTimeoutActionDisplayValue = selectionOption.Key;
             await _vaultTimeoutService.SetVaultTimeoutOptionsAsync(GetVaultTimeoutFromKey(_vaultTimeoutDisplayValue),
                 selectionOption.Value);
@@ -349,7 +357,11 @@ namespace Bit.App.Pages
             var securityItems = new List<SettingsPageListItem>
             {
                 new SettingsPageListItem { Name = AppResources.VaultTimeout, SubLabel = _vaultTimeoutDisplayValue },
-                new SettingsPageListItem { Name = AppResources.VaultTimeoutAction, SubLabel = _vaultTimeoutActionDisplayValue },
+                new SettingsPageListItem 
+                {
+                    Name = AppResources.VaultTimeoutAction,
+                    SubLabel = _vaultTimeoutActionDisplayValue
+                },
                 new SettingsPageListItem
                 {
                     Name = AppResources.UnlockWithPIN,

--- a/src/iOS.Core/Utilities/ASHelpers.cs
+++ b/src/iOS.Core/Utilities/ASHelpers.cs
@@ -15,6 +15,11 @@ namespace Bit.iOS.Core.Utilities
             if (await AutofillEnabled())
             {
                 var storageService = ServiceContainer.Resolve<IStorageService>("storageService");
+                var timeoutAction = await storageService.GetAsync<string>(Bit.Core.Constants.VaultTimeoutActionKey);
+                if (timeoutAction == "logOut")
+                {
+                    return;
+                }
                 var vaultTimeoutService = ServiceContainer.Resolve<IVaultTimeoutService>("vaultTimeoutService");
                 if (await vaultTimeoutService.IsLockedAsync())
                 {
@@ -42,6 +47,12 @@ namespace Bit.iOS.Core.Utilities
 
         public static async Task<bool> IdentitiesCanIncremental()
         {
+            var storageService = ServiceContainer.Resolve<IStorageService>("storageService");
+            var timeoutAction = await storageService.GetAsync<string>(Bit.Core.Constants.VaultTimeoutActionKey);
+            if (timeoutAction == "logOut")
+            {
+                return false;
+            }
             var state = await ASCredentialIdentityStore.SharedStore?.GetCredentialIdentityStoreStateAsync();
             return state != null && state.Enabled && state.SupportsIncrementalUpdates;
         }

--- a/src/iOS/AppDelegate.cs
+++ b/src/iOS/AppDelegate.cs
@@ -174,6 +174,18 @@ namespace Bit.iOS
                 {
                     await ASHelpers.ReplaceAllIdentities();
                 }
+                else if (message.Command == "vaultTimeoutActionChanged")
+                {
+                    var timeoutAction = await _storageService.GetAsync<string>(Constants.VaultTimeoutActionKey);
+                    if (timeoutAction == "logOut")
+                    {
+                        await ASCredentialIdentityStore.SharedStore?.RemoveAllCredentialIdentitiesAsync();
+                    }
+                    else
+                    {
+                        await ASHelpers.ReplaceAllIdentities();
+                    }
+                }
             });
 
             return base.FinishedLaunching(app, options);

--- a/src/iOS/AppDelegate.cs
+++ b/src/iOS/AppDelegate.cs
@@ -120,7 +120,8 @@ namespace Bit.iOS
                         }
                     }
                 }
-                else if (message.Command == "addedCipher" || message.Command == "editedCipher" || message.Command == "restoredCipher")
+                else if (message.Command == "addedCipher" || message.Command == "editedCipher" ||
+                    message.Command == "restoredCipher")
                 {
                     if (_deviceActionService.SystemMajorVersion() >= 12)
                     {


### PR DESCRIPTION
If users are using the vault timeout feature to log out of the app, the autofill index may not be cleared when they are logged out (ex, the app just terminates). This is because the traditional loggedout message event may never occur. I would consider this a security issue since it would lead to a logged out user still receiving hints in their keyboard about items that were in their vault. If a user is using the vault timeout == "logOut" feature, we cannot maintain the autofill index for keyboard hints.