### PR TITLE
check for empty string on malformed URL

### DIFF
--- a/src/Core/Utilities/CoreHelpers.cs
+++ b/src/Core/Utilities/CoreHelpers.cs
@@ -37,13 +37,13 @@ namespace Bit.Core.Utilities
         public static string GetHostname(string uriString)
         {
             var uri = GetUri(uriString);
-            return uri != null && uri.Host != string.Empty ? uri.Host : null;
+            return string.IsNullOrEmpty(uri?.Host) ? null : uri.Host;
         }
 
         public static string GetHost(string uriString)
         {
             var uri = GetUri(uriString);
-            if (uri != null && uri.Host != string.Empty)
+            if (!string.IsNullOrEmpty(uri?.Host))
             {
                 if (uri.IsDefaultPort)
                 {


### PR DESCRIPTION
When parsing a URL string that meets the proper format to construct a URL, but the hostname/host is malformed, you end up with an empty string for the hostname/host rather than `null`. We handle the `null` condition when comparing URLs for autofill, but not an empty string. This leads to two malformed hostnames/hosts being able to match `('' === '') == true`. This PR ensures that hostname/host parsing always treats an empty string the same as `null`.