### PR TITLE
Singleton LiteDatabase

### DIFF
--- a/src/Core/Core.csproj
+++ b/src/Core/Core.csproj
@@ -24,7 +24,7 @@
 
   <ItemGroup>
     <PackageReference Include="CsvHelper" Version="15.0.5" />
-    <PackageReference Include="LiteDB" Version="5.0.4" />
+    <PackageReference Include="LiteDB" Version="5.0.8" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="PCLCrypto" Version="2.0.147" />
   </ItemGroup>

--- a/src/Core/Services/LiteDbStorageService.cs
+++ b/src/Core/Services/LiteDbStorageService.cs
@@ -2,14 +2,16 @@
 using LiteDB;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
-using System;
 using System.Linq;
 using System.Threading.Tasks;
 
 namespace Bit.Core.Services
 {
-    public class LiteDbStorageService : IStorageService, IDisposable
+    public class LiteDbStorageService : IStorageService
     {
+        private static LiteDatabase _db;
+        private static readonly object _lock = new object();
+
         private readonly JsonSerializerSettings _jsonSettings = new JsonSerializerSettings
         {
             ContractResolver = new CamelCasePropertyNamesContractResolver()
@@ -17,7 +19,6 @@ namespace Bit.Core.Services
         private readonly string _dbPath;
         private ILiteCollection<JsonItem> _collection;
         private Task _initTask;
-        private LiteDatabase _db;
 
         public LiteDbStorageService(string dbPath)
         {
@@ -38,7 +39,13 @@ namespace Bit.Core.Services
             {
                 try
                 {
-                    _db = new LiteDatabase($"Filename={_dbPath};Upgrade=true;");
+                    lock (_lock)
+                    {
+                        if (_db == null)
+                        {
+                            _db = new LiteDatabase($"Filename={_dbPath};Upgrade=true;");
+                        }
+                    }
                     _collection = _db.GetCollection<JsonItem>("json_items");
                 }
                 finally

--- a/src/Core/Services/LiteDbStorageService.cs
+++ b/src/Core/Services/LiteDbStorageService.cs
@@ -80,11 +80,6 @@ namespace Bit.Core.Services
             _collection.DeleteMany(i => i.Id == key);
         }
 
-        public void Dispose()
-        {
-            _db?.Dispose();
-        }
-
         private class JsonItem
         {
             public JsonItem() { }


### PR DESCRIPTION
Use a static singleton instance of LiteDatabase instead of trying to manually dispose. This should get around the Lite Database file locking issue we have been experiencing and allow us to upgrade to the latest LiteDB version that we need to resolve other bugs.