### PR TITLE
Add support for Bromite's vanilla build of Chromium

### DIFF
--- a/src/Android/Accessibility/AccessibilityHelpers.cs
+++ b/src/Android/Accessibility/AccessibilityHelpers.cs
@@ -70,6 +70,7 @@ namespace Bit.Droid.Accessibility
             new Browser("org.adblockplus.browser", "url_bar,url_bar_title"), // 2nd = Legacy (before v2)
             new Browser("org.adblockplus.browser.beta", "url_bar,url_bar_title"), // 2nd = Legacy (before v2)
             new Browser("org.bromite.bromite", "url_bar"),
+            new Browser("org.bromite.chromium", "url_bar"),
             new Browser("org.chromium.chrome", "url_bar"),
             new Browser("org.codeaurora.swe.browser", "url_bar"),
             new Browser("org.gnu.icecat", "url_bar_title,mozac_browser_toolbar_url_view"), // 2nd = Anticipation

--- a/src/Android/Autofill/AutofillHelpers.cs
+++ b/src/Android/Autofill/AutofillHelpers.cs
@@ -75,6 +75,7 @@ namespace Bit.Droid.Autofill
             "org.adblockplus.browser",
             "org.adblockplus.browser.beta",
             "org.bromite.bromite",
+            "org.bromite.chromium",
             "org.chromium.chrome",
             "org.codeaurora.swe.browser",
             "org.gnu.icecat",

--- a/src/Android/Resources/xml/autofillservice.xml
+++ b/src/Android/Resources/xml/autofillservice.xml
@@ -122,6 +122,9 @@
     android:name="org.bromite.bromite"
     android:maxLongVersionCode="10000000000"/>
   <compatibility-package
+    android:name="org.bromite.chromium"
+    android:maxLongVersionCode="10000000000"/>
+  <compatibility-package
     android:name="org.chromium.chrome"
     android:maxLongVersionCode="10000000000"/>
   <compatibility-package


### PR DESCRIPTION
There is a Chromium build with package name `org.bromite.chromium` with minimal patches which is used mostly to test whether issues come from upstream (Chromium) or are only in Bromite; see also https://www.bromite.org/chromium

This could be useful to test the Bitwarden integration as well.