### PR TITLE
Fix for deadlock in iOS autofill & share extensions

### DIFF
--- a/src/iOS.Autofill/SetupViewController.cs
+++ b/src/iOS.Autofill/SetupViewController.cs
@@ -25,6 +25,7 @@ namespace Bit.iOS.Autofill
 
             ActivatedLabel.Text = AppResources.AutofillActivated;
             ActivatedLabel.Font = UIFont.FromDescriptor(descriptor, descriptor.PointSize * 1.3f);
+            ActivatedLabel.TextColor = ThemeHelpers.SuccessColor;
 
             BackButton.Title = AppResources.Back;
             base.ViewDidLoad();

--- a/src/iOS.Extension/LoadingViewController.cs
+++ b/src/iOS.Extension/LoadingViewController.cs
@@ -6,9 +6,9 @@ using Bit.iOS.Core;
 using Bit.iOS.Extension.Models;
 using MobileCoreServices;
 using Bit.iOS.Core.Utilities;
-using Bit.App.Resources;
 using Bit.iOS.Core.Controllers;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Bit.iOS.Core.Models;
 using Bit.Core.Utilities;
 using Bit.Core.Abstractions;
@@ -63,7 +63,7 @@ namespace Bit.iOS.Extension
             }
         }
 
-        public override void ViewDidAppear(bool animated)
+        public override async void ViewDidAppear(bool animated)
         {
             base.ViewDidAppear(animated);
             if (_context.ProviderType == Constants.UTTypeAppExtensionSetup)
@@ -71,12 +71,12 @@ namespace Bit.iOS.Extension
                 PerformSegue("setupSegue", this);
                 return;
             }
-            if (!IsAuthed())
+            if (! await IsAuthed())
             {
                 LaunchLoginFlow();
                 return;
             }
-            else if (IsLocked())
+            else if (await IsLocked())
             {
                 PerformSegue("lockPasswordSegue", this);
             }
@@ -408,16 +408,16 @@ namespace Bit.iOS.Extension
             iOSCoreHelpers.SubscribeBroadcastReceiver(this, _nfcSession, _nfcDelegate);
         }
 
-        private bool IsLocked()
+        private Task<bool> IsLocked()
         {
             var vaultTimeoutService = ServiceContainer.Resolve<IVaultTimeoutService>("vaultTimeoutService");
-            return vaultTimeoutService.IsLockedAsync().GetAwaiter().GetResult();
+            return vaultTimeoutService.IsLockedAsync();
         }
 
-        private bool IsAuthed()
+        private Task<bool> IsAuthed()
         {
             var userService = ServiceContainer.Resolve<IUserService>("userService");
-            return userService.IsAuthenticatedAsync().GetAwaiter().GetResult();
+            return userService.IsAuthenticatedAsync();
         }
 
         private void LaunchLoginFlow()


### PR DESCRIPTION
Replaced use of `GetAwaiter().GetResult()` within autofill and sharing extension view controllers, fixes frozen and/or partially drawn autofill windows when setting up and using autofill.

Before:

![before](https://user-images.githubusercontent.com/59324545/83959899-6f841a80-a850-11ea-82f7-22233f345360.png)

After:

![after](https://user-images.githubusercontent.com/59324545/83959900-76129200-a850-11ea-8a0c-732ba32f9da1.png)

Also fixed the dark-text-on-dark-background issue for the autofill setup completion header (now matches "success" color used in share extension)

Autofill:

![autofill_success](https://user-images.githubusercontent.com/59324545/83959950-f2a57080-a850-11ea-9007-138faf2bf986.png)

Share:

![share_success](https://user-images.githubusercontent.com/59324545/83959955-fb964200-a850-11ea-968f-216878817888.png)
