### PR TITLE
Biometrics cleanup

### DIFF
--- a/src/App/Abstractions/IDeviceActionService.cs
+++ b/src/App/Abstractions/IDeviceActionService.cs
@@ -23,9 +23,6 @@ namespace Bit.App.Abstractions
         void RateApp();
         bool SupportsFaceBiometric();
         Task<bool> SupportsFaceBiometricAsync();
-        Task<bool> BiometricAvailableAsync();
-        bool UseNativeBiometric();
-        Task<bool> AuthenticateBiometricAsync(string text = null);
         bool SupportsNfc();
         bool SupportsCamera();
         bool SupportsAutofillService();

--- a/src/App/App.xaml.cs
+++ b/src/App/App.xaml.cs
@@ -219,7 +219,7 @@ namespace Bit.App
             SyncIfNeeded();
             if (Current.MainPage is NavigationPage navPage && navPage.CurrentPage is LockPage lockPage)
             {
-                await lockPage.PromptFingerprintAfterResumeAsync();
+                await lockPage.PromptBiometricAfterResumeAsync();
             }
         }
 
@@ -246,7 +246,7 @@ namespace Bit.App
                 _passwordGenerationService.ClearAsync(),
                 _vaultTimeoutService.ClearAsync(),
                 _stateService.PurgeAsync());
-            _vaultTimeoutService.FingerprintLocked = true;
+            _vaultTimeoutService.BiometricLocked = true;
             _searchService.ClearIndex();
             _authService.LogOut(() =>
             {
@@ -404,21 +404,20 @@ namespace Bit.App
             }
         }
 
-        private async Task LockedAsync(bool autoPromptFingerprint)
+        private async Task LockedAsync(bool autoPromptBiometric)
         {
             await _stateService.PurgeAsync();
-            if (autoPromptFingerprint && Device.RuntimePlatform == Device.iOS)
+            if (autoPromptBiometric && Device.RuntimePlatform == Device.iOS)
             {
                 var vaultTimeout = await _storageService.GetAsync<int?>(Constants.VaultTimeoutKey);
                 if (vaultTimeout == 0)
                 {
-                    autoPromptFingerprint = false;
+                    autoPromptBiometric = false;
                 }
             }
-            else if (autoPromptFingerprint && Device.RuntimePlatform == Device.Android &&
-                _deviceActionService.UseNativeBiometric())
+            else if (autoPromptBiometric && Device.RuntimePlatform == Device.Android)
             {
-                autoPromptFingerprint = false;
+                autoPromptBiometric = false;
             }
             PreviousPageInfo lastPageBeforeLock = null;
             if (Current.MainPage is TabbedPage tabbedPage && tabbedPage.Navigation.ModalStack.Count > 0)
@@ -445,7 +444,7 @@ namespace Bit.App
                 }
             }
             await _storageService.SaveAsync(Constants.PreviousPageKey, lastPageBeforeLock);
-            var lockPage = new LockPage(Options, autoPromptFingerprint);
+            var lockPage = new LockPage(Options, autoPromptBiometric);
             Device.BeginInvokeOnMainThread(() => Current.MainPage = new NavigationPage(lockPage));
         }
     }

--- a/src/App/Pages/Accounts/LockPage.xaml
+++ b/src/App/Pages/Accounts/LockPage.xaml
@@ -106,8 +106,8 @@
                     Margin="0, 10, 0, 0" />
             </StackLayout>
             <StackLayout Padding="10, 0">
-                <Button Text="{Binding FingerprintButtonText}" Clicked="Fingerprint_Clicked"
-                        IsVisible="{Binding FingerprintLock}"></Button>
+                <Button Text="{Binding BiometricButtonText}" Clicked="Biometric_Clicked"
+                        IsVisible="{Binding BiometricLock}"></Button>
                 <Button Text="{u:I18n LogOut}" Clicked="LogOut_Clicked"></Button>
             </StackLayout>
         </StackLayout>

--- a/src/App/Pages/Accounts/LockPage.xaml.cs
+++ b/src/App/Pages/Accounts/LockPage.xaml.cs
@@ -12,17 +12,17 @@ namespace Bit.App.Pages
     {
         private readonly IStorageService _storageService;
         private readonly AppOptions _appOptions;
-        private readonly bool _autoPromptFingerprint;
+        private readonly bool _autoPromptBiometric;
         private readonly LockPageViewModel _vm;
 
         private bool _promptedAfterResume;
         private bool _appeared;
 
-        public LockPage(AppOptions appOptions = null, bool autoPromptFingerprint = true)
+        public LockPage(AppOptions appOptions = null, bool autoPromptBiometric = true)
         {
             _storageService = ServiceContainer.Resolve<IStorageService>("storageService");
             _appOptions = appOptions;
-            _autoPromptFingerprint = autoPromptFingerprint;
+            _autoPromptBiometric = autoPromptBiometric;
             InitializeComponent();
             _vm = BindingContext as LockPageViewModel;
             _vm.Page = this;
@@ -34,15 +34,15 @@ namespace Bit.App.Pages
         public Entry MasterPasswordEntry { get; set; }
         public Entry PinEntry { get; set; }
 
-        public async Task PromptFingerprintAfterResumeAsync()
+        public async Task PromptBiometricAfterResumeAsync()
         {
-            if (_vm.FingerprintLock)
+            if (_vm.BiometricLock)
             {
                 await Task.Delay(500);
                 if (!_promptedAfterResume)
                 {
                     _promptedAfterResume = true;
-                    await _vm?.PromptFingerprintAsync();
+                    await _vm?.PromptBiometricAsync();
                 }
             }
         }
@@ -55,8 +55,8 @@ namespace Bit.App.Pages
                 return;
             }
             _appeared = true;
-            await _vm.InitAsync(_autoPromptFingerprint);
-            if (!_vm.FingerprintLock)
+            await _vm.InitAsync(_autoPromptBiometric);
+            if (!_vm.BiometricLock)
             {
                 if (_vm.PinLock)
                 {
@@ -89,11 +89,11 @@ namespace Bit.App.Pages
             }
         }
 
-        private async void Fingerprint_Clicked(object sender, EventArgs e)
+        private async void Biometric_Clicked(object sender, EventArgs e)
         {
             if (DoOnce())
             {
-                await _vm.PromptFingerprintAsync();
+                await _vm.PromptBiometricAsync();
             }
         }
 

--- a/src/App/Pages/Settings/SettingsPage/SettingsPage.xaml.cs
+++ b/src/App/Pages/Settings/SettingsPage/SettingsPage.xaml.cs
@@ -143,19 +143,15 @@ namespace Bit.App.Pages
             }
             else
             {
-                var fingerprintName = AppResources.Fingerprint;
+                var biometricName = AppResources.Biometrics;
                 if (Device.RuntimePlatform == Device.iOS)
                 {
                     var supportsFace = await _deviceActionService.SupportsFaceBiometricAsync();
-                    fingerprintName = supportsFace ? AppResources.FaceID : AppResources.TouchID;
+                    biometricName = supportsFace ? AppResources.FaceID : AppResources.TouchID;
                 }
-                else if (Device.RuntimePlatform == Device.Android && _deviceActionService.UseNativeBiometric())
+                if (item.Name == string.Format(AppResources.UnlockWith, biometricName))
                 {
-                    fingerprintName = AppResources.Biometrics;
-                }
-                if (item.Name == string.Format(AppResources.UnlockWith, fingerprintName))
-                {
-                    await _vm.UpdateFingerprintAsync();
+                    await _vm.UpdateBiometricAsync();
                 }
             }
         }

--- a/src/App/Resources/AppResources.Designer.cs
+++ b/src/App/Resources/AppResources.Designer.cs
@@ -9,7 +9,6 @@
 
 namespace Bit.App.Resources {
     using System;
-    using System.Reflection;
     
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]

--- a/src/App/Resources/AppResources.resx
+++ b/src/App/Resources/AppResources.resx
@@ -1564,7 +1564,7 @@
     <value>Your login session has expired.</value>
   </data>
   <data name="BiometricsDirection" xml:space="preserve">
-    <value>Use biometrics to verify.</value>
+    <value>Biometric Verification</value>
   </data>
   <data name="Biometrics" xml:space="preserve">
     <value>Biometrics</value>

--- a/src/Core/Abstractions/IVaultTimeoutService.cs
+++ b/src/Core/Abstractions/IVaultTimeoutService.cs
@@ -7,13 +7,13 @@ namespace Bit.Core.Abstractions
     public interface IVaultTimeoutService
     {
         CipherString PinProtectedKey { get; set; }
-        bool FingerprintLocked { get; set; }
+        bool BiometricLocked { get; set; }
 
         Task CheckVaultTimeoutAsync();
         Task ClearAsync();
         Task<bool> IsLockedAsync();
         Task<Tuple<bool, bool>> IsPinLockSetAsync();
-        Task<bool> IsFingerprintLockSetAsync();
+        Task<bool> IsBiometricLockSetAsync();
         Task LockAsync(bool allowSoftLock = false, bool userInitiated = false);
         Task LogOutAsync();
         Task SetVaultTimeoutOptionsAsync(int? timeout, string action);

--- a/src/Core/Constants.cs
+++ b/src/Core/Constants.cs
@@ -7,7 +7,7 @@
         public static string VaultTimeoutKey = "lockOption";
         public static string VaultTimeoutActionKey = "vaultTimeoutAction";
         public static string LastActiveKey = "lastActive";
-        public static string FingerprintUnlockKey = "fingerprintUnlock";
+        public static string BiometricUnlockKey = "fingerprintUnlock";
         public static string ProtectedPin = "protectedPin";
         public static string PinProtectedKey = "pinProtectedKey";
         public static string DefaultUriMatch = "defaultUriMatch";

--- a/src/Core/Services/AuthService.cs
+++ b/src/Core/Services/AuthService.cs
@@ -315,7 +315,7 @@ namespace Bit.Core.Services
                 await _cryptoService.SetEncPrivateKeyAsync(tokenResponse.PrivateKey);
             }
 
-            _vaultTimeoutService.FingerprintLocked = false;
+            _vaultTimeoutService.BiometricLocked = false;
             _messagingService.Send("loggedIn");
             return result;
         }

--- a/src/Core/Services/CryptoService.cs
+++ b/src/Core/Services/CryptoService.cs
@@ -48,8 +48,8 @@ namespace Bit.Core.Services
         {
             _key = key;
             var option = await _storageService.GetAsync<int?>(Constants.VaultTimeoutKey);
-            var fingerprint = await _storageService.GetAsync<bool?>(Constants.FingerprintUnlockKey);
-            if (option.HasValue && !fingerprint.GetValueOrDefault())
+            var biometric = await _storageService.GetAsync<bool?>(Constants.BiometricUnlockKey);
+            if (option.HasValue && !biometric.GetValueOrDefault())
             {
                 // If we have a lock option set, we do not store the key
                 return;
@@ -354,8 +354,8 @@ namespace Bit.Core.Services
         {
             var key = await GetKeyAsync();
             var option = await _storageService.GetAsync<int?>(Constants.VaultTimeoutKey);
-            var fingerprint = await _storageService.GetAsync<bool?>(Constants.FingerprintUnlockKey);
-            if (!fingerprint.GetValueOrDefault() && (option != null || option == 0))
+            var biometric = await _storageService.GetAsync<bool?>(Constants.BiometricUnlockKey);
+            if (!biometric.GetValueOrDefault() && (option != null || option == 0))
             {
                 await ClearKeyAsync();
                 _key = key;

--- a/src/Core/Services/VaultTimeoutService.cs
+++ b/src/Core/Services/VaultTimeoutService.cs
@@ -49,15 +49,15 @@ namespace Bit.Core.Services
         }
 
         public CipherString PinProtectedKey { get; set; } = null;
-        public bool FingerprintLocked { get; set; } = true;
+        public bool BiometricLocked { get; set; } = true;
 
         public async Task<bool> IsLockedAsync()
         {
             var hasKey = await _cryptoService.HasKeyAsync();
             if (hasKey)
             {
-                var fingerprintSet = await IsFingerprintLockSetAsync();
-                if (fingerprintSet && FingerprintLocked)
+                var biometricSet = await IsBiometricLockSetAsync();
+                if (biometricSet && BiometricLocked)
                 {
                     return true;
                 }
@@ -120,8 +120,8 @@ namespace Bit.Core.Services
             }
             if (allowSoftLock)
             {
-                FingerprintLocked = await IsFingerprintLockSetAsync();
-                if (FingerprintLocked)
+                BiometricLocked = await IsBiometricLockSetAsync();
+                if (BiometricLocked)
                 {
                     _messagingService.Send("locked", userInitiated);
                     _lockedCallback?.Invoke(userInitiated);
@@ -165,10 +165,10 @@ namespace Bit.Core.Services
             return new Tuple<bool, bool>(protectedPin != null, pinProtectedKey != null);
         }
 
-        public async Task<bool> IsFingerprintLockSetAsync()
+        public async Task<bool> IsBiometricLockSetAsync()
         {
-            var fingerprintLock = await _storageService.GetAsync<bool?>(Constants.FingerprintUnlockKey);
-            return fingerprintLock.GetValueOrDefault();
+            var biometricLock = await _storageService.GetAsync<bool?>(Constants.BiometricUnlockKey);
+            return biometricLock.GetValueOrDefault();
         }
 
         public async Task ClearAsync()

--- a/src/iOS.Core/Controllers/LockPasswordViewController.cs
+++ b/src/iOS.Core/Controllers/LockPasswordViewController.cs
@@ -52,7 +52,7 @@ namespace Bit.iOS.Core.Controllers
 
             _pinSet = _vaultTimeoutService.IsPinLockSetAsync().GetAwaiter().GetResult();
             _pinLock = (_pinSet.Item1 && _vaultTimeoutService.PinProtectedKey != null) || _pinSet.Item2;
-            _fingerprintLock = _vaultTimeoutService.IsFingerprintLockSetAsync().GetAwaiter().GetResult();
+            _fingerprintLock = _vaultTimeoutService.IsBiometricLockSetAsync().GetAwaiter().GetResult();
 
             BaseNavItem.Title = _pinLock ? AppResources.VerifyPIN : AppResources.VerifyMasterPassword;
             BaseCancelButton.Title = AppResources.Cancel;
@@ -205,7 +205,7 @@ namespace Bit.iOS.Core.Controllers
 
         private void DoContinue()
         {
-            _vaultTimeoutService.FingerprintLocked = false;
+            _vaultTimeoutService.BiometricLocked = false;
             MasterPasswordCell.TextField.ResignFirstResponder();
             Success();
         }
@@ -219,7 +219,7 @@ namespace Bit.iOS.Core.Controllers
             var success = await _platformUtilsService.AuthenticateBiometricAsync(null,
                 _pinLock ? AppResources.PIN : AppResources.MasterPassword,
                 () => MasterPasswordCell.TextField.BecomeFirstResponder());
-            _vaultTimeoutService.FingerprintLocked = !success;
+            _vaultTimeoutService.BiometricLocked = !success;
             if (success)
             {
                 DoContinue();
@@ -261,11 +261,11 @@ namespace Bit.iOS.Core.Controllers
                 {
                     if (indexPath.Row == 0)
                     {
-                        var fingerprintButtonText = _controller._deviceActionService.SupportsFaceBiometric() ?
+                        var biometricButtonText = _controller._deviceActionService.SupportsFaceBiometric() ?
                             AppResources.UseFaceIDToUnlock : AppResources.UseFingerprintToUnlock;
                         var cell = new ExtendedUITableViewCell();
                         cell.TextLabel.TextColor = ThemeHelpers.PrimaryColor;
-                        cell.TextLabel.Text = fingerprintButtonText;
+                        cell.TextLabel.Text = biometricButtonText;
                         return cell;
                     }
                 }

--- a/src/iOS.Core/Services/DeviceActionService.cs
+++ b/src/iOS.Core/Services/DeviceActionService.cs
@@ -15,7 +15,6 @@ using Foundation;
 using LocalAuthentication;
 using MobileCoreServices;
 using Photos;
-using Plugin.Fingerprint;
 using UIKit;
 using Xamarin.Forms;
 
@@ -269,28 +268,6 @@ namespace Bit.iOS.Core.Services
         public Task<bool> SupportsFaceBiometricAsync()
         {
             return Task.FromResult(SupportsFaceBiometric());
-        }
-
-        public async Task<bool> BiometricAvailableAsync()
-        {
-            try
-            {
-                return await CrossFingerprint.Current.IsAvailableAsync();
-            }
-            catch
-            {
-                return false;
-            }
-        }
-
-        public bool UseNativeBiometric()
-        {
-            return false;
-        }
-
-        public Task<bool> AuthenticateBiometricAsync(string text = null)
-        {
-            throw new NotSupportedException();
         }
 
         public bool SupportsNfc()


### PR DESCRIPTION
- Refactored code to use "biometric" terminology so it doesn't conflict with "fingerprint" (phrase)
- Removed native biometric code for Android 10 as the plugin handles it now
- Changed phrasing on Android to "Biometric Verification" as it's the system's responsibility to identify the method used.  Even though the Biometric API was added in Android 10, the BiometricPrompt API was added in 9 to cover for vendors introducing other methods (face, iris).  The system can do a better job of prompting the user than we can (see screenshots)
- iOS code remains mostly untouched

I'm hoping by removing any custom code we'll fix the fingerprint oddities we're seeing right now, as well as some labeling oddities for users running Anrdoid 9.

![Screen Shot 2020-06-07 at 10 21 52 PM](https://user-images.githubusercontent.com/59324545/83988280-cbae7380-a910-11ea-8630-807b987fbe73.png)

![device-2020-06-07-222337](https://user-images.githubusercontent.com/59324545/83988286-cf41fa80-a910-11ea-86ec-30389a45b9e8.png)

![device-2020-06-07-222608](https://user-images.githubusercontent.com/59324545/83988292-d36e1800-a910-11ea-971a-4ea833128dd0.png)

![Screen Shot 2020-06-07 at 10 29 52 PM](https://user-images.githubusercontent.com/59324545/83988297-d832cc00-a910-11ea-978b-3484d98a57b0.png)
