### PR TITLE
Fix for accessibility overlay on Android 5 & 6

### DIFF
--- a/src/Android/Accessibility/AccessibilityHelpers.cs
+++ b/src/Android/Accessibility/AccessibilityHelpers.cs
@@ -601,8 +601,8 @@ namespace Bit.Droid.Accessibility
         
         public static bool IsAutofillServicePromptVisible(IEnumerable<AccessibilityWindowInfo> windows)
         {
-            // AccessibilityWindowInfo.Title requires SDK 24
-            if (Build.VERSION.SdkInt >= BuildVersionCodes.N) 
+            // Autofill framework not available until API 26
+            if (Build.VERSION.SdkInt >= BuildVersionCodes.O) 
             {
                 return windows?.Any(w => w.Title?.ToLower().Contains("autofill") ?? false) ?? false;
             }


### PR DESCRIPTION
Turns out that while `AccessibilityWindowInfo` was added in Android 5, `AccessibilityWindowInfo.Title` didn't show up until Android 7.  We recently added the `Title` check to prevent any drawing conflicts with autofill windows.  Changed to just skip the check outright until Android 8 (when autofill was introduced).