### PR TITLE
Resolve passwords being hidden in upgrade path

### DIFF
--- a/src/Core/Models/Data/CipherData.cs
+++ b/src/Core/Models/Data/CipherData.cs
@@ -54,7 +54,7 @@ namespace Bit.Core.Models.Data
         public string FolderId { get; set; }
         public string UserId { get; set; }
         public bool Edit { get; set; }
-        public bool ViewPassword { get; set; }
+        public bool ViewPassword { get; set; } = true; // Fallback for old server versions
         public bool OrganizationUseTotp { get; set; }
         public bool Favorite { get; set; }
         public DateTime RevisionDate { get; set; }


### PR DESCRIPTION
Resolves #973.

When a vault is synced, the content is stored using the `Data` models, since the fallback path relied on `CipherResponse` defaulting the value, this did not happen for content already synced. By adding a default value to `ViewPassword` in `CipherData` de-serialized objects will now default with `ViewPassword` enabled.

We need to keep the other fallback as well, since otherwise the `CipherData` will copy the `ViewPassword=False` from `CipherResponse`.