### PR TITLE
Workaround for disabling predictive text in visible password fields

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -140,7 +140,6 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Decrypt secrets
-        if: github.ref == 'refs/heads/master'
         run: ./.github/scripts/ios/decrypt-secrets.ps1
         shell: pwsh
         env:
@@ -152,7 +151,6 @@ jobs:
         shell: pwsh
 
       - name: Set up keychain
-        if: github.ref == 'refs/heads/master'
         run: ./.github/scripts/ios/setup-keychain.ps1
         shell: pwsh
         env:
@@ -161,7 +159,6 @@ jobs:
           DIST_CERT_PASSWORD: ${{ secrets.IOS_DIST_CERT_PASSWORD }}
 
       - name: Set up provisioning profiles
-        if: github.ref == 'refs/heads/master'
         run: ./.github/scripts/ios/setup-profiles.ps1
         shell: pwsh
 

--- a/src/Android/Renderers/CustomEntryRenderer.cs
+++ b/src/Android/Renderers/CustomEntryRenderer.cs
@@ -1,5 +1,9 @@
-﻿using Android.Content;
+﻿using System.ComponentModel;
+using Android.Content;
+using Android.Graphics;
+using Android.Text;
 using Android.Views.InputMethods;
+using Android.Widget;
 using Bit.Droid.Renderers;
 using Xamarin.Forms;
 using Xamarin.Forms.Platform.Android;
@@ -22,6 +26,43 @@ namespace Bit.Droid.Renderers
                     Control.PaddingBottom + 20);
                 Control.ImeOptions = Control.ImeOptions | (ImeAction)ImeFlags.NoPersonalizedLearning |
                     (ImeAction)ImeFlags.NoExtractUi;
+            }
+        }
+
+        // Workaround for failure to disable text prediction on non-password fields
+        // see https://github.com/xamarin/Xamarin.Forms/issues/10857
+        protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
+        {
+            base.OnElementPropertyChanged(sender, e);
+            
+            // Check if changed property is "IsPassword", otherwise ignore
+            if (e.PropertyName == Entry.IsPasswordProperty.PropertyName)
+            {
+                // Check if field type is text, otherwise ignore (numeric passwords, etc.)
+                EditText.InputType = Element.Keyboard.ToInputType();
+                if ((EditText.InputType & InputTypes.ClassText) == InputTypes.ClassText)
+                {
+                    if (Element.IsPassword)
+                    {
+                        // Element is a password field, set inputType to TextVariationPassword which disables
+                        // predictive text by default
+                        EditText.InputType = EditText.InputType | InputTypes.TextVariationPassword;
+                    }
+                    else
+                    {
+                        // Element is not a password field, set inputType to TextVariationVisiblePassword to
+                        // disable predictive text while still displaying the content.
+                        EditText.InputType = EditText.InputType | InputTypes.TextVariationVisiblePassword;
+                    }
+                    
+                    // The workaround above forces a reset of the style properties, so we need to re-apply the font.
+                    // see https://xamarin.github.io/bugzilla-archives/33/33666/bug.html
+                    var typeface = Typeface.CreateFromAsset(Context.Assets, "RobotoMono_Regular.ttf");
+                    if (Control is TextView label)
+                    {
+                        label.Typeface = typeface;
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
A workaround for disabling predictive text while editing visible password fields on Android (see code comments for details/links on what and why).  This should suffice until the Xamarin.Forms bug has been fixed:

https://github.com/xamarin/Xamarin.Forms/issues/10857