### PR TITLE
Fix for non-master branch iOS builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -159,7 +159,6 @@ jobs:
           DIST_CERT_PASSWORD: ${{ secrets.IOS_DIST_CERT_PASSWORD }}
 
       - name: Set up provisioning profiles
-        if: github.ref == 'refs/heads/master'
         run: ./.github/scripts/ios/setup-profiles.ps1
         shell: pwsh
 


### PR DESCRIPTION
Re-enabled `Decrypt secrets`, `Set up keychain`, and `Set up provisioning profiles` steps to allow iOS builds to succeed from non-master branches
