### PR TITLE
Disabled iOS PR builds for now

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -140,6 +140,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Decrypt secrets
+        if: github.ref == 'refs/heads/master'
         run: ./.github/scripts/ios/decrypt-secrets.ps1
         shell: pwsh
         env:
@@ -151,6 +152,7 @@ jobs:
         shell: pwsh
 
       - name: Set up keychain
+        if: github.ref == 'refs/heads/master'
         run: ./.github/scripts/ios/setup-keychain.ps1
         shell: pwsh
         env:
@@ -159,6 +161,7 @@ jobs:
           DIST_CERT_PASSWORD: ${{ secrets.IOS_DIST_CERT_PASSWORD }}
 
       - name: Set up provisioning profiles
+        if: github.ref == 'refs/heads/master'
         run: ./.github/scripts/ios/setup-profiles.ps1
         shell: pwsh
 
@@ -170,10 +173,11 @@ jobs:
         run: ./.github/scripts/ios/build.ps1 -configuration AppStore -platform iPhone -archive
         shell: pwsh
 
-      - name: Build for App Store
-        if: github.ref != 'refs/heads/master'
-        run: ./.github/scripts/ios/build.ps1 -configuration AppStore -platform iPhone
-        shell: pwsh
+        # Disabled until secure method of building PRs is established
+        # - name: Build for App Store
+        # if: github.ref != 'refs/heads/master'
+        # run: ./.github/scripts/ios/build.ps1 -configuration AppStore -platform iPhone
+        # shell: pwsh
 
       - name: Export .ipa for App Store
         if: github.ref == 'refs/heads/master'


### PR DESCRIPTION
- Disabled iOS PR builds to prevent non-master build errors
- Restored prevention of secret decryption in non-master builds
