### PR TITLE
[KnownUsernameField] Compatibility with more browsers

### DIFF
--- a/src/Android/Accessibility/AccessibilityHelpers.cs
+++ b/src/Android/Accessibility/AccessibilityHelpers.cs
@@ -308,11 +308,13 @@ namespace Bit.Droid.Accessibility
         public static AccessibilityNodeInfo GetUsernameEditText(string uriString, 
             IEnumerable<AccessibilityNodeInfo> allEditTexts)
         {
+            string uriAuthority = null;
             string uriKey = null;
             string uriLocalPath = null;
             if (Uri.TryCreate(uriString, UriKind.Absolute, out var uri))
             {
-                uriKey = uri.Authority;
+                uriAuthority = uri.Authority;
+                uriKey = uriAuthority.StartsWith("www.") ? uriAuthority.Substring(4) : uriAuthority;
                 uriLocalPath = uri.LocalPath;
             }
 


### PR DESCRIPTION
### Context

Currently, the [new system](https://github.com/bitwarden/mobile/pull/880) allowing "email/username" field detection without "password" field, which uses the accessibility service, only works well with some browsers like Chrome.

Indeed, if the subdomain is specific like `signin.`example.com: no problem!
But if it's `www.`example.com, Bitwarden (with current entries) will assume that the browser will hide this part for comparison. _(This is a new trend in browsers.)_

### Problem

This is only the case in some browsers (currently: [Chrome](https://user-images.githubusercontent.com/4764956/86173097-bbf50a00-bb1f-11ea-8ee0-aa776e0c7b0c.png), [Firefox beta](https://user-images.githubusercontent.com/4764956/86173122-c6170880-bb1f-11ea-8fb1-cc9575e1a38b.png), etc.).

### Problem (illustration with Amazon but same with PayPal for ex.)

<details>
<summary>View me ...</summary>
&nbsp;

```csharp
new KnownUsernameField("amazon.com", "signin", "ap_email_login"),
[...]
if (KnownUsernameFields.ContainsKey(uriKey))
```

:arrow_right: **Chrome** :heavy_check_mark: _(match, because Chrome hides `www.`)_
<details>
<summary>View me ...</summary>

&nbsp;
![Screenshot_1593288746](https://user-images.githubusercontent.com/4764956/86159292-606c5180-bb0a-11ea-95f9-2c6532aca0e8.png)
```
>>> uriKey: amazon.com, uriLocalPath: /ap/signin, viewId: ap_email_login
```
</details>

:arrow_right: **Firefox for Android 68.x** :x: _(don't match, because Firefox shows `www.`)_
<details>
<summary>View me ...</summary>

&nbsp;
![Screenshot_1593535204](https://user-images.githubusercontent.com/4764956/86159359-7e39b680-bb0a-11ea-81fa-eeaa5caf4967.png)

```
>>> uriKey: www.amazon.com, uriLocalPath: /ap/signin, viewId: ap_email_login
```
</details>
</details>

### Solution

It's therefore advisable to remove the `www.` part on the Bitwarden side before comparison.

**This PR allows the use of this system with:**
- [Older versions of Chrome](https://user-images.githubusercontent.com/4764956/86160935-d2459a80-bb0c-11ea-9d8d-e6436816dba8.png) (+ forks) :heavy_check_mark:
- [Firefox for Android <= 68.x](https://user-images.githubusercontent.com/4764956/86160842-acb89100-bb0c-11ea-9de1-64e7486f40ac.png) (+ forks) :heavy_check_mark:
:bulb: _Current stable version at the time of writing: [68.10.0](https://www.mozilla.org/en-US/firefox/android/68.10.0/releasenotes/) ([68.9.0](https://play.google.com/store/apps/details?id=org.mozilla.firefox) on Google Play Store)_
- Some alternative browsers :heavy_check_mark:

:arrow_right: **Please note:** The logged `uriKey` value will now be the one to be used in practice. So, will always return the version without `www.` from now on.