### PR TITLE
Modified Permissions Flow

### DIFF
--- a/src/Android/MainActivity.cs
+++ b/src/Android/MainActivity.cs
@@ -18,6 +18,7 @@ using Android.Nfc;
 using Bit.App.Utilities;
 using System.Threading.Tasks;
 using AndroidX.Core.Content;
+using ZXing.Net.Mobile.Android;
 
 namespace Bit.Droid
 {
@@ -193,8 +194,7 @@ namespace Bit.Droid
             else
             {
                 Xamarin.Essentials.Platform.OnRequestPermissionsResult(requestCode, permissions, grantResults);
-                ZXing.Net.Mobile.Forms.Android.PermissionsHandler.OnRequestPermissionsResult(
-                    requestCode, permissions, grantResults);
+                PermissionsHandler.OnRequestPermissionsResult(requestCode, permissions, grantResults);
             }
             base.OnRequestPermissionsResult(requestCode, permissions, grantResults);
         }

--- a/src/App/Pages/Vault/AddEditPage.xaml.cs
+++ b/src/App/Pages/Vault/AddEditPage.xaml.cs
@@ -1,12 +1,14 @@
 ﻿using Bit.App.Abstractions;
 using Bit.App.Models;
 using Bit.App.Resources;
+using Bit.App.Utilities;
 using Bit.Core;
 using Bit.Core.Abstractions;
 using Bit.Core.Enums;
 using Bit.Core.Utilities;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Xamarin.Essentials;
 using Xamarin.Forms;
 using Xamarin.Forms.PlatformConfiguration;
 using Xamarin.Forms.PlatformConfiguration.iOSSpecific;
@@ -243,6 +245,12 @@ namespace Bit.App.Pages
         {
             if (DoOnce())
             {
+                var cameraPermission = await PermissionManager.CheckAndRequestPermissionAsync(new Permissions.Camera());
+                if (cameraPermission != PermissionStatus.Granted)
+                {
+                    return;
+                }
+
                 var page = new ScanPage(key =>
                 {
                     Device.BeginInvokeOnMainThread(async () =>

--- a/src/App/Utilities/PermissionManager.cs
+++ b/src/App/Utilities/PermissionManager.cs
@@ -1,0 +1,21 @@
+﻿using System.Threading.Tasks;
+using Xamarin.Essentials;
+using static Xamarin.Essentials.Permissions;
+
+namespace Bit.App.Utilities
+{
+    public static class PermissionManager
+    {
+        public static async Task<PermissionStatus> CheckAndRequestPermissionAsync<T>(T permission)
+            where T : BasePermission
+        {
+            var status = await permission.CheckStatusAsync();
+            if (status != PermissionStatus.Granted)
+            {
+                status = await permission.RequestAsync();
+            }
+
+            return status;
+        }
+    }
+}


### PR DESCRIPTION
## Objective 

Permissions flow for Android was causing the white screen on initial permission grant on occasion. Moved permission grant to pre-TOTP page load. This resvoles #975 

## Code Changes

**src/Android/MainActivity.cs** - ZXing.Net.Mobile.Forms.Android.PermissionsHandler.OnRequestPermissionsResult was deprecated, and with new flow, was hanging. I've modified this to point to the new method.

**src/App/Pages/Vault/AddEditPage.xaml.cs** - Added permissions check on click to confirm access to camera. If access is denied, return to add page.

**src/App/Utilities/PermissionManager.cs** - Added static method for checking/requesting permissions using Xamarin Essentials, for this use case and potential future consumption. 

## Known Issues (Must Fix)

* None known. Requesting a test on a physical device before merging with master to confirm. Emulator runs without issue. Physical device confirmation would be preferred.