### PR TITLE
Forcing autofill refresh on sync/modification of stored cred

### DIFF
--- a/src/Android/Services/DeviceActionService.cs
+++ b/src/Android/Services/DeviceActionService.cs
@@ -811,5 +811,11 @@ namespace Bit.Droid.Services
                 Context.ClipboardService) as Android.Content.ClipboardManager;
             clipboardManager.PrimaryClip = ClipData.NewPlainText("bitwarden", text);
         }
+
+        public Task RefreshAutoFillAsync()
+        {
+            // iOS Service Only
+            return Task.CompletedTask;
+        }
     }
 }

--- a/src/App/Abstractions/IDeviceActionService.cs
+++ b/src/App/Abstractions/IDeviceActionService.cs
@@ -41,5 +41,6 @@ namespace Bit.App.Abstractions
         void OpenAccessibilityOverlayPermissionSettings();
         void OpenAutofillSettings();
         bool UsingDarkTheme();
+        Task RefreshAutoFillAsync();
     }
 }

--- a/src/App/Pages/Settings/SyncPageViewModel.cs
+++ b/src/App/Pages/Settings/SyncPageViewModel.cs
@@ -56,6 +56,7 @@ namespace Bit.App.Pages
             {
                 await _deviceActionService.ShowLoadingAsync(AppResources.Syncing);
                 var success = await _syncService.FullSyncAsync(true);
+                await _deviceActionService.RefreshAutoFillAsync();
                 await _deviceActionService.HideLoadingAsync();
                 if (success)
                 {

--- a/src/App/Pages/Vault/AddEditPageViewModel.cs
+++ b/src/App/Pages/Vault/AddEditPageViewModel.cs
@@ -455,7 +455,7 @@ namespace Bit.App.Pages
                 _platformUtilsService.ShowToast("success", null,
                     EditMode && !CloneMode ? AppResources.ItemUpdated : AppResources.NewItemCreated);
                 _messagingService.Send(EditMode && !CloneMode ? "editedCipher" : "addedCipher", Cipher.Id);
-               await _deviceActionService.RefreshAutoFillAsync();
+                await _deviceActionService.RefreshAutoFillAsync();
 
                 if (Page is AddEditPage page && page.FromAutofillFramework)
                 {

--- a/src/App/Pages/Vault/AddEditPageViewModel.cs
+++ b/src/App/Pages/Vault/AddEditPageViewModel.cs
@@ -455,6 +455,7 @@ namespace Bit.App.Pages
                 _platformUtilsService.ShowToast("success", null,
                     EditMode && !CloneMode ? AppResources.ItemUpdated : AppResources.NewItemCreated);
                 _messagingService.Send(EditMode && !CloneMode ? "editedCipher" : "addedCipher", Cipher.Id);
+               await _deviceActionService.RefreshAutoFillAsync();
 
                 if (Page is AddEditPage page && page.FromAutofillFramework)
                 {

--- a/src/iOS.Core/Services/DeviceActionService.cs
+++ b/src/iOS.Core/Services/DeviceActionService.cs
@@ -552,6 +552,11 @@ namespace Bit.iOS.Core.Services
             throw new NotImplementedException();
         }
 
+        public async Task RefreshAutoFillAsync()
+        {
+            await ASHelpers.ReplaceAllIdentities();
+        }
+
         public class PickerDelegate : UIDocumentPickerDelegate
         {
             private readonly DeviceActionService _deviceActionService;


### PR DESCRIPTION
## Objective

Issue #980 appears to be happening in 2 places:

1. Changing credentials on the device, name or password, and going to the browser and attempting to auto fill. 
2. Syncing on device after credentials are changed on another device.

For some reason, the ASHelpers. ReplaceAllIdentities function is called within the stack ... but it wouldn't function 100% of the time within the existing process. Explicitly calling it after the credential change OR the sync, seems to resolve this inconsistency.

This fix will close #980.

## Code Changes

**src/App/Abstractions/IDeviceActionService.cs**
**src/Android/Services/DeviceActionService.cs**
**src/iOS.Core/Services/DeviceActionService.cs**

Added new RefreshAutoFillAsync function. This gives the App access to the individual devices. Android is just a return statement. This is only applicable to iOS, Android seems to be unaffected.

**src/App/Pages/Settings/SyncPageViewModel.cs**
**src/App/Pages/Vault/AddEditPageViewModel.cs**

Implemented call to new function. Sync is when the sync is explicitly called. Add/Edit is on credential change.