### PR TITLE
[KnownUsernameField] Engine update (make the system more flexible)

### DIFF
--- a/src/Android/Accessibility/AccessibilityHelpers.cs
+++ b/src/Android/Accessibility/AccessibilityHelpers.cs
@@ -364,7 +364,7 @@ namespace Bit.Droid.Accessibility
                         else if (curUriPathWanted.StartsWith("icontains:", StringComparison.Ordinal))
                         {
                             curUriPathWanted = curUriPathWanted.Substring(10);
-                            uriLocalPathMatches = uriLocalPath.IndexOf(curUriPathWanted, StringComparison.OrdinalIgnoreCase) >= 0;
+                            uriLocalPathMatches = uriLocalPath.Contains(curUriPathWanted, StringComparison.OrdinalIgnoreCase);
                         }
                         else if (curUriPathWanted.StartsWith("iendswith:", StringComparison.Ordinal))
                         {

--- a/src/Android/Accessibility/AccessibilityHelpers.cs
+++ b/src/Android/Accessibility/AccessibilityHelpers.cs
@@ -133,12 +133,12 @@ namespace Bit.Droid.Accessibility
         // Be sure to keep these entries sorted alphabetically
         public static Dictionary<string, KnownUsernameField> KnownUsernameFields => new List<KnownUsernameField>
         {
-            new KnownUsernameField("accounts.google.com",   new string[,] { { "ServiceLogin", "Email" } }),
-            new KnownUsernameField("amazon.com",            new string[,] { { "signin", "ap_email_login" } }),
-            new KnownUsernameField("github.com",            new string[,] { { "", "user[login]-footer" } }),
-            new KnownUsernameField("paypal.com",            new string[,] { { "signin", "email" } }),
-            new KnownUsernameField("signin.aws.amazon.com", new string[,] { { "signin", "resolving_input" } }),
-            new KnownUsernameField("signin.ebay.com",       new string[,] { { "eBayISAPI.dll", "userid" } }),
+            new KnownUsernameField("accounts.google.com",   new (string, string)[] { ("ServiceLogin", "Email") }),
+            new KnownUsernameField("amazon.com",            new (string, string)[] { ("signin", "ap_email_login") }),
+            new KnownUsernameField("github.com",            new (string, string)[] { ("", "user[login]-footer") }),
+            new KnownUsernameField("paypal.com",            new (string, string)[] { ("signin", "email") }),
+            new KnownUsernameField("signin.aws.amazon.com", new (string, string)[] { ("signin", "resolving_input") }),
+            new KnownUsernameField("signin.ebay.com",       new (string, string)[] { ("eBayISAPI.dll", "userid") }),
         }.ToDictionary(n => n.UriAuthority);
 
         public static void PrintTestData(AccessibilityNodeInfo root, AccessibilityEvent e)
@@ -330,12 +330,12 @@ namespace Bit.Droid.Accessibility
                 if (KnownUsernameFields.ContainsKey(uriKey))
                 {
                     var usernameField = KnownUsernameFields[uriKey];
-                    string[,] accessOptions = usernameField.AccessOptions;
+                    (string UriPathWanted, string UsernameViewId)[] accessOptions = usernameField.AccessOptions;
 
-                    for (int i = 0; i < accessOptions.GetLength(0); i++)
+                    for (int i = 0; i < accessOptions.Length; i++)
                     {
-                        string curUriPathWanted = accessOptions[i, 0];
-                        string curUsernameViewId = accessOptions[i, 1];
+                        string curUriPathWanted = accessOptions[i].UriPathWanted;
+                        string curUsernameViewId = accessOptions[i].UsernameViewId;
                         bool uriLocalPathMatches = false;
 
                         // Case-sensitive comparison

--- a/src/Android/Accessibility/KnownUsernameField.cs
+++ b/src/Android/Accessibility/KnownUsernameField.cs
@@ -2,15 +2,13 @@
 {
     public class KnownUsernameField
     {
-        public KnownUsernameField(string uriAuthority, string uriPathEnd, string usernameViewId)
+        public KnownUsernameField(string uriAuthority, string[,] accessOptions)
         {
             UriAuthority = uriAuthority;
-            UriPathEnd = uriPathEnd;
-            UsernameViewId = usernameViewId;
+            AccessOptions = accessOptions;
         }
 
         public string UriAuthority { get; set; }
-        public string UriPathEnd { get; set; }
-        public string UsernameViewId { get; set; }
+        public string[,] AccessOptions { get; set; }
     }
 }

--- a/src/Android/Accessibility/KnownUsernameField.cs
+++ b/src/Android/Accessibility/KnownUsernameField.cs
@@ -2,13 +2,13 @@
 {
     public class KnownUsernameField
     {
-        public KnownUsernameField(string uriAuthority, string[,] accessOptions)
+        public KnownUsernameField(string uriAuthority, (string UriPathWanted, string UsernameViewId)[] accessOptions)
         {
             UriAuthority = uriAuthority;
             AccessOptions = accessOptions;
         }
 
         public string UriAuthority { get; set; }
-        public string[,] AccessOptions { get; set; }
+        public (string UriPathWanted, string UsernameViewId)[] AccessOptions { get; set; }
     }
 }


### PR DESCRIPTION
**CONTEXT:** This is an update of [this new system](https://github.com/bitwarden/mobile/pull/880) _(system allowing "user ID" field detection — i.e. email/username/phone/whatever — without "password" field using the accessibility service)_.

**UPDATED:** Engine.
:arrow_right_hook: _Prerequisite for my next PR which concerns the **entries**._
___
&nbsp;
**This:**
- allows to have multiple pairs "path / username view ID" per domain;

- adds more advanced path support:

  - in its case-sensitive version: `startswith:string`, `contains:string`, `endswith:string` and
  - in its case-insensitive version: `istartswith:string`, `icontains:string`, `iendswith:string`.
&nbsp;

:bulb: About using `StringComparison.Ordinal` and `StringComparison.OrdinalIgnoreCase`, this is recommended for a variety of reasons including better performance. See the page [Best Practices for Using Strings in .NET](https://docs.microsoft.com/en-us/dotnet/standard/base-types/best-practices-strings#recommendations-for-string-usage) from Microsoft documentation.
&nbsp;
&nbsp;