### PR TITLE
Allow only non-deleted creds to be added to autofill

### DIFF
--- a/src/iOS.Core/Utilities/ASHelpers.cs
+++ b/src/iOS.Core/Utilities/ASHelpers.cs
@@ -29,7 +29,7 @@ namespace Bit.iOS.Core.Utilities
                 var cipherService = ServiceContainer.Resolve<ICipherService>("cipherService");
                 var identities = new List<ASPasswordCredentialIdentity>();
                 var ciphers = await cipherService.GetAllDecryptedAsync();
-                foreach (var cipher in ciphers)
+                foreach (var cipher in ciphers.Where(x => !x.IsDeleted))
                 {
                     var identity = ToCredentialIdentity(cipher);
                     if (identity != null)


### PR DESCRIPTION
## Objective

Prevent trashed credentials from being made available in iOS autofill. Didn't appear to be an issue on Android.

## Code Changes

**src/iOS.Core/Utilities/ASHelpers.cs** - Was going to create a new service method that returned untrashed/undeleted credentials, but this seemed like the path of least resistance.

This will close #1014 