### PR TITLE
Added android:installLocation=internalOnly to manifest

### DIFF
--- a/src/Android/Properties/AndroidManifest.xml
+++ b/src/Android/Properties/AndroidManifest.xml
@@ -4,6 +4,7 @@
   xmlns:tools="http://schemas.android.com/tools"
   android:versionCode="1"
   android:versionName="2.5.6"
+  android:installLocation="internalOnly"
   package="com.x8bit.bitwarden">
 
   <uses-sdk android:minSdkVersion="21" android:targetSdkVersion="29" />


### PR DESCRIPTION
Fixes https://github.com/bitwarden/mobile-maui/issues/1018 by forcing `installLocation` to `internalOnly` per [@mportune-bw 's comments](https://github.com/bitwarden/mobile/issues/1018#issuecomment-662485499)