### PR TITLE
Fix Pin cannot be hidden after showing it #1025

### DIFF
--- a/src/Android/Renderers/CustomEntryRenderer.cs
+++ b/src/Android/Renderers/CustomEntryRenderer.cs
@@ -40,19 +40,23 @@ namespace Bit.Droid.Renderers
             {
                 // Check if field type is text, otherwise ignore (numeric passwords, etc.)
                 EditText.InputType = Element.Keyboard.ToInputType();
-                if ((EditText.InputType & InputTypes.ClassText) == InputTypes.ClassText)
+                bool isText = (EditText.InputType & InputTypes.ClassText) == InputTypes.ClassText,
+                    isNumber = (EditText.InputType & InputTypes.ClassNumber) == InputTypes.ClassNumber;
+                if (isText || isNumber)
                 {
                     if (Element.IsPassword)
                     {
                         // Element is a password field, set inputType to TextVariationPassword which disables
                         // predictive text by default
-                        EditText.InputType = EditText.InputType | InputTypes.TextVariationPassword;
+                        EditText.InputType = EditText.InputType |
+                            (isText ? InputTypes.TextVariationPassword : InputTypes.NumberVariationPassword);
                     }
                     else
                     {
                         // Element is not a password field, set inputType to TextVariationVisiblePassword to
                         // disable predictive text while still displaying the content.
-                        EditText.InputType = EditText.InputType | InputTypes.TextVariationVisiblePassword;
+                        EditText.InputType = EditText.InputType |
+                            (isText ? InputTypes.TextVariationVisiblePassword : InputTypes.NumberVariationNormal);
                     }
                     
                     // The workaround above forces a reset of the style properties, so we need to re-apply the font.


### PR DESCRIPTION
Fixes #1025 

## Overview

Xamarin Forms handles the scenario where a Numeric keyboard type + IsPassword setting properly sets the native Android Input Type between Numeric vs. NumericPassword. This is overridden by BW's custom entry renderer's implementation which maps custom fonts and behavior for Android.

This change adds the scenario to handle a PIN style (numeric keyboard) which should be masked/password and can be toggled accordingly.

![image](https://user-images.githubusercontent.com/3904944/88946143-e50ed480-d25c-11ea-9a2f-52c1f4a3d4d2.png)

![image](https://user-images.githubusercontent.com/3904944/88946200-f35cf080-d25c-11ea-9c74-f9d93938b475.png)

![image](https://user-images.githubusercontent.com/3904944/88946246-fe178580-d25c-11ea-86a8-4df27c76dfab.png)
