### PR TITLE
[KnownUsernameField] Entries update (main ones)

### DIFF
--- a/src/Android/Accessibility/AccessibilityHelpers.cs
+++ b/src/Android/Accessibility/AccessibilityHelpers.cs
@@ -218,8 +218,8 @@ namespace Bit.Droid.Accessibility
              * G
              */
 
-            // Google ——— 1st = used in some cases (v1) / 2nd = used in most cases (v2).
-            new KnownUsernameField("accounts.google.com",    new (string, string)[] { ("ServiceLogin", "Email"), ("identifier", "identifierId") }),
+            // Google ——— 1st = used in most cases (v2) / 2nd = used in some cases (v1).
+            new KnownUsernameField("accounts.google.com",    new (string, string)[] { ("identifier", "identifierId"), ("ServiceLogin", "Email") }),
 
             /*
              * P


### PR DESCRIPTION
**CONTEXT:** This is an update of [this new system](https://github.com/bitwarden/mobile/pull/880) _(system allowing "user ID" field detection — i.e. email/username/phone/whatever — without "password" field using the accessibility service)_.

**UPDATED:** Entries.

**RELATED:** https://github.com/bitwarden/mobile/pull/880#issuecomment-646830516
___
&nbsp;
# Summary
&nbsp;
**This fixes support for:**
- [see post n°1 below] **Google**

**This adds missing OAuth support for:**
- [see post n°2 below] **PayPal**

**This adds support for:**
- [see post n°3 below] national + desktop **Amazon** — the latter uses a different value.
- [see post n°4 below] national **eBay**
- [see post n°5 below] **Atlassian**
- [see post n°6 below] **Bitly** — enterprise users.
- [see post n°7 below] **Tumblr**
- [see post n°8 below] **Yandex**
-
- [see post n°9 below] ... + **My docomo** from [NTT DOCOMO](https://en.wikipedia.org/wiki/NTT_Docomo) — in a separate section, as part of a **Top 20 Japan**.
&nbsp;

:bulb: **For all:** Both the mobile version and the desktop version of these web sites/applications have been tested and are supported.
&nbsp;

# About OAuth authentication
<details>
<summary>Read me ...</summary>

&nbsp;

**Taken from the source code:**
```
// NOTE: The case of OAuth compatible web sites/applications that also provide
//       a "user ID only" login page in this situation
//       was taken into account in the tests as well.
```
:arrow_right_hook: See screenshots in the posts below for web sites/applications using a "user ID only" login page also for OAuth authentication.
&nbsp;

### OAuth usage examples ...

![OAuth_Google_Yandex_example](https://user-images.githubusercontent.com/4764956/88304117-21e04600-cd08-11ea-995e-0652d914ce87.png)
:arrow_right: Example of login using OAuth _(right)_, in this case with a lot of choices because on a support forum of a website selling ... an OAuth module for a known CMS and a popular forum system _(and using it as a proof of proper functioning on its own website and forum)_.

![OAuth_Atlassian_Bitbucket_example](https://user-images.githubusercontent.com/4764956/88304110-20168280-cd08-11ea-8603-fa923fac0634.png)
:arrow_right: Example of login using OAuth, in this case on AppVeyor.
</details>
&nbsp;
&nbsp;

# About n°6/7/8/9 (coming from the Top 100 WW)
<details>
<summary>Read me ...</summary>
&nbsp;

These were added as part of a standard verification (checked one by one, looking for "user ID only" login pages, in two rounds — **round 1:** desktop mode, **round 2:** mobile mode) of a [recent Top 100 of the most visited websites in the world](https://www.visualcapitalist.com/ranking-the-top-100-websites-in-the-world/)(*, see warning before) _(source: SimilarWeb 2019)_ followed by the same process for [this Top 50](https://en.wikipedia.org/wiki/List_of_most_popular_websites) _(source: Alexa Internet 2020)_.

For the Top 100, about a dozen used a "user ID only" login page, but the majority was well coded, allowing Bitwarden to display a prompt automatically.

### Among the remaining contenders:
- **One** was not to be added in the main section (customer area of a Japanese mobile phone operator, despite being [the first one](https://en.wikipedia.org/wiki/List_of_mobile_network_operators_of_the_Asia_Pacific_region#Japan) there in Japan, namely **NTT DOCOMO**). Added but in a separate section, as part of a Top 20 Japan.
- **Two** did not have an "id" attribute regarding their login field (**mail.ru** both in desktop and mobile version + **baidu.com** mobile).
- ... There were ultimately **three** entries that were addable: **Bitly** (.com), **Tumblr** (.com) and **Yandex** (.com/.ru/various TLDs). :octocat:

![top-100-websites-worldwide](https://user-images.githubusercontent.com/4764956/87396414-1af05f80-c5b3-11ea-84a9-c3bddc402405.jpg)
&nbsp;

###### (*) WARNING ＞ Two entries in this Top 100 list are visibly known to be a source of adware/malware: _tsyndicate_ (position 86) and _crptgate_ (position 95). Also note that _microsoftonline.com_ (position 52) is indeed a [domain name belonging to Microsoft](https://forums.malwarebytes.com/topic/242508-delist-loginmicrosoftonlinecom/), despite what the image above indicates.
</details>

&nbsp;
&nbsp;

:information_source: Based on my research for this PR, I will take the opportunity to improve a little bit [this file](https://github.com/bitwarden/server/blob/004e3c58ee866398a4cf31201cf7205d334fac7b/src/Core/Utilities/StaticStore.cs) as well. :thumbsup: