### PR TITLE
[KnownUsernameField] Entries update (main ones)

### DIFF
--- a/src/Android/Accessibility/AccessibilityHelpers.cs
+++ b/src/Android/Accessibility/AccessibilityHelpers.cs
@@ -248,7 +248,6 @@ namespace Bit.Droid.Accessibility
             new KnownUsernameField("passport.yandex.ua",     new (string, string)[] { ("auth", "passp-field-login") }),
             new KnownUsernameField("passport.yandex.uz",     new (string, string)[] { ("auth", "passp-field-login") }),
 
-
             /**************************************************************************************
              * SECTION B ——— Top 100 worldwide
              *************************************************************************************/
@@ -258,7 +257,6 @@ namespace Bit.Droid.Accessibility
             // matched section A.
             //
             // Therefore, no entry currently.
-
 
             /**************************************************************************************
              * SECTION C ——— Top 20 for selected countries
@@ -278,7 +276,6 @@ namespace Bit.Droid.Accessibility
             // NTT DOCOMO ——— mainly used for "My docomo".
             new KnownUsernameField("cfg.smt.docomo.ne.jp",   new (string, string)[] { ("contains:/auth/", "Di_Uid") }),
 
-
             /**************************************************************************************
              * SECTION D ——— Miscellaneous
              *************************************************************************************/
@@ -287,8 +284,7 @@ namespace Bit.Droid.Accessibility
              * Various entries ——— Following user requests, etc.
              */
 
-            // >>> No entry, currently.
-
+            // No entry, currently.
 
             /**************************************************************************************
              * SECTION Z ——— Special forms
@@ -300,7 +296,7 @@ namespace Bit.Droid.Accessibility
              * Main
              */
 
-            // >>> No entry, currently.
+            // No entry, currently.
 
             /*
              * Test/example purposes only

--- a/src/Android/Accessibility/AccessibilityHelpers.cs
+++ b/src/Android/Accessibility/AccessibilityHelpers.cs
@@ -129,16 +129,205 @@ namespace Bit.Droid.Accessibility
             "com.ss.squarehome2",
             "com.treydev.pns"
         };
-        
-        // Be sure to keep these entries sorted alphabetically
+
+        // Be sure to keep these sections sorted alphabetically
         public static Dictionary<string, KnownUsernameField> KnownUsernameFields => new List<KnownUsernameField>
         {
-            new KnownUsernameField("accounts.google.com",   new (string, string)[] { ("ServiceLogin", "Email") }),
-            new KnownUsernameField("amazon.com",            new (string, string)[] { ("signin", "ap_email_login") }),
-            new KnownUsernameField("github.com",            new (string, string)[] { ("", "user[login]-footer") }),
-            new KnownUsernameField("paypal.com",            new (string, string)[] { ("signin", "email") }),
-            new KnownUsernameField("signin.aws.amazon.com", new (string, string)[] { ("signin", "resolving_input") }),
-            new KnownUsernameField("signin.ebay.com",       new (string, string)[] { ("eBayISAPI.dll", "userid") }),
+            /**************************************************************************************
+             * SECTION A ——— World-renowned web sites/applications
+             *************************************************************************************/
+
+
+            // REM.:  For this type of web sites/applications, the Top 100 (SimilarWeb, 2019)
+            //        and the Top 50 (Alexa Internet, 2020) are covered. National variants
+            //        have been added when available. Mobile and desktop versions supported.
+            //
+            //        A few other popular web sites/applications have also been added.
+            //
+            //        Could not be added, however:
+            //        web sites/applications that don't use an "id" attribute for their login field.
+
+
+            // NOTE:  The case of OAuth compatible web sites/applications that also provide
+            //        a "user ID only" login page in this situation
+            //        was taken into account in the tests as well.
+
+
+            /*
+             * A
+             */
+
+            // Amazon ——— ap_email_login = mobile / ap_email = desktop (amazon.co.jp currently uses ap_email in both cases, as of July 2020).
+            new KnownUsernameField("amazon.ae",              new (string, string)[] { ("contains:/ap/signin", "ap_email_login,ap_email") }),
+            new KnownUsernameField("amazon.ca",              new (string, string)[] { ("contains:/ap/signin", "ap_email_login,ap_email") }),
+            new KnownUsernameField("amazon.cn",              new (string, string)[] { ("contains:/ap/signin", "ap_email_login,ap_email") }),
+            new KnownUsernameField("amazon.co.jp",           new (string, string)[] { ("contains:/ap/signin", "ap_email_login,ap_email") }),
+            new KnownUsernameField("amazon.co.uk",           new (string, string)[] { ("contains:/ap/signin", "ap_email_login,ap_email") }),
+            new KnownUsernameField("amazon.com",             new (string, string)[] { ("contains:/ap/signin", "ap_email_login,ap_email") }),
+            new KnownUsernameField("amazon.com.au",          new (string, string)[] { ("contains:/ap/signin", "ap_email_login,ap_email") }),
+            new KnownUsernameField("amazon.com.br",          new (string, string)[] { ("contains:/ap/signin", "ap_email_login,ap_email") }),
+            new KnownUsernameField("amazon.com.mx",          new (string, string)[] { ("contains:/ap/signin", "ap_email_login,ap_email") }),
+            new KnownUsernameField("amazon.com.tr",          new (string, string)[] { ("contains:/ap/signin", "ap_email_login,ap_email") }),
+            new KnownUsernameField("amazon.de",              new (string, string)[] { ("contains:/ap/signin", "ap_email_login,ap_email") }),
+            new KnownUsernameField("amazon.es",              new (string, string)[] { ("contains:/ap/signin", "ap_email_login,ap_email") }),
+            new KnownUsernameField("amazon.fr",              new (string, string)[] { ("contains:/ap/signin", "ap_email_login,ap_email") }),
+            new KnownUsernameField("amazon.in",              new (string, string)[] { ("contains:/ap/signin", "ap_email_login,ap_email") }),
+            new KnownUsernameField("amazon.it",              new (string, string)[] { ("contains:/ap/signin", "ap_email_login,ap_email") }),
+            new KnownUsernameField("amazon.nl",              new (string, string)[] { ("contains:/ap/signin", "ap_email_login,ap_email") }),
+            new KnownUsernameField("amazon.sa",              new (string, string)[] { ("contains:/ap/signin", "ap_email_login,ap_email") }),
+            new KnownUsernameField("amazon.sg",              new (string, string)[] { ("contains:/ap/signin", "ap_email_login,ap_email") }),
+
+            // Amazon Web Services
+            new KnownUsernameField("signin.aws.amazon.com",  new (string, string)[] { ("signin", "resolving_input") }),
+
+            // Atlassian
+            new KnownUsernameField("id.atlassian.com",       new (string, string)[] { ("login", "username") }),
+
+
+            /*
+             * B
+             */
+
+            // Bitly ——— enterprise users.
+            new KnownUsernameField("bitly.com",              new (string, string)[] { ("/sso/url_slug", "url_slug") }),
+
+
+            /*
+             * E
+             */
+
+            // eBay ——— 1st = traditional access / 2nd = direct access (i.e. https://signin.ebay.tld/).
+            new KnownUsernameField("signin.befr.ebay.be",    new (string, string)[] { ("iendswith:eBayISAPI.dll", "userid"), ("icontains:/signin/", "userid") }),
+            new KnownUsernameField("signin.benl.ebay.be",    new (string, string)[] { ("iendswith:eBayISAPI.dll", "userid"), ("icontains:/signin/", "userid") }),
+            new KnownUsernameField("signin.cafr.ebay.ca",    new (string, string)[] { ("iendswith:eBayISAPI.dll", "userid"), ("icontains:/signin/", "userid") }),
+            new KnownUsernameField("signin.ebay.at",         new (string, string)[] { ("iendswith:eBayISAPI.dll", "userid"), ("icontains:/signin/", "userid") }),
+            new KnownUsernameField("signin.ebay.be",         new (string, string)[] { ("iendswith:eBayISAPI.dll", "userid"), ("icontains:/signin/", "userid") }),
+            new KnownUsernameField("signin.ebay.ca",         new (string, string)[] { ("iendswith:eBayISAPI.dll", "userid"), ("icontains:/signin/", "userid") }),
+            new KnownUsernameField("signin.ebay.ch",         new (string, string)[] { ("iendswith:eBayISAPI.dll", "userid"), ("icontains:/signin/", "userid") }),
+            new KnownUsernameField("signin.ebay.co.uk",      new (string, string)[] { ("iendswith:eBayISAPI.dll", "userid"), ("icontains:/signin/", "userid") }),
+            new KnownUsernameField("signin.ebay.com",        new (string, string)[] { ("iendswith:eBayISAPI.dll", "userid"), ("icontains:/signin/", "userid") }),
+            new KnownUsernameField("signin.ebay.com.au",     new (string, string)[] { ("iendswith:eBayISAPI.dll", "userid"), ("icontains:/signin/", "userid") }),
+            new KnownUsernameField("signin.ebay.com.hk",     new (string, string)[] { ("iendswith:eBayISAPI.dll", "userid"), ("icontains:/signin/", "userid") }),
+            new KnownUsernameField("signin.ebay.com.my",     new (string, string)[] { ("iendswith:eBayISAPI.dll", "userid"), ("icontains:/signin/", "userid") }),
+            new KnownUsernameField("signin.ebay.com.sg",     new (string, string)[] { ("iendswith:eBayISAPI.dll", "userid"), ("icontains:/signin/", "userid") }),
+            new KnownUsernameField("signin.ebay.de",         new (string, string)[] { ("iendswith:eBayISAPI.dll", "userid"), ("icontains:/signin/", "userid") }),
+            new KnownUsernameField("signin.ebay.es",         new (string, string)[] { ("iendswith:eBayISAPI.dll", "userid"), ("icontains:/signin/", "userid") }),
+            new KnownUsernameField("signin.ebay.fr",         new (string, string)[] { ("iendswith:eBayISAPI.dll", "userid"), ("icontains:/signin/", "userid") }),
+            new KnownUsernameField("signin.ebay.ie",         new (string, string)[] { ("iendswith:eBayISAPI.dll", "userid"), ("icontains:/signin/", "userid") }),
+            new KnownUsernameField("signin.ebay.it",         new (string, string)[] { ("iendswith:eBayISAPI.dll", "userid"), ("icontains:/signin/", "userid") }),
+            new KnownUsernameField("signin.ebay.nl",         new (string, string)[] { ("iendswith:eBayISAPI.dll", "userid"), ("icontains:/signin/", "userid") }),
+            new KnownUsernameField("signin.ebay.ph",         new (string, string)[] { ("iendswith:eBayISAPI.dll", "userid"), ("icontains:/signin/", "userid") }),
+            new KnownUsernameField("signin.ebay.pl",         new (string, string)[] { ("iendswith:eBayISAPI.dll", "userid"), ("icontains:/signin/", "userid") }),
+
+
+            /*
+             * G
+             */
+
+            // Google ——— 1st = used in some cases (v1) / 2nd = used in most cases (v2).
+            new KnownUsernameField("accounts.google.com",    new (string, string)[] { ("ServiceLogin", "Email"), ("identifier", "identifierId") }),
+
+
+            /*
+             * P
+             */
+
+            // PayPal ——— 1st = traditional access / 2nd = access using OAuth.
+            new KnownUsernameField("paypal.com",             new (string, string)[] { ("signin", "email"), ("contains:/connect/", "email") }),
+
+
+            /*
+             * T
+             */
+
+            // Tumblr ——— despite "signup" in its ID, it's the login field (the website offers registration if the account doesn't exist).
+            new KnownUsernameField("tumblr.com",             new (string, string)[] { ("login", "signup_determine_email") }),
+
+
+            /*
+             * Y
+             */
+
+            // Yandex
+            new KnownUsernameField("passport.yandex.by",     new (string, string)[] { ("auth", "passp-field-login") }),
+            new KnownUsernameField("passport.yandex.com",    new (string, string)[] { ("auth", "passp-field-login") }),
+            new KnownUsernameField("passport.yandex.com.tr", new (string, string)[] { ("auth", "passp-field-login") }),
+            new KnownUsernameField("passport.yandex.kz",     new (string, string)[] { ("auth", "passp-field-login") }),
+            new KnownUsernameField("passport.yandex.ru",     new (string, string)[] { ("auth", "passp-field-login") }),
+            new KnownUsernameField("passport.yandex.ua",     new (string, string)[] { ("auth", "passp-field-login") }),
+            new KnownUsernameField("passport.yandex.uz",     new (string, string)[] { ("auth", "passp-field-login") }),
+
+
+
+            /**************************************************************************************
+             * SECTION B ——— Top 100 worldwide
+             *************************************************************************************/
+
+
+            //  As of July 2020, all entries that needed to be added from
+            //  Top 100 (SimilarWeb, 2019) and Top 50 (Alexa Internet, 2020)
+            //  matched section A.
+            //
+            //  Therefore, no entry currently.
+
+
+
+            /**************************************************************************************
+             * SECTION C ——— Top 20 for selected countries
+             *************************************************************************************/
+
+
+            // REM.:  For these selected countries, the Top 20 (SimilarWeb, 2020)
+            //        and the Top 20 (Alexa Internet, 2020) are covered.
+            //        Mobile and desktop versions supported.
+            //
+            //        Could not be added, however:
+            //        web sites/applications that don't use an "id" attribute for their login field.
+
+
+            /*
+             * Japan
+             */
+
+            // NTT DOCOMO ——— mainly used for "My docomo".
+            new KnownUsernameField("cfg.smt.docomo.ne.jp",   new (string, string)[] { ("contains:/auth/", "Di_Uid") }),
+
+
+
+            /**************************************************************************************
+             * SECTION D ——— Miscellaneous
+             *************************************************************************************/
+
+
+            /*
+             * Various entries ——— Following user requests, etc.
+             */
+
+            // >>> No entry, currently.
+
+
+
+
+            /**************************************************************************************
+             * SECTION Z ——— Special forms
+             *
+             * Despite "user ID + password" fields both visible, detection rules required.
+             *************************************************************************************/
+
+
+            /*
+             * Main
+             */
+
+            // >>> No entry, currently.
+
+
+            /*
+             * Test/example purposes only
+             */
+
+            // GitHub ——— VERY special case (signup form, just to test the proper functioning of special forms).
+            new KnownUsernameField("github.com",             new (string, string)[] { ("", "user[login]-footer") }),
         }.ToDictionary(n => n.UriAuthority);
 
         public static void PrintTestData(AccessibilityNodeInfo root, AccessibilityEvent e)

--- a/src/Android/Accessibility/AccessibilityHelpers.cs
+++ b/src/Android/Accessibility/AccessibilityHelpers.cs
@@ -180,14 +180,12 @@ namespace Bit.Droid.Accessibility
             // Atlassian
             new KnownUsernameField("id.atlassian.com",       new (string, string)[] { ("login", "username") }),
 
-
             /*
              * B
              */
 
             // Bitly ——— enterprise users.
             new KnownUsernameField("bitly.com",              new (string, string)[] { ("/sso/url_slug", "url_slug") }),
-
 
             /*
              * E
@@ -216,14 +214,12 @@ namespace Bit.Droid.Accessibility
             new KnownUsernameField("signin.ebay.ph",         new (string, string)[] { ("iendswith:eBayISAPI.dll", "userid"), ("icontains:/signin/", "userid") }),
             new KnownUsernameField("signin.ebay.pl",         new (string, string)[] { ("iendswith:eBayISAPI.dll", "userid"), ("icontains:/signin/", "userid") }),
 
-
             /*
              * G
              */
 
             // Google ——— 1st = used in some cases (v1) / 2nd = used in most cases (v2).
             new KnownUsernameField("accounts.google.com",    new (string, string)[] { ("ServiceLogin", "Email"), ("identifier", "identifierId") }),
-
 
             /*
              * P
@@ -232,14 +228,12 @@ namespace Bit.Droid.Accessibility
             // PayPal ——— 1st = traditional access / 2nd = access using OAuth.
             new KnownUsernameField("paypal.com",             new (string, string)[] { ("signin", "email"), ("contains:/connect/", "email") }),
 
-
             /*
              * T
              */
 
             // Tumblr ——— despite "signup" in its ID, it's the login field (the website offers registration if the account doesn't exist).
             new KnownUsernameField("tumblr.com",             new (string, string)[] { ("login", "signup_determine_email") }),
-
 
             /*
              * Y
@@ -307,7 +301,6 @@ namespace Bit.Droid.Accessibility
              */
 
             // >>> No entry, currently.
-
 
             /*
              * Test/example purposes only

--- a/src/Android/Accessibility/AccessibilityHelpers.cs
+++ b/src/Android/Accessibility/AccessibilityHelpers.cs
@@ -137,21 +137,18 @@ namespace Bit.Droid.Accessibility
              * SECTION A ——— World-renowned web sites/applications
              *************************************************************************************/
 
-
-            // REM.:  For this type of web sites/applications, the Top 100 (SimilarWeb, 2019)
-            //        and the Top 50 (Alexa Internet, 2020) are covered. National variants
-            //        have been added when available. Mobile and desktop versions supported.
+            // REM.: For this type of web sites/applications, the Top 100 (SimilarWeb, 2019)
+            //       and the Top 50 (Alexa Internet, 2020) are covered. National variants
+            //       have been added when available. Mobile and desktop versions supported.
             //
-            //        A few other popular web sites/applications have also been added.
+            //       A few other popular web sites/applications have also been added.
             //
-            //        Could not be added, however:
-            //        web sites/applications that don't use an "id" attribute for their login field.
+            //       Could not be added, however:
+            //       web sites/applications that don't use an "id" attribute for their login field.
 
-
-            // NOTE:  The case of OAuth compatible web sites/applications that also provide
-            //        a "user ID only" login page in this situation
-            //        was taken into account in the tests as well.
-
+            // NOTE: The case of OAuth compatible web sites/applications that also provide
+            //       a "user ID only" login page in this situation
+            //       was taken into account in the tests as well.
 
             /*
              * A
@@ -258,32 +255,27 @@ namespace Bit.Droid.Accessibility
             new KnownUsernameField("passport.yandex.uz",     new (string, string)[] { ("auth", "passp-field-login") }),
 
 
-
             /**************************************************************************************
              * SECTION B ——— Top 100 worldwide
              *************************************************************************************/
 
-
-            //  As of July 2020, all entries that needed to be added from
-            //  Top 100 (SimilarWeb, 2019) and Top 50 (Alexa Internet, 2020)
-            //  matched section A.
+            // As of July 2020, all entries that needed to be added from
+            // Top 100 (SimilarWeb, 2019) and Top 50 (Alexa Internet, 2020)
+            // matched section A.
             //
-            //  Therefore, no entry currently.
-
+            // Therefore, no entry currently.
 
 
             /**************************************************************************************
              * SECTION C ——— Top 20 for selected countries
              *************************************************************************************/
 
-
-            // REM.:  For these selected countries, the Top 20 (SimilarWeb, 2020)
-            //        and the Top 20 (Alexa Internet, 2020) are covered.
-            //        Mobile and desktop versions supported.
+            // REM.: For these selected countries, the Top 20 (SimilarWeb, 2020)
+            //       and the Top 20 (Alexa Internet, 2020) are covered.
+            //       Mobile and desktop versions supported.
             //
-            //        Could not be added, however:
-            //        web sites/applications that don't use an "id" attribute for their login field.
-
+            //       Could not be added, however:
+            //       web sites/applications that don't use an "id" attribute for their login field.
 
             /*
              * Japan
@@ -293,11 +285,9 @@ namespace Bit.Droid.Accessibility
             new KnownUsernameField("cfg.smt.docomo.ne.jp",   new (string, string)[] { ("contains:/auth/", "Di_Uid") }),
 
 
-
             /**************************************************************************************
              * SECTION D ——— Miscellaneous
              *************************************************************************************/
-
 
             /*
              * Various entries ——— Following user requests, etc.
@@ -306,14 +296,11 @@ namespace Bit.Droid.Accessibility
             // >>> No entry, currently.
 
 
-
-
             /**************************************************************************************
              * SECTION Z ——— Special forms
              *
              * Despite "user ID + password" fields both visible, detection rules required.
              *************************************************************************************/
-
 
             /*
              * Main

--- a/src/Android/Accessibility/AccessibilityHelpers.cs
+++ b/src/Android/Accessibility/AccessibilityHelpers.cs
@@ -218,8 +218,8 @@ namespace Bit.Droid.Accessibility
              * G
              */
 
-            // Google ——— 1st = used in some cases (v1) / 2nd = used in most cases (v2).
-            new KnownUsernameField("accounts.google.com",    new (string, string)[] { ("ServiceLogin", "Email"), ("identifier", "identifierId") }),
+            // Google ——— 1st = used in most cases (v2) / 2nd = used in some cases (v1).
+            new KnownUsernameField("accounts.google.com",    new (string, string)[] { ("identifier", "identifierId"), ("ServiceLogin", "Email") }),
 
             /*
              * P


### PR DESCRIPTION
**CONTEXT:** This is an update of [this new system](https://github.com/bitwarden/mobile/pull/880) _(system allowing "user ID" field detection — i.e. email/username/phone/whatever — without "password" field using the accessibility service)_.

**UPDATED:** Entries.

**RELATED:** https://github.com/bitwarden/mobile/pull/880#issuecomment-646830516
___
&nbsp;
# Summary
&nbsp;
**This fixes support for:**
- [see post n°1 below] **Google**

**This adds missing OAuth support for:**
- [see post n°2 below] **PayPal**

**This adds support for:**
- [see post n°3 below] national + desktop **Amazon** — the latter uses a different value.
- [see post n°4 below] national **eBay**
- [see post n°5 below] **Atlassian**
- [see post n°6 below] **Bitly** — enterprise users.
- [see post n°7 below] **Tumblr**
- [see post n°8 below] **Yandex**
-
- [see post n°9 below] ... + **My docomo** from [NTT DOCOMO](https://en.wikipedia.org/wiki/NTT_Docomo) — in a separate section, as part of a **Top 20 Japan**.
&nbsp;

:bulb: **For all:** Both the mobile version and the desktop version of these web sites/applications have been tested and are supported.
&nbsp;

# About OAuth authentication
<details>
<summary>Read me ...</summary>

&nbsp;

**Taken from the source code:**
```
// NOTE: The case of OAuth compatible web sites/applications that also provide
//       a "user ID only" login page in this situation
//       was taken into account in the tests as well.
```
:arrow_right_hook: See screenshots in the posts below for web sites/applications using a "user ID only" login page also for OAuth authentication.
&nbsp;

### OAuth usage examples ...

![OAuth_Google_Yandex_example](https://user-images.githubusercontent.com/4764956/88304117-21e04600-cd08-11ea-995e-0652d914ce87.png)
:arrow_right: Example of login using OAuth _(right)_, in this case with a lot of choices because on a support forum of a website selling ... an OAuth module for a known CMS and a popular forum system _(and using it as a proof of proper functioning on its own website and forum)_.

![OAuth_Atlassian_Bitbucket_example](https://user-images.githubusercontent.com/4764956/88304110-20168280-cd08-11ea-8603-fa923fac0634.png)
:arrow_right: Example of login using OAuth, in this case on AppVeyor.
</details>
&nbsp;
&nbsp;

# About n°6/7/8/9 (coming from the Top 100 WW)
<details>
<summary>Read me ...</summary>
&nbsp;

These were added as part of a standard verification (checked one by one, looking for "user ID only" login pages, in two rounds — **round 1:** desktop mode, **round 2:** mobile mode) of a [recent Top 100 of the most visited websites in the world](https://www.visualcapitalist.com/ranking-the-top-100-websites-in-the-world/)(*, see warning before) _(source: SimilarWeb 2019)_ followed by the same process for [this Top 50](https://en.wikipedia.org/wiki/List_of_most_popular_websites) _(source: Alexa Internet 2020)_.

For the Top 100, about a dozen used a "user ID only" login page, but the majority was well coded, allowing Bitwarden to display a prompt automatically.

### Among the remaining contenders:
- **One** was not to be added in the main section (customer area of a Japanese mobile phone operator, despite being [the first one](https://en.wikipedia.org/wiki/List_of_mobile_network_operators_of_the_Asia_Pacific_region#Japan) there in Japan, namely **NTT DOCOMO**). Added but in a separate section, as part of a Top 20 Japan.
- **Two** did not have an "id" attribute regarding their login field (**mail.ru** both in desktop and mobile version + **baidu.com** mobile).
- ... There were ultimately **three** entries that were addable: **Bitly** (.com), **Tumblr** (.com) and **Yandex** (.com/.ru/various TLDs). :octocat:

![top-100-websites-worldwide](https://user-images.githubusercontent.com/4764956/87396414-1af05f80-c5b3-11ea-84a9-c3bddc402405.jpg)
&nbsp;

###### (*) WARNING: two entries in this Top 100 list are visibly known to be a source of adware/malware: _tsyndicate_ (position 86) and _crptgate_ (position 95).
</details>

&nbsp;
&nbsp;

:information_source: Based on my research for this PR, I will take the opportunity to improve a little bit [this file](https://github.com/bitwarden/server/blob/004e3c58ee866398a4cf31201cf7205d334fac7b/src/Core/Utilities/StaticStore.cs) as well. :thumbsup: