### PR TITLE
Biometric integrity check always fails

### DIFF
--- a/src/Android/Services/BiometricService.cs
+++ b/src/Android/Services/BiometricService.cs
@@ -71,7 +71,7 @@ namespace Bit.Droid.Services
                 CreateKey();
             }
 
-            return Task.FromResult(false);
+            return Task.FromResult(true);
         }
 
         private void CreateKey()


### PR DESCRIPTION
During testing I accidentally reversed the expected result from `ValidateIntegrityAsync`. (Emulator has issues with detecting biometric changes, so to verify the message I inverted the check)

Should solve https://github.com/bitwarden/mobile/pull/1026#issuecomment-672996129