### PR TITLE
[KnownUsernameField] Fix for the special case "eBay India"

### DIFF
--- a/src/Android/Accessibility/AccessibilityHelpers.cs
+++ b/src/Android/Accessibility/AccessibilityHelpers.cs
@@ -209,6 +209,7 @@ namespace Bit.Droid.Accessibility
             new KnownUsernameField("signin.ebay.es",         new (string, string)[] { ("iendswith:eBayISAPI.dll", "userid"), ("icontains:/signin/", "userid") }),
             new KnownUsernameField("signin.ebay.fr",         new (string, string)[] { ("iendswith:eBayISAPI.dll", "userid"), ("icontains:/signin/", "userid") }),
             new KnownUsernameField("signin.ebay.ie",         new (string, string)[] { ("iendswith:eBayISAPI.dll", "userid"), ("icontains:/signin/", "userid") }),
+            new KnownUsernameField("signin.ebay.in",         new (string, string)[] { ("iendswith:eBayISAPI.dll", "userid"), ("icontains:/signin/", "userid") }),
             new KnownUsernameField("signin.ebay.it",         new (string, string)[] { ("iendswith:eBayISAPI.dll", "userid"), ("icontains:/signin/", "userid") }),
             new KnownUsernameField("signin.ebay.nl",         new (string, string)[] { ("iendswith:eBayISAPI.dll", "userid"), ("icontains:/signin/", "userid") }),
             new KnownUsernameField("signin.ebay.ph",         new (string, string)[] { ("iendswith:eBayISAPI.dll", "userid"), ("icontains:/signin/", "userid") }),


### PR DESCRIPTION
# Spotted a special case, that of **eBay India**.
&nbsp;

As a reminder, `www.ebay.in` is the only one in the list — available in the footer of `www.ebay.com` — with `www.ebay.se` to have their domain name redirecting to `ebay.com`.

**But** unlike the `.se` where the `signin.ebay.se` does not exist or no longer exists, the `.in` still has it: `signin.ebay.in`. With a message indicating this **transition period**, though.

:arrow_right_hook: _Although inaccessible from the home page because now redirected to `in.ebay.com` (which uses `signin.ebay.com`)._
&nbsp;
&nbsp;

## Screenshots

**Main URL:**

![signin.ebay.in_main](https://user-images.githubusercontent.com/4764956/90286997-3c28c200-de77-11ea-80ce-638ec2166a2c.png)

**Alternative URL:**

![signin.ebay.in_alt](https://user-images.githubusercontent.com/4764956/90287001-3e8b1c00-de77-11ea-8612-a1157bad14c3.png)

> To buy and sell on www.ebay.com or other eBay sites internationally, existing users can login using their credentials or new users can register an eBay account on ebay.in. **Kindly note you can no longer buy or sell on eBay.in.**

&nbsp;

## Action taken

:arrow_right: Added `signin.ebay.in`.

:bulb: Value `userid` checked, both in mobile and desktop mode.