### PR TITLE
Fix auto biometric prompt on vault timeout

### DIFF
--- a/src/App/App.xaml.cs
+++ b/src/App/App.xaml.cs
@@ -415,10 +415,6 @@ namespace Bit.App
                     autoPromptBiometric = false;
                 }
             }
-            else if (autoPromptBiometric && Device.RuntimePlatform == Device.Android)
-            {
-                autoPromptBiometric = false;
-            }
             PreviousPageInfo lastPageBeforeLock = null;
             if (Current.MainPage is TabbedPage tabbedPage && tabbedPage.Navigation.ModalStack.Count > 0)
             {

--- a/src/App/App.xaml.cs
+++ b/src/App/App.xaml.cs
@@ -407,18 +407,6 @@ namespace Bit.App
         private async Task LockedAsync(bool autoPromptBiometric)
         {
             await _stateService.PurgeAsync();
-            if (autoPromptBiometric && Device.RuntimePlatform == Device.iOS)
-            {
-                var vaultTimeout = await _storageService.GetAsync<int?>(Constants.VaultTimeoutKey);
-                if (vaultTimeout == 0)
-                {
-                    autoPromptBiometric = false;
-                }
-            }
-            else if (autoPromptBiometric && Device.RuntimePlatform == Device.Android)
-            {
-                autoPromptBiometric = false;
-            }
             PreviousPageInfo lastPageBeforeLock = null;
             if (Current.MainPage is TabbedPage tabbedPage && tabbedPage.Navigation.ModalStack.Count > 0)
             {

--- a/src/App/App.xaml.cs
+++ b/src/App/App.xaml.cs
@@ -407,6 +407,18 @@ namespace Bit.App
         private async Task LockedAsync(bool autoPromptBiometric)
         {
             await _stateService.PurgeAsync();
+            if (autoPromptBiometric && Device.RuntimePlatform == Device.iOS)
+            {
+                var vaultTimeout = await _storageService.GetAsync<int?>(Constants.VaultTimeoutKey);
+                if (vaultTimeout == 0)
+                {
+                    autoPromptBiometric = false;
+                }
+            }
+            else if (autoPromptBiometric && Device.RuntimePlatform == Device.Android)
+            {
+                autoPromptBiometric = false;
+            }
             PreviousPageInfo lastPageBeforeLock = null;
             if (Current.MainPage is TabbedPage tabbedPage && tabbedPage.Navigation.ModalStack.Count > 0)
             {


### PR DESCRIPTION
A condition force to not show the auto biometric prompt (https://github.com/bitwarden/mobile/issues/1045).

This condition don't change the case about when you lock manually the vault from settings page or app bar, because the value of the function parameter is false in those cases, and the prompt is not shown, as expected.

However, in the case that the vault is not locked and you hit the home button or when you lock the phone screen, the value of the function parameter is true, and the condition set it on false, then the prompt will not be shown when you'll access back to the app. Whatever vault timeout selected, it's happen when the vault timed out. When it sets to "Immediatly" this behavior is annoying when you want to switch to another app and go back to it.

<details>
  <summary>GIF issue (expand)</summary>

![gif](https://i.gyazo.com/0a32a289e100f62ab74882ab2ee894f5.gif)
</details>

I don't get this issue on iOS version, it's maybe due to the sub condition vaultTimeout, i have always his value on null when i try it on Android but since i don't have any Mac environment, i can't debug it on iOS.
