### PR TITLE
[KnownUsernameField] Entries update (Top 20 JP enhancement)

### DIFF
--- a/src/Android/Accessibility/AccessibilityHelpers.cs
+++ b/src/Android/Accessibility/AccessibilityHelpers.cs
@@ -290,6 +290,7 @@ namespace Bit.Droid.Accessibility
 
             // NTT DOCOMO ——— mainly used for "My docomo".
             new KnownUsernameField("cfg.smt.docomo.ne.jp",   new (string, string)[] { ("contains:/auth/", "Di_Uid") }),
+            new KnownUsernameField("id.smt.docomo.ne.jp",    new (string, string)[] { ("contains:/cgi7/", "Di_Uid") }),
 
             /**************************************************************************************
              * SECTION D ——— Miscellaneous


### PR DESCRIPTION
### This:
- adds support for alternative access for **NTT DOCOMO** _(KnownUsernameField > Top 20 Japan)_.
&nbsp;

# Screenshots
<details>
<summary>View me ...</summary>

# Short _access URL_
![NTT_Docomo_AltAccess_001](https://user-images.githubusercontent.com/4764956/91481567-f15e6f80-e8a4-11ea-9078-f85b5a6dc9bc.png)

# Typical _access URL_
![NTT_Docomo_AltAccess_002a](https://user-images.githubusercontent.com/4764956/91481823-53b77000-e8a5-11ea-8187-278250329757.png)
![NTT_Docomo_AltAccess_002b](https://user-images.githubusercontent.com/4764956/91481828-54e89d00-e8a5-11ea-8b07-3197f0cb7624.png)
</details>


