### PR TITLE
publish to google play internal test track

### DIFF
--- a/.github/scripts/android/deploy-play.ps1
+++ b/.github/scripts/android/deploy-play.ps1
@@ -4,6 +4,6 @@ $homePath = Resolve-Path "~" | Select-Object -ExpandProperty Path;
 $publisherPath = $($rootPath + "/store/google/Publisher/bin/Release/netcoreapp2.0/Publisher.dll");
 $credsPath = $($homePath + "/secrets/play_creds.json");
 $aabPath = $($rootPath + "/com.x8bit.bitwarden.aab");
-$track = "alpha";
+$track = "internal";
 
 dotnet $publisherPath $credsPath $aabPath $track


### PR DESCRIPTION
Publish directly to internal test track to skip play store approval process for internal testers (artifact can then be manually promoted to alpha > beta > prod like before).  This should bring the testing experience up to speed with TestFlight for iOS (i.e. push code > ci build > immediate availability).

Edit: For clarification the signup process requires maintaining a list of the testers' email addresses, combined with each tester clicking a "join the program" from a page that only renders for them if they're on the list.  Nothing goes public until we push it.