### PR TITLE
Fix iOS biometric unlock

### DIFF
--- a/src/iOS.Core/Services/BiometricService.cs
+++ b/src/iOS.Core/Services/BiometricService.cs
@@ -36,7 +36,7 @@ namespace Bit.iOS.Core.Services
             {
                 var state = GetState();
 
-                return FromBase64(oldState) == state;
+                return FromBase64(oldState).Equals(state);
             }
         }
 


### PR DESCRIPTION
Fixed comparison of stored state string to use value instead of instance (manifested itself as a "biometrics changed, login with master password" error on lock screen)