### PR TITLE
fix for passphrase generator persistent settings

### DIFF
--- a/src/App/Pages/Generator/GeneratorPageViewModel.cs
+++ b/src/App/Pages/Generator/GeneratorPageViewModel.cs
@@ -286,6 +286,10 @@ namespace Bit.App.Pages
 
         public async Task SliderInputAsync()
         {
+            if (!_doneIniting)
+            {
+                return;
+            }
             SetOptions();
             _passwordGenerationService.NormalizeOptions(_options, _enforcedPolicyOptions);
             Password = await _passwordGenerationService.GeneratePasswordAsync(_options);


### PR DESCRIPTION
Upon page creation, `SliderInputAsync()` was firing before `InitAsync()` which would overwrite any existing settings with defaults before the previously saved values could be loaded.  Simply blocking this by checking `_doneIniting` allows the saved values to be loaded first.  Fixes #1059 

Edit: Clarification - I should say `InitAsync()` is actually called first, but it calls `LoadFromOptions()` which sets `Length` which in turn calls `SliderInputAsync()` before `InitAsync()` is truly finished.  At the moment this happens there are two values which have not yet been loaded from options.  Which values?  You guessed it - `Capitalize` and `IncludeNumber` from the passphrase generator page.