### PR TITLE
Fix Host matching of androidapp:// URIs

### DIFF
--- a/src/Core/Utilities/CoreHelpers.cs
+++ b/src/Core/Utilities/CoreHelpers.cs
@@ -87,7 +87,7 @@ namespace Bit.Core.Utilities
                 return null;
             }
             var hasHttpProtocol = uriString.StartsWith("http://") || uriString.StartsWith("https://");
-            if (!hasHttpProtocol && uriString.Contains("."))
+            if (!hasHttpProtocol && !uriString.Contains("://") && uriString.Contains("."))
             {
                 if (Uri.TryCreate("http://" + uriString, UriKind.Absolute, out var uri))
                 {


### PR DESCRIPTION
This fixes bitwarden/mobile#967.

The issue is that [during comparison](https://github.com/bitwarden/mobile/blob/ce965ba5e1b71ac9e3ea98bdf7568d7f8830365a/src/Core/Services/CipherService.cs#L378-L379), if the URIs don't match `http://` or `https://`, `http://` is prepended to the URI, and subsequent calls to `uri.Host` always return `androidapp`.

This change simply avoids prepending `http://` in the case where a protocol is defined. It might make sense to use a regular expression to avoid the edge case of [matching that pattern later in the URL](https://stackoverflow.com/a/43283492/434343).