### PR TITLE
check authed before checking if token has premium

### DIFF
--- a/src/Core/Services/UserService.cs
+++ b/src/Core/Services/UserService.cs
@@ -124,6 +124,12 @@ namespace Bit.Core.Services
 
         public async Task<bool> CanAccessPremiumAsync()
         {
+            var authed = await IsAuthenticatedAsync();
+            if (!authed)
+            {
+                return false;
+            }
+
             var tokenPremium = _tokenService.GetPremium();
             if (tokenPremium)
             {


### PR DESCRIPTION
Any checks to canAccessPremium will throw an exception when not authed since there is no token to reference. This stops it from even trying to access the token.

This is the same as https://github.com/bitwarden/jslib/pull/170