### PR TITLE
Biometric Integrity crash fix on iOS

### DIFF
--- a/src/iOS.Core/Services/BiometricService.cs
+++ b/src/iOS.Core/Services/BiometricService.cs
@@ -17,7 +17,10 @@ namespace Bit.iOS.Core.Services
         public async Task<bool> SetupBiometricAsync()
         {
             var state = GetState();
-            await _storageService.SaveAsync("biometricState", ToBase64(state));
+            if (state != null)
+            {
+                await _storageService.SaveAsync("biometricState", ToBase64(state));
+            }
 
             return true;
         }
@@ -35,8 +38,12 @@ namespace Bit.iOS.Core.Services
             else
             {
                 var state = GetState();
+                if (state != null)
+                {
+                    return FromBase64(oldState).Equals(state);
+                }
 
-                return FromBase64(oldState).Equals(state);
+                return true;
             }
         }
 


### PR DESCRIPTION
The EvaluatedPolicyDomainState can be null.

"This property returns a value only when the canEvaluatePolicy(_:error:) method succeeds for a biometric policy or the evaluatePolicy(_:localizedReason:reply:) method is called and a successful biometric authentication is performed. Otherwise, nil is returned."

https://developer.apple.com/documentation/localauthentication/lacontext/1514150-evaluatedpolicydomainstate

Might solve #1078 and #1055 