### PR TITLE
fix for sso login when bio unlock already enabled

### DIFF
--- a/src/App/Pages/Accounts/LockPageViewModel.cs
+++ b/src/App/Pages/Accounts/LockPageViewModel.cs
@@ -116,7 +116,7 @@ namespace Bit.App.Pages
         {
             _pinSet = await _vaultTimeoutService.IsPinLockSetAsync();
             PinLock = (_pinSet.Item1 && _vaultTimeoutService.PinProtectedKey != null) || _pinSet.Item2;
-            BiometricLock = await _vaultTimeoutService.IsBiometricLockSetAsync();
+            BiometricLock = await _vaultTimeoutService.IsBiometricLockSetAsync() && await _cryptoService.HasKeyAsync();
             _email = await _userService.GetEmailAsync();
             var webVault = _environmentService.GetWebVaultUrl();
             if (string.IsNullOrWhiteSpace(webVault))

--- a/src/Core/Services/CryptoService.cs
+++ b/src/Core/Services/CryptoService.cs
@@ -54,7 +54,7 @@ namespace Bit.Core.Services
                 // If we have a lock option set, we do not store the key
                 return;
             }
-            await _secureStorageService.SaveAsync(Keys_Key, key.KeyB64);
+            await _secureStorageService.SaveAsync(Keys_Key, key?.KeyB64);
         }
 
         public async Task SetKeyHashAsync(string keyHash)


### PR DESCRIPTION
Fix for missing key issue when logging in with SSO with biometric unlock already enabled from previous login.

`LockPageViewModel`: Added check for existence of key before allowing biometric unlock.  This will force password unlock when logging in with SSO as a key has not yet been established.
`CryptoService`: Null check key before attempting Base64 conversion to prevent NPE when logging in with SSO if biometric unlock is already enabled