### PR TITLE
[SSO] New user provision flow

### DIFF
--- a/src/App/Pages/Accounts/LoginSsoPage.xaml.cs
+++ b/src/App/Pages/Accounts/LoginSsoPage.xaml.cs
@@ -93,14 +93,14 @@ namespace Bit.App.Pages
         private async Task StartTwoFactorAsync()
         {
             RestoreAppOptionsFromCopy();
-            var page = new TwoFactorPage(true, _appOptions);
+            var page = new TwoFactorPage(true, _appOptions, _vm.OrgIdentifier);
             await Navigation.PushModalAsync(new NavigationPage(page));
         }
 
         private async Task StartSetPasswordAsync()
         {
             RestoreAppOptionsFromCopy();
-            var page = new SetPasswordPage(_appOptions);
+            var page = new SetPasswordPage(_appOptions, _vm.OrgIdentifier);
             await Navigation.PushModalAsync(new NavigationPage(page));
         }
 

--- a/src/App/Pages/Accounts/SetPasswordPage.xaml.cs
+++ b/src/App/Pages/Accounts/SetPasswordPage.xaml.cs
@@ -14,7 +14,7 @@ namespace Bit.App.Pages
         private readonly SetPasswordPageViewModel _vm;
         private readonly AppOptions _appOptions;
 
-        public SetPasswordPage(AppOptions appOptions = null)
+        public SetPasswordPage(AppOptions appOptions = null, string orgIdentifier = null)
         {
             _messagingService = ServiceContainer.Resolve<IMessagingService>("messagingService");
             _messagingService.Send("showStatusBar", true);
@@ -29,6 +29,7 @@ namespace Bit.App.Pages
                 _messagingService.Send("showStatusBar", false);
                 await Navigation.PopModalAsync();
             };
+            _vm.OrgIdentifier = orgIdentifier;
             if (Device.RuntimePlatform == Device.Android)
             {
                 ToolbarItems.RemoveAt(0);

--- a/src/App/Pages/Accounts/SetPasswordPageViewModel.cs
+++ b/src/App/Pages/Accounts/SetPasswordPageViewModel.cs
@@ -85,6 +85,7 @@ namespace Bit.App.Pages
         public string Hint { get; set; }
         public Action SetPasswordSuccessAction { get; set; }
         public Action CloseAction { get; set; }
+        public string OrgIdentifier { get; set; }
 
         public async Task InitAsync()
         {
@@ -158,6 +159,7 @@ namespace Bit.App.Pages
                 MasterPasswordHint = Hint,
                 Kdf = kdf,
                 KdfIterations = kdfIterations,
+                OrgIdentifier = OrgIdentifier,
                 Keys = new KeysRequest
                 {
                     PublicKey = keys.Item1,

--- a/src/App/Pages/Accounts/TwoFactorPage.xaml.cs
+++ b/src/App/Pages/Accounts/TwoFactorPage.xaml.cs
@@ -20,13 +20,15 @@ namespace Bit.App.Pages
         private TwoFactorPageViewModel _vm;
         private bool _inited;
         private bool _authingWithSso;
+        private string _orgIdentifier;
 
-        public TwoFactorPage(bool? authingWithSso = false, AppOptions appOptions = null)
+        public TwoFactorPage(bool? authingWithSso = false, AppOptions appOptions = null, string orgIdentifier = null)
         {
             InitializeComponent();
             SetActivityIndicator();
             _authingWithSso = authingWithSso ?? false;
             _appOptions = appOptions;
+            _orgIdentifier = orgIdentifier;
             _storageService = ServiceContainer.Resolve<IStorageService>("storageService");
             _broadcasterService = ServiceContainer.Resolve<IBroadcasterService>("broadcasterService");
             _messagingService = ServiceContainer.Resolve<IMessagingService>("messagingService");
@@ -170,7 +172,7 @@ namespace Bit.App.Pages
         private async Task StartSetPasswordAsync()
         {
             _vm.CloseAction();
-            var page = new SetPasswordPage(_appOptions);
+            var page = new SetPasswordPage(_appOptions, _orgIdentifier);
             await Navigation.PushModalAsync(new NavigationPage(page));
         }
 

--- a/src/Core/Models/Request/SetPasswordRequest.cs
+++ b/src/Core/Models/Request/SetPasswordRequest.cs
@@ -10,5 +10,6 @@ namespace Bit.Core.Models.Request
         public KeysRequest Keys { get; set; }
         public KdfType Kdf { get; set; }
         public int KdfIterations { get; set; }
+        public string OrgIdentifier { get; set; }
     }
 }


### PR DESCRIPTION
## Objective
> Currently, when a new bitwarden/org user is created, they are given a status of `accepted`.  This can create issues for organizations trying to `confirm` the same user (which can't happen until they've set their master password). To alleviate the issue, change new user's `orgUser` status to `invited` until after they've set a master password. Pass through the necessary information for the `2fa` and `set-password` components.

## Code Changes
- **LoginSsoPage.xaml.cs**: Passed already existing `_vm.orgIdentifier` into the constructor for both the `2fa` and `SetPassword` pages.
- **SetPasswordPage.xaml.cs**: Added `orgIdentifier` to the constructor. Saved parameter value to the underlying view model.
- **SetPasswordPageViewModel.cs**: Created `OrgIdentifier` property and assigned value to the `SetPasswordRequest` `OrgIdentifier` field.
- **TwoFactorPage.xaml.cs**: Added `orgIdentifier` to the constructor and created member variable for passing along the result to the `SetPasswordPage`
- **SetPasswordRequest.cs**: Added `OrgIdentifier` string to the request object.
