### PR TITLE
fix issue with search bar color on iOS

### DIFF
--- a/src/App/Controls/ExtendedSearchBar.cs
+++ b/src/App/Controls/ExtendedSearchBar.cs
@@ -1,5 +1,4 @@
-﻿using Bit.App.Abstractions;
-using Bit.Core.Utilities;
+﻿using Bit.App.Utilities;
 using Xamarin.Forms;
 
 namespace Bit.App.Controls
@@ -10,8 +9,7 @@ namespace Bit.App.Controls
         {
             if (Device.RuntimePlatform == Device.iOS)
             {
-                var deviceActionService = ServiceContainer.Resolve<IDeviceActionService>("deviceActionService", true);
-                if (!deviceActionService?.UsingDarkTheme() ?? false)
+                if (ThemeManager.UsingLightTheme)
                 {
                     TextColor = Color.Black;
                 }


### PR DESCRIPTION
Search bar text color was not taking app theme into account (only system theme) so a light system with dark app theme resulted in dark text on a dark background.  By using themehelper here we take both the app and system theme into account.  