### PR TITLE
Allow alphanumeric card numbers

### DIFF
--- a/src/App/Pages/Vault/AddEditPage.xaml
+++ b/src/App/Pages/Vault/AddEditPage.xaml
@@ -203,8 +203,7 @@
                         <Entry
                             x:Name="_cardNumberEntry"
                             Text="{Binding Cipher.Card.Number}"
-                            StyleClass="box-value"
-                            Keyboard="Numeric" />
+                            StyleClass="box-value" />
                     </StackLayout>
                     <StackLayout StyleClass="box-row, box-row-input">
                         <Label


### PR DESCRIPTION
Removed Keyboard="Numeric" property from CardNumberEntry. European debit card numbers are alphanumeric. See also https://en.wikipedia.org/wiki/International_Bank_Account_Number.