### PR TITLE
re-select support for android tabbed page buttons

### DIFF
--- a/src/Android/Android.csproj
+++ b/src/Android/Android.csproj
@@ -120,6 +120,7 @@
     <Compile Include="Receivers\LockAlarmReceiver.cs" />
     <Compile Include="Receivers\PackageReplacedReceiver.cs" />
     <Compile Include="Renderers\CipherViewCellRenderer.cs" />
+    <Compile Include="Renderers\CustomTabbedRenderer.cs" />
     <Compile Include="Renderers\ExtendedSliderRenderer.cs" />
     <Compile Include="Renderers\CustomEditorRenderer.cs" />
     <Compile Include="Renderers\CustomPickerRenderer.cs" />

--- a/src/Android/Renderers/CustomTabbedRenderer.cs
+++ b/src/Android/Renderers/CustomTabbedRenderer.cs
@@ -7,7 +7,6 @@ using Xamarin.Forms.Platform.Android;
 using Xamarin.Forms.Platform.Android.AppCompat;
 
 [assembly: ExportRenderer(typeof(TabbedPage), typeof(CustomTabbedRenderer))]
-
 namespace Bit.Droid.Renderers
 {
     public class CustomTabbedRenderer : TabbedPageRenderer, BottomNavigationView.IOnNavigationItemReselectedListener

--- a/src/Android/Renderers/CustomTabbedRenderer.cs
+++ b/src/Android/Renderers/CustomTabbedRenderer.cs
@@ -1,0 +1,61 @@
+﻿using Android.Content;
+using Android.Views;
+using Bit.Droid.Renderers;
+using Google.Android.Material.BottomNavigation;
+using Xamarin.Forms;
+using Xamarin.Forms.Platform.Android;
+using Xamarin.Forms.Platform.Android.AppCompat;
+
+[assembly: ExportRenderer(typeof(TabbedPage), typeof(CustomTabbedRenderer))]
+
+namespace Bit.Droid.Renderers
+{
+    public class CustomTabbedRenderer : TabbedPageRenderer, BottomNavigationView.IOnNavigationItemReselectedListener
+    {
+        private TabbedPage _page;
+
+        public CustomTabbedRenderer(Context context) : base(context) { }
+
+        protected override void OnElementChanged(ElementChangedEventArgs<TabbedPage> e)
+        {
+            base.OnElementChanged(e);
+            if (e.NewElement != null)
+            {
+                _page = e.NewElement;
+                GetBottomNavigationView()?.SetOnNavigationItemReselectedListener(this);
+            }
+            else
+            {
+                _page = e.OldElement;
+            }
+        }
+
+        private BottomNavigationView GetBottomNavigationView()
+        {
+            for (var i = 0; i <= ViewGroup.ChildCount - 1; i++)
+            {
+                var childView = ViewGroup.GetChildAt(i);
+                if (childView is ViewGroup viewGroup)
+                {
+                    for (var j = 0; j <= viewGroup.ChildCount - 1; j++)
+                    {
+                        var childRelativeLayoutView = viewGroup.GetChildAt(j);
+                        if (childRelativeLayoutView is BottomNavigationView bottomNavigationView)
+                        {
+                            return bottomNavigationView;
+                        }
+                    }
+                }
+            }
+            return null;
+        }
+
+        async void BottomNavigationView.IOnNavigationItemReselectedListener.OnNavigationItemReselected(IMenuItem item)
+        {
+            if (_page?.CurrentPage?.Navigation != null && _page.CurrentPage.Navigation.NavigationStack.Count > 0)
+            {
+                await _page.CurrentPage.Navigation.PopToRootAsync();
+            }
+        }
+    }
+}

--- a/src/Android/Renderers/CustomTabbedRenderer.cs
+++ b/src/Android/Renderers/CustomTabbedRenderer.cs
@@ -32,12 +32,12 @@ namespace Bit.Droid.Renderers
 
         private BottomNavigationView GetBottomNavigationView()
         {
-            for (var i = 0; i <= ViewGroup.ChildCount - 1; i++)
+            for (var i = 0; i < ViewGroup.ChildCount; i++)
             {
                 var childView = ViewGroup.GetChildAt(i);
                 if (childView is ViewGroup viewGroup)
                 {
-                    for (var j = 0; j <= viewGroup.ChildCount - 1; j++)
+                    for (var j = 0; j < viewGroup.ChildCount; j++)
                     {
                         var childRelativeLayoutView = viewGroup.GetChildAt(j);
                         if (childRelativeLayoutView is BottomNavigationView bottomNavigationView)


### PR DESCRIPTION
Added support for tab button re-selection in Android to match behavior from iOS, enabling the user to return to the vault root `GroupingsPage` from within a Type page (Login, Card, etc.) simply by tapping `My Vault` again.  Since we're using bottom-nav a little extra song and dance was required to get ahold of the view and set the listener.