### PR TITLE
Add support for Iceraven browser

### DIFF
--- a/src/Android/Accessibility/AccessibilityHelpers.cs
+++ b/src/Android/Accessibility/AccessibilityHelpers.cs
@@ -69,7 +69,7 @@ namespace Bit.Droid.Accessibility
             new Browser("idm.internet.download.manager", "search"),
             new Browser("idm.internet.download.manager.adm.lite", "search"),
             new Browser("idm.internet.download.manager.plus", "search"),
-            new Browser("io.github.forkmaintainers.iceraven", "url_bar_title,mozac_browser_toolbar_url_view"),
+            new Browser("io.github.forkmaintainers.iceraven", "mozac_browser_toolbar_url_view"),
             new Browser("mark.via.gp", "aw"),
             new Browser("org.adblockplus.browser", "url_bar,url_bar_title"), // 2nd = Legacy (before v2)
             new Browser("org.adblockplus.browser.beta", "url_bar,url_bar_title"), // 2nd = Legacy (before v2)

--- a/src/Android/Accessibility/AccessibilityHelpers.cs
+++ b/src/Android/Accessibility/AccessibilityHelpers.cs
@@ -69,6 +69,7 @@ namespace Bit.Droid.Accessibility
             new Browser("idm.internet.download.manager", "search"),
             new Browser("idm.internet.download.manager.adm.lite", "search"),
             new Browser("idm.internet.download.manager.plus", "search"),
+            new Browser("io.github.forkmaintainers.iceraven", "url_bar_title,mozac_browser_toolbar_url_view"),
             new Browser("mark.via.gp", "aw"),
             new Browser("org.adblockplus.browser", "url_bar,url_bar_title"), // 2nd = Legacy (before v2)
             new Browser("org.adblockplus.browser.beta", "url_bar,url_bar_title"), // 2nd = Legacy (before v2)

--- a/src/Android/Autofill/AutofillHelpers.cs
+++ b/src/Android/Autofill/AutofillHelpers.cs
@@ -74,6 +74,7 @@ namespace Bit.Droid.Autofill
             "idm.internet.download.manager",
             "idm.internet.download.manager.adm.lite",
             "idm.internet.download.manager.plus",
+            "io.github.forkmaintainers.iceraven",
             "mark.via.gp",
             "org.adblockplus.browser",
             "org.adblockplus.browser.beta",

--- a/src/Android/Resources/xml/autofillservice.xml
+++ b/src/Android/Resources/xml/autofillservice.xml
@@ -119,6 +119,9 @@
     android:name="idm.internet.download.manager.plus"
     android:maxLongVersionCode="10000000000"/>
   <compatibility-package
+    android:name="io.github.forkmaintainers.iceraven"
+    android:maxLongVersionCode="10000000000"/>
+  <compatibility-package
     android:name="mark.via.gp"
     android:maxLongVersionCode="10000000000"/>
   <compatibility-package


### PR DESCRIPTION
Closes #1105  (issue I recently created). [Iceraven ](https://github.com/fork-maintainers/iceraven-browser)is a Firefox Android fork