### PR TITLE
Support for storing multiple biometric integrity states for iOS

### DIFF
--- a/src/Android/Services/BiometricService.cs
+++ b/src/Android/Services/BiometricService.cs
@@ -30,8 +30,9 @@ namespace Bit.Droid.Services
             _keystore.Load(null);
         }
 
-        public Task<bool> SetupBiometricAsync()
+        public Task<bool> SetupBiometricAsync(string bioIntegrityKey = null)
         {
+            // bioIntegrityKey used in iOS only
             if (Build.VERSION.SdkInt >= BuildVersionCodes.M)
             {
                 CreateKey();
@@ -40,8 +41,9 @@ namespace Bit.Droid.Services
             return Task.FromResult(true);
         }
 
-        public Task<bool> ValidateIntegrityAsync()
+        public Task<bool> ValidateIntegrityAsync(string bioIntegrityKey = null)
         {
+            // bioIntegrityKey used in iOS only
             if (Build.VERSION.SdkInt < BuildVersionCodes.M)
             {
                 return Task.FromResult(true);

--- a/src/Core/Abstractions/IBiometricService.cs
+++ b/src/Core/Abstractions/IBiometricService.cs
@@ -4,7 +4,7 @@ namespace Bit.Core.Abstractions
 {
     public interface IBiometricService
     {
-        Task<bool> SetupBiometricAsync();
-        Task<bool> ValidateIntegrityAsync();
+        Task<bool> SetupBiometricAsync(string bioIntegrityKey = null);
+        Task<bool> ValidateIntegrityAsync(string bioIntegrityKey = null);
     }
 }

--- a/src/iOS.Autofill/LockPasswordViewController.cs
+++ b/src/iOS.Autofill/LockPasswordViewController.cs
@@ -7,7 +7,9 @@ namespace Bit.iOS.Autofill
     {
         public LockPasswordViewController(IntPtr handle)
             : base(handle)
-        { }
+        {
+            BiometricIntegrityKey = "autofillBiometricState";
+        }
 
         public CredentialProviderViewController CPViewController { get; set; }
         public override UINavigationItem BaseNavItem => NavItem;

--- a/src/iOS.Core/Controllers/LockPasswordViewController.cs
+++ b/src/iOS.Core/Controllers/LockPasswordViewController.cs
@@ -41,6 +41,8 @@ namespace Bit.iOS.Core.Controllers
 
         public FormEntryTableViewCell MasterPasswordCell { get; set; } = new FormEntryTableViewCell(
             AppResources.MasterPassword);
+        
+        public string BiometricIntegrityKey { get; set; }
 
         public override void ViewDidLoad()
         {
@@ -86,7 +88,8 @@ namespace Bit.iOS.Core.Controllers
 
             if (_biometricLock)
             {
-                _biometricIntegrityValid = _biometricService.ValidateIntegrityAsync().GetAwaiter().GetResult();
+                _biometricIntegrityValid = _biometricService.ValidateIntegrityAsync(BiometricIntegrityKey).GetAwaiter()
+                    .GetResult();
                 if (!_biometricIntegrityValid)
                 {
                     return;

--- a/src/iOS.Core/Controllers/LockPasswordViewController.cs
+++ b/src/iOS.Core/Controllers/LockPasswordViewController.cs
@@ -197,6 +197,12 @@ namespace Bit.iOS.Core.Controllers
                         _vaultTimeoutService.PinProtectedKey = await _cryptoService.EncryptAsync(key2.Key, pinKey);
                     }
                     await SetKeyAndContinueAsync(key2);
+                    
+                    // Re-enable biometrics
+                    if (_biometricLock & !_biometricIntegrityValid)
+                    {
+                        await _biometricService.SetupBiometricAsync(BiometricIntegrityKey);
+                    }
                 }
                 else
                 {

--- a/src/iOS.Core/Services/BiometricService.cs
+++ b/src/iOS.Core/Services/BiometricService.cs
@@ -48,7 +48,6 @@ namespace Bit.iOS.Core.Services
                 var state = GetState();
                 if (state != null)
                 {
-                    var getState = ToBase64(state);
                     return FromBase64(oldState).Equals(state);
                 }
 

--- a/src/iOS.Core/Services/BiometricService.cs
+++ b/src/iOS.Core/Services/BiometricService.cs
@@ -14,24 +14,32 @@ namespace Bit.iOS.Core.Services
             _storageService = storageService;
         }
 
-        public async Task<bool> SetupBiometricAsync()
+        public async Task<bool> SetupBiometricAsync(string bioIntegrityKey = null)
         {
+            if (bioIntegrityKey == null)
+            {
+                bioIntegrityKey = "biometricState";
+            }
             var state = GetState();
             if (state != null)
             {
-                await _storageService.SaveAsync("biometricState", ToBase64(state));
+                await _storageService.SaveAsync(bioIntegrityKey, ToBase64(state));
             }
 
             return true;
         }
 
-        public async Task<bool> ValidateIntegrityAsync()
+        public async Task<bool> ValidateIntegrityAsync(string bioIntegrityKey = null)
         {
-            var oldState = await _storageService.GetAsync<string>("biometricState");
+            if (bioIntegrityKey == null)
+            {
+                bioIntegrityKey = "biometricState";
+            }
+            var oldState = await _storageService.GetAsync<string>(bioIntegrityKey);
             if (oldState == null)
             {
                 // Fallback for upgraded devices
-                await SetupBiometricAsync();
+                await SetupBiometricAsync(bioIntegrityKey);
 
                 return true;
             }
@@ -40,6 +48,7 @@ namespace Bit.iOS.Core.Services
                 var state = GetState();
                 if (state != null)
                 {
+                    var getState = ToBase64(state);
                     return FromBase64(oldState).Equals(state);
                 }
 

--- a/src/iOS.Extension/LockPasswordViewController.cs
+++ b/src/iOS.Extension/LockPasswordViewController.cs
@@ -8,7 +8,9 @@ namespace Bit.iOS.Extension
     {
         public LockPasswordViewController(IntPtr handle)
             : base(handle)
-        { }
+        {
+            BiometricIntegrityKey = "extensionBiometricState";
+        }
 
         public LoadingViewController LoadingController { get; set; }
         public override UINavigationItem BaseNavItem => NavItem;


### PR DESCRIPTION
iOS extensions are returning a different biometric state from the main app (derived from bundle ID):

https://developer.apple.com/forums/thread/70570

This PR adds support for performing integrity validation based on the source of the query (extension vs app).  Unfortunately this means both the extension(s) and the main app will have to re-enter the password for verification after a change in biometric integrity, independent of each other.  Not an ideal experience, but since an integrity change shouldn't happen frequently I believe this is our best course of action.