### PR TITLE
Firefox (+ some forks): switch resource-id priority order

### DIFF
--- a/src/Android/Accessibility/AccessibilityHelpers.cs
+++ b/src/Android/Accessibility/AccessibilityHelpers.cs
@@ -56,7 +56,7 @@ namespace Bit.Droid.Accessibility
             new Browser("com.opera.mini.native", "url_field"),
             new Browser("com.opera.mini.native.beta", "url_field"),
             new Browser("com.opera.touch", "addressbarEdit"),
-            new Browser("com.qwant.liberty", "url_bar_title,mozac_browser_toolbar_url_view"), // 2nd = Anticipation
+            new Browser("com.qwant.liberty", "mozac_browser_toolbar_url_view,url_bar_title"), // 2nd = Legacy (before v4)
             new Browser("com.sec.android.app.sbrowser", "location_bar_edit_text"),
             new Browser("com.sec.android.app.sbrowser.beta", "location_bar_edit_text"),
             new Browser("com.stoutner.privacybrowser.free", "url_edittext"),
@@ -79,17 +79,17 @@ namespace Bit.Droid.Accessibility
             new Browser("org.codeaurora.swe.browser", "url_bar"),
             new Browser("org.gnu.icecat", "url_bar_title,mozac_browser_toolbar_url_view"), // 2nd = Anticipation
             new Browser("org.mozilla.fenix", "mozac_browser_toolbar_url_view"),
-            new Browser("org.mozilla.fenix.nightly", "mozac_browser_toolbar_url_view"),
-            new Browser("org.mozilla.fennec_aurora", "mozac_browser_toolbar_url_view,url_bar_title"), // 2nd = Legacy
-            new Browser("org.mozilla.fennec_fdroid", "url_bar_title,mozac_browser_toolbar_url_view"), // 2nd = Anticipation
-            new Browser("org.mozilla.firefox", "url_bar_title,mozac_browser_toolbar_url_view"), // 2nd = Anticipation
+            new Browser("org.mozilla.fenix.nightly", "mozac_browser_toolbar_url_view"), // [DEPRECATED]
+            new Browser("org.mozilla.fennec_aurora", "mozac_browser_toolbar_url_view,url_bar_title"), // [DEPRECATED]
+            new Browser("org.mozilla.fennec_fdroid", "mozac_browser_toolbar_url_view,url_bar_title"), // 2nd = Legacy
+            new Browser("org.mozilla.firefox", "mozac_browser_toolbar_url_view,url_bar_title"), // 2nd = Legacy
             new Browser("org.mozilla.firefox_beta", "mozac_browser_toolbar_url_view,url_bar_title"), // 2nd = Legacy
             new Browser("org.mozilla.focus", "display_url"),
             new Browser("org.mozilla.klar", "display_url"),
             new Browser("org.mozilla.reference.browser", "mozac_browser_toolbar_url_view"),
             new Browser("org.mozilla.rocket", "display_url"),
             new Browser("org.torproject.torbrowser", "url_bar_title,mozac_browser_toolbar_url_view"), // 2nd = Anticipation
-            new Browser("org.torproject.torbrowser_alpha", "url_bar_title,mozac_browser_toolbar_url_view"), // 2nd = Anticipation
+            new Browser("org.torproject.torbrowser_alpha", "mozac_browser_toolbar_url_view,url_bar_title"), // 2nd = Legacy (before v10.0a8)
             new Browser("org.ungoogled.chromium", "url_bar"),
 
             // [Section B] Entries only present here


### PR DESCRIPTION
### This:
- switches the order of priority "Fennec,Fenix" to "Fenix,Fennec" for `org.mozilla.firefox` (+ for some Firefox forks which have already switched to a Fenix base).
&nbsp;

<details>
<summary>Read more …</summary>

# Freshly downloaded APKs
```bash
$ strings -f *.apk | egrep "url_bar_title|mozac_browser_toolbar_url_view"
com.qwant.liberty_40000271_apps.evozi.com.apk: mozac_browser_toolbar_url_view
org.mozilla.fennec_fdroid_811320.apk: mozac_browser_toolbar_url_view
org.mozilla.firefox_81.1.4-2015768387_minAPI21(arm64-v8a)(nodpi)_apkmirror.com.apk: mozac_browser_toolbar_url_view
org.torproject.torbrowser_alpha_10.0a8_(81.1.2-Beta)-2015713931_minAPI21(arm64-v8a)(nodpi)_apkmirror.com.apk: mozac_browser_toolbar_url_view
```

# About
#### :diamonds: _Firefox Browser: fast, private & safe web browser_
New resource-id used since v79 ([1](https://user-images.githubusercontent.com/4764956/96039124-778c4080-0e68-11eb-8de9-747f32668036.png), [2](https://user-images.githubusercontent.com/4764956/96039126-7824d700-0e68-11eb-8799-7621b2efbdff.png), [3](https://user-images.githubusercontent.com/4764956/96039127-78bd6d80-0e68-11eb-9fd0-cc0f051b0aa5.png)).

#### :diamond_shape_with_a_dot_inside: Qwant - Privacy & Ethics
v4 ([1](https://user-images.githubusercontent.com/4764956/96038890-1fedd500-0e68-11eb-8ac9-1d87285e0a48.png), [2](https://user-images.githubusercontent.com/4764956/96038896-211f0200-0e68-11eb-8e2d-3ed250e96035.png), [3](https://user-images.githubusercontent.com/4764956/96038897-211f0200-0e68-11eb-998a-847c90238b18.png)) in gradual deployment. You might still have v3.5.0 in your Google Play Store.

#### :diamond_shape_with_a_dot_inside: Tor Browser (Alpha)
See [their news](https://blog.torproject.org/new-release-tor-browser-100a8) on this subject.

#### :diamond_shape_with_a_dot_inside: Fennec F-Droid
They kept the historical name (despite "Fennec" in it), the package name too, but they [did migrate](https://f-droid.org/en/packages/org.mozilla.fennec_fdroid/) to a Fenix base.

# :heavy_plus_sign: Bonus
**`// [DEPRECATED]`** added for `org.mozilla.fenix.nightly` and `org.mozilla.fennec_aurora`.
Because regarding **Firefox for Android**, since the transition/simplification, only exist:
- [org.mozilla.firefox](https://play.google.com/store/apps/details?id=org.mozilla.firefox) -> stable
- [org.mozilla.firefox_beta](https://play.google.com/store/apps/details?id=org.mozilla.firefox_beta) -> beta
- [org.mozilla.fenix](https://play.google.com/store/apps/details?id=org.mozilla.fenix) -> nightly
</details>