### PR TITLE
fix for stuck extension sheets when dismissed by swipe

### DIFF
--- a/src/iOS.Autofill/CredentialProviderViewController.cs
+++ b/src/iOS.Autofill/CredentialProviderViewController.cs
@@ -12,6 +12,7 @@ using UIKit;
 using Xamarin.Forms;
 using Bit.App.Utilities;
 using Bit.App.Models;
+using Bit.iOS.Core.Views;
 using CoreNFC;
 
 namespace Bit.iOS.Autofill
@@ -158,19 +159,27 @@ namespace Bit.iOS.Autofill
                 {
                     listLoginController.Context = _context;
                     listLoginController.CPViewController = this;
+                    segue.DestinationViewController.PresentationController.Delegate =
+                        new CustomPresentationControllerDelegate(listLoginController.DismissModalAction);
                 }
                 else if (navController.TopViewController is LoginSearchViewController listSearchController)
                 {
                     listSearchController.Context = _context;
                     listSearchController.CPViewController = this;
+                    segue.DestinationViewController.PresentationController.Delegate =
+                        new CustomPresentationControllerDelegate(listSearchController.DismissModalAction);
                 }
                 else if (navController.TopViewController is LockPasswordViewController passwordViewController)
                 {
                     passwordViewController.CPViewController = this;
+                    segue.DestinationViewController.PresentationController.Delegate =
+                        new CustomPresentationControllerDelegate(passwordViewController.DismissModalAction);
                 }
                 else if (navController.TopViewController is SetupViewController setupViewController)
                 {
                     setupViewController.CPViewController = this;
+                    segue.DestinationViewController.PresentationController.Delegate =
+                        new CustomPresentationControllerDelegate(setupViewController.DismissModalAction);
                 }
             }
         }

--- a/src/iOS.Autofill/LockPasswordViewController.cs
+++ b/src/iOS.Autofill/LockPasswordViewController.cs
@@ -9,6 +9,7 @@ namespace Bit.iOS.Autofill
             : base(handle)
         {
             BiometricIntegrityKey = "autofillBiometricState";
+            DismissModalAction = () => Cancel();
         }
 
         public CredentialProviderViewController CPViewController { get; set; }

--- a/src/iOS.Autofill/LockPasswordViewController.cs
+++ b/src/iOS.Autofill/LockPasswordViewController.cs
@@ -9,7 +9,7 @@ namespace Bit.iOS.Autofill
             : base(handle)
         {
             BiometricIntegrityKey = "autofillBiometricState";
-            DismissModalAction = () => Cancel();
+            DismissModalAction = Cancel;
         }
 
         public CredentialProviderViewController CPViewController { get; set; }

--- a/src/iOS.Autofill/LoginAddViewController.cs
+++ b/src/iOS.Autofill/LoginAddViewController.cs
@@ -1,4 +1,5 @@
 using System;
+using Bit.iOS.Core.Views;
 using Foundation;
 using UIKit;
 
@@ -8,7 +9,9 @@ namespace Bit.iOS.Autofill
     {
         public LoginAddViewController(IntPtr handle)
             : base(handle)
-        { }
+        {
+            DismissModalAction = () => Cancel();
+        }
 
         public LoginListViewController LoginListController { get; set; }
         public LoginSearchViewController LoginSearchController { get; set; }
@@ -24,6 +27,11 @@ namespace Bit.iOS.Autofill
         };
 
         partial void CancelBarButton_Activated(UIBarButtonItem sender)
+        {
+            Cancel();
+        }
+        
+        private void Cancel()
         {
             DismissViewController(true, null);
         }
@@ -41,6 +49,8 @@ namespace Bit.iOS.Autofill
                 {
                     passwordGeneratorController.PasswordOptions = Context.PasswordOptions;
                     passwordGeneratorController.Parent = this;
+                    segue.DestinationViewController.PresentationController.Delegate =
+                        new CustomPresentationControllerDelegate(passwordGeneratorController.DismissModalAction);
                 }
             }
         }

--- a/src/iOS.Autofill/LoginAddViewController.cs
+++ b/src/iOS.Autofill/LoginAddViewController.cs
@@ -10,7 +10,7 @@ namespace Bit.iOS.Autofill
         public LoginAddViewController(IntPtr handle)
             : base(handle)
         {
-            DismissModalAction = () => Cancel();
+            DismissModalAction = Cancel;
         }
 
         public LoginListViewController LoginListController { get; set; }

--- a/src/iOS.Autofill/LoginListViewController.cs
+++ b/src/iOS.Autofill/LoginListViewController.cs
@@ -17,7 +17,7 @@ namespace Bit.iOS.Autofill
         public LoginListViewController(IntPtr handle)
             : base(handle)
         {
-            DismissModalAction = () => Cancel();
+            DismissModalAction = Cancel;
         }
 
         public Context Context { get; set; }

--- a/src/iOS.Autofill/LoginListViewController.cs
+++ b/src/iOS.Autofill/LoginListViewController.cs
@@ -16,7 +16,9 @@ namespace Bit.iOS.Autofill
     {
         public LoginListViewController(IntPtr handle)
             : base(handle)
-        { }
+        {
+            DismissModalAction = () => Cancel();
+        }
 
         public Context Context { get; set; }
         public CredentialProviderViewController CPViewController { get; set; }
@@ -43,6 +45,11 @@ namespace Bit.iOS.Autofill
 
         partial void CancelBarButton_Activated(UIBarButtonItem sender)
         {
+            Cancel();
+        }
+
+        private void Cancel()
+        {
             CPViewController.CompleteRequest();
         }
 
@@ -64,12 +71,16 @@ namespace Bit.iOS.Autofill
                 {
                     addLoginController.Context = Context;
                     addLoginController.LoginListController = this;
+                    segue.DestinationViewController.PresentationController.Delegate =
+                        new CustomPresentationControllerDelegate(addLoginController.DismissModalAction);
                 }
                 if (navController.TopViewController is LoginSearchViewController searchLoginController)
                 {
                     searchLoginController.Context = Context;
                     searchLoginController.CPViewController = CPViewController;
                     searchLoginController.FromList = true;
+                    segue.DestinationViewController.PresentationController.Delegate =
+                        new CustomPresentationControllerDelegate(searchLoginController.DismissModalAction);
                 }
             }
         }

--- a/src/iOS.Autofill/LoginSearchViewController.cs
+++ b/src/iOS.Autofill/LoginSearchViewController.cs
@@ -14,7 +14,9 @@ namespace Bit.iOS.Autofill
     {
         public LoginSearchViewController(IntPtr handle)
             : base(handle)
-        { }
+        {
+            DismissModalAction = () => Cancel();
+        }
 
         public Context Context { get; set; }
         public CredentialProviderViewController CPViewController { get; set; }
@@ -47,6 +49,11 @@ namespace Bit.iOS.Autofill
 
         partial void CancelBarButton_Activated(UIBarButtonItem sender)
         {
+            Cancel();
+        }
+
+        private void Cancel()
+        {
             if (FromList)
             {
                 DismissViewController(true, null);
@@ -70,6 +77,8 @@ namespace Bit.iOS.Autofill
                 {
                     addLoginController.Context = Context;
                     addLoginController.LoginSearchController = this;
+                    segue.DestinationViewController.PresentationController.Delegate =
+                        new CustomPresentationControllerDelegate(addLoginController.DismissModalAction);
                 }
             }
         }

--- a/src/iOS.Autofill/LoginSearchViewController.cs
+++ b/src/iOS.Autofill/LoginSearchViewController.cs
@@ -15,7 +15,7 @@ namespace Bit.iOS.Autofill
         public LoginSearchViewController(IntPtr handle)
             : base(handle)
         {
-            DismissModalAction = () => Cancel();
+            DismissModalAction = Cancel;
         }
 
         public Context Context { get; set; }

--- a/src/iOS.Autofill/PasswordGeneratorViewController.cs
+++ b/src/iOS.Autofill/PasswordGeneratorViewController.cs
@@ -7,7 +7,9 @@ namespace Bit.iOS.Autofill
     {
         public PasswordGeneratorViewController(IntPtr handle)
             : base(handle)
-        { }
+        {
+            DismissModalAction = () => Cancel();
+        }
 
         public LoginAddViewController Parent { get; set; }
         public override UINavigationItem BaseNavItem => NavItem;
@@ -21,6 +23,11 @@ namespace Bit.iOS.Autofill
         }
 
         partial void CancelBarButton_Activated(UIBarButtonItem sender)
+        {
+            Cancel();
+        }
+        
+        private void Cancel()
         {
             DismissViewController(true, null);
         }

--- a/src/iOS.Autofill/PasswordGeneratorViewController.cs
+++ b/src/iOS.Autofill/PasswordGeneratorViewController.cs
@@ -8,7 +8,7 @@ namespace Bit.iOS.Autofill
         public PasswordGeneratorViewController(IntPtr handle)
             : base(handle)
         {
-            DismissModalAction = () => Cancel();
+            DismissModalAction = Cancel;
         }
 
         public LoginAddViewController Parent { get; set; }

--- a/src/iOS.Autofill/SetupViewController.cs
+++ b/src/iOS.Autofill/SetupViewController.cs
@@ -11,7 +11,7 @@ namespace Bit.iOS.Autofill
         public SetupViewController(IntPtr handle)
             : base(handle)
         {
-            DismissModalAction = () => Cancel();
+            DismissModalAction = Cancel;
         }
 
         public CredentialProviderViewController CPViewController { get; set; }

--- a/src/iOS.Autofill/SetupViewController.cs
+++ b/src/iOS.Autofill/SetupViewController.cs
@@ -10,7 +10,9 @@ namespace Bit.iOS.Autofill
     {
         public SetupViewController(IntPtr handle)
             : base(handle)
-        { }
+        {
+            DismissModalAction = () => Cancel();
+        }
 
         public CredentialProviderViewController CPViewController { get; set; }
 
@@ -33,6 +35,11 @@ namespace Bit.iOS.Autofill
         }
 
         partial void BackButton_Activated(UIBarButtonItem sender)
+        {
+            Cancel();
+        }
+
+        private void Cancel()
         {
             CPViewController.CompleteRequest();
         }

--- a/src/iOS.Core/Controllers/ExtendedUITableViewController.cs
+++ b/src/iOS.Core/Controllers/ExtendedUITableViewController.cs
@@ -6,6 +6,8 @@ namespace Bit.iOS.Core.Controllers
 {
     public class ExtendedUITableViewController : UITableViewController
     {
+        public Action DismissModalAction { get; set; }
+        
         public ExtendedUITableViewController(IntPtr handle)
             : base(handle)
         {

--- a/src/iOS.Core/Controllers/ExtendedUIViewController.cs
+++ b/src/iOS.Core/Controllers/ExtendedUIViewController.cs
@@ -6,6 +6,8 @@ namespace Bit.iOS.Core.Controllers
 {
     public class ExtendedUIViewController : UIViewController
     {
+        public Action DismissModalAction { get; set; }
+        
         public ExtendedUIViewController(IntPtr handle)
             : base(handle)
         {

--- a/src/iOS.Core/Views/CustomPresentationControllerDelegate.cs
+++ b/src/iOS.Core/Views/CustomPresentationControllerDelegate.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using Foundation;
+using UIKit;
+
+namespace Bit.iOS.Core.Views
+{
+    public class CustomPresentationControllerDelegate : UIAdaptivePresentationControllerDelegate
+    {
+        private readonly Action DismissModalAction;
+
+        public CustomPresentationControllerDelegate(Action dismissModalAction)
+        {
+            DismissModalAction = dismissModalAction;
+        }
+
+        [Export("presentationControllerDidDismiss:")]
+        public override void DidDismiss(UIPresentationController presentationController)
+        {
+            DismissModalAction?.Invoke();
+        }
+    }
+}

--- a/src/iOS.Core/iOS.Core.csproj
+++ b/src/iOS.Core/iOS.Core.csproj
@@ -175,6 +175,7 @@
     <Compile Include="Utilities\iOSCoreHelpers.cs" />
     <Compile Include="Utilities\iOSHelpers.cs" />
     <Compile Include="Utilities\ThemeHelpers.cs" />
+    <Compile Include="Views\CustomPresentationControllerDelegate.cs" />
     <Compile Include="Views\ExtensionSearchDelegate.cs" />
     <Compile Include="Views\ExtensionTableSource.cs" />
     <Compile Include="Views\FormEntryTableViewCell.cs" />

--- a/src/iOS.Extension/LoadingViewController.cs
+++ b/src/iOS.Extension/LoadingViewController.cs
@@ -18,6 +18,7 @@ using Xamarin.Forms;
 using Bit.App.Pages;
 using Bit.App.Models;
 using Bit.App.Utilities;
+using Bit.iOS.Core.Views;
 
 namespace Bit.iOS.Extension
 {
@@ -94,20 +95,28 @@ namespace Bit.iOS.Extension
                 {
                     listLoginController.Context = _context;
                     listLoginController.LoadingController = this;
+                    segue.DestinationViewController.PresentationController.Delegate =
+                        new CustomPresentationControllerDelegate(listLoginController.DismissModalAction);
                 }
                 else if (navController.TopViewController is LoginAddViewController addLoginController)
                 {
                     addLoginController.Context = _context;
                     addLoginController.LoadingController = this;
+                    segue.DestinationViewController.PresentationController.Delegate =
+                        new CustomPresentationControllerDelegate(addLoginController.DismissModalAction);
                 }
                 else if (navController.TopViewController is LockPasswordViewController passwordViewController)
                 {
                     passwordViewController.LoadingController = this;
+                    segue.DestinationViewController.PresentationController.Delegate =
+                        new CustomPresentationControllerDelegate(passwordViewController.DismissModalAction);
                 }
                 else if (navController.TopViewController is SetupViewController setupViewController)
                 {
                     setupViewController.Context = _context;
                     setupViewController.LoadingController = this;
+                    segue.DestinationViewController.PresentationController.Delegate =
+                        new CustomPresentationControllerDelegate(setupViewController.DismissModalAction);
                 }
             }
         }

--- a/src/iOS.Extension/LockPasswordViewController.cs
+++ b/src/iOS.Extension/LockPasswordViewController.cs
@@ -10,7 +10,7 @@ namespace Bit.iOS.Extension
             : base(handle)
         {
             BiometricIntegrityKey = "extensionBiometricState";
-            DismissModalAction = () => Cancel();
+            DismissModalAction = Cancel;
         }
 
         public LoadingViewController LoadingController { get; set; }

--- a/src/iOS.Extension/LockPasswordViewController.cs
+++ b/src/iOS.Extension/LockPasswordViewController.cs
@@ -10,6 +10,7 @@ namespace Bit.iOS.Extension
             : base(handle)
         {
             BiometricIntegrityKey = "extensionBiometricState";
+            DismissModalAction = () => Cancel();
         }
 
         public LoadingViewController LoadingController { get; set; }

--- a/src/iOS.Extension/LoginAddViewController.cs
+++ b/src/iOS.Extension/LoginAddViewController.cs
@@ -1,5 +1,6 @@
 using System;
 using Bit.iOS.Core.Utilities;
+using Bit.iOS.Core.Views;
 using Foundation;
 using UIKit;
 
@@ -9,7 +10,9 @@ namespace Bit.iOS.Extension
     {
         public LoginAddViewController(IntPtr handle)
             : base(handle)
-        { }
+        {
+            DismissModalAction = () => Cancel();
+        }
 
         public LoginListViewController LoginListController { get; set; }
         public LoadingViewController LoadingController { get; set; }
@@ -40,6 +43,11 @@ namespace Bit.iOS.Extension
 
         partial void CancelBarButton_Activated(UIBarButtonItem sender)
         {
+            Cancel();
+        }
+        
+        private void Cancel()
+        {
             if (LoginListController != null)
             {
                 DismissViewController(true, null);
@@ -63,6 +71,8 @@ namespace Bit.iOS.Extension
                 {
                     passwordGeneratorController.PasswordOptions = Context.PasswordOptions;
                     passwordGeneratorController.Parent = this;
+                    segue.DestinationViewController.PresentationController.Delegate =
+                        new CustomPresentationControllerDelegate(passwordGeneratorController.DismissModalAction);
                 }
             }
         }

--- a/src/iOS.Extension/LoginAddViewController.cs
+++ b/src/iOS.Extension/LoginAddViewController.cs
@@ -11,7 +11,7 @@ namespace Bit.iOS.Extension
         public LoginAddViewController(IntPtr handle)
             : base(handle)
         {
-            DismissModalAction = () => Cancel();
+            DismissModalAction = Cancel;
         }
 
         public LoginListViewController LoginListController { get; set; }

--- a/src/iOS.Extension/LoginListViewController.cs
+++ b/src/iOS.Extension/LoginListViewController.cs
@@ -18,7 +18,9 @@ namespace Bit.iOS.Extension
     {
         public LoginListViewController(IntPtr handle)
             : base(handle)
-        { }
+        {
+            DismissModalAction = () => Cancel();
+        }
 
         public Context Context { get; set; }
         public LoadingViewController LoadingController { get; set; }
@@ -57,6 +59,11 @@ namespace Bit.iOS.Extension
 
         partial void CancelBarButton_Activated(UIBarButtonItem sender)
         {
+            Cancel();
+        }
+        
+        private void Cancel()
+        {
             LoadingController.CompleteRequest(null, null);
         }
 
@@ -73,6 +80,8 @@ namespace Bit.iOS.Extension
                 {
                     addLoginController.Context = Context;
                     addLoginController.LoginListController = this;
+                    segue.DestinationViewController.PresentationController.Delegate =
+                        new CustomPresentationControllerDelegate(addLoginController.DismissModalAction);
                 }
             }
         }

--- a/src/iOS.Extension/LoginListViewController.cs
+++ b/src/iOS.Extension/LoginListViewController.cs
@@ -19,7 +19,7 @@ namespace Bit.iOS.Extension
         public LoginListViewController(IntPtr handle)
             : base(handle)
         {
-            DismissModalAction = () => Cancel();
+            DismissModalAction = Cancel;
         }
 
         public Context Context { get; set; }

--- a/src/iOS.Extension/PasswordGeneratorViewController.cs
+++ b/src/iOS.Extension/PasswordGeneratorViewController.cs
@@ -8,7 +8,9 @@ namespace Bit.iOS.Extension
     {
         public PasswordGeneratorViewController(IntPtr handle)
             : base(handle)
-        { }
+        {
+            DismissModalAction = () => Cancel();
+        }
         
         public LoginAddViewController Parent { get; set; }
         public override UINavigationItem BaseNavItem => NavItem;
@@ -29,6 +31,11 @@ namespace Bit.iOS.Extension
         }
 
         partial void CancelBarButton_Activated(UIBarButtonItem sender)
+        {
+            Cancel();
+        }
+        
+        private void Cancel()
         {
             DismissViewController(true, null);
         }

--- a/src/iOS.Extension/PasswordGeneratorViewController.cs
+++ b/src/iOS.Extension/PasswordGeneratorViewController.cs
@@ -9,7 +9,7 @@ namespace Bit.iOS.Extension
         public PasswordGeneratorViewController(IntPtr handle)
             : base(handle)
         {
-            DismissModalAction = () => Cancel();
+            DismissModalAction = Cancel;
         }
         
         public LoginAddViewController Parent { get; set; }

--- a/src/iOS.Extension/SetupViewController.cs
+++ b/src/iOS.Extension/SetupViewController.cs
@@ -13,6 +13,7 @@ namespace Bit.iOS.Extension
             : base(handle)
         {
             ModalPresentationStyle = UIModalPresentationStyle.FullScreen;
+            DismissModalAction = () => Cancel();
         }
 
         public Context Context { get; set; }
@@ -37,6 +38,11 @@ namespace Bit.iOS.Extension
         }
 
         partial void BackButton_Activated(UIBarButtonItem sender)
+        {
+            Cancel();
+        }
+        
+        private void Cancel()
         {
             LoadingController.CompleteRequest(null, null);
         }

--- a/src/iOS.Extension/SetupViewController.cs
+++ b/src/iOS.Extension/SetupViewController.cs
@@ -13,7 +13,7 @@ namespace Bit.iOS.Extension
             : base(handle)
         {
             ModalPresentationStyle = UIModalPresentationStyle.FullScreen;
-            DismissModalAction = () => Cancel();
+            DismissModalAction = Cancel;
         }
 
         public Context Context { get; set; }


### PR DESCRIPTION
On iOS 13+ the extension modals are displayed as sheets which enables the user to swipe them away as a method of cancelation.  We have varying levels of logic attached to our cancel buttons that was not firing when the user swiped the sheet(s) away, resulting in an un-dismiss-able sheet that requires the app that triggered it to be killed.  This PR attaches a delegate to each view controller to capture a dismiss-by-swipe event and fire off the same code used by the cancel buttons.  Viola, no more frozen treats!  According to Apple this callback only fires on dismiss-by-swipe, so using the cancel button won't result in code being executed twice.