### PR TITLE
Update support for Ungoogled Chromium browser. Fixes #1118

### DIFF
--- a/src/Android/Accessibility/AccessibilityHelpers.cs
+++ b/src/Android/Accessibility/AccessibilityHelpers.cs
@@ -90,7 +90,9 @@ namespace Bit.Droid.Accessibility
             new Browser("org.mozilla.rocket", "display_url"),
             new Browser("org.torproject.torbrowser", "url_bar_title,mozac_browser_toolbar_url_view"), // 2nd = Anticipation
             new Browser("org.torproject.torbrowser_alpha", "url_bar_title,mozac_browser_toolbar_url_view"), // 2nd = Anticipation
-            new Browser("org.ungoogled.chromium", "url_bar"),
+            new Browser("org.ungoogled.chromium", "url_bar"), // [DEPRECATED]
+            new Browser("org.ungoogled.chromium.extensions.stable", "url_bar"),
+            new Browser("org.ungoogled.chromium.stable", "url_bar"),
 
             // [Section B] Entries only present here
             //

--- a/src/Android/Autofill/AutofillHelpers.cs
+++ b/src/Android/Autofill/AutofillHelpers.cs
@@ -94,6 +94,8 @@ namespace Bit.Droid.Autofill
             "org.torproject.torbrowser",
             "org.torproject.torbrowser_alpha",
             "org.ungoogled.chromium",
+            "org.ungoogled.chromium.extensions.stable",
+            "org.ungoogled.chromium.stable",
         };
 
         // The URLs are blacklisted from autofilling

--- a/src/Android/Resources/xml/autofillservice.xml
+++ b/src/Android/Resources/xml/autofillservice.xml
@@ -178,4 +178,10 @@
   <compatibility-package
     android:name="org.ungoogled.chromium"
     android:maxLongVersionCode="10000000000"/>
+  <compatibility-package
+    android:name="org.ungoogled.chromium.extensions.stable"
+    android:maxLongVersionCode="10000000000"/>
+  <compatibility-package
+    android:name="org.ungoogled.chromium.stable"
+    android:maxLongVersionCode="10000000000"/>
 </autofill-service>


### PR DESCRIPTION
### This:
- updates support for **Ungoogled Chromium** browser.

# Details
- keeps (for a few months)  `org.ungoogled.chromium` with the comment `// [DEPRECATED]`;
- adds `org.ungoogled.chromium.stable`, but also `org.ungoogled.chromium.extensions.stable` (see [their CHANGELOG](https://git.droidware.info/wchen342/ungoogled-chromium-android/src/commit/1812d0258510535da8406ea0e39cdd0c26a21342/CHANGELOG.md) regarding this).
&nbsp;

Fixes #1118