### PR TITLE
Remove deprecated info.plist key

### DIFF
--- a/src/iOS/Info.plist
+++ b/src/iOS/Info.plist
@@ -125,7 +125,5 @@
 	<string>Use Face ID to unlock your vault.</string>
 	<key>NFCReaderUsageDescription</key>
 	<string>Use Yubikeys for two-facor authentication.</string>
-	<key>UILaunchImages</key>
-	<string>Resources/Assets.xcassets/LaunchScreen.imageset</string>
 </dict>
 </plist>


### PR DESCRIPTION
Apparently this key was deprecated and is no longer necessary (confirmed via simulator test on all versions back to iOS 10).  The presence of the key is preventing publishing, so away it goes.