### PR TITLE
[GDPR] Adjusted TOS/Privacy acceptance

### DIFF
--- a/src/App/Pages/Accounts/RegisterPage.xaml
+++ b/src/App/Pages/Accounts/RegisterPage.xaml
@@ -129,7 +129,8 @@
                     <Switch
                         IsToggled="{Binding AcceptPolicies}"
                         StyleClass="box-value"
-                        HorizontalOptions="Start" />
+                        HorizontalOptions="Start"
+                        Margin="{Binding GetSwitchMargin}"/>
                     <Label StyleClass="box-footer-label"
                            HorizontalOptions="Fill">
                         <Label.FormattedText>

--- a/src/App/Pages/Accounts/RegisterPage.xaml
+++ b/src/App/Pages/Accounts/RegisterPage.xaml
@@ -123,6 +123,38 @@
                     Text="{u:I18n MasterPasswordHintDescription}"
                     StyleClass="box-footer-label" />
             </StackLayout>
+            <StackLayout StyleClass="box">
+                <StackLayout StyleClass="box-row, box-row-switch"
+                            IsVisible="{Binding ShowTerms}">
+                    <Switch
+                        IsToggled="{Binding AcceptPolicies}"
+                        StyleClass="box-value"
+                        HorizontalOptions="Start" />
+                    <Label StyleClass="box-footer-label"
+                           HorizontalOptions="Fill">
+                        <Label.FormattedText>
+                            <FormattedString>
+                                <Span Text="{u:I18n AcceptPolicies}" />
+                                <Span Text="{u:I18n TermsOfService}"
+                                      TextColor="Blue">
+                                    <Span.GestureRecognizers>
+                                        <TapGestureRecognizer Command="{Binding PoliciesClickCommand}"
+                                                              CommandParameter="https://bitwarden.com/terms/" />
+                                    </Span.GestureRecognizers>
+                                </Span>
+                                <Span Text=", " />
+                                <Span Text="{u:I18n PrivacyPolicy}"
+                                      TextColor="Blue">
+                                    <Span.GestureRecognizers>
+                                        <TapGestureRecognizer Command="{Binding PoliciesClickCommand}"
+                                                              CommandParameter="https://bitwarden.com/privacy/" />
+                                    </Span.GestureRecognizers>
+                                </Span>
+                            </FormattedString>
+                        </Label.FormattedText>
+                    </Label>
+                </StackLayout>
+            </StackLayout>
         </StackLayout>
     </ScrollView>
 

--- a/src/App/Pages/Accounts/RegisterPage.xaml
+++ b/src/App/Pages/Accounts/RegisterPage.xaml
@@ -130,7 +130,7 @@
                         IsToggled="{Binding AcceptPolicies}"
                         StyleClass="box-value"
                         HorizontalOptions="Start"
-                        Margin="{Binding GetSwitchMargin}"/>
+                        Margin="{Binding SwitchMargin}"/>
                     <Label StyleClass="box-footer-label"
                            HorizontalOptions="Fill">
                         <Label.FormattedText>

--- a/src/App/Pages/Accounts/RegisterPageViewModel.cs
+++ b/src/App/Pages/Accounts/RegisterPageViewModel.cs
@@ -56,6 +56,13 @@ namespace Bit.App.Pages
             set => SetProperty(ref _acceptPolicies, value);
         }
         
+        public Thickness GetSwitchMargin
+        {
+            get => Device.RuntimePlatform == Device.Android 
+                ? new Thickness(0, 0, 0, 0) 
+                : new Thickness(0, 0, 10, 0);
+        }
+        
         public bool ShowTerms { get; set; }
         public Command SubmitCommand { get; }
         public Command TogglePasswordCommand { get; }

--- a/src/App/Pages/Accounts/RegisterPageViewModel.cs
+++ b/src/App/Pages/Accounts/RegisterPageViewModel.cs
@@ -7,6 +7,7 @@ using Bit.Core.Models.Request;
 using Bit.Core.Utilities;
 using System;
 using System.Threading.Tasks;
+using System.Windows.Input;
 using Xamarin.Forms;
 
 namespace Bit.App.Pages
@@ -18,6 +19,7 @@ namespace Bit.App.Pages
         private readonly ICryptoService _cryptoService;
         private readonly IPlatformUtilsService _platformUtilsService;
         private bool _showPassword;
+        private bool _acceptPolicies;
 
         public RegisterPageViewModel()
         {
@@ -30,7 +32,13 @@ namespace Bit.App.Pages
             TogglePasswordCommand = new Command(TogglePassword);
             ToggleConfirmPasswordCommand = new Command(ToggleConfirmPassword);
             SubmitCommand = new Command(async () => await SubmitAsync());
+            ShowTerms = !_platformUtilsService.IsSelfHost();
         }
+        
+        public ICommand PoliciesClickCommand => new Command<string>((url) =>
+        {
+            _platformUtilsService.LaunchUri(url);
+        });
 
         public bool ShowPassword
         {
@@ -41,7 +49,14 @@ namespace Bit.App.Pages
                     nameof(ShowPasswordIcon)
                 });
         }
-
+        
+        public bool AcceptPolicies
+        {
+            get => _acceptPolicies;
+            set => SetProperty(ref _acceptPolicies, value);
+        }
+        
+        public bool ShowTerms { get; set; }
         public Command SubmitCommand { get; }
         public Command TogglePasswordCommand { get; }
         public Command ToggleConfirmPasswordCommand { get; }
@@ -91,6 +106,12 @@ namespace Bit.App.Pages
             {
                 await Page.DisplayAlert(AppResources.AnErrorHasOccurred,
                     AppResources.MasterPasswordConfirmationValMessage, AppResources.Ok);
+                return;
+            }
+            if (ShowTerms && !AcceptPolicies)
+            {
+                await Page.DisplayAlert(AppResources.AnErrorHasOccurred,
+                    AppResources.AcceptPoliciesError, AppResources.Ok);
                 return;
             }
 

--- a/src/App/Pages/Accounts/RegisterPageViewModel.cs
+++ b/src/App/Pages/Accounts/RegisterPageViewModel.cs
@@ -56,7 +56,7 @@ namespace Bit.App.Pages
             set => SetProperty(ref _acceptPolicies, value);
         }
         
-        public Thickness GetSwitchMargin
+        public Thickness SwitchMargin
         {
             get => Device.RuntimePlatform == Device.Android 
                 ? new Thickness(0, 0, 0, 0) 

--- a/src/App/Resources/AppResources.Designer.cs
+++ b/src/App/Resources/AppResources.Designer.cs
@@ -3050,5 +3050,29 @@ namespace Bit.App.Resources {
                 return ResourceManager.GetString("Loading", resourceCulture);
             }
         }
+        
+        public static string AcceptPolicies {
+            get {
+                return ResourceManager.GetString("AcceptPolicies", resourceCulture);
+            }
+        }
+        
+        public static string AcceptPoliciesError {
+            get {
+                return ResourceManager.GetString("AcceptPoliciesError", resourceCulture);
+            }
+        }
+        
+        public static string TermsOfService {
+            get {
+                return ResourceManager.GetString("TermsOfService", resourceCulture);
+            }
+        }
+        
+        public static string PrivacyPolicy {
+            get {
+                return ResourceManager.GetString("PrivacyPolicy", resourceCulture);
+            }
+        }
     }
 }

--- a/src/App/Resources/AppResources.resx
+++ b/src/App/Resources/AppResources.resx
@@ -1731,4 +1731,17 @@
   <data name="Loading" xml:space="preserve">
     <value>Loading</value>
   </data>
+  <data name="AcceptPolicies" xml:space="preserve">
+    <value>By activating this switch you agree to the following:
+</value>
+  </data>
+  <data name="AcceptPoliciesError" xml:space="preserve">
+    <value>Terms of Service and Privacy Policy have not been acknowledged.</value>
+  </data>
+  <data name="TermsOfService" xml:space="preserve">
+    <value>Terms of Service</value>
+  </data>
+  <data name="PrivacyPolicy" xml:space="preserve">
+    <value>Privacy Policy</value>
+  </data>
 </root>


### PR DESCRIPTION
## Objective
> In order to complete GDPR compliance, moving forward with new user creation, we need to have explicit user interaction for Terms of Service and Privacy Policy acknowledgement.

## Code Changes
- **RegisterPage.xaml**: Added UI for terms/privacy acknowledgement. Created formatted label text with spannable selectors for each of the policies. Use specialized margin based on platform.
- **RegisterPageViewModel.cs**: Added variables for `ShowTerms`, `AcceptPolicies`, and created `PoliciesClickCommand` for opening URIs. Added `Submit` logic. Added getter property to handle switch margin based on platform.
- **AppResources.resx**: Added strings. Note: formatting for the `AcceptPolicies` string looks weird, but is necessary because of the intentional line break (xml:preserve takes the string as is).

## Screenshots
![mobile-android-0-base](https://user-images.githubusercontent.com/26154748/98120010-0510ee00-1e73-11eb-97ed-22685c8091bf.png)
![mobile-android-1-error](https://user-images.githubusercontent.com/26154748/98120015-06421b00-1e73-11eb-8731-6f7a1e5603cc.png)


