### PR TITLE
Include revision date in cipher requests

### DIFF
--- a/src/Core/Models/Request/CipherRequest.cs
+++ b/src/Core/Models/Request/CipherRequest.cs
@@ -3,6 +3,7 @@ using Bit.Core.Models.Api;
 using Bit.Core.Models.Domain;
 using System.Collections.Generic;
 using System.Linq;
+using System;
 
 namespace Bit.Core.Models.Request
 {
@@ -16,6 +17,7 @@ namespace Bit.Core.Models.Request
             Name = cipher.Name?.EncryptedString;
             Notes = cipher.Notes?.EncryptedString;
             Favorite = cipher.Favorite;
+            LastKnownRevisionDate = cipher.RevisionDate;
 
             switch (Type)
             {
@@ -118,5 +120,6 @@ namespace Bit.Core.Models.Request
         public List<PasswordHistoryRequest> PasswordHistory { get; set; }
         public Dictionary<string, string> Attachments { get; set; }
         public Dictionary<string, AttachmentRequest> Attachments2 { get; set; }
+        public DateTime LastKnownRevisionDate { get; set; }
     }
 }

--- a/src/Core/Services/CipherService.cs
+++ b/src/Core/Services/CipherService.cs
@@ -176,7 +176,8 @@ namespace Bit.Core.Services
                 Favorite = model.Favorite,
                 OrganizationId = model.OrganizationId,
                 Type = model.Type,
-                CollectionIds = model.CollectionIds
+                CollectionIds = model.CollectionIds,
+                RevisionDate = model.RevisionDate
             };
 
             if (key == null && cipher.OrganizationId != null)


### PR DESCRIPTION
# Objective

This is a companion PR to API changes found in bitwarden/server#994

# Code Changes

* **CipherRequest.cs**: Add revision date to request model for validation.
* **CipherService.cs**: Include revision date in encryption of ciphers so it can be included in the request model.

# Prereqs

- [ ] Merge in bitwarden/server#994
