### PR TITLE
Fix for missing biometric integrity check in iOS extensions under certain conditions

### DIFF
--- a/src/App/Resources/AppResources.Designer.cs
+++ b/src/App/Resources/AppResources.Designer.cs
@@ -2943,6 +2943,12 @@ namespace Bit.App.Resources {
             }
         }
         
+        public static string BiometricInvalidatedExtension {
+            get {
+                return ResourceManager.GetString("BiometricInvalidatedExtension", resourceCulture);
+            }
+        }
+        
         public static string EnableSyncOnRefresh {
             get {
                 return ResourceManager.GetString("EnableSyncOnRefresh", resourceCulture);

--- a/src/App/Resources/AppResources.resx
+++ b/src/App/Resources/AppResources.resx
@@ -1675,7 +1675,10 @@
     <comment>Confirmation alert message when soft-deleting a cipher.</comment>
   </data>
   <data name="BiometricInvalidated" xml:space="preserve">
-    <value>Biometric change detected, login using Master Password to enable again.</value>
+    <value>Biometric unlock disabled pending verification of master password.</value>
+  </data>
+  <data name="BiometricInvalidatedExtension" xml:space="preserve">
+    <value>Biometric unlock for autofill disabled pending verification of master password.</value>
   </data>
   <data name="EnableSyncOnRefresh" xml:space="preserve">
     <value>Enable sync on refresh</value>

--- a/src/App/Services/MobileStorageService.cs
+++ b/src/App/Services/MobileStorageService.cs
@@ -32,8 +32,11 @@ namespace Bit.App.Services
             Constants.MigratedFromV1AutofillPromptShown,
             Constants.TriedV1Resync,
             Constants.ClearCiphersCacheKey,
+            Constants.BiometricIntegrityKey,
             Constants.iOSAutoFillClearCiphersCacheKey,
+            Constants.iOSAutoFillBiometricIntegrityKey,
             Constants.iOSExtensionClearCiphersCacheKey,
+            Constants.iOSExtensionBiometricIntegrityKey,
             Constants.EnvironmentUrlsKey,
             Constants.InlineAutofillEnabledKey,
         };

--- a/src/Core/Constants.cs
+++ b/src/Core/Constants.cs
@@ -29,8 +29,11 @@
         public static string OldUserIdKey = "userId";
         public static string AddSitePromptShownKey = "addSitePromptShown";
         public static string ClearCiphersCacheKey = "clearCiphersCache";
+        public static string BiometricIntegrityKey = "biometricState";
         public static string iOSAutoFillClearCiphersCacheKey = "iOSAutoFillClearCiphersCache";
+        public static string iOSAutoFillBiometricIntegrityKey = "iOSAutoFillBiometricState";
         public static string iOSExtensionClearCiphersCacheKey = "iOSExtensionClearCiphersCache";
+        public static string iOSExtensionBiometricIntegrityKey = "iOSExtensionBiometricState";
         public static string MigratedFromV1 = "migratedFromV1";
         public static string MigratedFromV1AutofillPromptShown = "migratedV1AutofillPromptShown";
         public static string TriedV1Resync = "triedV1Resync";

--- a/src/Core/Constants.cs
+++ b/src/Core/Constants.cs
@@ -29,11 +29,11 @@
         public static string OldUserIdKey = "userId";
         public static string AddSitePromptShownKey = "addSitePromptShown";
         public static string ClearCiphersCacheKey = "clearCiphersCache";
-        public static string BiometricIntegrityKey = "biometricState";
+        public static string BiometricIntegrityKey = "biometricIntegrityState";
         public static string iOSAutoFillClearCiphersCacheKey = "iOSAutoFillClearCiphersCache";
-        public static string iOSAutoFillBiometricIntegrityKey = "iOSAutoFillBiometricState";
+        public static string iOSAutoFillBiometricIntegrityKey = "iOSAutoFillBiometricIntegrityState";
         public static string iOSExtensionClearCiphersCacheKey = "iOSExtensionClearCiphersCache";
-        public static string iOSExtensionBiometricIntegrityKey = "iOSExtensionBiometricState";
+        public static string iOSExtensionBiometricIntegrityKey = "iOSExtensionBiometricIntegrityState";
         public static string MigratedFromV1 = "migratedFromV1";
         public static string MigratedFromV1AutofillPromptShown = "migratedV1AutofillPromptShown";
         public static string TriedV1Resync = "triedV1Resync";

--- a/src/iOS.Autofill/LockPasswordViewController.cs
+++ b/src/iOS.Autofill/LockPasswordViewController.cs
@@ -8,7 +8,7 @@ namespace Bit.iOS.Autofill
         public LockPasswordViewController(IntPtr handle)
             : base(handle)
         {
-            BiometricIntegrityKey = "autofillBiometricState";
+            BiometricIntegrityKey = Bit.Core.Constants.iOSAutoFillBiometricIntegrityKey;
             DismissModalAction = Cancel;
         }
 

--- a/src/iOS.Core/Controllers/LockPasswordViewController.cs
+++ b/src/iOS.Core/Controllers/LockPasswordViewController.cs
@@ -59,6 +59,8 @@ namespace Bit.iOS.Core.Controllers
             _pinLock = (_pinSet.Item1 && _vaultTimeoutService.PinProtectedKey != null) || _pinSet.Item2;
             _biometricLock = _vaultTimeoutService.IsBiometricLockSetAsync().GetAwaiter().GetResult() &&
                 _cryptoService.HasKeyAsync().GetAwaiter().GetResult();
+            _biometricIntegrityValid = _biometricService.ValidateIntegrityAsync(BiometricIntegrityKey).GetAwaiter()
+                .GetResult();
 
             BaseNavItem.Title = _pinLock ? AppResources.VerifyPIN : AppResources.VerifyMasterPassword;
             BaseCancelButton.Title = AppResources.Cancel;
@@ -86,8 +88,6 @@ namespace Bit.iOS.Core.Controllers
 
             base.ViewDidLoad();
 
-            _biometricIntegrityValid = _biometricService.ValidateIntegrityAsync(BiometricIntegrityKey).GetAwaiter()
-                .GetResult();
             if (_biometricLock)
             {
                 if (!_biometricIntegrityValid)

--- a/src/iOS.Core/Controllers/LockPasswordViewController.cs
+++ b/src/iOS.Core/Controllers/LockPasswordViewController.cs
@@ -86,10 +86,10 @@ namespace Bit.iOS.Core.Controllers
 
             base.ViewDidLoad();
 
+            _biometricIntegrityValid = _biometricService.ValidateIntegrityAsync(BiometricIntegrityKey).GetAwaiter()
+                .GetResult();
             if (_biometricLock)
             {
-                _biometricIntegrityValid = _biometricService.ValidateIntegrityAsync(BiometricIntegrityKey).GetAwaiter()
-                    .GetResult();
                 if (!_biometricIntegrityValid)
                 {
                     return;

--- a/src/iOS.Core/Controllers/LockPasswordViewController.cs
+++ b/src/iOS.Core/Controllers/LockPasswordViewController.cs
@@ -293,7 +293,7 @@ namespace Bit.iOS.Core.Controllers
                             cell.TextLabel.Font = ThemeHelpers.GetDangerFont();
                             cell.TextLabel.Lines = 0;
                             cell.TextLabel.LineBreakMode = UILineBreakMode.WordWrap;
-                            cell.TextLabel.Text = AppResources.BiometricInvalidated;
+                            cell.TextLabel.Text = AppResources.BiometricInvalidatedExtension;
                         }
                         return cell;
                     }

--- a/src/iOS.Core/Services/BiometricService.cs
+++ b/src/iOS.Core/Services/BiometricService.cs
@@ -18,7 +18,7 @@ namespace Bit.iOS.Core.Services
         {
             if (bioIntegrityKey == null)
             {
-                bioIntegrityKey = "biometricState";
+                bioIntegrityKey = Bit.Core.Constants.BiometricIntegrityKey;
             }
             var state = GetState();
             if (state != null)
@@ -33,7 +33,7 @@ namespace Bit.iOS.Core.Services
         {
             if (bioIntegrityKey == null)
             {
-                bioIntegrityKey = "biometricState";
+                bioIntegrityKey = Bit.Core.Constants.BiometricIntegrityKey;
             }
             var oldState = await _storageService.GetAsync<string>(bioIntegrityKey);
             if (oldState == null)

--- a/src/iOS.Core/Services/BiometricService.cs
+++ b/src/iOS.Core/Services/BiometricService.cs
@@ -31,6 +31,13 @@ namespace Bit.iOS.Core.Services
 
         public async Task<bool> ValidateIntegrityAsync(string bioIntegrityKey = null)
         {
+            var state = GetState();
+            if (state == null)
+            {
+                // Fallback for devices unable to retrieve state
+                return true;
+            }
+            
             if (bioIntegrityKey == null)
             {
                 bioIntegrityKey = Bit.Core.Constants.BiometricIntegrityKey;
@@ -40,23 +47,11 @@ namespace Bit.iOS.Core.Services
             {
                 oldState = await GetMigratedIntegrityState(bioIntegrityKey);
             }
-            if (oldState == null)
+            if (oldState != null)
             {
-                // Fallback for upgraded devices
-                await SetupBiometricAsync(bioIntegrityKey);
-
-                return true;
+                return FromBase64(oldState).Equals(state);
             }
-            else
-            {
-                var state = GetState();
-                if (state != null)
-                {
-                    return FromBase64(oldState).Equals(state);
-                }
-
-                return true;
-            }
+            return false;
         }
 
         private NSData GetState()

--- a/src/iOS.Extension/LockPasswordViewController.cs
+++ b/src/iOS.Extension/LockPasswordViewController.cs
@@ -9,7 +9,7 @@ namespace Bit.iOS.Extension
         public LockPasswordViewController(IntPtr handle)
             : base(handle)
         {
-            BiometricIntegrityKey = "extensionBiometricState";
+            BiometricIntegrityKey = Bit.Core.Constants.iOSExtensionBiometricIntegrityKey;
             DismissModalAction = Cancel;
         }
 


### PR DESCRIPTION
A path was discovered where a user could modify biometric credentials on an iOS device then bypass the Bitwarden integrity check by using the autofill extension.

Reason: While the extensions do properly perform the integrity check per #1110 , the check would fail to catch the change **only if the extension had yet to be triggered once biometric unlock was enabled within the app**  (because the very first check results in a null value, then updates to the current integrity key value and returns true to indicate success - see [BiometricService line 39](https://github.com/bitwarden/mobile/blob/e27370cf32ece73ba44d7eadd6aebf519d82fdce/src/iOS.Core/Services/BiometricService.cs#L39)).

_Solution Part 1_: By performing the check regardless of the biometric unlock setting in the app, the null integrity value for the extension is replaced with a legitimate value when autofill is first enabled (by opening the extension for user verification).  By the time the scenario above plays out, a proper integrity value is in place and the extension catches the change and forces the user to enter their master password.

_Solution Part 2_:  While testing part 1 I witnessed the behavior occasionally revert to skipping the check.  As the issue with sharing the DB across processes is still a thorn in my side, I've moved the integrity values to pref storage (where I should have put them in the first place) and added migration to prevent any unnecessary panic brought on by an unplanned bio integrity mismatch.  After this change, I've been unable to repro the failure.