### PR TITLE
[Policy] Personal Ownership

### DIFF
--- a/src/Android/Autofill/AutofillService.cs
+++ b/src/Android/Autofill/AutofillService.cs
@@ -23,6 +23,7 @@ namespace Bit.Droid.Autofill
         private ICipherService _cipherService;
         private IVaultTimeoutService _vaultTimeoutService;
         private IStorageService _storageService;
+        private IPolicyService _policyService;
 
         public async override void OnFillRequest(FillRequest request, CancellationSignal cancellationSignal,
             FillCallback callback)
@@ -89,6 +90,14 @@ namespace Bit.Droid.Autofill
                 return;
             }
 
+            _policyService ??= ServiceContainer.Resolve<IPolicyService>("policyService");
+
+            var personalOwnershipPolicies = await _policyService.GetAll(PolicyType.PersonalOwnership);
+            if (personalOwnershipPolicies != null && personalOwnershipPolicies.Any(policy => policy.Enabled))
+            {
+                    return;
+            }
+            
             var parser = new Parser(structure, ApplicationContext);
             parser.Parse();
 

--- a/src/App/Pages/Vault/AddEditPageViewModel.cs
+++ b/src/App/Pages/Vault/AddEditPageViewModel.cs
@@ -439,8 +439,7 @@ namespace Bit.App.Pages
                     AppResources.Ok);
                 return false;
             }
-
-            Cipher.OrganizationId = null;
+            
             if ((!EditMode || CloneMode) && !AllowPersonal && string.IsNullOrWhiteSpace(Cipher.OrganizationId))
             {
                 await Page.DisplayAlert(AppResources.AnErrorHasOccurred,

--- a/src/App/Pages/Vault/AddEditPageViewModel.cs
+++ b/src/App/Pages/Vault/AddEditPageViewModel.cs
@@ -387,6 +387,12 @@ namespace Bit.App.Pages
                     IdentityTitleOptions.FindIndex(k => k.Value == Cipher.Identity.Title);
                 OwnershipSelectedIndex = string.IsNullOrWhiteSpace(Cipher.OrganizationId) ? 0 :
                     OwnershipOptions.FindIndex(k => k.Value == Cipher.OrganizationId);
+                
+                // If the selected organization is on Index 0 and we've removed the personal option, force refresh
+                if (!AllowPersonal && OwnershipSelectedIndex == 0)
+                {
+                    OrganizationChanged();
+                }
 
                 if ((!EditMode || CloneMode) && (CollectionIds?.Any() ?? false))
                 {
@@ -434,6 +440,7 @@ namespace Bit.App.Pages
                 return false;
             }
 
+            Cipher.OrganizationId = null;
             if ((!EditMode || CloneMode) && !AllowPersonal && string.IsNullOrWhiteSpace(Cipher.OrganizationId))
             {
                 await Page.DisplayAlert(AppResources.AnErrorHasOccurred,

--- a/src/App/Pages/Vault/AddEditPageViewModel.cs
+++ b/src/App/Pages/Vault/AddEditPageViewModel.cs
@@ -25,6 +25,7 @@ namespace Bit.App.Pages
         private readonly IAuditService _auditService;
         private readonly IMessagingService _messagingService;
         private readonly IEventService _eventService;
+        private readonly IPolicyService _policyService;
         private CipherView _cipher;
         private bool _showNotesSeparator;
         private bool _showPassword;
@@ -78,6 +79,7 @@ namespace Bit.App.Pages
             _messagingService = ServiceContainer.Resolve<IMessagingService>("messagingService");
             _collectionService = ServiceContainer.Resolve<ICollectionService>("collectionService");
             _eventService = ServiceContainer.Resolve<IEventService>("eventService");
+            _policyService = ServiceContainer.Resolve<IPolicyService>("policyService");
             GeneratePasswordCommand = new Command(GeneratePassword);
             TogglePasswordCommand = new Command(TogglePassword);
             ToggleCardCodeCommand = new Command(ToggleCardCode);
@@ -87,6 +89,7 @@ namespace Bit.App.Pages
             Uris = new ExtendedObservableCollection<LoginUriView>();
             Fields = new ExtendedObservableCollection<AddEditPageFieldViewModel>();
             Collections = new ExtendedObservableCollection<CollectionViewModel>();
+            AllowPersonal = true;
 
             TypeOptions = new List<KeyValuePair<string, CipherType>>
             {
@@ -276,6 +279,7 @@ namespace Bit.App.Pages
         public string ShowCardCodeIcon => ShowCardCode ? "" : "";
         public int PasswordFieldColSpan => Cipher.ViewPassword ? 1 : 4;
         public int TotpColumnSpan => Cipher.ViewPassword ? 1 : 2;
+        public bool AllowPersonal { get; set; }
 
         public void Init()
         {
@@ -284,6 +288,7 @@ namespace Bit.App.Pages
 
         public async Task<bool> LoadAsync(AppOptions appOptions = null)
         {
+            var policies = (await _policyService.GetAll(PolicyType.PersonalOwnership))?.ToList();
             var myEmail = await _userService.GetEmailAsync();
             OwnershipOptions.Add(new KeyValuePair<string, string>(myEmail, null));
             var orgs = await _userService.GetAllOrganizationAsync();
@@ -292,6 +297,24 @@ namespace Bit.App.Pages
                 if (org.Enabled && org.Status == OrganizationUserStatusType.Confirmed)
                 {
                     OwnershipOptions.Add(new KeyValuePair<string, string>(org.Name, org.Id));
+                    if (policies != null && org.UsePolicies && !org.IsAdmin && AllowPersonal)
+                    {
+                        foreach (var policy in policies)
+                        {
+                            if (policy.OrganizationId == org.Id && policy.Enabled)
+                            {
+                                AllowPersonal = false;
+                                // Remove personal ownership
+                                OwnershipOptions.RemoveAt(0);
+                                // Default to the organization who owns this policy for now (if necessary)
+                                if (string.IsNullOrWhiteSpace(OrganizationId))
+                                {
+                                    OrganizationId = org.Id;
+                                }
+                                break;
+                            }
+                        }
+                    }
                 }
             }
 
@@ -408,6 +431,13 @@ namespace Bit.App.Pages
                 await Page.DisplayAlert(AppResources.AnErrorHasOccurred,
                     string.Format(AppResources.ValidationFieldRequired, AppResources.Name),
                     AppResources.Ok);
+                return false;
+            }
+
+            if ((!EditMode || CloneMode) && !AllowPersonal && string.IsNullOrWhiteSpace(Cipher.OrganizationId))
+            {
+                await Page.DisplayAlert(AppResources.AnErrorHasOccurred,
+                    AppResources.PersonalOwnershipSubmitError,AppResources.Ok);
                 return false;
             }
 

--- a/src/App/Resources/AppResources.Designer.cs
+++ b/src/App/Resources/AppResources.Designer.cs
@@ -3158,5 +3158,11 @@ namespace Bit.App.Resources {
                 return ResourceManager.GetString("DrawOverDescription3", resourceCulture);
             }
         }
+        
+        public static string PersonalOwnershipSubmitError {
+            get {
+                return ResourceManager.GetString("PersonalOwnershipSubmitError", resourceCulture);
+            }
+        }
     }
 }

--- a/src/App/Resources/AppResources.resx
+++ b/src/App/Resources/AppResources.resx
@@ -1787,6 +1787,6 @@
     <value>If enabled, accessibility will show a popup to augment the Autofill Service for older apps that don't support the Android Autofill Framework.</value>
   </data>
   <data name="PersonalOwnershipSubmitError" xml:space="preserve">
-    <value>Due to an Enterprise Policy, you are restricted from saving items to your personal vault. Change the Ownership Option to an organization and choose from available Collections.</value>
+    <value>Due to an Enterprise Policy, you are restricted from saving items to your personal vault. Change the Ownership option to an organization and choose from available Collections.</value>
   </data>
 </root>

--- a/src/App/Resources/AppResources.resx
+++ b/src/App/Resources/AppResources.resx
@@ -1786,4 +1786,7 @@
   <data name="DrawOverDescription3" xml:space="preserve">
     <value>If enabled, accessibility will show a popup to augment the Autofill Service for older apps that don't support the Android Autofill Framework.</value>
   </data>
+  <data name="PersonalOwnershipSubmitError" xml:space="preserve">
+    <value>Due to an Enterprise Policy, you are restricted from saving items to your personal vault. Change the Ownership Option to an organization and choose from available Collections.</value>
+  </data>
 </root>

--- a/src/Core/Enums/PolicyType.cs
+++ b/src/Core/Enums/PolicyType.cs
@@ -6,6 +6,7 @@
         MasterPassword = 1,
         PasswordGenerator = 2,
         OnlyOrg = 3,
-        RequireSso = 4
+        RequireSso = 4,
+        PersonalOwnership = 5,
     }
 }

--- a/src/Core/Models/Data/OrganizationData.cs
+++ b/src/Core/Models/Data/OrganizationData.cs
@@ -20,6 +20,7 @@ namespace Bit.Core.Models.Data
             UseTotp = response.UseTotp;
             Use2fa = response.Use2fa;
             UseApi = response.UseApi;
+            UsePolicies = response.UsePolicies;
             SelfHost = response.SelfHost;
             UsersGetPremium = response.UsersGetPremium;
             Seats = response.Seats;
@@ -38,6 +39,7 @@ namespace Bit.Core.Models.Data
         public bool UseTotp { get; set; }
         public bool Use2fa { get; set; }
         public bool UseApi { get; set; }
+        public bool UsePolicies { get; set; }
         public bool SelfHost { get; set; }
         public bool UsersGetPremium { get; set; }
         public int Seats { get; set; }

--- a/src/Core/Models/Domain/Organization.cs
+++ b/src/Core/Models/Domain/Organization.cs
@@ -20,6 +20,7 @@ namespace Bit.Core.Models.Domain
             UseTotp = obj.UseTotp;
             Use2fa = obj.Use2fa;
             UseApi = obj.UseApi;
+            UsePolicies = obj.UsePolicies;
             SelfHost = obj.SelfHost;
             UsersGetPremium = obj.UsersGetPremium;
             Seats = obj.Seats;
@@ -38,6 +39,7 @@ namespace Bit.Core.Models.Domain
         public bool UseTotp { get; set; }
         public bool Use2fa { get; set; }
         public bool UseApi { get; set; }
+        public bool UsePolicies { get; set; }
         public bool SelfHost { get; set; }
         public bool UsersGetPremium { get; set; }
         public int Seats { get; set; }

--- a/src/Core/Models/Response/ProfileOrganizationResponse.cs
+++ b/src/Core/Models/Response/ProfileOrganizationResponse.cs
@@ -12,6 +12,7 @@ namespace Bit.Core.Models.Response
         public bool UseTotp { get; set; }
         public bool Use2fa { get; set; }
         public bool UseApi { get; set; }
+        public bool UsePolicies { get; set; }
         public bool UsersGetPremium { get; set; }
         public bool SelfHost { get; set; }
         public int Seats { get; set; }


### PR DESCRIPTION
## Objective
> Allow organizations to restrict user's from saving added/cloned items to their personal vaults. Remove the personal ownership option when this policy is enabled and the user is not an Admin/Owner of the organization.

## Code Changes
- **Android/AutofillService**: Added checks to prevent user's from being able to auto-fill/save new logins (defaults to personal ownership, otherwise)
- **AddEditPageViewModel**: Added `PolicyService` to constructor. Added logic during construction of personal ownership list to remove the personal ownership option if necessary. **Note**: ran into a special use case where the list of collections was not being updated when defaulting to an organization because of the personal ownership policy. If the `OwnershipOrgIndex` remained at position 0, the change detection would not occur: Forced a refresh if specific condition met. Added check during submit to make sure the user didn't select personal ownership when not available.
- **AppResource**: Added error message
- **PolicyType**: Added `PersonalOwnership` policy type
- **OrganizationData**: Added `UsePolicies`
- **Organization**: Added `UsePolicies`
- **ProfileOrganizationResponse**: Added `UsePolicies`

## Screenshots
![0-list](https://user-images.githubusercontent.com/26154748/102019959-e5a39580-3d3b-11eb-952d-70c63181b316.png)
![1-error](https://user-images.githubusercontent.com/26154748/102019960-e6d4c280-3d3b-11eb-92a5-698ed93e8124.png)

