### PR TITLE
Make KdfIterations nullable

### DIFF
--- a/src/Core/Abstractions/IUserService.cs
+++ b/src/Core/Abstractions/IUserService.cs
@@ -20,7 +20,7 @@ namespace Bit.Core.Abstractions
         Task<string> GetUserIdAsync();
         Task<bool> IsAuthenticatedAsync();
         Task ReplaceOrganizationsAsync(Dictionary<string, OrganizationData> organizations);
-        Task SetInformationAsync(string userId, string email, KdfType kdf, int kdfIterations);
+        Task SetInformationAsync(string userId, string email, KdfType kdf, int? kdfIterations);
         Task SetSecurityStampAsync(string stamp);
     }
 }

--- a/src/Core/Models/Response/IdentityTokenResponse.cs
+++ b/src/Core/Models/Response/IdentityTokenResponse.cs
@@ -19,6 +19,6 @@ namespace Bit.Core.Models.Response
         public string Key { get; set; }
         public string TwoFactorToken { get; set; }
         public KdfType Kdf { get; set; }
-        public int KdfIterations { get; set; }
+        public int? KdfIterations { get; set; }
     }
 }

--- a/src/Core/Services/UserService.cs
+++ b/src/Core/Services/UserService.cs
@@ -32,7 +32,7 @@ namespace Bit.Core.Services
             _tokenService = tokenService;
         }
 
-        public async Task SetInformationAsync(string userId, string email, KdfType kdf, int kdfIterations)
+        public async Task SetInformationAsync(string userId, string email, KdfType kdf, int? kdfIterations)
         {
             _email = email;
             _userId = userId;


### PR DESCRIPTION
This fixes the issue where the app would throw if the value was missing as it was stored as zero instead of null.  The result is now an invalid password prompt on unlock instead of crashing (bringing mobile to parity with other clients).