### PR TITLE
Change text for clearing a clipboard to a space instead of an empty string on Android

### DIFF
--- a/src/Android/Receivers/ClearClipboardAlarmReceiver.cs
+++ b/src/Android/Receivers/ClearClipboardAlarmReceiver.cs
@@ -8,7 +8,7 @@ namespace Bit.Droid.Receivers
         public override void OnReceive(Context context, Intent intent)
         {
             var clipboardManager = context.GetSystemService(Context.ClipboardService) as ClipboardManager;
-            clipboardManager.PrimaryClip = ClipData.NewPlainText("bitwarden", string.Empty);
+            clipboardManager.PrimaryClip = ClipData.NewPlainText("bitwarden", " ");
         }
     }
 }


### PR DESCRIPTION
Per #1165, on Android 11 the Google Keyboard will suggest passwords copied to the clipboard even after they have been cleared by Bitwarden.

This is because the latest suggestion is not updated after the primary text on the clipboard is set to an empty string. The suggestion is removed correctly if the clipboard clear text is a space instead. Using a space to clear the clipboard matches the behavior of the Chromium browser extension.

This is what the suggestion looks like after Bitwarden has set the text in the clipboard to a space.
![image](https://user-images.githubusercontent.com/9373058/101730441-de943300-3a6e-11eb-9f74-be14516f79bd.png)
