### PR TITLE
Workaround for lack of shared DB support

### DIFF
--- a/src/Android/MainApplication.cs
+++ b/src/Android/MainApplication.cs
@@ -87,7 +87,6 @@ namespace Bit.Droid
             var preferencesStorage = new PreferencesStorageService(null);
             var documentsPath = System.Environment.GetFolderPath(System.Environment.SpecialFolder.Personal);
             var liteDbStorage = new LiteDbStorageService(Path.Combine(documentsPath, "bitwarden.db"));
-            liteDbStorage.InitAsync();
             var localizeService = new LocalizeService();
             var broadcasterService = new BroadcasterService();
             var messagingService = new MobileBroadcasterMessagingService(broadcasterService);

--- a/src/iOS.Core/Utilities/iOSCoreHelpers.cs
+++ b/src/iOS.Core/Utilities/iOSCoreHelpers.cs
@@ -43,7 +43,6 @@ namespace Bit.iOS.Core.Utilities
             var appGroupContainer = new NSFileManager().GetContainerUrl(AppGroupId);
             var liteDbStorage = new LiteDbStorageService(
                 Path.Combine(appGroupContainer.Path, "Library", "bitwarden.db"));
-            liteDbStorage.InitAsync();
             var localizeService = new LocalizeService();
             var broadcasterService = new BroadcasterService();
             var messagingService = new MobileBroadcasterMessagingService(broadcasterService);


### PR DESCRIPTION
Our DB library currently does not support shared connections across processes on Xamarin.iOS.  This limitation manifests itself in our app as new or modified ciphers missing from autofill.  We didn't discover this until after we enhanced our cipher caching mechanism **[here](https://github.com/bitwarden/mobile/pull/1112),** when it became apparent the DB was keeping it's own cache and not recognizing modifications made by another process.

This workaround, while heavy-handed, allows our enhanced caching to function as originally intended by spinning up and disposing a DB connection for every R/W operation, giving the access layer the latest data to work with regardless of which process wrote it.  Initial tests show no noticeable reduction in performance using test vaults of 1000+ ciphers.  I'd like to get this into QA/CS's hands for more aggressive testing.

The maintainer of our DB library has mentioned the next major version supporting shared connections in Xamarin.iOS, at which time we can revert this entire commit and simply add `Shared=true;` to the connection string.