### PR TITLE
Add encrypted hint json property

### DIFF
--- a/src/Core/Services/ExportService.cs
+++ b/src/Core/Services/ExportService.cs
@@ -162,6 +162,7 @@ namespace Bit.Core.Services
         {
             var jsonDoc = new
             {
+                Encrypted = false,
                 Folders = decryptedFolders.Where(f => f.Id != null).Select(f => new FolderWithId(f)),
                 Items = decryptedCiphers.Where(c => c.OrganizationId == null)
                     .Select(c => new CipherWithId(c) { CollectionIds = null })
@@ -179,6 +180,7 @@ namespace Bit.Core.Services
         {
             var jsonDoc = new
             {
+                Encrypted = true,
                 Folders = folders,
                 Items = ciphers,
             };


### PR DESCRIPTION
# Overview

I missed the top-level `encrypted: true` hint on my first pass. Thanks to @kspearrin for pointing this out. Test encrypted exports now import correctly through web vault.

# Files Changed

* **ExportService.cs**: Add Encrypted properties to jsonDoc objects. Note, these are lowercased by the `CamelCasePropertyNamesContractResolver` call.