### PR TITLE
Show vault export warning as popup

### DIFF
--- a/src/App/Pages/Settings/ExportVaultPage.xaml
+++ b/src/App/Pages/Settings/ExportVaultPage.xaml
@@ -76,19 +76,6 @@
                 <Label
                     Text="{u:I18n ExportVaultMasterPasswordDescription}"
                     StyleClass="box-footer-label, box-footer-label-switch" />
-                <Label
-                    StyleClass="box-footer-label, box-footer-label-switch"
-                    Margin="0, 20">
-                    <Label.FormattedText>
-                        <FormattedString>
-                            <Span
-                                Text="{Binding Converter={StaticResource toUpper}, ConverterParameter={u:I18n Warning}}"
-                                FontAttributes="Bold" />
-                            <Span Text=": " FontAttributes="Bold" />
-                            <Span Text="{Binding ExportWarningMessage}" />
-                        </FormattedString>
-                    </Label.FormattedText>
-                </Label>
                 <StackLayout Spacing="20">
                     <Button Text="{u:I18n ExportVault}"
                             Clicked="ExportVault_Clicked"

--- a/src/App/Resources/AppResources.Designer.cs
+++ b/src/App/Resources/AppResources.Designer.cs
@@ -2827,6 +2827,14 @@ namespace Bit.App.Resources {
             }
         }
 
+        public static string ExportVaultConfirmationTitle
+        {
+            get
+            {
+                return ResourceManager.GetString("ExportVaultConfirmationTitle", resourceCulture);
+            }
+        }
+
         public static string Warning {
             get {
                 return ResourceManager.GetString("Warning", resourceCulture);

--- a/src/App/Resources/AppResources.resx
+++ b/src/App/Resources/AppResources.resx
@@ -1605,6 +1605,10 @@
   <data name="EncExportVaultWarning" xml:space="preserve">
     <value>This export encrypts your data using your account's encryption key. If you ever rotate your account's encryption key you should export again since you will not be able to decrypt this export file.</value>
   </data>
+  <data name="ExportVaultConfirmationTitle" xml:space="preserve">
+    <value>Confirm Vault Export</value>
+    <comment>Title for the alert to confirm vault exports.</comment>
+  </data>
   <data name="Warning" xml:space="preserve">
     <value>Warning</value>
   </data>


### PR DESCRIPTION
# Overview

We decided with the subtle change between export warnings to use a confirmation popup to warn about the failings of each export type. 

This PR removes the view's warning message and renders it as a popup after the master password has been confirmed.  Ialso inverted the password `if/else` to minimize nesting.

# Screenshots

### Json export -- unencrypted warning
<img width="423" alt="image" src="https://user-images.githubusercontent.com/18214891/102666388-6a335100-414c-11eb-942d-156f7959380f.png">

### encrypted export -- encrypted warning
<img width="423" alt="image" src="https://user-images.githubusercontent.com/18214891/102666815-75d34780-414d-11eb-8bc4-5d8cd95a0bbe.png">
