### PR TITLE
Attempt URI healing with https prior to http

### DIFF
--- a/src/Android/Accessibility/AccessibilityHelpers.cs
+++ b/src/Android/Accessibility/AccessibilityHelpers.cs
@@ -390,12 +390,15 @@ namespace Bit.Droid.Accessibility
                 var hasHttpProtocol = uri.StartsWith("http://") || uri.StartsWith("https://");
                 if (!hasHttpProtocol && uri.Contains("."))
                 {
-                    if (Uri.TryCreate("http://" + uri, UriKind.Absolute, out var uri2))
+                    if (Uri.TryCreate("https://" + uri, UriKind.Absolute, out var _))
+                    {
+                        return string.Concat("https://", uri);
+                    } else if (Uri.TryCreate("http://" + uri, UriKind.Absolute, out var _))
                     {
                         return string.Concat("http://", uri);
                     }
                 }
-                if (Uri.TryCreate(uri, UriKind.Absolute, out var uri3))
+                if (Uri.TryCreate(uri, UriKind.Absolute, out var _))
                 {
                     return uri;
                 }

--- a/src/Android/Accessibility/AccessibilityHelpers.cs
+++ b/src/Android/Accessibility/AccessibilityHelpers.cs
@@ -393,9 +393,6 @@ namespace Bit.Droid.Accessibility
                     if (Uri.TryCreate("https://" + uri, UriKind.Absolute, out var _))
                     {
                         return string.Concat("https://", uri);
-                    } else if (Uri.TryCreate("http://" + uri, UriKind.Absolute, out var _))
-                    {
-                        return string.Concat("http://", uri);
                     }
                 }
                 if (Uri.TryCreate(uri, UriKind.Absolute, out var _))


### PR DESCRIPTION
# Overview

Related to #1021. 

Browsers are moving away from displaying URI scheme in a way accessibility can easily grab. This causes this URI healing to be relied upon more frequently. It should attempt https prior to http due to prevelence of https and security concerns with passwords over http.

# Files changed

* **AccessibilityHelpers.cs**: This helper is responsible for grabbing the Uri out of  a browser's address node. If a URI scheme isn't present, it heals the URI with `https://`.  It seems unlikely that any URI that isn't healed by `https://` would be by prepending `http://`, but the attempt isn't very expensive.