### PR TITLE
[Bug] Clone personal ownership

### DIFF
--- a/src/App/Pages/Vault/AddEditPageViewModel.cs
+++ b/src/App/Pages/Vault/AddEditPageViewModel.cs
@@ -342,6 +342,11 @@ namespace Bit.App.Pages
                     if (CloneMode)
                     {
                         Cipher.Name += " - " + AppResources.Clone;
+                        // If not allowing personal ownership, update cipher's org Id to prompt downstream changes
+                        if (Cipher.OrganizationId == null && !AllowPersonal) 
+                        {
+                            Cipher.OrganizationId = OrganizationId;
+                        }
                     }
                 }
                 else


### PR DESCRIPTION
## Objective
> Cloning a cipher when personal ownership is not allowed would result in an unexpected experience with the ownership list (nothing would be selected, but the personal option would be removed).  Fix by adjusting logic for downstream changes in clone mode when personal ownership is not allowed.

## Code Changes
- **AddEditPageViewModel**: Added explicit check for `null` Organization ID on the cipher being edited and if allowing personal ownership was disabled - if so, the cipher's Organization ID will be updated to the (first) organization enforcing this policy forcing the necessary downstream UI updates for ownership/collection(s)