### PR TITLE
Do not export items that have been deleted

### DIFF
--- a/src/Core/Services/ExportService.cs
+++ b/src/Core/Services/ExportService.cs
@@ -34,14 +34,15 @@ namespace Bit.Core.Services
             if (format == "encrypted_json")
             {
                 var folders = (await _folderService.GetAllAsync()).Where(f => f.Id != null).Select(f => new FolderWithId(f));
-                var items = (await _cipherService.GetAllAsync()).Where(c => c.OrganizationId == null).Select(c => new CipherWithId(c));
+                var items = (await _cipherService.GetAllAsync()).Where(c => c.OrganizationId == null && c.DeletedDate == null)
+                    .Select(c => new CipherWithId(c));
 
                 return ExportEncryptedJson(folders, items);
             }
             else
             {
                 var decryptedFolders = await _folderService.GetAllDecryptedAsync();
-                var decryptedCiphers = await _cipherService.GetAllDecryptedAsync();
+                var decryptedCiphers = (await _cipherService.GetAllDecryptedAsync()).Where(c => c.DeletedDate == null);
 
                 return format == "csv" ? ExportCsv(decryptedFolders, decryptedCiphers) : ExportJson(decryptedFolders, decryptedCiphers);
             }


### PR DESCRIPTION
# Overview

Do not export items that have been trashed. Related to [this community request](https://community.bitwarden.com/t/deleted-password-shows-up-in-vault-export/13246/14).

It seems like in the future we will want to optionally export trashed items with a flag showing they are trashed. However, this aligns closer to expected behavior for now.

# Files Changed

* **ExportService.ce**: Filter all ciphers to include only those without `DeletedDate`s