### PR TITLE
Use .json extension for encrypted json export

### DIFF
--- a/src/App/Pages/Settings/ExportVaultPageViewModel.cs
+++ b/src/App/Pages/Settings/ExportVaultPageViewModel.cs
@@ -125,6 +125,8 @@ namespace Bit.App.Pages
             {
                 var data = await _exportService.GetExport(FileFormatOptions[FileFormatSelectedIndex].Key);
                 var fileFormat = FileFormatOptions[FileFormatSelectedIndex].Key;
+                fileFormat = fileFormat == "encrypted_json" ? "json" : fileFormat;
+
                 _defaultFilename = _exportService.GetFileName(null, fileFormat);
                 _exportResult = Encoding.ASCII.GetBytes(data);
 


### PR DESCRIPTION
# Overview

Match jslib behavior to use `.json` as file extension for encrypted json export.

# Files Changed

* **ExportVaultPageViewModel.cs**: detect encrypted fileFormat and set extension to just `.json`