### PR TITLE
Update revision date from server on restore

### DIFF
--- a/src/Core/Abstractions/IApiService.cs
+++ b/src/Core/Abstractions/IApiService.cs
@@ -40,7 +40,7 @@ namespace Bit.Core.Abstractions
         Task<FolderResponse> PutFolderAsync(string id, FolderRequest request);
         Task<CipherResponse> PutShareCipherAsync(string id, CipherShareRequest request);
         Task PutDeleteCipherAsync(string id);
-        Task PutRestoreCipherAsync(string id);
+        Task<CipherResponse> PutRestoreCipherAsync(string id);
         Task RefreshIdentityTokenAsync();
         Task<object> PreValidateSso(string identifier);
         Task<TResponse> SendAsync<TRequest, TResponse>(HttpMethod method, string path,

--- a/src/Core/Services/ApiService.cs
+++ b/src/Core/Services/ApiService.cs
@@ -262,9 +262,9 @@ namespace Bit.Core.Services
             return SendAsync<object, object>(HttpMethod.Put, string.Concat("/ciphers/", id, "/delete"), null, true, false);
         }
 
-        public Task PutRestoreCipherAsync(string id)
+        public Task<CipherResponse> PutRestoreCipherAsync(string id)
         {
-            return SendAsync<object, object>(HttpMethod.Put, string.Concat("/ciphers/", id, "/restore"), null, true, false);
+            return SendAsync<object, CipherResponse>(HttpMethod.Put, string.Concat("/ciphers/", id, "/restore"), null, true, true);
         }
 
         #endregion

--- a/src/Core/Services/CipherService.cs
+++ b/src/Core/Services/CipherService.cs
@@ -760,8 +760,9 @@ namespace Bit.Core.Services
             {
                 return;
             }
-            await _apiService.PutRestoreCipherAsync(id);
+            var response = await _apiService.PutRestoreCipherAsync(id);
             ciphers[id].DeletedDate = null;
+            ciphers[id].RevisionDate = response.RevisionDate;
             await _storageService.SaveAsync(cipherKey, ciphers);
             await ClearCacheAsync();
         }


### PR DESCRIPTION
# Overview

Related to https://app.asana.com/0/1169444489336079/1199337616674667/f
Related to bitwarden/web/issues/748
Related to bitwarden/server#1072

Allows edit of restored cipher without forced resync.

# Files changed
* **ApiService.cs**: Api now responds with updated Ciphers upon restore (bitwarden/server#1072)
* **CipherService.cs**: Update revision date to match the server's response.