### PR TITLE
[iOS Accessibility] Bugfix: VoiceOver always seeing fields for all entry types

### DIFF
--- a/src/App/Pages/Vault/AddEditPage.xaml
+++ b/src/App/Pages/Vault/AddEditPage.xaml
@@ -95,7 +95,7 @@
                         Grid.Row="0"
                         Grid.Column="1"
                         Grid.RowSpan="2"
-                        AutomationProperties.IsInAccessibleTree="True"
+                        AutomationProperties.IsInAccessibleTree="{Binding Cipher.ViewPassword}"
                         AutomationProperties.Name="{u:I18n CheckPassword}"
                         IsVisible="{Binding Cipher.ViewPassword}" />
                     <controls:FaButton 
@@ -105,7 +105,7 @@
                         Grid.Row="0"
                         Grid.Column="2"
                         Grid.RowSpan="2"
-                        AutomationProperties.IsInAccessibleTree="True"
+                        AutomationProperties.IsInAccessibleTree="{Binding Cipher.ViewPassword}"
                         AutomationProperties.Name="{u:I18n ToggleVisibility}"
                         IsVisible="{Binding Cipher.ViewPassword}" />
                     <controls:FaButton 
@@ -115,7 +115,7 @@
                         Grid.Row="0"
                         Grid.Column="3"
                         Grid.RowSpan="2"
-                        AutomationProperties.IsInAccessibleTree="True"
+                        AutomationProperties.IsInAccessibleTree="{Binding Cipher.ViewPassword}"
                         AutomationProperties.Name="{u:I18n GeneratePassword}"
                         IsVisible="{Binding Cipher.ViewPassword}" />
                 </Grid>
@@ -153,7 +153,7 @@
                         Grid.Column="1"
                         Grid.RowSpan="2"
                         IsVisible="{Binding Cipher.ViewPassword}"
-                        AutomationProperties.IsInAccessibleTree="True"
+                        AutomationProperties.IsInAccessibleTree="{Binding Cipher.ViewPassword}"
                         AutomationProperties.Name="{u:I18n ScanQrTitle}" />
                 </Grid>
             </StackLayout>
@@ -435,7 +435,8 @@
                         <Label
                             Text="{u:I18n PersonalOwnershipPolicyInEffect}"
                             StyleClass="text-muted, text-sm, text-bold"
-                            HorizontalTextAlignment="Center" />
+                            HorizontalTextAlignment="Center"
+                            AutomationProperties.IsInAccessibleTree="{Binding OwnershipPolicyInEffect}" />
                     </Frame>
                 </Grid>
                 <StackLayout StyleClass="box-row-header">
@@ -446,12 +447,14 @@
                              IsVisible="{Binding EditMode, Converter={StaticResource inverseBool}}">
                     <Label
                         Text="{u:I18n Type}"
-                        StyleClass="box-label" />
+                        StyleClass="box-label"
+                        AutomationProperties.IsInAccessibleTree="{Binding EditMode, Converter={StaticResource inverseBool}}" />
                     <Picker
                         x:Name="_typePicker"
                         ItemsSource="{Binding TypeOptions, Mode=OneTime}"
                         SelectedIndex="{Binding TypeSelectedIndex}"
-                        StyleClass="box-value" />
+                        StyleClass="box-value"
+                        AutomationProperties.IsInAccessibleTree="{Binding EditMode, Converter={StaticResource inverseBool}}" />
                 </StackLayout>
                 <StackLayout StyleClass="box-row, box-row-input">
                     <Label
@@ -466,7 +469,8 @@
             <StackLayout StyleClass="box" IsVisible="{Binding IsLogin}">
                 <StackLayout StyleClass="box-row-header">
                     <Label Text="{u:I18n URIs, Header=True}"
-                           StyleClass="box-header, box-header-platform" />
+                           StyleClass="box-header, box-header-platform"
+                           AutomationProperties.IsInAccessibleTree="{Binding IsLogin}" />
                 </StackLayout>
                 <controls:RepeaterView ItemsSource="{Binding Uris}">
                     <controls:RepeaterView.ItemTemplate>
@@ -484,13 +488,15 @@
                                     Text="{u:I18n URI}"
                                     StyleClass="box-label"
                                     Grid.Row="0"
-                                    Grid.Column="0" />
+                                    Grid.Column="0"
+                                    AutomationProperties.IsInAccessibleTree="{Binding BindingContext.IsLogin, Source={x:Reference _page}}" />
                                 <Entry
                                     Text="{Binding Uri}"
                                     Keyboard="Url"
                                     StyleClass="box-value"
                                     Grid.Row="1"
-                                    Grid.Column="0" />
+                                    Grid.Column="0"
+                                    AutomationProperties.IsInAccessibleTree="{Binding BindingContext.IsLogin, Source={x:Reference _page}}" />
                                 <controls:FaButton
                                     StyleClass="box-row-button, box-row-button-platform"
                                     Text="&#xf013;"
@@ -499,14 +505,15 @@
                                     Grid.Row="0"
                                     Grid.Column="1"
                                     Grid.RowSpan="2"
-                                    AutomationProperties.IsInAccessibleTree="True"
+                                    AutomationProperties.IsInAccessibleTree="{Binding BindingContext.IsLogin, Source={x:Reference _page}}"
                                     AutomationProperties.Name="{u:I18n Options}" />
                             </Grid>
                         </DataTemplate>
                     </controls:RepeaterView.ItemTemplate>
                 </controls:RepeaterView>
                 <Button Text="{u:I18n NewUri}" StyleClass="box-button-row"
-                        Clicked="NewUri_Clicked"></Button>
+                        Clicked="NewUri_Clicked"
+                        AutomationProperties.IsInAccessibleTree="{Binding IsLogin}"></Button>
             </StackLayout>
             <StackLayout StyleClass="box">
                 <StackLayout StyleClass="box-row-header">
@@ -571,12 +578,15 @@
                                     <Label
                                         Text="{Binding Field.Name, Mode=OneWay}"
                                         IsVisible="{Binding IsBooleanType, Mode=OneWay, Converter={StaticResource inverseBool}}"
+                                        AutomationProperties.IsInAccessibleTree="{Binding IsBooleanType, Mode=OneWay,
+                                            Converter={StaticResource inverseBool}}"
                                         StyleClass="box-label"
                                         Grid.Row="0"
                                         Grid.Column="0" />
                                     <Label
                                         Text="{Binding Field.Name, Mode=OneWay}"
                                         IsVisible="{Binding IsBooleanType, Mode=OneWay}"
+                                        AutomationProperties.IsInAccessibleTree="{Binding IsBooleanType, Mode=OneWay}"
                                         StyleClass="box-value"
                                         VerticalOptions="FillAndExpand"
                                         VerticalTextAlignment="Center"
@@ -588,13 +598,15 @@
                                         StyleClass="box-value"
                                         Grid.Row="1"
                                         Grid.Column="0"
-                                        IsVisible="{Binding IsTextType}" />
+                                        IsVisible="{Binding IsTextType}"
+                                        AutomationProperties.IsInAccessibleTree="{Binding IsTextType}" />
                                     <controls:MonoEntry
                                         Text="{Binding Field.Value}"
                                         StyleClass="box-value"
                                         Grid.Row="1"
                                         Grid.Column="0"
                                         IsVisible="{Binding IsHiddenType}"
+                                        AutomationProperties.IsInAccessibleTree="{Binding IsHiddenType}"
                                         IsPassword="{Binding ShowHiddenValue, Converter={StaticResource inverseBool}}"
                                         IsEnabled="{Binding ShowViewHidden}"
                                         IsSpellCheckEnabled="False"
@@ -612,7 +624,8 @@
                                         Grid.Row="0"
                                         Grid.Column="1"
                                         Grid.RowSpan="2"
-                                        IsVisible="{Binding IsBooleanType}" />
+                                        IsVisible="{Binding IsBooleanType}"
+                                        AutomationProperties.IsInAccessibleTree="{Binding IsBooleanType}" />
                                     <controls:FaButton 
                                         StyleClass="box-row-button, box-row-button-platform"
                                         Text="{Binding ShowHiddenValueIcon}"
@@ -621,7 +634,7 @@
                                         Grid.Row="0"
                                         Grid.Column="1"
                                         Grid.RowSpan="2"
-                                        AutomationProperties.IsInAccessibleTree="True"
+                                        AutomationProperties.IsInAccessibleTree="{Binding ShowViewHidden}"
                                         AutomationProperties.Name="{u:I18n ToggleVisibility}" />
                                     <controls:FaButton 
                                         StyleClass="box-row-button, box-row-button-platform"
@@ -645,28 +658,33 @@
             <StackLayout StyleClass="box" IsVisible="{Binding ShowOwnershipOptions}">
                 <StackLayout StyleClass="box-row-header">
                     <Label Text="{u:I18n Ownership, Header=True}"
-                           StyleClass="box-header, box-header-platform" />
+                           StyleClass="box-header, box-header-platform"
+                           AutomationProperties.IsInAccessibleTree="{Binding ShowOwnershipOptions}" />
                 </StackLayout>
                 <StackLayout StyleClass="box-row, box-row-input">
                     <Label
                         Text="{u:I18n WhoOwnsThisItem}"
-                        StyleClass="box-label" />
+                        StyleClass="box-label"
+                        AutomationProperties.IsInAccessibleTree="{Binding ShowOwnershipOptions}" />
                     <Picker
                         x:Name="_ownershipPicker"
                         ItemsSource="{Binding OwnershipOptions, Mode=OneTime}"
                         SelectedIndex="{Binding OwnershipSelectedIndex}"
-                        StyleClass="box-value" />
+                        StyleClass="box-value"
+                        AutomationProperties.IsInAccessibleTree="{Binding ShowOwnershipOptions}" />
                 </StackLayout>
             </StackLayout>
             <StackLayout StyleClass="box" IsVisible="{Binding ShowCollections}">
                 <StackLayout StyleClass="box-row-header">
                     <Label Text="{u:I18n Collections, Header=True}"
-                           StyleClass="box-header, box-header-platform" />
+                           StyleClass="box-header, box-header-platform"
+                           AutomationProperties.IsInAccessibleTree="{Binding ShowCollections}" />
                 </StackLayout>
                 <StackLayout Spacing="0" Padding="0"
                                 IsVisible="{Binding HasCollections, Converter={StaticResource inverseBool}}">
                     <StackLayout StyleClass="box-row, box-row-switch">
-                        <Label Text="{u:I18n NoCollectionsToList}" />
+                        <Label Text="{u:I18n NoCollectionsToList}"
+                               AutomationProperties.IsInAccessibleTree="{Binding HasCollections, Converter={StaticResource inverseBool}}" />
                     </StackLayout>
                     <BoxView StyleClass="box-row-separator" />
                 </StackLayout>
@@ -678,11 +696,13 @@
                                     <Label
                                         Text="{Binding Collection.Name}"
                                         StyleClass="box-label, box-label-regular"
-                                        HorizontalOptions="StartAndExpand" />
+                                        HorizontalOptions="StartAndExpand"
+                                        AutomationProperties.IsInAccessibleTree="{Binding BindingContext.HasCollections,Source={x:Reference _page}}" />
                                     <Switch
                                         IsToggled="{Binding Checked}"
                                         StyleClass="box-value"
-                                        HorizontalOptions="End" />
+                                        HorizontalOptions="End"
+                                        AutomationProperties.IsInAccessibleTree="{Binding BindingContext.HasCollections,Source={x:Reference _page}}" />
                                 </StackLayout>
                                 <BoxView StyleClass="box-row-separator" />
                             </StackLayout>

--- a/src/App/Pages/Vault/AddEditPage.xaml
+++ b/src/App/Pages/Vault/AddEditPage.xaml
@@ -488,15 +488,13 @@
                                     Text="{u:I18n URI}"
                                     StyleClass="box-label"
                                     Grid.Row="0"
-                                    Grid.Column="0"
-                                    AutomationProperties.IsInAccessibleTree="{Binding BindingContext.IsLogin, Source={x:Reference _page}}" />
+                                    Grid.Column="0" />
                                 <Entry
                                     Text="{Binding Uri}"
                                     Keyboard="Url"
                                     StyleClass="box-value"
                                     Grid.Row="1"
-                                    Grid.Column="0"
-                                    AutomationProperties.IsInAccessibleTree="{Binding BindingContext.IsLogin, Source={x:Reference _page}}" />
+                                    Grid.Column="0" />
                                 <controls:FaButton
                                     StyleClass="box-row-button, box-row-button-platform"
                                     Text="&#xf013;"
@@ -505,7 +503,7 @@
                                     Grid.Row="0"
                                     Grid.Column="1"
                                     Grid.RowSpan="2"
-                                    AutomationProperties.IsInAccessibleTree="{Binding BindingContext.IsLogin, Source={x:Reference _page}}"
+                                    AutomationProperties.IsInAccessibleTree="True"
                                     AutomationProperties.Name="{u:I18n Options}" />
                             </Grid>
                         </DataTemplate>
@@ -696,13 +694,11 @@
                                     <Label
                                         Text="{Binding Collection.Name}"
                                         StyleClass="box-label, box-label-regular"
-                                        HorizontalOptions="StartAndExpand"
-                                        AutomationProperties.IsInAccessibleTree="{Binding BindingContext.HasCollections,Source={x:Reference _page}}" />
+                                        HorizontalOptions="StartAndExpand" />
                                     <Switch
                                         IsToggled="{Binding Checked}"
                                         StyleClass="box-value"
-                                        HorizontalOptions="End"
-                                        AutomationProperties.IsInAccessibleTree="{Binding BindingContext.HasCollections,Source={x:Reference _page}}" />
+                                        HorizontalOptions="End" />
                                 </StackLayout>
                                 <BoxView StyleClass="box-row-separator" />
                             </StackLayout>

--- a/src/App/Pages/Vault/AddEditPage.xaml
+++ b/src/App/Pages/Vault/AddEditPage.xaml
@@ -50,12 +50,371 @@
                          IsDestructive="True"
                          x:Name="_deleteItem"
                          x:Key="deleteItem" />
+            <StackLayout Spacing="0" Padding="0"
+                         x:Name="_loginControls" x:Key="loginControls">
+                <StackLayout StyleClass="box-row, box-row-input">
+                    <Label
+                        Text="{u:I18n Username}"
+                        StyleClass="box-label" />
+                    <Entry
+                        x:Name="_loginUsernameEntry"
+                        Text="{Binding Cipher.Login.Username}"
+                        StyleClass="box-value" />
+                </StackLayout>
+                <Grid StyleClass="box-row, box-row-input">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="*" />
+                    </Grid.RowDefinitions>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+                    <Label
+                        Text="{u:I18n Password}"
+                        StyleClass="box-label"
+                        Grid.Row="0"
+                        Grid.Column="0" />
+                    <controls:MonoEntry
+                        x:Name="_loginPasswordEntry"
+                        Text="{Binding Cipher.Login.Password}"
+                        StyleClass="box-value"
+                        Grid.Row="1"
+                        Grid.Column="0"
+                        Grid.ColumnSpan="{Binding PasswordFieldColSpan}"
+                        IsPassword="{Binding ShowPassword, Converter={StaticResource inverseBool}}"
+                        IsSpellCheckEnabled="False"
+                        IsTextPredictionEnabled="False"
+                        IsEnabled="{Binding Cipher.ViewPassword}"/>
+                    <controls:FaButton 
+                        StyleClass="box-row-button, box-row-button-platform"
+                        Text="&#xf058;"
+                        Command="{Binding CheckPasswordCommand}"
+                        Grid.Row="0"
+                        Grid.Column="1"
+                        Grid.RowSpan="2"
+                        AutomationProperties.IsInAccessibleTree="True"
+                        AutomationProperties.Name="{u:I18n CheckPassword}"
+                        IsVisible="{Binding Cipher.ViewPassword}" />
+                    <controls:FaButton 
+                        StyleClass="box-row-button, box-row-button-platform"
+                        Text="{Binding ShowPasswordIcon}"
+                        Command="{Binding TogglePasswordCommand}"
+                        Grid.Row="0"
+                        Grid.Column="2"
+                        Grid.RowSpan="2"
+                        AutomationProperties.IsInAccessibleTree="True"
+                        AutomationProperties.Name="{u:I18n ToggleVisibility}"
+                        IsVisible="{Binding Cipher.ViewPassword}" />
+                    <controls:FaButton 
+                        StyleClass="box-row-button, box-row-button-platform"
+                        Text="&#xf021;"
+                        Command="{Binding GeneratePasswordCommand}"
+                        Grid.Row="0"
+                        Grid.Column="3"
+                        Grid.RowSpan="2"
+                        AutomationProperties.IsInAccessibleTree="True"
+                        AutomationProperties.Name="{u:I18n GeneratePassword}"
+                        IsVisible="{Binding Cipher.ViewPassword}" />
+                </Grid>
+
+                <Grid StyleClass="box-row, box-row-input">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="*" />
+                    </Grid.RowDefinitions>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+                    <Label
+                        Text="{u:I18n AuthenticatorKey}"
+                        StyleClass="box-label"
+                        Grid.Row="0"
+                        Grid.Column="0" />
+                    <controls:MonoEntry
+                        x:Name="_loginTotpEntry"
+                        Text="{Binding Cipher.Login.Totp}"
+                        IsSpellCheckEnabled="False"
+                        IsTextPredictionEnabled="False"
+                        IsPassword="{Binding Cipher.ViewPassword, Converter={StaticResource inverseBool}}"
+                        IsEnabled="{Binding Cipher.ViewPassword}"
+                        StyleClass="box-value"
+                        Grid.Row="1"
+                        Grid.Column="0"
+                        Grid.ColumnSpan="{Binding TotpColumnSpan}" />
+                    <controls:FaButton 
+                        StyleClass="box-row-button, box-row-button-platform"
+                        Text="&#xf030;"
+                        Clicked="ScanTotp_Clicked"
+                        Grid.Row="0"
+                        Grid.Column="1"
+                        Grid.RowSpan="2"
+                        IsVisible="{Binding Cipher.ViewPassword}"
+                        AutomationProperties.IsInAccessibleTree="True"
+                        AutomationProperties.Name="{u:I18n ScanQrTitle}" />
+                </Grid>
+            </StackLayout>
+            <StackLayout Spacing="0" Padding="0"
+                         x:Name="_cardControls" x:Key="cardControls">
+                <StackLayout StyleClass="box-row, box-row-input">
+                    <Label
+                        Text="{u:I18n CardholderName}"
+                        StyleClass="box-label" />
+                    <Entry
+                        x:Name="_cardholderNameEntry"
+                        Text="{Binding Cipher.Card.CardholderName}"
+                        StyleClass="box-value" />
+                </StackLayout>
+                <StackLayout StyleClass="box-row, box-row-input">
+                    <Label
+                        Text="{u:I18n Number}"
+                        StyleClass="box-label" />
+                    <Entry
+                        x:Name="_cardNumberEntry"
+                        Text="{Binding Cipher.Card.Number}"
+                        StyleClass="box-value" />
+                </StackLayout>
+                <StackLayout StyleClass="box-row, box-row-input">
+                    <Label
+                        Text="{u:I18n Brand}"
+                        StyleClass="box-label" />
+                    <Picker
+                        x:Name="_cardBrandPicker"
+                        ItemsSource="{Binding CardBrandOptions, Mode=OneTime}"
+                        SelectedIndex="{Binding CardBrandSelectedIndex}"
+                        StyleClass="box-value" />
+                </StackLayout>
+                <StackLayout StyleClass="box-row, box-row-input">
+                    <Label
+                        Text="{u:I18n ExpirationMonth}"
+                        StyleClass="box-label" />
+                    <Picker
+                        x:Name="_cardExpMonthPicker"
+                        ItemsSource="{Binding CardExpMonthOptions, Mode=OneTime}"
+                        SelectedIndex="{Binding CardExpMonthSelectedIndex}"
+                        StyleClass="box-value" />
+                </StackLayout>
+                <StackLayout StyleClass="box-row, box-row-input">
+                    <Label
+                        Text="{u:I18n ExpirationYear}"
+                        StyleClass="box-label" />
+                    <Entry
+                        x:Name="_cardExpYearEntry"
+                        Text="{Binding Cipher.Card.ExpYear}"
+                        StyleClass="box-value"
+                        Keyboard="Numeric" />
+                </StackLayout>
+                <Grid StyleClass="box-row, box-row-input">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="*" />
+                    </Grid.RowDefinitions>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+                    <Label
+                        Text="{u:I18n SecurityCode}"
+                        StyleClass="box-label"
+                        Grid.Row="0"
+                        Grid.Column="0" />
+                    <controls:MonoEntry
+                        x:Name="_cardCodeEntry"
+                        Text="{Binding Cipher.Card.Code}"
+                        StyleClass="box-value"
+                        Grid.Row="1"
+                        Grid.Column="0"
+                        Keyboard="Numeric"
+                        IsPassword="{Binding ShowCardCode, Converter={StaticResource inverseBool}}"
+                        IsSpellCheckEnabled="False"
+                        IsTextPredictionEnabled="False" />
+                    <controls:FaButton 
+                        StyleClass="box-row-button, box-row-button-platform"
+                        Text="{Binding ShowCardCodeIcon}"
+                        Command="{Binding ToggleCardCodeCommand}"
+                        Grid.Row="0"
+                        Grid.Column="1"
+                        Grid.RowSpan="2"
+                        AutomationProperties.IsInAccessibleTree="True"
+                        AutomationProperties.Name="{u:I18n ToggleVisibility}" />
+                </Grid>
+            </StackLayout>
+            <StackLayout Spacing="0" Padding="0"
+                         x:Name="_identityControls" x:Key="identityControls">
+                <StackLayout StyleClass="box-row, box-row-input">
+                    <Label
+                        Text="{u:I18n Title}"
+                        StyleClass="box-label" />
+                    <Picker
+                        x:Name="_identityTitlePicker"
+                        ItemsSource="{Binding IdentityTitleOptions, Mode=OneTime}"
+                        SelectedIndex="{Binding IdentityTitleSelectedIndex}"
+                        StyleClass="box-value" />
+                </StackLayout>
+                <StackLayout StyleClass="box-row, box-row-input">
+                    <Label
+                        Text="{u:I18n FirstName}"
+                        StyleClass="box-label" />
+                    <Entry
+                        x:Name="_identityFirstNameEntry"
+                        Text="{Binding Cipher.Identity.FirstName}"
+                        StyleClass="box-value" />
+                </StackLayout>
+                <StackLayout StyleClass="box-row, box-row-input">
+                    <Label
+                        Text="{u:I18n MiddleName}"
+                        StyleClass="box-label" />
+                    <Entry
+                        x:Name="_identityMiddleNameEntry"
+                        Text="{Binding Cipher.Identity.MiddleName}"
+                        StyleClass="box-value" />
+                </StackLayout>
+                <StackLayout StyleClass="box-row, box-row-input">
+                    <Label
+                        Text="{u:I18n LastName}"
+                        StyleClass="box-label" />
+                    <Entry
+                        x:Name="_identityLastNameEntry"
+                        Text="{Binding Cipher.Identity.LastName}"
+                        StyleClass="box-value" />
+                </StackLayout>
+                <StackLayout StyleClass="box-row, box-row-input">
+                    <Label
+                        Text="{u:I18n Username}"
+                        StyleClass="box-label" />
+                    <Entry
+                        x:Name="_identityUsernameEntry"
+                        Text="{Binding Cipher.Identity.Username}"
+                        StyleClass="box-value" />
+                </StackLayout>
+                <StackLayout StyleClass="box-row, box-row-input">
+                    <Label
+                        Text="{u:I18n Company}"
+                        StyleClass="box-label" />
+                    <Entry
+                        x:Name="_identityCompanyEntry"
+                        Text="{Binding Cipher.Identity.Company}"
+                        StyleClass="box-value" />
+                </StackLayout>
+                <StackLayout StyleClass="box-row, box-row-input">
+                    <Label
+                        Text="{u:I18n SSN}"
+                        StyleClass="box-label" />
+                    <Entry
+                        x:Name="_identitySsnEntry"
+                        Text="{Binding Cipher.Identity.SSN}"
+                        StyleClass="box-value" />
+                </StackLayout>
+                <StackLayout StyleClass="box-row, box-row-input">
+                    <Label
+                        Text="{u:I18n PassportNumber}"
+                        StyleClass="box-label" />
+                    <Entry
+                        x:Name="_identityPassportNumberEntry"
+                        Text="{Binding Cipher.Identity.PassportNumber}"
+                        StyleClass="box-value" />
+                </StackLayout>
+                <StackLayout StyleClass="box-row, box-row-input">
+                    <Label
+                        Text="{u:I18n LicenseNumber}"
+                        StyleClass="box-label" />
+                    <Entry
+                        x:Name="_identityLicenseNumberEntry"
+                        Text="{Binding Cipher.Identity.LicenseNumber}"
+                        StyleClass="box-value" />
+                </StackLayout>
+                <StackLayout StyleClass="box-row, box-row-input">
+                    <Label
+                        Text="{u:I18n Email}"
+                        StyleClass="box-label" />
+                    <Entry
+                        x:Name="_identityEmailEntry"
+                        Keyboard="Email"
+                        Text="{Binding Cipher.Identity.Email}"
+                        StyleClass="box-value" />
+                </StackLayout>
+                <StackLayout StyleClass="box-row, box-row-input">
+                    <Label
+                        Text="{u:I18n Phone}"
+                        StyleClass="box-label" />
+                    <Entry
+                        x:Name="_identityPhoneEntry"
+                        Text="{Binding Cipher.Identity.Phone}"
+                        StyleClass="box-value" />
+                </StackLayout>
+                <StackLayout StyleClass="box-row, box-row-input">
+                    <Label
+                        Text="{u:I18n Address1}"
+                        StyleClass="box-label" />
+                    <Entry
+                        x:Name="_identityAddress1Entry"
+                        Text="{Binding Cipher.Identity.Address1}"
+                        StyleClass="box-value" />
+                </StackLayout>
+                <StackLayout StyleClass="box-row, box-row-input">
+                    <Label
+                        Text="{u:I18n Address2}"
+                        StyleClass="box-label" />
+                    <Entry
+                        x:Name="_identityAddress2Entry"
+                        Text="{Binding Cipher.Identity.Address2}"
+                        StyleClass="box-value" />
+                </StackLayout>
+                <StackLayout StyleClass="box-row, box-row-input">
+                    <Label
+                        Text="{u:I18n Address3}"
+                        StyleClass="box-label" />
+                    <Entry
+                        x:Name="_identityAddress3Entry"
+                        Text="{Binding Cipher.Identity.Address3}"
+                        StyleClass="box-value" />
+                </StackLayout>
+                <StackLayout StyleClass="box-row, box-row-input">
+                    <Label
+                        Text="{u:I18n CityTown}"
+                        StyleClass="box-label" />
+                    <Entry
+                        x:Name="_identityCityEntry"
+                        Text="{Binding Cipher.Identity.City}"
+                        StyleClass="box-value" />
+                </StackLayout>
+                <StackLayout StyleClass="box-row, box-row-input">
+                    <Label
+                        Text="{u:I18n StateProvince}"
+                        StyleClass="box-label" />
+                    <Entry
+                        x:Name="_identityStateEntry"
+                        Text="{Binding Cipher.Identity.State}"
+                        StyleClass="box-value" />
+                </StackLayout>
+                <StackLayout StyleClass="box-row, box-row-input">
+                    <Label
+                        Text="{u:I18n ZipPostalCode}"
+                        StyleClass="box-label" />
+                    <Entry
+                        x:Name="_identityPostalCodeEntry"
+                        Text="{Binding Cipher.Identity.PostalCode}"
+                        StyleClass="box-value" />
+                </StackLayout>
+                <StackLayout StyleClass="box-row, box-row-input">
+                    <Label
+                        Text="{u:I18n Country}"
+                        StyleClass="box-label" />
+                    <Entry
+                        x:Name="_identityCountryEntry"
+                        Text="{Binding Cipher.Identity.Country}"
+                        StyleClass="box-value" />
+                </StackLayout>
+            </StackLayout>
         </ResourceDictionary>
     </ContentPage.Resources>
 
     <ScrollView x:Name="_scrollView" Padding="0, 0, 0, 20">
         <StackLayout Spacing="20">
-            <StackLayout StyleClass="box">
+            <StackLayout StyleClass="box" x:Name="_itemControls">
                 <Grid IsVisible="{Binding OwnershipPolicyInEffect}"
                       Margin="0, 12, 0, 0"
                       RowSpacing="0"
@@ -102,362 +461,6 @@
                         x:Name="_nameEntry"
                         Text="{Binding Cipher.Name}"
                         StyleClass="box-value" />
-                </StackLayout>
-                <StackLayout IsVisible="{Binding IsLogin}" Spacing="0" Padding="0">
-                    <StackLayout StyleClass="box-row, box-row-input">
-                        <Label
-                            Text="{u:I18n Username}"
-                            StyleClass="box-label" />
-                        <Entry
-                            x:Name="_loginUsernameEntry"
-                            Text="{Binding Cipher.Login.Username}"
-                            StyleClass="box-value" />
-                    </StackLayout>
-                    <Grid StyleClass="box-row, box-row-input">
-                        <Grid.RowDefinitions>
-                            <RowDefinition Height="Auto" />
-                            <RowDefinition Height="*" />
-                        </Grid.RowDefinitions>
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="*" />
-                            <ColumnDefinition Width="Auto" />
-                            <ColumnDefinition Width="Auto" />
-                            <ColumnDefinition Width="Auto" />
-                        </Grid.ColumnDefinitions>
-                        <Label
-                            Text="{u:I18n Password}"
-                            StyleClass="box-label"
-                            Grid.Row="0"
-                            Grid.Column="0" />
-                        <controls:MonoEntry
-                            x:Name="_loginPasswordEntry"
-                            Text="{Binding Cipher.Login.Password}"
-                            StyleClass="box-value"
-                            Grid.Row="1"
-                            Grid.Column="0"
-                            Grid.ColumnSpan="{Binding PasswordFieldColSpan}"
-                            IsPassword="{Binding ShowPassword, Converter={StaticResource inverseBool}}"
-                            IsSpellCheckEnabled="False"
-                            IsTextPredictionEnabled="False"
-                            IsEnabled="{Binding Cipher.ViewPassword}"/>
-                        <controls:FaButton 
-                            StyleClass="box-row-button, box-row-button-platform"
-                            Text="&#xf058;"
-                            Command="{Binding CheckPasswordCommand}"
-                            Grid.Row="0"
-                            Grid.Column="1"
-                            Grid.RowSpan="2"
-                            AutomationProperties.IsInAccessibleTree="True"
-                            AutomationProperties.Name="{u:I18n CheckPassword}"
-                            IsVisible="{Binding Cipher.ViewPassword}" />
-                        <controls:FaButton 
-                            StyleClass="box-row-button, box-row-button-platform"
-                            Text="{Binding ShowPasswordIcon}"
-                            Command="{Binding TogglePasswordCommand}"
-                            Grid.Row="0"
-                            Grid.Column="2"
-                            Grid.RowSpan="2"
-                            AutomationProperties.IsInAccessibleTree="True"
-                            AutomationProperties.Name="{u:I18n ToggleVisibility}"
-                            IsVisible="{Binding Cipher.ViewPassword}" />
-                        <controls:FaButton 
-                            StyleClass="box-row-button, box-row-button-platform"
-                            Text="&#xf021;"
-                            Command="{Binding GeneratePasswordCommand}"
-                            Grid.Row="0"
-                            Grid.Column="3"
-                            Grid.RowSpan="2"
-                            AutomationProperties.IsInAccessibleTree="True"
-                            AutomationProperties.Name="{u:I18n GeneratePassword}"
-                            IsVisible="{Binding Cipher.ViewPassword}" />
-                    </Grid>
-
-                    <Grid StyleClass="box-row, box-row-input">
-                        <Grid.RowDefinitions>
-                            <RowDefinition Height="Auto" />
-                            <RowDefinition Height="*" />
-                        </Grid.RowDefinitions>
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="*" />
-                            <ColumnDefinition Width="Auto" />
-                        </Grid.ColumnDefinitions>
-                        <Label
-                            Text="{u:I18n AuthenticatorKey}"
-                            StyleClass="box-label"
-                            Grid.Row="0"
-                            Grid.Column="0" />
-                        <controls:MonoEntry
-                            x:Name="_loginTotpEntry"
-                            Text="{Binding Cipher.Login.Totp}"
-                            IsSpellCheckEnabled="False"
-                            IsTextPredictionEnabled="False"
-                            IsPassword="{Binding Cipher.ViewPassword, Converter={StaticResource inverseBool}}"
-                            IsEnabled="{Binding Cipher.ViewPassword}"
-                            StyleClass="box-value"
-                            Grid.Row="1"
-                            Grid.Column="0"
-                            Grid.ColumnSpan="{Binding TotpColumnSpan}" />
-                        <controls:FaButton 
-                            StyleClass="box-row-button, box-row-button-platform"
-                            Text="&#xf030;"
-                            Clicked="ScanTotp_Clicked"
-                            Grid.Row="0"
-                            Grid.Column="1"
-                            Grid.RowSpan="2"
-                            IsVisible="{Binding Cipher.ViewPassword}"
-                            AutomationProperties.IsInAccessibleTree="True"
-                            AutomationProperties.Name="{u:I18n ScanQrTitle}" />
-                    </Grid>
-                </StackLayout>
-                <StackLayout IsVisible="{Binding IsCard}" Spacing="0" Padding="0">
-                    <StackLayout StyleClass="box-row, box-row-input">
-                        <Label
-                            Text="{u:I18n CardholderName}"
-                            StyleClass="box-label" />
-                        <Entry
-                            x:Name="_cardholderNameEntry"
-                            Text="{Binding Cipher.Card.CardholderName}"
-                            StyleClass="box-value" />
-                    </StackLayout>
-                    <StackLayout StyleClass="box-row, box-row-input">
-                        <Label
-                            Text="{u:I18n Number}"
-                            StyleClass="box-label" />
-                        <Entry
-                            x:Name="_cardNumberEntry"
-                            Text="{Binding Cipher.Card.Number}"
-                            StyleClass="box-value" />
-                    </StackLayout>
-                    <StackLayout StyleClass="box-row, box-row-input">
-                        <Label
-                            Text="{u:I18n Brand}"
-                            StyleClass="box-label" />
-                        <Picker
-                            x:Name="_cardBrandPicker"
-                            ItemsSource="{Binding CardBrandOptions, Mode=OneTime}"
-                            SelectedIndex="{Binding CardBrandSelectedIndex}"
-                            StyleClass="box-value" />
-                    </StackLayout>
-                    <StackLayout StyleClass="box-row, box-row-input">
-                        <Label
-                            Text="{u:I18n ExpirationMonth}"
-                            StyleClass="box-label" />
-                        <Picker
-                            x:Name="_cardExpMonthPicker"
-                            ItemsSource="{Binding CardExpMonthOptions, Mode=OneTime}"
-                            SelectedIndex="{Binding CardExpMonthSelectedIndex}"
-                            StyleClass="box-value" />
-                    </StackLayout>
-                    <StackLayout StyleClass="box-row, box-row-input">
-                        <Label
-                            Text="{u:I18n ExpirationYear}"
-                            StyleClass="box-label" />
-                        <Entry
-                            x:Name="_cardExpYearEntry"
-                            Text="{Binding Cipher.Card.ExpYear}"
-                            StyleClass="box-value"
-                            Keyboard="Numeric" />
-                    </StackLayout>
-                    <Grid StyleClass="box-row, box-row-input">
-                        <Grid.RowDefinitions>
-                            <RowDefinition Height="Auto" />
-                            <RowDefinition Height="*" />
-                        </Grid.RowDefinitions>
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="*" />
-                            <ColumnDefinition Width="Auto" />
-                        </Grid.ColumnDefinitions>
-                        <Label
-                            Text="{u:I18n SecurityCode}"
-                            StyleClass="box-label"
-                            Grid.Row="0"
-                            Grid.Column="0" />
-                        <controls:MonoEntry
-                            x:Name="_cardCodeEntry"
-                            Text="{Binding Cipher.Card.Code}"
-                            StyleClass="box-value"
-                            Grid.Row="1"
-                            Grid.Column="0"
-                            Keyboard="Numeric"
-                            IsPassword="{Binding ShowCardCode, Converter={StaticResource inverseBool}}"
-                            IsSpellCheckEnabled="False"
-                            IsTextPredictionEnabled="False" />
-                        <controls:FaButton 
-                            StyleClass="box-row-button, box-row-button-platform"
-                            Text="{Binding ShowCardCodeIcon}"
-                            Command="{Binding ToggleCardCodeCommand}"
-                            Grid.Row="0"
-                            Grid.Column="1"
-                            Grid.RowSpan="2"
-                            AutomationProperties.IsInAccessibleTree="True"
-                            AutomationProperties.Name="{u:I18n ToggleVisibility}" />
-                    </Grid>
-                </StackLayout>
-                <StackLayout IsVisible="{Binding IsIdentity}" Spacing="0" Padding="0">
-                    <StackLayout StyleClass="box-row, box-row-input">
-                        <Label
-                            Text="{u:I18n Title}"
-                            StyleClass="box-label" />
-                        <Picker
-                            x:Name="_identityTitlePicker"
-                            ItemsSource="{Binding IdentityTitleOptions, Mode=OneTime}"
-                            SelectedIndex="{Binding IdentityTitleSelectedIndex}"
-                            StyleClass="box-value" />
-                    </StackLayout>
-                    <StackLayout StyleClass="box-row, box-row-input">
-                        <Label
-                            Text="{u:I18n FirstName}"
-                            StyleClass="box-label" />
-                        <Entry
-                            x:Name="_identityFirstNameEntry"
-                            Text="{Binding Cipher.Identity.FirstName}"
-                            StyleClass="box-value" />
-                    </StackLayout>
-                    <StackLayout StyleClass="box-row, box-row-input">
-                        <Label
-                            Text="{u:I18n MiddleName}"
-                            StyleClass="box-label" />
-                        <Entry
-                            x:Name="_identityMiddleNameEntry"
-                            Text="{Binding Cipher.Identity.MiddleName}"
-                            StyleClass="box-value" />
-                    </StackLayout>
-                    <StackLayout StyleClass="box-row, box-row-input">
-                        <Label
-                            Text="{u:I18n LastName}"
-                            StyleClass="box-label" />
-                        <Entry
-                            x:Name="_identityLastNameEntry"
-                            Text="{Binding Cipher.Identity.LastName}"
-                            StyleClass="box-value" />
-                    </StackLayout>
-                    <StackLayout StyleClass="box-row, box-row-input">
-                        <Label
-                            Text="{u:I18n Username}"
-                            StyleClass="box-label" />
-                        <Entry
-                            x:Name="_identityUsernameEntry"
-                            Text="{Binding Cipher.Identity.Username}"
-                            StyleClass="box-value" />
-                    </StackLayout>
-                    <StackLayout StyleClass="box-row, box-row-input">
-                        <Label
-                            Text="{u:I18n Company}"
-                            StyleClass="box-label" />
-                        <Entry
-                            x:Name="_identityCompanyEntry"
-                            Text="{Binding Cipher.Identity.Company}"
-                            StyleClass="box-value" />
-                    </StackLayout>
-                    <StackLayout StyleClass="box-row, box-row-input">
-                        <Label
-                            Text="{u:I18n SSN}"
-                            StyleClass="box-label" />
-                        <Entry
-                            x:Name="_identitySsnEntry"
-                            Text="{Binding Cipher.Identity.SSN}"
-                            StyleClass="box-value" />
-                    </StackLayout>
-                    <StackLayout StyleClass="box-row, box-row-input">
-                        <Label
-                            Text="{u:I18n PassportNumber}"
-                            StyleClass="box-label" />
-                        <Entry
-                            x:Name="_identityPassportNumberEntry"
-                            Text="{Binding Cipher.Identity.PassportNumber}"
-                            StyleClass="box-value" />
-                    </StackLayout>
-                    <StackLayout StyleClass="box-row, box-row-input">
-                        <Label
-                            Text="{u:I18n LicenseNumber}"
-                            StyleClass="box-label" />
-                        <Entry
-                            x:Name="_identityLicenseNumberEntry"
-                            Text="{Binding Cipher.Identity.LicenseNumber}"
-                            StyleClass="box-value" />
-                    </StackLayout>
-                    <StackLayout StyleClass="box-row, box-row-input">
-                        <Label
-                            Text="{u:I18n Email}"
-                            StyleClass="box-label" />
-                        <Entry
-                            x:Name="_identityEmailEntry"
-                            Keyboard="Email"
-                            Text="{Binding Cipher.Identity.Email}"
-                            StyleClass="box-value" />
-                    </StackLayout>
-                    <StackLayout StyleClass="box-row, box-row-input">
-                        <Label
-                            Text="{u:I18n Phone}"
-                            StyleClass="box-label" />
-                        <Entry
-                            x:Name="_identityPhoneEntry"
-                            Text="{Binding Cipher.Identity.Phone}"
-                            StyleClass="box-value" />
-                    </StackLayout>
-                    <StackLayout StyleClass="box-row, box-row-input">
-                        <Label
-                            Text="{u:I18n Address1}"
-                            StyleClass="box-label" />
-                        <Entry
-                            x:Name="_identityAddress1Entry"
-                            Text="{Binding Cipher.Identity.Address1}"
-                            StyleClass="box-value" />
-                    </StackLayout>
-                    <StackLayout StyleClass="box-row, box-row-input">
-                        <Label
-                            Text="{u:I18n Address2}"
-                            StyleClass="box-label" />
-                        <Entry
-                            x:Name="_identityAddress2Entry"
-                            Text="{Binding Cipher.Identity.Address2}"
-                            StyleClass="box-value" />
-                    </StackLayout>
-                    <StackLayout StyleClass="box-row, box-row-input">
-                        <Label
-                            Text="{u:I18n Address3}"
-                            StyleClass="box-label" />
-                        <Entry
-                            x:Name="_identityAddress3Entry"
-                            Text="{Binding Cipher.Identity.Address3}"
-                            StyleClass="box-value" />
-                    </StackLayout>
-                    <StackLayout StyleClass="box-row, box-row-input">
-                        <Label
-                            Text="{u:I18n CityTown}"
-                            StyleClass="box-label" />
-                        <Entry
-                            x:Name="_identityCityEntry"
-                            Text="{Binding Cipher.Identity.City}"
-                            StyleClass="box-value" />
-                    </StackLayout>
-                    <StackLayout StyleClass="box-row, box-row-input">
-                        <Label
-                            Text="{u:I18n StateProvince}"
-                            StyleClass="box-label" />
-                        <Entry
-                            x:Name="_identityStateEntry"
-                            Text="{Binding Cipher.Identity.State}"
-                            StyleClass="box-value" />
-                    </StackLayout>
-                    <StackLayout StyleClass="box-row, box-row-input">
-                        <Label
-                            Text="{u:I18n ZipPostalCode}"
-                            StyleClass="box-label" />
-                        <Entry
-                            x:Name="_identityPostalCodeEntry"
-                            Text="{Binding Cipher.Identity.PostalCode}"
-                            StyleClass="box-value" />
-                    </StackLayout>
-                    <StackLayout StyleClass="box-row, box-row-input">
-                        <Label
-                            Text="{u:I18n Country}"
-                            StyleClass="box-label" />
-                        <Entry
-                            x:Name="_identityCountryEntry"
-                            Text="{Binding Cipher.Identity.Country}"
-                            StyleClass="box-value" />
-                    </StackLayout>
                 </StackLayout>
             </StackLayout>
             <StackLayout StyleClass="box" IsVisible="{Binding IsLogin}">

--- a/src/App/Pages/Vault/AddEditPage.xaml.cs
+++ b/src/App/Pages/Vault/AddEditPage.xaml.cs
@@ -136,6 +136,8 @@ namespace Bit.App.Pages
             _identityStateEntry.ReturnCommand = new Command(() => _identityPostalCodeEntry.Focus());
             _identityPostalCodeEntry.ReturnType = ReturnType.Next;
             _identityPostalCodeEntry.ReturnCommand = new Command(() => _identityCountryEntry.Focus());
+
+            _typePicker.SelectedIndexChanged += TypePicker_SelectedIndexChanged;
         }
 
         public bool FromAutofillFramework { get; set; }
@@ -305,6 +307,26 @@ namespace Bit.App.Pages
             if (DoOnce())
             {
                 await Navigation.PopModalAsync();
+            }
+        }
+
+        private void TypePicker_SelectedIndexChanged(object sender, System.EventArgs e)
+        {
+            _itemControls.Children.Remove(_loginControls);
+            _itemControls.Children.Remove(_identityControls);
+            _itemControls.Children.Remove(_cardControls);
+
+            if (_vm.IsLogin)
+            {
+                _itemControls.Children.Add(_loginControls);
+            }
+            else if (_vm.IsIdentity)
+            {
+                _itemControls.Children.Add(_identityControls);
+            }
+            else if (_vm.IsCard)
+            {
+                _itemControls.Children.Add(_cardControls);
             }
         }
 

--- a/src/App/Pages/Vault/ViewPage.xaml
+++ b/src/App/Pages/Vault/ViewPage.xaml
@@ -45,9 +45,393 @@
             <ToolbarItem Text="{u:I18n Clone}" Clicked="Clone_Clicked" Order="Secondary"
                          x:Name="_cloneItem" x:Key="cloneItem" />
 
+            <StackLayout x:Name="_loginControls" x:Key="loginControls"
+                         Spacing="0" Padding="0">
+                <Grid StyleClass="box-row"
+                        IsVisible="{Binding Cipher.Login.Username, Converter={StaticResource stringHasValue}}">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="*" />
+                    </Grid.RowDefinitions>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+                    <Label
+                        Text="{u:I18n Username}"
+                        StyleClass="box-label"
+                        Grid.Row="0"
+                        Grid.Column="0" />
+                    <Label
+                        Text="{Binding Cipher.Login.Username, Mode=OneWay}"
+                        StyleClass="box-value"
+                        Grid.Row="1"
+                        Grid.Column="0" />
+                    <controls:FaButton 
+                        StyleClass="box-row-button, box-row-button-platform"
+                        Text="&#xf24d;"
+                        Command="{Binding CopyCommand}"
+                        CommandParameter="LoginUsername"
+                        Grid.Row="0"
+                        Grid.Column="1"
+                        Grid.RowSpan="2"
+                        AutomationProperties.IsInAccessibleTree="True"
+                        AutomationProperties.Name="{u:I18n CopyUsername}" />
+                </Grid>
+                <BoxView StyleClass="box-row-separator"
+                            IsVisible="{Binding Cipher.Login.Username, Converter={StaticResource stringHasValue}}" />
+                <Grid StyleClass="box-row" 
+                        IsVisible="{Binding Cipher.Login.Password, Converter={StaticResource stringHasValue}}">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="*" />
+                    </Grid.RowDefinitions>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+                    <Label
+                        Text="{u:I18n Password}"
+                        StyleClass="box-label"
+                        Grid.Row="0"
+                        Grid.Column="0" />
+                    <controls:MonoLabel
+                        Text="{Binding Cipher.Login.MaskedPassword, Mode=OneWay}"
+                        StyleClass="box-value"
+                        Grid.Row="1"
+                        Grid.Column="0"
+                        IsVisible="{Binding ShowPassword, Converter={StaticResource inverseBool}}"
+                        AutomationProperties.IsInAccessibleTree="{Binding ShowPassword, Converter={StaticResource inverseBool}}" />
+                    <controls:MonoLabel
+                        Text="{Binding ColoredPassword, Mode=OneWay}"
+                        TextType="Html"
+                        StyleClass="box-value"
+                        Grid.Row="1"
+                        Grid.Column="0"
+                        LineBreakMode="CharacterWrap"
+                        IsVisible="{Binding ShowPassword}"
+                        AutomationProperties.IsInAccessibleTree="{Binding ShowPassword}" />
+                    <controls:FaButton 
+                        StyleClass="box-row-button, box-row-button-platform"
+                        Text="&#xf058;"
+                        Command="{Binding CheckPasswordCommand}"
+                        Grid.Row="0"
+                        Grid.Column="1"
+                        Grid.RowSpan="2"
+                        AutomationProperties.IsInAccessibleTree="True"
+                        AutomationProperties.Name="{u:I18n CheckPassword}"
+                        IsVisible="{Binding Cipher.ViewPassword}" />
+                    <controls:FaButton 
+                        StyleClass="box-row-button, box-row-button-platform"
+                        Text="{Binding ShowPasswordIcon}"
+                        Command="{Binding TogglePasswordCommand}"
+                        Grid.Row="0"
+                        Grid.Column="2"
+                        Grid.RowSpan="2"
+                        AutomationProperties.IsInAccessibleTree="True"
+                        AutomationProperties.Name="{u:I18n ToggleVisibility}"
+                        IsVisible="{Binding Cipher.ViewPassword}" />
+                    <controls:FaButton 
+                        StyleClass="box-row-button, box-row-button-platform"
+                        Text="&#xf24d;"
+                        Command="{Binding CopyCommand}"
+                        CommandParameter="LoginPassword"
+                        Grid.Row="0"
+                        Grid.Column="3"
+                        Grid.RowSpan="2"
+                        AutomationProperties.IsInAccessibleTree="True"
+                        AutomationProperties.Name="{u:I18n CopyPassword}"
+                        IsVisible="{Binding Cipher.ViewPassword}" />
+                </Grid>
+                <BoxView StyleClass="box-row-separator"
+                            IsVisible="{Binding Cipher.Login.Password, Converter={StaticResource stringHasValue}}" />
+                <Grid StyleClass="box-row" IsVisible="{Binding ShowTotp}">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="*" />
+                    </Grid.RowDefinitions>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+                    <Label
+                        Text="{u:I18n VerificationCodeTotp}"
+                        StyleClass="box-label"
+                        Grid.Row="0"
+                        Grid.Column="0" />
+                    <controls:MonoLabel
+                        Text="{Binding TotpCodeFormatted, Mode=OneWay}"
+                        StyleClass="box-value"
+                        Grid.Row="1"
+                        Grid.Column="0" />
+                    <Label
+                        Text="{Binding TotpSec, Mode=OneWay}"
+                        Style="{DynamicResource textTotp}"
+                        Margin="0, 0, 10, 0"
+                        Grid.Row="0"
+                        Grid.Column="1"
+                        Grid.RowSpan="2"
+                        HorizontalOptions="End"
+                        HorizontalTextAlignment="End"
+                        VerticalOptions="CenterAndExpand" />
+                    <controls:FaButton 
+                        StyleClass="box-row-button, box-row-button-platform"
+                        Text="&#xf24d;"
+                        Command="{Binding CopyCommand}"
+                        CommandParameter="LoginTotp"
+                        Grid.Row="0"
+                        Grid.Column="2"
+                        Grid.RowSpan="2"
+                        AutomationProperties.IsInAccessibleTree="True"
+                        AutomationProperties.Name="{u:I18n CopyTotp}" />
+                </Grid>
+                <BoxView StyleClass="box-row-separator" IsVisible="{Binding ShowTotp}" />
+            </StackLayout>
+
+            <StackLayout x:Name="_cardControls" x:Key="cardControls"
+                         Spacing="0" Padding="0">
+                <StackLayout StyleClass="box-row"
+                                IsVisible="{Binding Cipher.Card.CardholderName, Converter={StaticResource stringHasValue}}">
+                    <Label
+                        Text="{u:I18n CardholderName}"
+                        StyleClass="box-label" />
+                    <Label
+                        Text="{Binding Cipher.Card.CardholderName, Mode=OneWay}"
+                        StyleClass="box-value" />
+                </StackLayout>
+                <BoxView StyleClass="box-row-separator"
+                            IsVisible="{Binding Cipher.Card.CardholderName, Converter={StaticResource stringHasValue}}" />
+                <Grid StyleClass="box-row"
+                        IsVisible="{Binding Cipher.Card.Number, Converter={StaticResource stringHasValue}}">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="*" />
+                    </Grid.RowDefinitions>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+                    <Label
+                        Text="{u:I18n Number}"
+                        StyleClass="box-label"
+                        Grid.Row="0"
+                        Grid.Column="0" />
+                    <Label
+                        Text="{Binding Cipher.Card.Number, Mode=OneWay}"
+                        StyleClass="box-value"
+                        Grid.Row="1"
+                        Grid.Column="0" />
+                    <controls:FaButton 
+                        StyleClass="box-row-button, box-row-button-platform"
+                        Text="&#xf24d;"
+                        Command="{Binding CopyCommand}"
+                        CommandParameter="CardNumber"
+                        Grid.Row="0"
+                        Grid.Column="1"
+                        Grid.RowSpan="2"
+                        AutomationProperties.IsInAccessibleTree="True"
+                        AutomationProperties.Name="{u:I18n CopyNumber}" />
+                </Grid>
+                <BoxView StyleClass="box-row-separator"
+                            IsVisible="{Binding Cipher.Card.Number, Converter={StaticResource stringHasValue}}" />
+                <StackLayout StyleClass="box-row"
+                                IsVisible="{Binding Cipher.Card.Brand, Converter={StaticResource stringHasValue}}">
+                    <Label
+                        Text="{u:I18n Brand}"
+                        StyleClass="box-label" />
+                    <Label
+                        Text="{Binding Cipher.Card.Brand, Mode=OneWay}"
+                        StyleClass="box-value" />
+                </StackLayout>
+                <BoxView StyleClass="box-row-separator"
+                            IsVisible="{Binding Cipher.Card.Brand, Converter={StaticResource stringHasValue}}" />
+                <StackLayout StyleClass="box-row"
+                                IsVisible="{Binding Cipher.Card.Expiration, Converter={StaticResource stringHasValue}}">
+                    <Label
+                        Text="{u:I18n Expiration}"
+                        StyleClass="box-label" />
+                    <Label
+                        Text="{Binding Cipher.Card.Expiration, Mode=OneWay}"
+                        StyleClass="box-value" />
+                </StackLayout>
+                <BoxView StyleClass="box-row-separator"
+                            IsVisible="{Binding Cipher.Card.Expiration, Converter={StaticResource stringHasValue}}" />
+                <Grid StyleClass="box-row"
+                        IsVisible="{Binding Cipher.Card.Code, Converter={StaticResource stringHasValue}}">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="*" />
+                    </Grid.RowDefinitions>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+                    <Label
+                        Text="{u:I18n SecurityCode}"
+                        StyleClass="box-label"
+                        Grid.Row="0"
+                        Grid.Column="0" />
+                    <controls:MonoLabel
+                        Text="{Binding Cipher.Card.MaskedCode, Mode=OneWay}"
+                        StyleClass="box-value"
+                        Grid.Row="1"
+                        Grid.Column="0"
+                        IsVisible="{Binding ShowCardCode, Converter={StaticResource inverseBool}}" />
+                    <controls:MonoLabel
+                        Text="{Binding Cipher.Card.Code, Mode=OneWay}"
+                        StyleClass="box-value"
+                        Grid.Row="1"
+                        Grid.Column="0"
+                        IsVisible="{Binding ShowCardCode}" />
+                    <controls:FaButton 
+                        StyleClass="box-row-button, box-row-button-platform"
+                        Text="{Binding ShowCardCodeIcon}"
+                        Command="{Binding ToggleCardCodeCommand}"
+                        Grid.Row="0"
+                        Grid.Column="1"
+                        Grid.RowSpan="2"
+                        AutomationProperties.IsInAccessibleTree="True"
+                        AutomationProperties.Name="{u:I18n ToggleVisibility}" />
+                    <controls:FaButton 
+                        StyleClass="box-row-button, box-row-button-platform"
+                        Text="&#xf24d;"
+                        Command="{Binding CopyCommand}"
+                        CommandParameter="CardCode"
+                        Grid.Row="0"
+                        Grid.Column="2"
+                        Grid.RowSpan="2"
+                        AutomationProperties.IsInAccessibleTree="True"
+                        AutomationProperties.Name="{u:I18n CopySecurityCode}" />
+                </Grid>
+                <BoxView StyleClass="box-row-separator"
+                            IsVisible="{Binding Cipher.Card.Code, Converter={StaticResource stringHasValue}}" />
+            </StackLayout>
+
+            <StackLayout x:Name="_identityControls" x:Key="identityControls"
+                         Spacing="0" Padding="0">
+                <StackLayout StyleClass="box-row"
+                                IsVisible="{Binding Cipher.Identity.FullName, Converter={StaticResource stringHasValue}}">
+                    <Label
+                        Text="{u:I18n IdentityName}"
+                        StyleClass="box-label" />
+                    <Label
+                        Text="{Binding Cipher.Identity.FullName, Mode=OneWay}"
+                        StyleClass="box-value" />
+                </StackLayout>
+                <BoxView StyleClass="box-row-separator"
+                            IsVisible="{Binding Cipher.Identity.FullName, Converter={StaticResource stringHasValue}}" />
+                <StackLayout StyleClass="box-row"
+                                IsVisible="{Binding Cipher.Identity.Username, Converter={StaticResource stringHasValue}}">
+                    <Label
+                        Text="{u:I18n Username}"
+                        StyleClass="box-label" />
+                    <Label
+                        Text="{Binding Cipher.Identity.Username, Mode=OneWay}"
+                        StyleClass="box-value" />
+                </StackLayout>
+                <BoxView StyleClass="box-row-separator"
+                            IsVisible="{Binding Cipher.Identity.Username, Converter={StaticResource stringHasValue}}" />
+                <StackLayout StyleClass="box-row"
+                                IsVisible="{Binding Cipher.Identity.Company, Converter={StaticResource stringHasValue}}">
+                    <Label
+                        Text="{u:I18n Company}"
+                        StyleClass="box-label" />
+                    <Label
+                        Text="{Binding Cipher.Identity.Company, Mode=OneWay}"
+                        StyleClass="box-value" />
+                </StackLayout>
+                <BoxView StyleClass="box-row-separator"
+                            IsVisible="{Binding Cipher.Identity.Company, Converter={StaticResource stringHasValue}}" />
+                <StackLayout StyleClass="box-row"
+                                IsVisible="{Binding Cipher.Identity.SSN, Converter={StaticResource stringHasValue}}">
+                    <Label
+                        Text="{u:I18n SSN}"
+                        StyleClass="box-label" />
+                    <Label
+                        Text="{Binding Cipher.Identity.SSN, Mode=OneWay}"
+                        StyleClass="box-value" />
+                </StackLayout>
+                <BoxView StyleClass="box-row-separator"
+                            IsVisible="{Binding Cipher.Identity.SSN, Converter={StaticResource stringHasValue}}" />
+                <StackLayout StyleClass="box-row"
+                                IsVisible="{Binding Cipher.Identity.PassportNumber, Converter={StaticResource stringHasValue}}">
+                    <Label
+                        Text="{u:I18n PassportNumber}"
+                        StyleClass="box-label" />
+                    <Label
+                        Text="{Binding Cipher.Identity.PassportNumber, Mode=OneWay}"
+                        StyleClass="box-value" />
+                </StackLayout>
+                <BoxView StyleClass="box-row-separator"
+                            IsVisible="{Binding Cipher.Identity.PassportNumber, Converter={StaticResource stringHasValue}}" />
+                <StackLayout StyleClass="box-row"
+                                IsVisible="{Binding Cipher.Identity.LicenseNumber, Converter={StaticResource stringHasValue}}">
+                    <Label
+                        Text="{u:I18n LicenseNumber}"
+                        StyleClass="box-label" />
+                    <Label
+                        Text="{Binding Cipher.Identity.LicenseNumber, Mode=OneWay}"
+                        StyleClass="box-value" />
+                </StackLayout>
+                <BoxView StyleClass="box-row-separator"
+                            IsVisible="{Binding Cipher.Identity.LicenseNumber, Converter={StaticResource stringHasValue}}" />
+                <StackLayout StyleClass="box-row"
+                                IsVisible="{Binding Cipher.Identity.Email, Converter={StaticResource stringHasValue}}">
+                    <Label
+                        Text="{u:I18n Email}"
+                        StyleClass="box-label" />
+                    <Label
+                        Text="{Binding Cipher.Identity.Email, Mode=OneWay}"
+                        StyleClass="box-value" />
+                </StackLayout>
+                <BoxView StyleClass="box-row-separator"
+                            IsVisible="{Binding Cipher.Identity.Email, Converter={StaticResource stringHasValue}}" />
+                <StackLayout StyleClass="box-row"
+                                IsVisible="{Binding Cipher.Identity.Phone, Converter={StaticResource stringHasValue}}">
+                    <Label
+                        Text="{u:I18n Phone}"
+                        StyleClass="box-label" />
+                    <Label
+                        Text="{Binding Cipher.Identity.Phone, Mode=OneWay}"
+                        StyleClass="box-value" />
+                </StackLayout>
+                <BoxView StyleClass="box-row-separator"
+                            IsVisible="{Binding Cipher.Identity.Phone, Converter={StaticResource stringHasValue}}" />
+                <StackLayout StyleClass="box-row" IsVisible="{Binding ShowIdentityAddress}">
+                    <Label
+                        Text="{u:I18n Address}"
+                        StyleClass="box-label" />
+                    <Label
+                        Text="{Binding Cipher.Identity.Address1, Mode=OneWay}"
+                        IsVisible="{Binding Cipher.Identity.Address1, Converter={StaticResource stringHasValue}}"
+                        StyleClass="box-value" />
+                    <Label
+                        Text="{Binding Cipher.Identity.Address2, Mode=OneWay}"
+                        IsVisible="{Binding Cipher.Identity.Address2, Converter={StaticResource stringHasValue}}"
+                        StyleClass="box-value" />
+                    <Label
+                        Text="{Binding Cipher.Identity.Address3, Mode=OneWay}"
+                        IsVisible="{Binding Cipher.Identity.Address3, Converter={StaticResource stringHasValue}}"
+                        StyleClass="box-value" />
+                    <Label
+                        Text="{Binding Cipher.Identity.FullAddressPart2, Mode=OneWay}"
+                        IsVisible="{Binding Cipher.Identity.FullAddressPart2, Converter={StaticResource stringHasValue}}"
+                        StyleClass="box-value" />
+                    <Label
+                        Text="{Binding Cipher.Identity.Country, Mode=OneWay}"
+                        IsVisible="{Binding Cipher.Identity.Country, Converter={StaticResource stringHasValue}}"
+                        StyleClass="box-value" />
+                </StackLayout>
+                <BoxView StyleClass="box-row-separator" IsVisible="{Binding ShowIdentityAddress}" />
+            </StackLayout>
+
             <ScrollView x:Key="scrollView" x:Name="_scrollView">
                 <StackLayout Spacing="20" x:Name="_mainLayout">
-                    <StackLayout StyleClass="box">
+                    <StackLayout StyleClass="box" x:Name="_itemControls">
                         <StackLayout StyleClass="box-row-header">
                             <Label Text="{u:I18n ItemInformation, Header=True}"
                                    StyleClass="box-header, box-header-platform" />
@@ -61,384 +445,6 @@
                                 StyleClass="box-value" />
                         </StackLayout>
                         <BoxView StyleClass="box-row-separator" />
-                        <StackLayout IsVisible="{Binding IsLogin}" Spacing="0" Padding="0">
-                            <Grid StyleClass="box-row"
-                                  IsVisible="{Binding Cipher.Login.Username, Converter={StaticResource stringHasValue}}">
-                                <Grid.RowDefinitions>
-                                    <RowDefinition Height="Auto" />
-                                    <RowDefinition Height="*" />
-                                </Grid.RowDefinitions>
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="*" />
-                                    <ColumnDefinition Width="Auto" />
-                                </Grid.ColumnDefinitions>
-                                <Label
-                                    Text="{u:I18n Username}"
-                                    StyleClass="box-label"
-                                    Grid.Row="0"
-                                    Grid.Column="0" />
-                                <Label
-                                    Text="{Binding Cipher.Login.Username, Mode=OneWay}"
-                                    StyleClass="box-value"
-                                    Grid.Row="1"
-                                    Grid.Column="0" />
-                                <controls:FaButton 
-                                    StyleClass="box-row-button, box-row-button-platform"
-                                    Text="&#xf24d;"
-                                    Command="{Binding CopyCommand}"
-                                    CommandParameter="LoginUsername"
-                                    Grid.Row="0"
-                                    Grid.Column="1"
-                                    Grid.RowSpan="2"
-                                    AutomationProperties.IsInAccessibleTree="True"
-                                    AutomationProperties.Name="{u:I18n CopyUsername}" />
-                            </Grid>
-                            <BoxView StyleClass="box-row-separator"
-                                     IsVisible="{Binding Cipher.Login.Username, Converter={StaticResource stringHasValue}}" />
-                            <Grid StyleClass="box-row" 
-                                  IsVisible="{Binding Cipher.Login.Password, Converter={StaticResource stringHasValue}}">
-                                <Grid.RowDefinitions>
-                                    <RowDefinition Height="Auto" />
-                                    <RowDefinition Height="*" />
-                                </Grid.RowDefinitions>
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="*" />
-                                    <ColumnDefinition Width="Auto" />
-                                    <ColumnDefinition Width="Auto" />
-                                    <ColumnDefinition Width="Auto" />
-                                </Grid.ColumnDefinitions>
-                                <Label
-                                    Text="{u:I18n Password}"
-                                    StyleClass="box-label"
-                                    Grid.Row="0"
-                                    Grid.Column="0" />
-                                <controls:MonoLabel
-                                    Text="{Binding Cipher.Login.MaskedPassword, Mode=OneWay}"
-                                    StyleClass="box-value"
-                                    Grid.Row="1"
-                                    Grid.Column="0"
-                                    IsVisible="{Binding ShowPassword, Converter={StaticResource inverseBool}}"
-                                    AutomationProperties.IsInAccessibleTree="{Binding ShowPassword, Converter={StaticResource inverseBool}}" />
-                                <controls:MonoLabel
-                                    Text="{Binding ColoredPassword, Mode=OneWay}"
-                                    TextType="Html"
-                                    StyleClass="box-value"
-                                    Grid.Row="1"
-                                    Grid.Column="0"
-                                    LineBreakMode="CharacterWrap"
-                                    IsVisible="{Binding ShowPassword}"
-                                    AutomationProperties.IsInAccessibleTree="{Binding ShowPassword}" />
-                                <controls:FaButton 
-                                    StyleClass="box-row-button, box-row-button-platform"
-                                    Text="&#xf058;"
-                                    Command="{Binding CheckPasswordCommand}"
-                                    Grid.Row="0"
-                                    Grid.Column="1"
-                                    Grid.RowSpan="2"
-                                    AutomationProperties.IsInAccessibleTree="True"
-                                    AutomationProperties.Name="{u:I18n CheckPassword}"
-                                    IsVisible="{Binding Cipher.ViewPassword}" />
-                                <controls:FaButton 
-                                    StyleClass="box-row-button, box-row-button-platform"
-                                    Text="{Binding ShowPasswordIcon}"
-                                    Command="{Binding TogglePasswordCommand}"
-                                    Grid.Row="0"
-                                    Grid.Column="2"
-                                    Grid.RowSpan="2"
-                                    AutomationProperties.IsInAccessibleTree="True"
-                                    AutomationProperties.Name="{u:I18n ToggleVisibility}"
-                                    IsVisible="{Binding Cipher.ViewPassword}" />
-                                <controls:FaButton 
-                                    StyleClass="box-row-button, box-row-button-platform"
-                                    Text="&#xf24d;"
-                                    Command="{Binding CopyCommand}"
-                                    CommandParameter="LoginPassword"
-                                    Grid.Row="0"
-                                    Grid.Column="3"
-                                    Grid.RowSpan="2"
-                                    AutomationProperties.IsInAccessibleTree="True"
-                                    AutomationProperties.Name="{u:I18n CopyPassword}"
-                                    IsVisible="{Binding Cipher.ViewPassword}" />
-                            </Grid>
-                            <BoxView StyleClass="box-row-separator"
-                                     IsVisible="{Binding Cipher.Login.Password, Converter={StaticResource stringHasValue}}" />
-                            <Grid StyleClass="box-row" IsVisible="{Binding ShowTotp}">
-                                <Grid.RowDefinitions>
-                                    <RowDefinition Height="Auto" />
-                                    <RowDefinition Height="*" />
-                                </Grid.RowDefinitions>
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="*" />
-                                    <ColumnDefinition Width="Auto" />
-                                    <ColumnDefinition Width="Auto" />
-                                </Grid.ColumnDefinitions>
-                                <Label
-                                    Text="{u:I18n VerificationCodeTotp}"
-                                    StyleClass="box-label"
-                                    Grid.Row="0"
-                                    Grid.Column="0" />
-                                <controls:MonoLabel
-                                    Text="{Binding TotpCodeFormatted, Mode=OneWay}"
-                                    StyleClass="box-value"
-                                    Grid.Row="1"
-                                    Grid.Column="0" />
-                                <Label
-                                    Text="{Binding TotpSec, Mode=OneWay}"
-                                    Style="{DynamicResource textTotp}"
-                                    Margin="0, 0, 10, 0"
-                                    Grid.Row="0"
-                                    Grid.Column="1"
-                                    Grid.RowSpan="2"
-                                    HorizontalOptions="End"
-                                    HorizontalTextAlignment="End"
-                                    VerticalOptions="CenterAndExpand" />
-                                <controls:FaButton 
-                                    StyleClass="box-row-button, box-row-button-platform"
-                                    Text="&#xf24d;"
-                                    Command="{Binding CopyCommand}"
-                                    CommandParameter="LoginTotp"
-                                    Grid.Row="0"
-                                    Grid.Column="2"
-                                    Grid.RowSpan="2"
-                                    AutomationProperties.IsInAccessibleTree="True"
-                                    AutomationProperties.Name="{u:I18n CopyTotp}" />
-                            </Grid>
-                            <BoxView StyleClass="box-row-separator" IsVisible="{Binding ShowTotp}" />
-                        </StackLayout>
-                        <StackLayout IsVisible="{Binding IsCard}" Spacing="0" Padding="0">
-                            <StackLayout StyleClass="box-row"
-                                         IsVisible="{Binding Cipher.Card.CardholderName, Converter={StaticResource stringHasValue}}">
-                                <Label
-                                    Text="{u:I18n CardholderName}"
-                                    StyleClass="box-label" />
-                                <Label
-                                    Text="{Binding Cipher.Card.CardholderName, Mode=OneWay}"
-                                    StyleClass="box-value" />
-                            </StackLayout>
-                            <BoxView StyleClass="box-row-separator"
-                                     IsVisible="{Binding Cipher.Card.CardholderName, Converter={StaticResource stringHasValue}}" />
-                            <Grid StyleClass="box-row"
-                                  IsVisible="{Binding Cipher.Card.Number, Converter={StaticResource stringHasValue}}">
-                                <Grid.RowDefinitions>
-                                    <RowDefinition Height="Auto" />
-                                    <RowDefinition Height="*" />
-                                </Grid.RowDefinitions>
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="*" />
-                                    <ColumnDefinition Width="Auto" />
-                                </Grid.ColumnDefinitions>
-                                <Label
-                                    Text="{u:I18n Number}"
-                                    StyleClass="box-label"
-                                    Grid.Row="0"
-                                    Grid.Column="0" />
-                                <Label
-                                    Text="{Binding Cipher.Card.Number, Mode=OneWay}"
-                                    StyleClass="box-value"
-                                    Grid.Row="1"
-                                    Grid.Column="0" />
-                                <controls:FaButton 
-                                    StyleClass="box-row-button, box-row-button-platform"
-                                    Text="&#xf24d;"
-                                    Command="{Binding CopyCommand}"
-                                    CommandParameter="CardNumber"
-                                    Grid.Row="0"
-                                    Grid.Column="1"
-                                    Grid.RowSpan="2"
-                                    AutomationProperties.IsInAccessibleTree="True"
-                                    AutomationProperties.Name="{u:I18n CopyNumber}" />
-                            </Grid>
-                            <BoxView StyleClass="box-row-separator"
-                                     IsVisible="{Binding Cipher.Card.Number, Converter={StaticResource stringHasValue}}" />
-                            <StackLayout StyleClass="box-row"
-                                         IsVisible="{Binding Cipher.Card.Brand, Converter={StaticResource stringHasValue}}">
-                                <Label
-                                    Text="{u:I18n Brand}"
-                                    StyleClass="box-label" />
-                                <Label
-                                    Text="{Binding Cipher.Card.Brand, Mode=OneWay}"
-                                    StyleClass="box-value" />
-                            </StackLayout>
-                            <BoxView StyleClass="box-row-separator"
-                                     IsVisible="{Binding Cipher.Card.Brand, Converter={StaticResource stringHasValue}}" />
-                            <StackLayout StyleClass="box-row"
-                                         IsVisible="{Binding Cipher.Card.Expiration, Converter={StaticResource stringHasValue}}">
-                                <Label
-                                    Text="{u:I18n Expiration}"
-                                    StyleClass="box-label" />
-                                <Label
-                                    Text="{Binding Cipher.Card.Expiration, Mode=OneWay}"
-                                    StyleClass="box-value" />
-                            </StackLayout>
-                            <BoxView StyleClass="box-row-separator"
-                                     IsVisible="{Binding Cipher.Card.Expiration, Converter={StaticResource stringHasValue}}" />
-                            <Grid StyleClass="box-row"
-                                  IsVisible="{Binding Cipher.Card.Code, Converter={StaticResource stringHasValue}}">
-                                <Grid.RowDefinitions>
-                                    <RowDefinition Height="Auto" />
-                                    <RowDefinition Height="*" />
-                                </Grid.RowDefinitions>
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="*" />
-                                    <ColumnDefinition Width="Auto" />
-                                    <ColumnDefinition Width="Auto" />
-                                </Grid.ColumnDefinitions>
-                                <Label
-                                    Text="{u:I18n SecurityCode}"
-                                    StyleClass="box-label"
-                                    Grid.Row="0"
-                                    Grid.Column="0" />
-                                <controls:MonoLabel
-                                    Text="{Binding Cipher.Card.MaskedCode, Mode=OneWay}"
-                                    StyleClass="box-value"
-                                    Grid.Row="1"
-                                    Grid.Column="0"
-                                    IsVisible="{Binding ShowCardCode, Converter={StaticResource inverseBool}}" />
-                                <controls:MonoLabel
-                                    Text="{Binding Cipher.Card.Code, Mode=OneWay}"
-                                    StyleClass="box-value"
-                                    Grid.Row="1"
-                                    Grid.Column="0"
-                                    IsVisible="{Binding ShowCardCode}" />
-                                <controls:FaButton 
-                                    StyleClass="box-row-button, box-row-button-platform"
-                                    Text="{Binding ShowCardCodeIcon}"
-                                    Command="{Binding ToggleCardCodeCommand}"
-                                    Grid.Row="0"
-                                    Grid.Column="1"
-                                    Grid.RowSpan="2"
-                                    AutomationProperties.IsInAccessibleTree="True"
-                                    AutomationProperties.Name="{u:I18n ToggleVisibility}" />
-                                <controls:FaButton 
-                                    StyleClass="box-row-button, box-row-button-platform"
-                                    Text="&#xf24d;"
-                                    Command="{Binding CopyCommand}"
-                                    CommandParameter="CardCode"
-                                    Grid.Row="0"
-                                    Grid.Column="2"
-                                    Grid.RowSpan="2"
-                                    AutomationProperties.IsInAccessibleTree="True"
-                                    AutomationProperties.Name="{u:I18n CopySecurityCode}" />
-                            </Grid>
-                            <BoxView StyleClass="box-row-separator"
-                                     IsVisible="{Binding Cipher.Card.Code, Converter={StaticResource stringHasValue}}" />
-                        </StackLayout>
-                        <StackLayout IsVisible="{Binding IsIdentity}" Spacing="0" Padding="0">
-                            <StackLayout StyleClass="box-row"
-                                         IsVisible="{Binding Cipher.Identity.FullName, Converter={StaticResource stringHasValue}}">
-                                <Label
-                                    Text="{u:I18n IdentityName}"
-                                    StyleClass="box-label" />
-                                <Label
-                                    Text="{Binding Cipher.Identity.FullName, Mode=OneWay}"
-                                    StyleClass="box-value" />
-                            </StackLayout>
-                            <BoxView StyleClass="box-row-separator"
-                                     IsVisible="{Binding Cipher.Identity.FullName, Converter={StaticResource stringHasValue}}" />
-                            <StackLayout StyleClass="box-row"
-                                         IsVisible="{Binding Cipher.Identity.Username, Converter={StaticResource stringHasValue}}">
-                                <Label
-                                    Text="{u:I18n Username}"
-                                    StyleClass="box-label" />
-                                <Label
-                                    Text="{Binding Cipher.Identity.Username, Mode=OneWay}"
-                                    StyleClass="box-value" />
-                            </StackLayout>
-                            <BoxView StyleClass="box-row-separator"
-                                     IsVisible="{Binding Cipher.Identity.Username, Converter={StaticResource stringHasValue}}" />
-                            <StackLayout StyleClass="box-row"
-                                         IsVisible="{Binding Cipher.Identity.Company, Converter={StaticResource stringHasValue}}">
-                                <Label
-                                    Text="{u:I18n Company}"
-                                    StyleClass="box-label" />
-                                <Label
-                                    Text="{Binding Cipher.Identity.Company, Mode=OneWay}"
-                                    StyleClass="box-value" />
-                            </StackLayout>
-                            <BoxView StyleClass="box-row-separator"
-                                     IsVisible="{Binding Cipher.Identity.Company, Converter={StaticResource stringHasValue}}" />
-                            <StackLayout StyleClass="box-row"
-                                         IsVisible="{Binding Cipher.Identity.SSN, Converter={StaticResource stringHasValue}}">
-                                <Label
-                                    Text="{u:I18n SSN}"
-                                    StyleClass="box-label" />
-                                <Label
-                                    Text="{Binding Cipher.Identity.SSN, Mode=OneWay}"
-                                    StyleClass="box-value" />
-                            </StackLayout>
-                            <BoxView StyleClass="box-row-separator"
-                                     IsVisible="{Binding Cipher.Identity.SSN, Converter={StaticResource stringHasValue}}" />
-                            <StackLayout StyleClass="box-row"
-                                         IsVisible="{Binding Cipher.Identity.PassportNumber, Converter={StaticResource stringHasValue}}">
-                                <Label
-                                    Text="{u:I18n PassportNumber}"
-                                    StyleClass="box-label" />
-                                <Label
-                                    Text="{Binding Cipher.Identity.PassportNumber, Mode=OneWay}"
-                                    StyleClass="box-value" />
-                            </StackLayout>
-                            <BoxView StyleClass="box-row-separator"
-                                     IsVisible="{Binding Cipher.Identity.PassportNumber, Converter={StaticResource stringHasValue}}" />
-                            <StackLayout StyleClass="box-row"
-                                         IsVisible="{Binding Cipher.Identity.LicenseNumber, Converter={StaticResource stringHasValue}}">
-                                <Label
-                                    Text="{u:I18n LicenseNumber}"
-                                    StyleClass="box-label" />
-                                <Label
-                                    Text="{Binding Cipher.Identity.LicenseNumber, Mode=OneWay}"
-                                    StyleClass="box-value" />
-                            </StackLayout>
-                            <BoxView StyleClass="box-row-separator"
-                                     IsVisible="{Binding Cipher.Identity.LicenseNumber, Converter={StaticResource stringHasValue}}" />
-                            <StackLayout StyleClass="box-row"
-                                         IsVisible="{Binding Cipher.Identity.Email, Converter={StaticResource stringHasValue}}">
-                                <Label
-                                    Text="{u:I18n Email}"
-                                    StyleClass="box-label" />
-                                <Label
-                                    Text="{Binding Cipher.Identity.Email, Mode=OneWay}"
-                                    StyleClass="box-value" />
-                            </StackLayout>
-                            <BoxView StyleClass="box-row-separator"
-                                     IsVisible="{Binding Cipher.Identity.Email, Converter={StaticResource stringHasValue}}" />
-                            <StackLayout StyleClass="box-row"
-                                         IsVisible="{Binding Cipher.Identity.Phone, Converter={StaticResource stringHasValue}}">
-                                <Label
-                                    Text="{u:I18n Phone}"
-                                    StyleClass="box-label" />
-                                <Label
-                                    Text="{Binding Cipher.Identity.Phone, Mode=OneWay}"
-                                    StyleClass="box-value" />
-                            </StackLayout>
-                            <BoxView StyleClass="box-row-separator"
-                                     IsVisible="{Binding Cipher.Identity.Phone, Converter={StaticResource stringHasValue}}" />
-                            <StackLayout StyleClass="box-row" IsVisible="{Binding ShowIdentityAddress}">
-                                <Label
-                                    Text="{u:I18n Address}"
-                                    StyleClass="box-label" />
-                                <Label
-                                    Text="{Binding Cipher.Identity.Address1, Mode=OneWay}"
-                                    IsVisible="{Binding Cipher.Identity.Address1, Converter={StaticResource stringHasValue}}"
-                                    StyleClass="box-value" />
-                                <Label
-                                    Text="{Binding Cipher.Identity.Address2, Mode=OneWay}"
-                                    IsVisible="{Binding Cipher.Identity.Address2, Converter={StaticResource stringHasValue}}"
-                                    StyleClass="box-value" />
-                                <Label
-                                    Text="{Binding Cipher.Identity.Address3, Mode=OneWay}"
-                                    IsVisible="{Binding Cipher.Identity.Address3, Converter={StaticResource stringHasValue}}"
-                                    StyleClass="box-value" />
-                                <Label
-                                    Text="{Binding Cipher.Identity.FullAddressPart2, Mode=OneWay}"
-                                    IsVisible="{Binding Cipher.Identity.FullAddressPart2, Converter={StaticResource stringHasValue}}"
-                                    StyleClass="box-value" />
-                                <Label
-                                    Text="{Binding Cipher.Identity.Country, Mode=OneWay}"
-                                    IsVisible="{Binding Cipher.Identity.Country, Converter={StaticResource stringHasValue}}"
-                                    StyleClass="box-value" />
-                            </StackLayout>
-                            <BoxView StyleClass="box-row-separator" IsVisible="{Binding ShowIdentityAddress}" />
-                        </StackLayout>
                     </StackLayout>
                     <StackLayout StyleClass="box" IsVisible="{Binding ShowUris}">
                         <StackLayout StyleClass="box-row-header">

--- a/src/App/Pages/Vault/ViewPage.xaml
+++ b/src/App/Pages/Vault/ViewPage.xaml
@@ -61,12 +61,14 @@
                         Text="{u:I18n Username}"
                         StyleClass="box-label"
                         Grid.Row="0"
-                        Grid.Column="0" />
+                        Grid.Column="0"
+                        AutomationProperties.IsInAccessibleTree="{Binding Cipher.Login.Username, Converter={StaticResource stringHasValue}}"/>
                     <Label
                         Text="{Binding Cipher.Login.Username, Mode=OneWay}"
                         StyleClass="box-value"
                         Grid.Row="1"
-                        Grid.Column="0" />
+                        Grid.Column="0"
+                        AutomationProperties.IsInAccessibleTree="{Binding Cipher.Login.Username, Converter={StaticResource stringHasValue}}"/>
                     <controls:FaButton 
                         StyleClass="box-row-button, box-row-button-platform"
                         Text="&#xf24d;"
@@ -75,7 +77,7 @@
                         Grid.Row="0"
                         Grid.Column="1"
                         Grid.RowSpan="2"
-                        AutomationProperties.IsInAccessibleTree="True"
+                        AutomationProperties.IsInAccessibleTree="{Binding Cipher.Login.Username, Converter={StaticResource stringHasValue}}"
                         AutomationProperties.Name="{u:I18n CopyUsername}" />
                 </Grid>
                 <BoxView StyleClass="box-row-separator"
@@ -96,7 +98,8 @@
                         Text="{u:I18n Password}"
                         StyleClass="box-label"
                         Grid.Row="0"
-                        Grid.Column="0" />
+                        Grid.Column="0"
+                        AutomationProperties.IsInAccessibleTree="{Binding Cipher.Login.Password, Converter={StaticResource stringHasValue}}"/>
                     <controls:MonoLabel
                         Text="{Binding Cipher.Login.MaskedPassword, Mode=OneWay}"
                         StyleClass="box-value"
@@ -120,7 +123,7 @@
                         Grid.Row="0"
                         Grid.Column="1"
                         Grid.RowSpan="2"
-                        AutomationProperties.IsInAccessibleTree="True"
+                        AutomationProperties.IsInAccessibleTree="{Binding Cipher.Login.Password, Converter={StaticResource stringHasValue}}"
                         AutomationProperties.Name="{u:I18n CheckPassword}"
                         IsVisible="{Binding Cipher.ViewPassword}" />
                     <controls:FaButton 
@@ -130,7 +133,7 @@
                         Grid.Row="0"
                         Grid.Column="2"
                         Grid.RowSpan="2"
-                        AutomationProperties.IsInAccessibleTree="True"
+                        AutomationProperties.IsInAccessibleTree="{Binding Cipher.Login.Password, Converter={StaticResource stringHasValue}}"
                         AutomationProperties.Name="{u:I18n ToggleVisibility}"
                         IsVisible="{Binding Cipher.ViewPassword}" />
                     <controls:FaButton 
@@ -141,7 +144,7 @@
                         Grid.Row="0"
                         Grid.Column="3"
                         Grid.RowSpan="2"
-                        AutomationProperties.IsInAccessibleTree="True"
+                        AutomationProperties.IsInAccessibleTree="{Binding Cipher.Login.Password, Converter={StaticResource stringHasValue}}"
                         AutomationProperties.Name="{u:I18n CopyPassword}"
                         IsVisible="{Binding Cipher.ViewPassword}" />
                 </Grid>
@@ -161,12 +164,14 @@
                         Text="{u:I18n VerificationCodeTotp}"
                         StyleClass="box-label"
                         Grid.Row="0"
-                        Grid.Column="0" />
+                        Grid.Column="0"
+                        AutomationProperties.IsInAccessibleTree="{Binding ShowTotp}"/>
                     <controls:MonoLabel
                         Text="{Binding TotpCodeFormatted, Mode=OneWay}"
                         StyleClass="box-value"
                         Grid.Row="1"
-                        Grid.Column="0" />
+                        Grid.Column="0"
+                        AutomationProperties.IsInAccessibleTree="{Binding ShowTotp}"/>
                     <Label
                         Text="{Binding TotpSec, Mode=OneWay}"
                         Style="{DynamicResource textTotp}"
@@ -176,7 +181,8 @@
                         Grid.RowSpan="2"
                         HorizontalOptions="End"
                         HorizontalTextAlignment="End"
-                        VerticalOptions="CenterAndExpand" />
+                        VerticalOptions="CenterAndExpand"
+                        AutomationProperties.IsInAccessibleTree="{Binding ShowTotp}" />
                     <controls:FaButton 
                         StyleClass="box-row-button, box-row-button-platform"
                         Text="&#xf24d;"
@@ -185,7 +191,7 @@
                         Grid.Row="0"
                         Grid.Column="2"
                         Grid.RowSpan="2"
-                        AutomationProperties.IsInAccessibleTree="True"
+                        AutomationProperties.IsInAccessibleTree="{Binding ShowTotp}"
                         AutomationProperties.Name="{u:I18n CopyTotp}" />
                 </Grid>
                 <BoxView StyleClass="box-row-separator" IsVisible="{Binding ShowTotp}" />
@@ -197,10 +203,12 @@
                                 IsVisible="{Binding Cipher.Card.CardholderName, Converter={StaticResource stringHasValue}}">
                     <Label
                         Text="{u:I18n CardholderName}"
-                        StyleClass="box-label" />
+                        StyleClass="box-label"
+                        AutomationProperties.IsInAccessibleTree="{Binding Cipher.Card.CardholderName, Converter={StaticResource stringHasValue}}"/>
                     <Label
                         Text="{Binding Cipher.Card.CardholderName, Mode=OneWay}"
-                        StyleClass="box-value" />
+                        StyleClass="box-value"
+                        AutomationProperties.IsInAccessibleTree="{Binding Cipher.Card.CardholderName, Converter={StaticResource stringHasValue}}"/>
                 </StackLayout>
                 <BoxView StyleClass="box-row-separator"
                             IsVisible="{Binding Cipher.Card.CardholderName, Converter={StaticResource stringHasValue}}" />
@@ -218,12 +226,14 @@
                         Text="{u:I18n Number}"
                         StyleClass="box-label"
                         Grid.Row="0"
-                        Grid.Column="0" />
+                        Grid.Column="0"
+                        AutomationProperties.IsInAccessibleTree="{Binding Cipher.Card.Number, Converter={StaticResource stringHasValue}}"/>
                     <Label
                         Text="{Binding Cipher.Card.Number, Mode=OneWay}"
                         StyleClass="box-value"
                         Grid.Row="1"
-                        Grid.Column="0" />
+                        Grid.Column="0"
+                        AutomationProperties.IsInAccessibleTree="{Binding Cipher.Card.Number, Converter={StaticResource stringHasValue}}"/>
                     <controls:FaButton 
                         StyleClass="box-row-button, box-row-button-platform"
                         Text="&#xf24d;"
@@ -232,7 +242,7 @@
                         Grid.Row="0"
                         Grid.Column="1"
                         Grid.RowSpan="2"
-                        AutomationProperties.IsInAccessibleTree="True"
+                        AutomationProperties.IsInAccessibleTree="{Binding Cipher.Card.Number, Converter={StaticResource stringHasValue}}"
                         AutomationProperties.Name="{u:I18n CopyNumber}" />
                 </Grid>
                 <BoxView StyleClass="box-row-separator"
@@ -241,10 +251,12 @@
                                 IsVisible="{Binding Cipher.Card.Brand, Converter={StaticResource stringHasValue}}">
                     <Label
                         Text="{u:I18n Brand}"
-                        StyleClass="box-label" />
+                        StyleClass="box-label"
+                        AutomationProperties.IsInAccessibleTree="{Binding Cipher.Card.Number, Converter={StaticResource stringHasValue}}"/>
                     <Label
                         Text="{Binding Cipher.Card.Brand, Mode=OneWay}"
-                        StyleClass="box-value" />
+                        StyleClass="box-value"
+                        AutomationProperties.IsInAccessibleTree="{Binding Cipher.Card.Number, Converter={StaticResource stringHasValue}}"/>
                 </StackLayout>
                 <BoxView StyleClass="box-row-separator"
                             IsVisible="{Binding Cipher.Card.Brand, Converter={StaticResource stringHasValue}}" />
@@ -252,10 +264,12 @@
                                 IsVisible="{Binding Cipher.Card.Expiration, Converter={StaticResource stringHasValue}}">
                     <Label
                         Text="{u:I18n Expiration}"
-                        StyleClass="box-label" />
+                        StyleClass="box-label"
+                        AutomationProperties.IsInAccessibleTree="{Binding Cipher.Card.Expiration, Converter={StaticResource stringHasValue}}"/>
                     <Label
                         Text="{Binding Cipher.Card.Expiration, Mode=OneWay}"
-                        StyleClass="box-value" />
+                        StyleClass="box-value"
+                        AutomationProperties.IsInAccessibleTree="{Binding Cipher.Card.Expiration, Converter={StaticResource stringHasValue}}"/>
                 </StackLayout>
                 <BoxView StyleClass="box-row-separator"
                             IsVisible="{Binding Cipher.Card.Expiration, Converter={StaticResource stringHasValue}}" />
@@ -274,19 +288,22 @@
                         Text="{u:I18n SecurityCode}"
                         StyleClass="box-label"
                         Grid.Row="0"
-                        Grid.Column="0" />
+                        Grid.Column="0"
+                        AutomationProperties.IsInAccessibleTree="{Binding Cipher.Card.Code, Converter={StaticResource stringHasValue}}"/>
                     <controls:MonoLabel
                         Text="{Binding Cipher.Card.MaskedCode, Mode=OneWay}"
                         StyleClass="box-value"
                         Grid.Row="1"
                         Grid.Column="0"
-                        IsVisible="{Binding ShowCardCode, Converter={StaticResource inverseBool}}" />
+                        IsVisible="{Binding ShowCardCode, Converter={StaticResource inverseBool}}"
+                        AutomationProperties.IsInAccessibleTree="{Binding ShowCardCode, Converter={StaticResource inverseBool}}"/>
                     <controls:MonoLabel
                         Text="{Binding Cipher.Card.Code, Mode=OneWay}"
                         StyleClass="box-value"
                         Grid.Row="1"
                         Grid.Column="0"
-                        IsVisible="{Binding ShowCardCode}" />
+                        IsVisible="{Binding ShowCardCode}"
+                        AutomationProperties.IsInAccessibleTree="{Binding ShowCardCode}"/>
                     <controls:FaButton 
                         StyleClass="box-row-button, box-row-button-platform"
                         Text="{Binding ShowCardCodeIcon}"
@@ -294,7 +311,7 @@
                         Grid.Row="0"
                         Grid.Column="1"
                         Grid.RowSpan="2"
-                        AutomationProperties.IsInAccessibleTree="True"
+                        AutomationProperties.IsInAccessibleTree="{Binding Cipher.Card.Code, Converter={StaticResource stringHasValue}}"
                         AutomationProperties.Name="{u:I18n ToggleVisibility}" />
                     <controls:FaButton 
                         StyleClass="box-row-button, box-row-button-platform"
@@ -304,7 +321,7 @@
                         Grid.Row="0"
                         Grid.Column="2"
                         Grid.RowSpan="2"
-                        AutomationProperties.IsInAccessibleTree="True"
+                        AutomationProperties.IsInAccessibleTree="{Binding Cipher.Card.Code, Converter={StaticResource stringHasValue}}"
                         AutomationProperties.Name="{u:I18n CopySecurityCode}" />
                 </Grid>
                 <BoxView StyleClass="box-row-separator"
@@ -317,10 +334,12 @@
                                 IsVisible="{Binding Cipher.Identity.FullName, Converter={StaticResource stringHasValue}}">
                     <Label
                         Text="{u:I18n IdentityName}"
-                        StyleClass="box-label" />
+                        StyleClass="box-label"
+                        AutomationProperties.IsInAccessibleTree="{Binding Cipher.Identity.FullName, Converter={StaticResource stringHasValue}}"/>
                     <Label
                         Text="{Binding Cipher.Identity.FullName, Mode=OneWay}"
-                        StyleClass="box-value" />
+                        StyleClass="box-value"
+                        AutomationProperties.IsInAccessibleTree="{Binding Cipher.Identity.FullName, Converter={StaticResource stringHasValue}}"/>
                 </StackLayout>
                 <BoxView StyleClass="box-row-separator"
                             IsVisible="{Binding Cipher.Identity.FullName, Converter={StaticResource stringHasValue}}" />
@@ -328,10 +347,12 @@
                                 IsVisible="{Binding Cipher.Identity.Username, Converter={StaticResource stringHasValue}}">
                     <Label
                         Text="{u:I18n Username}"
-                        StyleClass="box-label" />
+                        StyleClass="box-label"
+                        AutomationProperties.IsInAccessibleTree="{Binding Cipher.Identity.Username, Converter={StaticResource stringHasValue}}"/>
                     <Label
                         Text="{Binding Cipher.Identity.Username, Mode=OneWay}"
-                        StyleClass="box-value" />
+                        StyleClass="box-value"
+                        AutomationProperties.IsInAccessibleTree="{Binding Cipher.Identity.Username, Converter={StaticResource stringHasValue}}"/>
                 </StackLayout>
                 <BoxView StyleClass="box-row-separator"
                             IsVisible="{Binding Cipher.Identity.Username, Converter={StaticResource stringHasValue}}" />
@@ -339,10 +360,12 @@
                                 IsVisible="{Binding Cipher.Identity.Company, Converter={StaticResource stringHasValue}}">
                     <Label
                         Text="{u:I18n Company}"
-                        StyleClass="box-label" />
+                        StyleClass="box-label"
+                        AutomationProperties.IsInAccessibleTree="{Binding Cipher.Identity.Company, Converter={StaticResource stringHasValue}}"/>
                     <Label
                         Text="{Binding Cipher.Identity.Company, Mode=OneWay}"
-                        StyleClass="box-value" />
+                        StyleClass="box-value"
+                        AutomationProperties.IsInAccessibleTree="{Binding Cipher.Identity.Company, Converter={StaticResource stringHasValue}}"/>
                 </StackLayout>
                 <BoxView StyleClass="box-row-separator"
                             IsVisible="{Binding Cipher.Identity.Company, Converter={StaticResource stringHasValue}}" />
@@ -350,10 +373,12 @@
                                 IsVisible="{Binding Cipher.Identity.SSN, Converter={StaticResource stringHasValue}}">
                     <Label
                         Text="{u:I18n SSN}"
-                        StyleClass="box-label" />
+                        StyleClass="box-label"
+                        AutomationProperties.IsInAccessibleTree="{Binding Cipher.Identity.SSN, Converter={StaticResource stringHasValue}}"/>
                     <Label
                         Text="{Binding Cipher.Identity.SSN, Mode=OneWay}"
-                        StyleClass="box-value" />
+                        StyleClass="box-value"
+                        AutomationProperties.IsInAccessibleTree="{Binding Cipher.Identity.SSN, Converter={StaticResource stringHasValue}}"/>
                 </StackLayout>
                 <BoxView StyleClass="box-row-separator"
                             IsVisible="{Binding Cipher.Identity.SSN, Converter={StaticResource stringHasValue}}" />
@@ -361,10 +386,12 @@
                                 IsVisible="{Binding Cipher.Identity.PassportNumber, Converter={StaticResource stringHasValue}}">
                     <Label
                         Text="{u:I18n PassportNumber}"
-                        StyleClass="box-label" />
+                        StyleClass="box-label"
+                        AutomationProperties.IsInAccessibleTree="{Binding Cipher.Identity.PassportNumber, Converter={StaticResource stringHasValue}}"/>
                     <Label
                         Text="{Binding Cipher.Identity.PassportNumber, Mode=OneWay}"
-                        StyleClass="box-value" />
+                        StyleClass="box-value"
+                        AutomationProperties.IsInAccessibleTree="{Binding Cipher.Identity.PassportNumber, Converter={StaticResource stringHasValue}}"/>
                 </StackLayout>
                 <BoxView StyleClass="box-row-separator"
                             IsVisible="{Binding Cipher.Identity.PassportNumber, Converter={StaticResource stringHasValue}}" />
@@ -372,10 +399,12 @@
                                 IsVisible="{Binding Cipher.Identity.LicenseNumber, Converter={StaticResource stringHasValue}}">
                     <Label
                         Text="{u:I18n LicenseNumber}"
-                        StyleClass="box-label" />
+                        StyleClass="box-label"
+                        AutomationProperties.IsInAccessibleTree="{Binding Cipher.Identity.LicenseNumber, Converter={StaticResource stringHasValue}}"/>
                     <Label
                         Text="{Binding Cipher.Identity.LicenseNumber, Mode=OneWay}"
-                        StyleClass="box-value" />
+                        StyleClass="box-value"
+                        AutomationProperties.IsInAccessibleTree="{Binding Cipher.Identity.LicenseNumber, Converter={StaticResource stringHasValue}}"/>
                 </StackLayout>
                 <BoxView StyleClass="box-row-separator"
                             IsVisible="{Binding Cipher.Identity.LicenseNumber, Converter={StaticResource stringHasValue}}" />
@@ -383,10 +412,12 @@
                                 IsVisible="{Binding Cipher.Identity.Email, Converter={StaticResource stringHasValue}}">
                     <Label
                         Text="{u:I18n Email}"
-                        StyleClass="box-label" />
+                        StyleClass="box-label"
+                        AutomationProperties.IsInAccessibleTree="{Binding Cipher.Identity.Email, Converter={StaticResource stringHasValue}}"/>
                     <Label
                         Text="{Binding Cipher.Identity.Email, Mode=OneWay}"
-                        StyleClass="box-value" />
+                        StyleClass="box-value"
+                        AutomationProperties.IsInAccessibleTree="{Binding Cipher.Identity.Email, Converter={StaticResource stringHasValue}}"/>
                 </StackLayout>
                 <BoxView StyleClass="box-row-separator"
                             IsVisible="{Binding Cipher.Identity.Email, Converter={StaticResource stringHasValue}}" />
@@ -394,36 +425,44 @@
                                 IsVisible="{Binding Cipher.Identity.Phone, Converter={StaticResource stringHasValue}}">
                     <Label
                         Text="{u:I18n Phone}"
-                        StyleClass="box-label" />
+                        StyleClass="box-label"
+                        AutomationProperties.IsInAccessibleTree="{Binding Cipher.Identity.Phone, Converter={StaticResource stringHasValue}}"/>
                     <Label
                         Text="{Binding Cipher.Identity.Phone, Mode=OneWay}"
-                        StyleClass="box-value" />
+                        StyleClass="box-value"
+                        AutomationProperties.IsInAccessibleTree="{Binding Cipher.Identity.Phone, Converter={StaticResource stringHasValue}}"/>
                 </StackLayout>
                 <BoxView StyleClass="box-row-separator"
                             IsVisible="{Binding Cipher.Identity.Phone, Converter={StaticResource stringHasValue}}" />
                 <StackLayout StyleClass="box-row" IsVisible="{Binding ShowIdentityAddress}">
                     <Label
                         Text="{u:I18n Address}"
-                        StyleClass="box-label" />
+                        StyleClass="box-label"
+                        AutomationProperties.IsInAccessibleTree="{Binding ShowIdentityAddress}" />
                     <Label
                         Text="{Binding Cipher.Identity.Address1, Mode=OneWay}"
                         IsVisible="{Binding Cipher.Identity.Address1, Converter={StaticResource stringHasValue}}"
+                        AutomationProperties.IsInAccessibleTree="{Binding Cipher.Identity.Address1, Converter={StaticResource stringHasValue}}"
                         StyleClass="box-value" />
                     <Label
                         Text="{Binding Cipher.Identity.Address2, Mode=OneWay}"
                         IsVisible="{Binding Cipher.Identity.Address2, Converter={StaticResource stringHasValue}}"
+                        AutomationProperties.IsInAccessibleTree="{Binding Cipher.Identity.Address2, Converter={StaticResource stringHasValue}}"
                         StyleClass="box-value" />
                     <Label
                         Text="{Binding Cipher.Identity.Address3, Mode=OneWay}"
                         IsVisible="{Binding Cipher.Identity.Address3, Converter={StaticResource stringHasValue}}"
+                        AutomationProperties.IsInAccessibleTree="{Binding Cipher.Identity.Address3, Converter={StaticResource stringHasValue}}"
                         StyleClass="box-value" />
                     <Label
                         Text="{Binding Cipher.Identity.FullAddressPart2, Mode=OneWay}"
                         IsVisible="{Binding Cipher.Identity.FullAddressPart2, Converter={StaticResource stringHasValue}}"
+                        AutomationProperties.IsInAccessibleTree="{Binding Cipher.Identity.FullAddressPart2, Converter={StaticResource stringHasValue}}"
                         StyleClass="box-value" />
                     <Label
                         Text="{Binding Cipher.Identity.Country, Mode=OneWay}"
                         IsVisible="{Binding Cipher.Identity.Country, Converter={StaticResource stringHasValue}}"
+                        AutomationProperties.IsInAccessibleTree="{Binding Cipher.Identity.Country, Converter={StaticResource stringHasValue}}"
                         StyleClass="box-value" />
                 </StackLayout>
                 <BoxView StyleClass="box-row-separator" IsVisible="{Binding ShowIdentityAddress}" />
@@ -449,7 +488,8 @@
                     <StackLayout StyleClass="box" IsVisible="{Binding ShowUris}">
                         <StackLayout StyleClass="box-row-header">
                             <Label Text="{u:I18n URIs, Header=True}"
-                                   StyleClass="box-header, box-header-platform" />
+                                   StyleClass="box-header, box-header-platform"
+                                   AutomationProperties.IsInAccessibleTree="{Binding ShowUris}"/>
                         </StackLayout>
                         <controls:RepeaterView ItemsSource="{Binding Cipher.Login.Uris}">
                             <controls:RepeaterView.ItemTemplate>
@@ -470,13 +510,15 @@
                                                 StyleClass="box-label"
                                                 Grid.Row="0"
                                                 Grid.Column="0"
-                                                IsVisible="{Binding IsWebsite, Mode=OneWay, Converter={StaticResource inverseBool}}" />
+                                                IsVisible="{Binding IsWebsite, Mode=OneWay, Converter={StaticResource inverseBool}}"
+                                                AutomationProperties.IsInAccessibleTree="{Binding IsWebsite, Mode=OneWay, Converter={StaticResource inverseBool}}" />
                                             <Label
                                                 Text="{u:I18n Website}"
                                                 StyleClass="box-label"
                                                 Grid.Row="0"
                                                 Grid.Column="0"
-                                                IsVisible="{Binding IsWebsite, Mode=OneWay}" />
+                                                IsVisible="{Binding IsWebsite, Mode=OneWay}"
+                                                AutomationProperties.IsInAccessibleTree="{Binding IsWebsite, Mode=OneWay}"/>
                                             <Label
                                                 Text="{Binding HostOrUri, Mode=OneWay}"
                                                 StyleClass="box-value"
@@ -491,7 +533,7 @@
                                                 Grid.Column="1"
                                                 Grid.RowSpan="2"
                                                 IsVisible="{Binding CanLaunch, Mode=OneWay}"
-                                                AutomationProperties.IsInAccessibleTree="True"
+                                                AutomationProperties.IsInAccessibleTree="{Binding CanLaunch, Mode=OneWay}"
                                                 AutomationProperties.Name="{u:I18n Launch}" />
                                             <controls:FaButton
                                                 StyleClass="box-row-button, box-row-button-platform"
@@ -514,13 +556,15 @@
                                  IsVisible="{Binding Cipher.Notes, Converter={StaticResource stringHasValue}}">
                         <StackLayout StyleClass="box-row-header">
                             <Label Text="{u:I18n Notes, Header=True}"
-                                   StyleClass="box-header, box-header-platform" />
+                                   StyleClass="box-header, box-header-platform"
+                                   AutomationProperties.IsInAccessibleTree="{Binding Cipher.Notes, Converter={StaticResource stringHasValue}}" />
                         </StackLayout>
                         <StackLayout StyleClass="box-row">
                             <Label
                                 Text="{Binding Cipher.Notes, Mode=OneWay}"
                                 StyleClass="box-value"
-                                LineBreakMode="WordWrap">
+                                LineBreakMode="WordWrap"
+                                AutomationProperties.IsInAccessibleTree="{Binding Cipher.Notes, Converter={StaticResource stringHasValue}}">
                                 <Label.Effects>
                                     <effects:SelectableLabelEffect />
                                 </Label.Effects>
@@ -531,7 +575,8 @@
                     <StackLayout StyleClass="box" IsVisible="{Binding Cipher.HasFields}">
                         <StackLayout StyleClass="box-row-header">
                             <Label Text="{u:I18n CustomFields, Header=True}"
-                                   StyleClass="box-header, box-header-platform" />
+                                   StyleClass="box-header, box-header-platform"
+                                   AutomationProperties.IsInAccessibleTree="{Binding Cipher.HasFields}" />
                         </StackLayout>
                         <controls:RepeaterView ItemsSource="{Binding Fields}">
                             <controls:RepeaterView.ItemTemplate>
@@ -557,13 +602,15 @@
                                                 StyleClass="box-value"
                                                 Grid.Row="1"
                                                 Grid.Column="0"
-                                                IsVisible="{Binding IsTextType}" />
+                                                IsVisible="{Binding IsTextType}"
+                                                AutomationProperties.IsInAccessibleTree="{Binding IsTextType} "/>
                                             <controls:FaLabel
                                                 Text="{Binding ValueText, Mode=OneWay}"
                                                 StyleClass="box-value"
                                                 Grid.Row="1"
                                                 Grid.Column="0"
                                                 IsVisible="{Binding IsBooleanType}"
+                                                AutomationProperties.IsInAccessibleTree="{Binding IsBooleanType}"
                                                 Margin="0, 5, 0, 0" />
                                             <StackLayout IsVisible="{Binding IsHiddenType}"
                                                          Grid.Row="1"
@@ -571,11 +618,13 @@
                                                 <controls:MonoLabel
                                                     Text="{Binding ValueText, Mode=OneWay}"
                                                     StyleClass="box-value"
-                                                    IsVisible="{Binding ShowHiddenValue}" />
+                                                    IsVisible="{Binding ShowHiddenValue}"
+                                                    AutomationProperties.IsInAccessibleTree="{Binding ShowHiddenValue}" />
                                                 <controls:MonoLabel
                                                     Text="{Binding Field.MaskedValue, Mode=OneWay}"
                                                     StyleClass="box-value"
-                                                    IsVisible="{Binding ShowHiddenValue, Converter={StaticResource inverseBool}}" />
+                                                    IsVisible="{Binding ShowHiddenValue, Converter={StaticResource inverseBool}}"
+                                                    AutomationProperties.IsInAccessibleTree="{Binding ShowHiddenValue, Converter={StaticResource inverseBool}}" />
                                             </StackLayout>
                                             <controls:FaButton 
                                                 StyleClass="box-row-button, box-row-button-platform"
@@ -585,7 +634,7 @@
                                                 Grid.Row="0"
                                                 Grid.Column="1"
                                                 Grid.RowSpan="2"
-                                                AutomationProperties.IsInAccessibleTree="True"
+                                                AutomationProperties.IsInAccessibleTree="{Binding ShowViewHidden}"
                                                 AutomationProperties.Name="{u:I18n ToggleVisibility}" />
                                             <controls:FaButton
                                                 StyleClass="box-row-button, box-row-button-platform"
@@ -596,7 +645,7 @@
                                                 Grid.Row="0"
                                                 Grid.Column="2"
                                                 Grid.RowSpan="2"
-                                                AutomationProperties.IsInAccessibleTree="True"
+                                                AutomationProperties.IsInAccessibleTree="{Binding ShowCopyButton}"
                                                 AutomationProperties.Name="{u:I18n Copy}" />
                                         </Grid>
                                         <BoxView StyleClass="box-row-separator" />
@@ -608,7 +657,8 @@
                     <StackLayout StyleClass="box" IsVisible="{Binding ShowAttachments}">
                         <StackLayout StyleClass="box-row-header">
                             <Label Text="{u:I18n Attachments, Header=True}"
-                                   StyleClass="box-header, box-header-platform" />
+                                   StyleClass="box-header, box-header-platform"
+                                   AutomationProperties.IsInAccessibleTree="{Binding ShowAttachments}"/>
                         </StackLayout>
                         <controls:RepeaterView ItemsSource="{Binding Cipher.Attachments}">
                             <controls:RepeaterView.ItemTemplate>
@@ -631,7 +681,7 @@
                                                 Command="{Binding BindingContext.DownloadAttachmentCommand, Source={x:Reference _page}}"
                                                 CommandParameter="{Binding .}"
                                                 VerticalOptions="Center"
-                                                AutomationProperties.IsInAccessibleTree="True"
+                                                AutomationProperties.IsInAccessibleTree="{Binding BindingContext.ShowAttachments, Source={x:Reference _page}}"
                                                 AutomationProperties.Name="{u:I18n Download}" />
                                         </StackLayout>
                                         <BoxView StyleClass="box-row-separator" />
@@ -645,14 +695,16 @@
                                StyleClass="box-footer-label" />
                         <Label FormattedText="{Binding PasswordUpdatedText}"
                                StyleClass="box-footer-label"
-                               IsVisible="{Binding Cipher.PasswordRevisionDisplayDate, Converter={StaticResource notNull}}">
+                               IsVisible="{Binding Cipher.PasswordRevisionDisplayDate, Converter={StaticResource notNull}}"
+                               AutomationProperties.IsInAccessibleTree="{Binding Cipher.PasswordRevisionDisplayDate, Converter={StaticResource notNull}}">
                             <Label.GestureRecognizers>
                                 <TapGestureRecognizer Tapped="PasswordHistory_Tapped" />
                             </Label.GestureRecognizers>
                         </Label>
                         <Label FormattedText="{Binding PasswordHistoryText}"
                                StyleClass="box-footer-label"
-                               IsVisible="{Binding Cipher.HasPasswordHistory}">
+                               IsVisible="{Binding Cipher.HasPasswordHistory}"
+                               AutomationProperties.IsInAccessibleTree="{Binding Cipher.HasPasswordHistory}">
                             <Label.GestureRecognizers>
                                 <TapGestureRecognizer Tapped="PasswordHistory_Tapped" />
                             </Label.GestureRecognizers>
@@ -680,7 +732,7 @@
             Style="{StaticResource btn-fab}"
             AbsoluteLayout.LayoutFlags="PositionProportional"
             AbsoluteLayout.LayoutBounds="1, 1, AutoSize, AutoSize"
-            AutomationProperties.IsInAccessibleTree="True"
+            AutomationProperties.IsInAccessibleTree="{Binding CanEdit}"
             AutomationProperties.Name="{u:I18n EditItem}"
             IsVisible="{Binding CanEdit}">
             <Button.Effects>

--- a/src/App/Pages/Vault/ViewPage.xaml
+++ b/src/App/Pages/Vault/ViewPage.xaml
@@ -117,7 +117,8 @@
                                     StyleClass="box-value"
                                     Grid.Row="1"
                                     Grid.Column="0"
-                                    IsVisible="{Binding ShowPassword, Converter={StaticResource inverseBool}}" />
+                                    IsVisible="{Binding ShowPassword, Converter={StaticResource inverseBool}}"
+                                    AutomationProperties.IsInAccessibleTree="{Binding ShowPassword, Converter={StaticResource inverseBool}}" />
                                 <controls:MonoLabel
                                     Text="{Binding ColoredPassword, Mode=OneWay}"
                                     TextType="Html"
@@ -125,7 +126,8 @@
                                     Grid.Row="1"
                                     Grid.Column="0"
                                     LineBreakMode="CharacterWrap"
-                                    IsVisible="{Binding ShowPassword}" />
+                                    IsVisible="{Binding ShowPassword}"
+                                    AutomationProperties.IsInAccessibleTree="{Binding ShowPassword}" />
                                 <controls:FaButton 
                                     StyleClass="box-row-button, box-row-button-platform"
                                     Text="&#xf058;"

--- a/src/App/Pages/Vault/ViewPage.xaml.cs
+++ b/src/App/Pages/Vault/ViewPage.xaml.cs
@@ -97,6 +97,19 @@ namespace Bit.App.Pages
                     await Navigation.PopModalAsync();
                 }
             }, _mainContent);
+
+            if (_vm.IsLogin)
+            {
+                _itemControls.Children.Add(_loginControls);
+            }
+            else if (_vm.IsIdentity)
+            {
+                _itemControls.Children.Add(_identityControls);
+            }
+            else if (_vm.IsCard)
+            {
+                _itemControls.Children.Add(_cardControls);
+            }
         }
 
         protected override void OnDisappearing()

--- a/src/App/Utilities/InverseBoolConverter.cs
+++ b/src/App/Utilities/InverseBoolConverter.cs
@@ -8,7 +8,7 @@ namespace Bit.App.Utilities
         public object Convert(object value, Type targetType, object parameter,
             System.Globalization.CultureInfo culture)
         {
-            if (targetType == typeof(bool))
+            if (targetType == typeof(bool) || targetType == typeof(Nullable<bool>))
             {
                 return !((bool?)value).GetValueOrDefault();
             }

--- a/src/App/Utilities/IsNotNullConverter.cs
+++ b/src/App/Utilities/IsNotNullConverter.cs
@@ -8,7 +8,7 @@ namespace Bit.App.Utilities
         public object Convert(object value, Type targetType, object parameter,
             System.Globalization.CultureInfo culture)
         {
-            if (targetType == typeof(bool))
+            if (targetType == typeof(bool) || targetType == typeof(Nullable<bool>))
             {
                 return value != null;
             }

--- a/src/App/Utilities/StringHasValueConverter.cs
+++ b/src/App/Utilities/StringHasValueConverter.cs
@@ -8,7 +8,7 @@ namespace Bit.App.Utilities
         public object Convert(object value, Type targetType, object parameter,
             System.Globalization.CultureInfo culture)
         {
-            if (targetType == typeof(bool))
+            if (targetType == typeof(bool) || targetType == typeof(Nullable<bool>))
             {
                 if (value == null)
                 {


### PR DESCRIPTION
# Objective

Bugfix for #1197:

> No matter what type of entry you're creating or viewing, VoiceOver is seeing the text fields for every other type of entry (IE, if creating a secure note you see text fields for username, password, credit card number and so on)

The cause of the bug was that VoiceOver (the iOS screenreader) reads invisible elements (i.e. those with `IsVisible="False"`). However, `IsVisible` is the primary means for showing/hiding relevant/irrelevant fields and controls.

# Code Changes

Whether an element is “visible” to VoiceOver is determined by a separate property, `AutomationProperties.IsInAccessibleTree`. However, unlike `IsVisible`, this does not affect child items, so it cannot effectively be applied to a parent `StackLayout` to hide its children from VoiceOver.

I have therefore generally taken the following approach:
* Where `IsVisible` is set on an individual element, set `IsInAccessibleTree` on that element with the same value.
* Where `IsVisible` is set on a layout element, add `IsInAccessibleTree` to each child with the same value as the parent.
* However, I didn't do this for the main controls for each item type, because of the large number of elements. Instead, they are added/removed from the element tree as required using code behind.

# Issues

The **Add URI** button is still being picked up by VoiceOver on the AddEdit page, even when it's invisible and `IsInAccessibleTree` is set to `False`. I figure I'd looked at this long enough, maybe someone else can spot what's going on.

Other than that, I have tested this on my iPhone 6 and it all works as expected.