### PR TITLE
null checked all the permissions

### DIFF
--- a/src/Core/Models/Data/OrganizationData.cs
+++ b/src/Core/Models/Data/OrganizationData.cs
@@ -26,7 +26,7 @@ namespace Bit.Core.Models.Data
             Seats = response.Seats;
             MaxCollections = response.MaxCollections;
             MaxStorageGb = response.MaxStorageGb;
-            Permissions = response.Permissions;
+            Permissions = response.Permissions ?? new Permissions();
         }
 
         public string Id { get; set; }
@@ -46,6 +46,6 @@ namespace Bit.Core.Models.Data
         public int Seats { get; set; }
         public int MaxCollections { get; set; }
         public short? MaxStorageGb { get; set; }
-        public Permissions Permissions { get; set; }
+        public Permissions Permissions { get; set; } = new Permissions();
     }
 }

--- a/src/Core/Models/Domain/Organization.cs
+++ b/src/Core/Models/Domain/Organization.cs
@@ -26,7 +26,7 @@ namespace Bit.Core.Models.Domain
             Seats = obj.Seats;
             MaxCollections = obj.MaxCollections;
             MaxStorageGb = obj.MaxStorageGb;
-            Permissions = obj.Permissions;
+            Permissions = obj.Permissions ?? new Permissions();
         }
 
         public string Id { get; set; }
@@ -46,7 +46,7 @@ namespace Bit.Core.Models.Domain
         public int Seats { get; set; }
         public int MaxCollections { get; set; }
         public short? MaxStorageGb { get; set; }
-        public Permissions Permissions { get; set; }
+        public Permissions Permissions { get; set; } = new Permissions();
 
         public bool CanAccess
         {

--- a/src/Core/Models/Response/ProfileOrganizationResponse.cs
+++ b/src/Core/Models/Response/ProfileOrganizationResponse.cs
@@ -23,6 +23,6 @@ namespace Bit.Core.Models.Response
         public OrganizationUserStatusType Status { get; set; }
         public OrganizationUserType Type { get; set; }
         public bool Enabled { get; set; }
-        public Permissions Permissions { get; set; }
+        public Permissions Permissions { get; set; } = new Permissions();
     }
 }


### PR DESCRIPTION
Just as no boolean value should ever be nullable, so too should a collection of boolean values never be nullable

This fixes a bug in the Testflight release that was causing editing organization ciphers to crash the app.