### PR TITLE
Add passphrase generator to iOS Extensions

### DIFF
--- a/src/iOS.Core/Controllers/PasswordGeneratorViewController.cs
+++ b/src/iOS.Core/Controllers/PasswordGeneratorViewController.cs
@@ -327,7 +327,7 @@ namespace Bit.iOS.Core.Controllers
 
                 if (_controller._passType == "password")
                 {
-                    return 7;
+                    return 8;
                 }
                 else
                 {

--- a/src/iOS.Core/Controllers/PasswordGeneratorViewController.cs
+++ b/src/iOS.Core/Controllers/PasswordGeneratorViewController.cs
@@ -325,7 +325,14 @@ namespace Bit.iOS.Core.Controllers
                     return 2;
                 }
 
-                return 7;
+                if (_controller._passType == "password")
+                {
+                    return 7;
+                }
+                else
+                {
+                    return 5;
+                }
             }
 
             public override nfloat GetHeightForHeader(UITableView tableView, nint section)

--- a/src/iOS.Core/Controllers/PasswordGeneratorViewController.cs
+++ b/src/iOS.Core/Controllers/PasswordGeneratorViewController.cs
@@ -37,6 +37,8 @@ namespace Bit.iOS.Core.Controllers
             AppResources.MinSpecial, 1, 0, 5, 1);
         public SliderTableViewCell LengthCell { get; set; } = new SliderTableViewCell(
             AppResources.Length, 10, 5, 64);
+        public SwitchTableViewCell AmbiguousCell { get; set; } = new SwitchTableViewCell(
+            AppResources.AvoidAmbiguousCharacters);
 
         public StepperTableViewCell NumWordsCell { get; set; } = new StepperTableViewCell(
             AppResources.NumberOfWords, 3, 3, 20, 1);
@@ -99,6 +101,7 @@ namespace Bit.iOS.Core.Controllers
             MinNumbersCell.Value = options.MinNumber.GetValueOrDefault(1);
             MinSpecialCell.Value = options.MinSpecial.GetValueOrDefault(1);
             LengthCell.Value = options.Length.GetValueOrDefault(14);
+            AmbiguousCell.Switch.On = options.Ambiguous.GetValueOrDefault();
 
             NumWordsCell.Value = options.NumWords.GetValueOrDefault(3);
             WordSeparatorCell.TextField.Text = options.WordSeparator ?? "";
@@ -112,6 +115,7 @@ namespace Bit.iOS.Core.Controllers
             MinNumbersCell.ValueChanged += Options_ValueChanged;
             MinSpecialCell.ValueChanged += Options_ValueChanged;
             LengthCell.ValueChanged += Options_ValueChanged;
+            AmbiguousCell.ValueChanged += Options_ValueChanged;
 
             NumWordsCell.ValueChanged += Options_ValueChanged;
             WordSeparatorCell.ValueChanged += Options_ValueChanged;
@@ -215,6 +219,7 @@ namespace Bit.iOS.Core.Controllers
                     Special = SpecialCell.Switch.On,
                     MinSpecial = MinSpecialCell.Value,
                     MinNumber = MinNumbersCell.Value,
+                    Ambiguous = AmbiguousCell.Switch.On,
                     NumWords = NumWordsCell.Value,
                     WordSeparator = WordSeparatorCell.TextField.Text,
                     Capitalize = CapitalizeCell.Switch.On,
@@ -283,7 +288,10 @@ namespace Bit.iOS.Core.Controllers
                     else if (indexPath.Row == 7)
                     {
                         return _controller.MinSpecialCell;
-                    }
+                    } else if (indexPath.Row == 8)
+                    {
+                        return _controller.AmbiguousCell;
+                    }    
                 }
                 else
                 {
@@ -327,7 +335,7 @@ namespace Bit.iOS.Core.Controllers
 
                 if (_controller._passType == "password")
                 {
-                    return 8;
+                    return 9;
                 }
                 else
                 {

--- a/src/iOS.Core/Controllers/PasswordGeneratorViewController.cs
+++ b/src/iOS.Core/Controllers/PasswordGeneratorViewController.cs
@@ -41,7 +41,7 @@ namespace Bit.iOS.Core.Controllers
         public StepperTableViewCell NumWordsCell { get; set; } = new StepperTableViewCell(
             AppResources.NumberOfWords, 3, 3, 20, 1);
         public FormEntryTableViewCell WordSeparatorCell { get; set; } = new FormEntryTableViewCell(
-            AppResources.WordSeparator);
+            AppResources.WordSeparator, leadingConstant: 20f);
         public SwitchTableViewCell CapitalizeCell { get; set; } = new SwitchTableViewCell(
             AppResources.Capitalize);
         public SwitchTableViewCell IncludeNumberCell { get; set; } = new SwitchTableViewCell(

--- a/src/iOS.Core/Controllers/PasswordGeneratorViewController.cs
+++ b/src/iOS.Core/Controllers/PasswordGeneratorViewController.cs
@@ -10,18 +10,23 @@ using Bit.App.Resources;
 using Bit.Core.Abstractions;
 using Bit.Core.Utilities;
 using System.Threading.Tasks;
+using System.Collections.Generic;
 
 namespace Bit.iOS.Core.Controllers
 {
     public abstract class PasswordGeneratorViewController : ExtendedUIViewController
     {
         private IPasswordGenerationService _passwordGenerationService;
+        private string _passType;
 
         public PasswordGeneratorViewController(IntPtr handle)
             : base(handle)
         { }
 
         public UITableViewController OptionsTableViewController { get; set; }
+        public PickerTableViewCell TypePickerCell { get; set; } = new PickerTableViewCell(
+            AppResources.Type);
+
         public SwitchTableViewCell UppercaseCell { get; set; } = new SwitchTableViewCell("A-Z");
         public SwitchTableViewCell LowercaseCell { get; set; } = new SwitchTableViewCell("a-z");
         public SwitchTableViewCell NumbersCell { get; set; } = new SwitchTableViewCell("0-9");
@@ -33,6 +38,17 @@ namespace Bit.iOS.Core.Controllers
         public SliderTableViewCell LengthCell { get; set; } = new SliderTableViewCell(
             AppResources.Length, 10, 5, 64);
 
+        public StepperTableViewCell NumWordsCell { get; set; } = new StepperTableViewCell(
+            AppResources.NumberOfWords, 3, 3, 20, 1);
+        public FormEntryTableViewCell WordSeparatorCell { get; set; } = new FormEntryTableViewCell(
+            AppResources.WordSeparator);
+        public SwitchTableViewCell CapitalizeCell { get; set; } = new SwitchTableViewCell(
+            AppResources.Capitalize);
+        public SwitchTableViewCell IncludeNumberCell { get; set; } = new SwitchTableViewCell(
+            AppResources.IncludeNumber);
+
+        public List<string> TypeOptions { get; set; } = new List<string> {
+            AppResources.Password, AppResources.Passphrase };
         public PasswordGenerationOptions PasswordOptions { get; set; }
         public abstract UINavigationItem BaseNavItem { get; }
         public abstract UIBarButtonItem BaseCancelButton { get; }
@@ -51,7 +67,7 @@ namespace Bit.iOS.Core.Controllers
             var descriptor = UIFontDescriptor.PreferredBody;
             BasePasswordLabel.Font = UIFont.FromName("Menlo-Regular", descriptor.PointSize * 1.3f);
             BasePasswordLabel.LineBreakMode = UILineBreakMode.TailTruncation;
-            BasePasswordLabel.Lines = 1;
+            BasePasswordLabel.Lines = 0;
             BasePasswordLabel.AdjustsFontSizeToFitWidth = false;
             BasePasswordLabel.TextColor = ThemeHelpers.TextColor;
 
@@ -71,6 +87,10 @@ namespace Bit.iOS.Core.Controllers
                 OptionsTableViewController.TableView.SeparatorColor = ThemeHelpers.SeparatorColor;
             }
 
+            TypePickerCell.Items = TypeOptions;
+            TypePickerCell.ValueChanged += Type_ValueChanged;
+            SetPassType();
+
             var (options, enforcedPolicyOptions) = await _passwordGenerationService.GetOptionsAsync();
             UppercaseCell.Switch.On = options.Uppercase.GetValueOrDefault();
             LowercaseCell.Switch.On = options.Lowercase.GetValueOrDefault(true);
@@ -80,6 +100,11 @@ namespace Bit.iOS.Core.Controllers
             MinSpecialCell.Value = options.MinSpecial.GetValueOrDefault(1);
             LengthCell.Value = options.Length.GetValueOrDefault(14);
 
+            NumWordsCell.Value = options.NumWords.GetValueOrDefault(3);
+            WordSeparatorCell.TextField.Text = options.WordSeparator ?? "";
+            CapitalizeCell.Switch.On = options.Capitalize.GetValueOrDefault();
+            IncludeNumberCell.Switch.On = options.IncludeNumber.GetValueOrDefault();
+
             UppercaseCell.ValueChanged += Options_ValueChanged;
             LowercaseCell.ValueChanged += Options_ValueChanged;
             NumbersCell.ValueChanged += Options_ValueChanged;
@@ -87,6 +112,11 @@ namespace Bit.iOS.Core.Controllers
             MinNumbersCell.ValueChanged += Options_ValueChanged;
             MinSpecialCell.ValueChanged += Options_ValueChanged;
             LengthCell.ValueChanged += Options_ValueChanged;
+
+            NumWordsCell.ValueChanged += Options_ValueChanged;
+            WordSeparatorCell.ValueChanged += Options_ValueChanged;
+            CapitalizeCell.ValueChanged += Options_ValueChanged;
+            IncludeNumberCell.ValueChanged += Options_ValueChanged;
 
             // Adjust based on context password options
             if (PasswordOptions != null)
@@ -154,6 +184,18 @@ namespace Bit.iOS.Core.Controllers
             var task = GeneratePasswordAsync();
         }
 
+        private void Type_ValueChanged(object sender, EventArgs e)
+        {
+            SetPassType();
+            OptionsTableViewController.TableView.ReloadData();
+            var task = GeneratePasswordAsync();
+        }
+
+        private void SetPassType()
+        {
+            _passType = TypePickerCell.SelectedIndex == 1 ? "passphrase" : "password";
+        }
+
         private bool InvalidState()
         {
             return !LowercaseCell.Switch.On && !UppercaseCell.Switch.On && !NumbersCell.Switch.On &&
@@ -165,6 +207,7 @@ namespace Bit.iOS.Core.Controllers
             BasePasswordLabel.Text = await _passwordGenerationService.GeneratePasswordAsync(
                 new Bit.Core.Models.Domain.PasswordGenerationOptions
                 {
+                    Type = _passType,
                     Length = LengthCell.Value,
                     Uppercase = UppercaseCell.Switch.On,
                     Lowercase = LowercaseCell.Switch.On,
@@ -172,6 +215,10 @@ namespace Bit.iOS.Core.Controllers
                     Special = SpecialCell.Switch.On,
                     MinSpecial = MinSpecialCell.Value,
                     MinNumber = MinNumbersCell.Value,
+                    NumWords = NumWordsCell.Value,
+                    WordSeparator = WordSeparatorCell.TextField.Text,
+                    Capitalize = CapitalizeCell.Switch.On,
+                    IncludeNumber = IncludeNumberCell.Switch.On
                 });
         }
 
@@ -203,31 +250,59 @@ namespace Bit.iOS.Core.Controllers
 
                 if (indexPath.Row == 0)
                 {
-                    return _controller.LengthCell;
+                    return _controller.TypePickerCell;
                 }
-                else if (indexPath.Row == 1)
+
+                if (_controller._passType == "password")
                 {
-                    return _controller.UppercaseCell;
+
+                    if (indexPath.Row == 1)
+                    {
+                        return _controller.LengthCell;
+                    }
+                    else if (indexPath.Row == 2)
+                    {
+                        return _controller.UppercaseCell;
+                    }
+                    else if (indexPath.Row == 3)
+                    {
+                        return _controller.LowercaseCell;
+                    }
+                    else if (indexPath.Row == 4)
+                    {
+                        return _controller.NumbersCell;
+                    }
+                    else if (indexPath.Row == 5)
+                    {
+                        return _controller.SpecialCell;
+                    }
+                    else if (indexPath.Row == 6)
+                    {
+                        return _controller.MinNumbersCell;
+                    }
+                    else if (indexPath.Row == 7)
+                    {
+                        return _controller.MinSpecialCell;
+                    }
                 }
-                else if (indexPath.Row == 2)
+                else
                 {
-                    return _controller.LowercaseCell;
-                }
-                else if (indexPath.Row == 3)
-                {
-                    return _controller.NumbersCell;
-                }
-                else if (indexPath.Row == 4)
-                {
-                    return _controller.SpecialCell;
-                }
-                else if (indexPath.Row == 5)
-                {
-                    return _controller.MinNumbersCell;
-                }
-                else if (indexPath.Row == 6)
-                {
-                    return _controller.MinSpecialCell;
+                    if (indexPath.Row == 1)
+                    {
+                        return _controller.NumWordsCell;
+                    }
+                    else if (indexPath.Row == 2)
+                    {
+                        return _controller.WordSeparatorCell;
+                    }
+                    else if (indexPath.Row == 3)
+                    {
+                        return _controller.CapitalizeCell;
+                    }
+                    else if (indexPath.Row == 4)
+                    {
+                        return _controller.IncludeNumberCell;
+                    }
                 }
 
                 return new ExtendedUITableViewCell();

--- a/src/iOS.Core/Views/FormEntryTableViewCell.cs
+++ b/src/iOS.Core/Views/FormEntryTableViewCell.cs
@@ -69,7 +69,13 @@ namespace Bit.iOS.Core.Views
                     ContentView.AddConstraint(
                         NSLayoutConstraint.Create(TextView, NSLayoutAttribute.Height, NSLayoutRelation.Equal, null, NSLayoutAttribute.NoAttribute, 1f, height.Value));
                 }
+
+                TextView.Changed += (object sender, EventArgs e) =>
+                {
+                    ValueChanged?.Invoke(sender, e);
+                };
             }
+
             else
             {
                 TextField = new UITextField
@@ -116,6 +122,11 @@ namespace Bit.iOS.Core.Views
                     ContentView.AddConstraint(
                         NSLayoutConstraint.Create(TextField, NSLayoutAttribute.Height, NSLayoutRelation.Equal, null, NSLayoutAttribute.NoAttribute, 1f, height.Value));
                 }
+
+                TextField.AddTarget((object sender, EventArgs e) =>
+                {
+                    ValueChanged?.Invoke(sender, e);
+                }, UIControlEvent.EditingChanged);
             }
 
             if (labelName != null && !useLabelAsPlaceholder)
@@ -131,6 +142,7 @@ namespace Bit.iOS.Core.Views
         public UILabel Label { get; set; }
         public UITextField TextField { get; set; }
         public UITextView TextView { get; set; }
+        public event EventHandler ValueChanged;
 
         public void Select()
         {

--- a/src/iOS.Core/Views/FormEntryTableViewCell.cs
+++ b/src/iOS.Core/Views/FormEntryTableViewCell.cs
@@ -11,7 +11,8 @@ namespace Bit.iOS.Core.Views
             string labelName = null,
             bool useTextView = false,
             nfloat? height = null,
-            bool useLabelAsPlaceholder = false)
+            bool useLabelAsPlaceholder = false,
+            float leadingConstant = 15f)
             : base(UITableViewCellStyle.Default, nameof(FormEntryTableViewCell))
         {
             var descriptor = UIFontDescriptor.PreferredBody;
@@ -48,7 +49,7 @@ namespace Bit.iOS.Core.Views
 
                 ContentView.Add(TextView);
                 ContentView.AddConstraints(new NSLayoutConstraint[] {
-                    NSLayoutConstraint.Create(TextView, NSLayoutAttribute.Leading, NSLayoutRelation.Equal, ContentView, NSLayoutAttribute.Leading, 1f, 15f),
+                    NSLayoutConstraint.Create(TextView, NSLayoutAttribute.Leading, NSLayoutRelation.Equal, ContentView, NSLayoutAttribute.Leading, 1f, leadingConstant),
                     NSLayoutConstraint.Create(ContentView, NSLayoutAttribute.Trailing, NSLayoutRelation.Equal, TextView, NSLayoutAttribute.Trailing, 1f, 15f),
                     NSLayoutConstraint.Create(ContentView, NSLayoutAttribute.Bottom, NSLayoutRelation.Equal, TextView, NSLayoutAttribute.Bottom, 1f, 10f)
                 });
@@ -101,7 +102,7 @@ namespace Bit.iOS.Core.Views
 
                 ContentView.Add(TextField);
                 ContentView.AddConstraints(new NSLayoutConstraint[] {
-                    NSLayoutConstraint.Create(TextField, NSLayoutAttribute.Leading, NSLayoutRelation.Equal, ContentView, NSLayoutAttribute.Leading, 1f, 15f),
+                    NSLayoutConstraint.Create(TextField, NSLayoutAttribute.Leading, NSLayoutRelation.Equal, ContentView, NSLayoutAttribute.Leading, 1f, leadingConstant),
                     NSLayoutConstraint.Create(ContentView, NSLayoutAttribute.Trailing, NSLayoutRelation.Equal, TextField, NSLayoutAttribute.Trailing, 1f, 15f),
                     NSLayoutConstraint.Create(ContentView, NSLayoutAttribute.Bottom, NSLayoutRelation.Equal, TextField, NSLayoutAttribute.Bottom, 1f, 10f)
                 });
@@ -132,7 +133,7 @@ namespace Bit.iOS.Core.Views
             if (labelName != null && !useLabelAsPlaceholder)
             {
                 ContentView.AddConstraints(new NSLayoutConstraint[] {
-                    NSLayoutConstraint.Create(Label, NSLayoutAttribute.Leading, NSLayoutRelation.Equal, ContentView, NSLayoutAttribute.Leading, 1f, 15f),
+                    NSLayoutConstraint.Create(Label, NSLayoutAttribute.Leading, NSLayoutRelation.Equal, ContentView, NSLayoutAttribute.Leading, 1f, leadingConstant),
                     NSLayoutConstraint.Create(Label, NSLayoutAttribute.Top, NSLayoutRelation.Equal, ContentView, NSLayoutAttribute.Top, 1f, 10f),
                     NSLayoutConstraint.Create(ContentView, NSLayoutAttribute.Trailing, NSLayoutRelation.Equal, Label, NSLayoutAttribute.Trailing, 1f, 15f)
                 });

--- a/src/iOS.Core/Views/PickerTableViewCell.cs
+++ b/src/iOS.Core/Views/PickerTableViewCell.cs
@@ -94,6 +94,8 @@ namespace Bit.iOS.Core.Views
         public UILabel Label { get; set; }
         public UIPickerView Picker { get; set; } = new UIPickerView();
 
+        public event EventHandler ValueChanged;
+
         public List<string> Items
         {
             get { return _items; }
@@ -199,6 +201,7 @@ namespace Bit.iOS.Core.Views
                 }
 
                 _cell.UpdatePickerFromModel(this);
+                _cell.ValueChanged?.Invoke(this, null);
             }
         }
     }


### PR DESCRIPTION
## Objective

Fix #620: the iOS autofill and extension password generator does not give the user the options to generate a passphrase.

Edit: I also noticed that the "Avoid ambiguous characters" switch was missing when generating a password, so I added that control as well.

## Code changes

- add required controls and logic to `iOS.Core/Controllers/PasswordGeneratorViewController.cs`.
- add some event handlers to `FormEntryTableViewCell` and `PickerTableViewCell` so that we can regenerate the password when their value changes
- let developer specify a custom indentation for `FormEntryTableViewCell` objects - this is required to line it up with the other controls (not sure if there is a better way of doing this)

## Screenshots
New passphrase controls:
<img src="https://user-images.githubusercontent.com/31796059/105260837-3bd8e380-5bda-11eb-8158-cbaadaa88cf8.png" width="50%">

Added "Avoid ambiguous characters" control (note that this now pushes the "Option defaults are set..." text off-screen on an iPhone 12 - not sure if that's worth worrying about):
<img src="https://user-images.githubusercontent.com/31796059/105269488-bfe19a00-5bdf-11eb-8720-ed3231fd1fad.png" width="50%">