### PR TITLE
Fix crash when using Yubikey via usb on Android

### DIFF
--- a/src/Android/MainActivity.cs
+++ b/src/Android/MainActivity.cs
@@ -28,7 +28,8 @@ namespace Bit.Droid
         Theme = "@style/LaunchTheme",
         MainLauncher = true,
         ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation |
-                               ConfigChanges.Keyboard | ConfigChanges.KeyboardHidden)]
+                               ConfigChanges.Keyboard | ConfigChanges.KeyboardHidden |
+                               ConfigChanges.Navigation)]
     [Register("com.x8bit.bitwarden.MainActivity")]
     public class MainActivity : Xamarin.Forms.Platform.Android.FormsAppCompatActivity
     {

--- a/src/Android/MainActivity.cs
+++ b/src/Android/MainActivity.cs
@@ -27,7 +27,8 @@ namespace Bit.Droid
         Icon = "@mipmap/ic_launcher",
         Theme = "@style/LaunchTheme",
         MainLauncher = true,
-        ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation)]
+        ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation |
+                               ConfigChanges.Keyboard | ConfigChanges.KeyboardHidden)]
     [Register("com.x8bit.bitwarden.MainActivity")]
     public class MainActivity : Xamarin.Forms.Platform.Android.FormsAppCompatActivity
     {

--- a/src/App/Pages/Accounts/TwoFactorPage.xaml.cs
+++ b/src/App/Pages/Accounts/TwoFactorPage.xaml.cs
@@ -102,6 +102,9 @@ namespace Bit.App.Pages
                 if (_vm.TotpMethod)
                 {
                     RequestFocus(_totpEntry);
+                } else if (_vm.YubikeyMethod)
+                {
+                    RequestFocus(_yubikeyTokenEntry);
                 }
                 return Task.FromResult(0);
             });


### PR DESCRIPTION
## Objective
Fix #769 and #350. Inserting a Yubikey via USB on the 2FA page will close the 2FA page and revert the user back to the initial welcome page. See example here: https://youtu.be/bKYIPMlMJVU

This actually happens on any of the pre-login pages, but obviously the 2FA page is the biggest concern.

## Cause of issue

Android apps use "Activity" objects to manage views and entry points into the app. Xamarin.Forms implements this by creating a single `MainActivity` to manage the app.

When certain configuration changes occur, Android rapidly destroys and recreates Activities to help them gracefully handle the configuration change. It is the app developer's responsibility to make sure that their Activities handle this lifecycle without loss of data or interruption to the user.

The problem is that plugging in a Yubikey or USB keyboard triggers a configuration change, which in turn destroys and recreats `MainActivity`. We evidently have nothing in place to handle this part of the lifecycle, so the app loses its state and reverts back to the entry page.

## Code changes

* `MainActivity.cs` - add Keyboard and KeyboardHidden events to the list of configuration changes that the app will handle itself without destroying and recreating the Activity. 
  * Note: [the official Android documentation says this is a "last resort" only](https://developer.android.com/guide/topics/manifest/activity-element.html#config) because our app should handle its Activity lifecycle properly. However, we already use this option for configuration changes triggered by screen size and orientation, so I've done the same. It seems to "just work" but we may want to consider handling it properly.

* `TwoFactorPage.xaml.cs` - fixed so that the app will focus on the Yubikey input element when the 2FA page loads. The app will not receive the Yubikey code unless this element has focus.

## Testing considerations

Note: Yubikeys are recognised as USB keyboards.

Expected behaviour:
* given the user is on the Yubikey 2FA page, the user should be able to plug in the Yubikey via USB, press the Yubikey's button, and be logged in without any further action required.
* user should be able to insert a Yubikey or USB keyboard on any page within the app without changing the current page or causing any errors.

If we are adopting the solution proposed above, QA should try triggering various events related to the keyboard on different pages to make sure that they are still properly handled by the app. e.g. plugging/unplugging a physical keyboard, hiding/showing software keyboard, rotating to change the software keyboard dimensions.