### PR TITLE
Fix autofill on Chrome from the iOS Share Extension

### DIFF
--- a/src/iOS.Core/Constants.cs
+++ b/src/iOS.Core/Constants.cs
@@ -28,6 +28,7 @@
         public const string UTTypeAppExtensionFillWebViewAction = "org.appextension.fill-webview-action";
         public const string UTTypeAppExtensionFillBrowserAction = "org.appextension.fill-browser-action";
         public const string UTTypeAppExtensionSetup = "com.8bit.bitwarden.extension-setup";
+        public const string UTTypeAppExtensionUrl = "public.url";
 
         public const string AutofillNeedsIdentityReplacementKey = "autofillNeedsIdentityReplacement";
     }

--- a/src/iOS.Extension/LoadingViewController.cs
+++ b/src/iOS.Extension/LoadingViewController.cs
@@ -49,6 +49,7 @@ namespace Bit.iOS.Extension
                         || ProcessFindLoginProvider(itemProvider)
                         || ProcessFindLoginBrowserProvider(itemProvider, Constants.UTTypeAppExtensionFillBrowserAction)
                         || ProcessFindLoginBrowserProvider(itemProvider, Constants.UTTypeAppExtensionFillWebViewAction)
+                        || ProcessFindLoginBrowserProvider(itemProvider, Constants.UTTypeAppExtensionUrl)
                         || ProcessSaveLoginProvider(itemProvider)
                         || ProcessChangePasswordProvider(itemProvider)
                         || ProcessExtensionSetupProvider(itemProvider))

--- a/src/iOS.Extension/LoginListViewController.cs
+++ b/src/iOS.Extension/LoginListViewController.cs
@@ -49,7 +49,8 @@ namespace Bit.iOS.Extension
         {
             if (Context.ProviderType != Constants.UTTypeAppExtensionFillBrowserAction
                 && Context.ProviderType != Constants.UTTypeAppExtensionFillWebViewAction
-                && Context.ProviderType != UTType.PropertyList)
+                && Context.ProviderType != UTType.PropertyList
+                && Context.ProviderType != Constants.UTTypeAppExtensionUrl)
             {
                 return true;
             }


### PR DESCRIPTION
## Objective
Fix #1035 - when using Chrome, the iOS Share Extension would not find any matching sites and would not autofill.

## Code Changes
As discussed, Chrome does not support our `extension.js` script required for autofill operations. This also meant that the URL was being passed to the extension using an unexpected data type.

We discussed allowing the user to copy/paste their login info instead of autofilling. There is actually already code there to do that! However, my guess is that Chrome changed the `UTType` it was using to send the URL information to the extension, which meant the app wasn't catching the URL info and wasn't activating the copy/paste options.

With that in mind, the changes are actually very minor to get this to work properly:
* `Constants.cs` - add the identifier for the [URL type](https://developer.apple.com/documentation/uniformtypeidentifiers/uttype/3551585-url), i.e. `public.url`
* `LoadingViewController.cs` - add the URL type for processing when the extension loads, so that the URL information is picked up
* `LoginListViewController.cs` - add the URL type to the conditions that will trigger copy/paste instead of autofill.

This fix assumes that any browser that uses the URL type to communicate with the extension suffers from this issue. I did a quick test with Brave (as another Chromium based browser), and it uses a different data type and auto-fills correctly. The risk here would be that we accidentally disable autofill on other browsers that don't actually experience this bug.

## Testing considerations
This change affects Bitwarden's behaviour from the share extension. i.e. open a browser, navigate to a login form, click the iOS share button, and select Bitwarden as the app to share to.

Expected behaviour:
* When sharing from all browsers, Bitwarden should load a list of matching logins for that URL.
* When sharing from Chrome only, Bitwarden should allow the user to copy the username, password and TOTP. This is done by clicking the login item and then selecting the information to copy from the menu. It should not autofill.
* When sharing from any other browser, Bitwarden should allow the user to autofill by clicking the login item.

Please test on a couple of major browsers, especially Chromium-based browsers, to make sure that autofilling is only disabled on browsers that suffer from this issue (which is only Chrome, to my knowledge).