### PR TITLE
UX tweaks for Send

### DIFF
--- a/src/App/Pages/Accounts/TwoFactorPage.xaml
+++ b/src/App/Pages/Accounts/TwoFactorPage.xaml
@@ -50,7 +50,7 @@
                     <StackLayout StyleClass="box-row, box-row-switch">
                         <Label
                             Text="{u:I18n RememberMe}"
-                            StyleClass="box-label, box-label-regular"
+                            StyleClass="box-label-regular"
                             HorizontalOptions="StartAndExpand" />
                         <Switch
                             IsToggled="{Binding Remember}"
@@ -85,7 +85,7 @@
                     <StackLayout StyleClass="box-row, box-row-switch">
                         <Label
                             Text="{u:I18n RememberMe}"
-                            StyleClass="box-label, box-label-regular"
+                            StyleClass="box-label-regular"
                             HorizontalOptions="StartAndExpand" />
                         <Switch
                             IsToggled="{Binding Remember}"
@@ -105,7 +105,7 @@
                     <StackLayout StyleClass="box-row, box-row-switch">
                         <Label
                             Text="{u:I18n RememberMe}"
-                            StyleClass="box-label, box-label-regular"
+                            StyleClass="box-label-regular"
                             HorizontalOptions="StartAndExpand" />
                         <Switch
                             IsToggled="{Binding Remember}"

--- a/src/App/Pages/Generator/GeneratorPage.xaml
+++ b/src/App/Pages/Generator/GeneratorPage.xaml
@@ -98,12 +98,12 @@
                     <StackLayout StyleClass="box-row, box-row-stepper">
                         <Label
                             Text="{u:I18n NumberOfWords}"
-                            StyleClass="box-label, box-label-regular"
+                            StyleClass="box-label-regular"
                             VerticalOptions="FillAndExpand"
                             VerticalTextAlignment="Center" />
                         <Label
                             Text="{Binding NumWords}"
-                            StyleClass="box-label, box-sub-label"
+                            StyleClass="box-sub-label"
                             HorizontalOptions="FillAndExpand"
                             HorizontalTextAlignment="End"
                             VerticalOptions="FillAndExpand"
@@ -128,7 +128,7 @@
                     <StackLayout StyleClass="box-row, box-row-switch">
                         <Label
                             Text="{u:I18n Capitalize}"
-                            StyleClass="box-label, box-label-regular"
+                            StyleClass="box-label-regular"
                             HorizontalOptions="StartAndExpand" />
                         <Switch
                             IsToggled="{Binding Capitalize}"
@@ -141,7 +141,7 @@
                     <StackLayout StyleClass="box-row, box-row-switch">
                         <Label
                             Text="{u:I18n IncludeNumber}"
-                            StyleClass="box-label, box-label-regular"
+                            StyleClass="box-label-regular"
                             HorizontalOptions="StartAndExpand" />
                         <Switch
                             IsToggled="{Binding IncludeNumber}"
@@ -155,11 +155,11 @@
                     <StackLayout StyleClass="box-row, box-row-slider">
                         <Label
                             Text="{u:I18n Length}"
-                            StyleClass="box-label, box-label-regular"
+                            StyleClass="box-label-regular"
                             VerticalOptions="CenterAndExpand" />
                         <Label
                             Text="{Binding Length}"
-                            StyleClass="box-label, box-sub-label"
+                            StyleClass="box-sub-label"
                             WidthRequest="30"
                             VerticalOptions="CenterAndExpand"
                             HorizontalTextAlignment="End" />
@@ -177,7 +177,7 @@
                     <StackLayout StyleClass="box-row, box-row-switch">
                         <Label
                             Text="A-Z"
-                            StyleClass="box-label, box-label-regular"
+                            StyleClass="box-label-regular"
                             HorizontalOptions="StartAndExpand" />
                         <Switch
                             IsToggled="{Binding Uppercase}"
@@ -190,7 +190,7 @@
                     <StackLayout StyleClass="box-row, box-row-switch">
                         <Label
                             Text="a-z"
-                            StyleClass="box-label, box-label-regular"
+                            StyleClass="box-label-regular"
                             HorizontalOptions="StartAndExpand" />
                         <Switch
                             IsToggled="{Binding Lowercase}"
@@ -203,7 +203,7 @@
                     <StackLayout StyleClass="box-row, box-row-switch">
                         <Label
                             Text="0-9"
-                            StyleClass="box-label, box-label-regular"
+                            StyleClass="box-label-regular"
                             HorizontalOptions="StartAndExpand" />
                         <Switch
                             IsToggled="{Binding Number}"
@@ -216,7 +216,7 @@
                     <StackLayout StyleClass="box-row, box-row-switch">
                         <Label
                             Text="!@#$%^&amp;*"
-                            StyleClass="box-label, box-label-regular"
+                            StyleClass="box-label-regular"
                             HorizontalOptions="StartAndExpand" />
                         <Switch
                             IsToggled="{Binding Special}"
@@ -229,12 +229,12 @@
                     <StackLayout StyleClass="box-row, box-row-stepper">
                         <Label
                             Text="{u:I18n MinNumbers}"
-                            StyleClass="box-label, box-label-regular"
+                            StyleClass="box-label-regular"
                             VerticalOptions="FillAndExpand"
                             VerticalTextAlignment="Center" />
                         <Label
                             Text="{Binding MinNumber}"
-                            StyleClass="box-label, box-sub-label"
+                            StyleClass="box-sub-label"
                             HorizontalOptions="FillAndExpand"
                             HorizontalTextAlignment="End"
                             VerticalOptions="FillAndExpand"
@@ -249,12 +249,12 @@
                     <StackLayout StyleClass="box-row, box-row-stepper">
                         <Label
                             Text="{u:I18n MinSpecial}"
-                            StyleClass="box-label, box-label-regular"
+                            StyleClass="box-label-regular"
                             VerticalOptions="FillAndExpand"
                             VerticalTextAlignment="Center" />
                         <Label
                             Text="{Binding MinSpecial}"
-                            StyleClass="box-label, box-sub-label"
+                            StyleClass="box-sub-label"
                             HorizontalOptions="FillAndExpand"
                             HorizontalTextAlignment="End"
                             VerticalOptions="FillAndExpand"
@@ -269,7 +269,7 @@
                     <StackLayout StyleClass="box-row, box-row-switch">
                         <Label
                             Text="{u:I18n AvoidAmbiguousCharacters}"
-                            StyleClass="box-label, box-label-regular"
+                            StyleClass="box-label-regular"
                             HorizontalOptions="StartAndExpand" />
                         <Switch
                             IsToggled="{Binding AvoidAmbiguous}"

--- a/src/App/Pages/Send/SendAddEditPage.xaml
+++ b/src/App/Pages/Send/SendAddEditPage.xaml
@@ -52,7 +52,27 @@
                          IsDestructive="True"
                          x:Name="_deleteItem"
                          x:Key="deleteItem" />
-
+            
+            <Style x:Key="segmentedButtonBase" TargetType="Button">
+                <Setter Property="HeightRequest" Value="{Binding SegmentedButtonHeight}" />              
+                <Setter Property="FontSize" Value="{Binding SegmentedButtonFontSize}" />
+                <Setter Property="CornerRadius" Value="0" />
+            </Style>
+            <Style x:Key="segmentedButtonNormal" BaseResourceKey="segmentedButtonBase" TargetType="Button">
+                <Setter Property="TextColor" Value="{StaticResource PrimaryColor}" />
+                <Setter Property="FontAttributes" Value="None" />
+                <Setter Property="BackgroundColor" Value="Transparent" />
+                <Setter Property="BorderColor" Value="{StaticResource PrimaryColor}" />
+                <Setter Property="BorderWidth" Value="1" />
+                
+            </Style>
+            <Style x:Key="segmentedButtonDisabled" BaseResourceKey="segmentedButtonBase" TargetType="Button">
+                <Setter Property="TextColor" Value="{StaticResource TitleTextColor}" />
+                <Setter Property="FontAttributes" Value="Bold" />
+                <Setter Property="BackgroundColor" Value="{StaticResource PrimaryColor}" />
+                <Setter Property="BorderWidth" Value="0" />
+            </Style>
+            
             <ScrollView x:Key="scrollView" x:Name="_scrollView">
                 <StackLayout Spacing="20">
                     <StackLayout StyleClass="box">
@@ -61,11 +81,58 @@
                             <Label
                                 Text="{u:I18n Type}"
                                 StyleClass="box-label" />
-                            <Picker
-                                x:Name="_typePicker"
-                                ItemsSource="{Binding TypeOptions, Mode=OneTime}"
-                                SelectedIndex="{Binding TypeSelectedIndex}"
-                                StyleClass="box-value" />
+                            <Grid RowSpacing="0" ColumnSpacing="0" Margin="{Binding SegmentedButtonMargins}">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*" />
+                                    <ColumnDefinition Width="*" />
+                                </Grid.ColumnDefinitions>
+                                <Button Text="{u:I18n TypeText}" 
+                                        IsEnabled="{Binding IsFile}"
+                                        Clicked="TextType_Clicked"
+                                        AutomationProperties.IsInAccessibleTree="True"
+                                        AutomationProperties.Name="{u:I18n Text}"
+                                        Grid.Column="0">
+                                    <VisualStateManager.VisualStateGroups>
+                                        <VisualStateGroup x:Name="CommonStates">
+                                            <VisualState x:Name="Normal">
+                                                <VisualState.Setters>
+                                                    <Setter Property="Style" 
+                                                            Value="{StaticResource segmentedButtonNormal}" />
+                                                </VisualState.Setters>
+                                            </VisualState>
+                                            <VisualState x:Name="Disabled">
+                                                <VisualState.Setters>
+                                                    <Setter Property="Style" 
+                                                            Value="{StaticResource segmentedButtonDisabled}" />
+                                                 </VisualState.Setters>
+                                            </VisualState>
+                                        </VisualStateGroup>
+                                    </VisualStateManager.VisualStateGroups>
+                                </Button>
+                                <Button Text="{u:I18n TypeFile}" 
+                                        IsEnabled="{Binding IsText}"
+                                        Clicked="FileType_Clicked"
+                                        AutomationProperties.IsInAccessibleTree="True"
+                                        AutomationProperties.Name="{u:I18n File}"
+                                        Grid.Column="1">
+                                    <VisualStateManager.VisualStateGroups>
+                                        <VisualStateGroup x:Name="CommonStates">
+                                            <VisualState x:Name="Normal">
+                                                <VisualState.Setters>
+                                                    <Setter Property="Style" 
+                                                            Value="{StaticResource segmentedButtonNormal}" />
+                                                </VisualState.Setters>
+                                            </VisualState>
+                                            <VisualState x:Name="Disabled">
+                                                <VisualState.Setters>
+                                                    <Setter Property="Style" 
+                                                            Value="{StaticResource segmentedButtonDisabled}" />
+                                                 </VisualState.Setters>
+                                            </VisualState>
+                                        </VisualStateGroup>
+                                    </VisualStateManager.VisualStateGroups>
+                                </Button>
+                            </Grid>
                         </StackLayout>
                         <StackLayout StyleClass="box-row">
                             <Label
@@ -99,7 +166,7 @@
                             <StackLayout StyleClass="box-row, box-row-switch">
                                 <Label
                                     Text="{u:I18n HideTextByDefault}"
-                                    StyleClass="text-sm"
+                                    StyleClass="box-label"
                                     VerticalOptions="Center"
                                     HorizontalOptions="StartAndExpand" />
                                 <Switch
@@ -138,9 +205,11 @@
                                         StyleClass="box-button-row"
                                         Clicked="ChooseFile_Clicked" />
                                 <Label
-                                    Margin="0, 10, 0, 0"
+                                    Margin="0, 5, 0, 0"
                                     Text="{u:I18n MaxFileSize}"
-                                    StyleClass="box-footer-label" />
+                                    StyleClass="text-sm, text-muted"
+                                    HorizontalOptions="FillAndExpand"
+                                    HorizontalTextAlignment="Center" />
                             </StackLayout>
                             <Label
                                 Text="{u:I18n TypeFileInfo}"
@@ -321,7 +390,7 @@
                         <StackLayout StyleClass="box-row, box-row-switch">
                             <Label
                                 Text="{u:I18n DisableSend}"
-                                StyleClass="text-sm"
+                                StyleClass="box-label"
                                 VerticalOptions="Center"
                                 HorizontalOptions="StartAndExpand" />
                             <Switch
@@ -332,7 +401,7 @@
                         <StackLayout StyleClass="box-row, box-row-switch">
                             <Label
                                 Text="{u:I18n ShareOnSave}"
-                                StyleClass="text-sm"
+                                StyleClass="box-label"
                                 VerticalOptions="Center"
                                 HorizontalOptions="StartAndExpand" />
                             <Switch

--- a/src/App/Pages/Send/SendAddEditPage.xaml
+++ b/src/App/Pages/Send/SendAddEditPage.xaml
@@ -75,6 +75,10 @@
                                 x:Name="_nameEntry"
                                 Text="{Binding Send.Name}"
                                 StyleClass="box-value" />
+                            <Label
+                                Text="{u:I18n NameInfo}"
+                                StyleClass="box-label"
+                                Margin="0,5,0,0" />
                         </StackLayout>
                         <StackLayout StyleClass="box-row"
                                      IsVisible="{Binding IsText}">
@@ -88,10 +92,14 @@
                                 StyleClass="box-value"
                                 Margin="{Binding EditorMargins}" />
                             <BoxView StyleClass="box-row-separator" IsVisible="{Binding ShowEditorSeparators}" />
+                            <Label
+                                Text="{u:I18n TypeTextInfo}"
+                                StyleClass="box-label"
+                                Margin="0,5,0,0" />
                             <StackLayout StyleClass="box-row, box-row-switch">
                                 <Label
                                     Text="{u:I18n HideTextByDefault}"
-                                    StyleClass="box-label"
+                                    StyleClass="text-sm"
                                     VerticalOptions="Center"
                                     HorizontalOptions="StartAndExpand" />
                                 <Switch
@@ -134,6 +142,10 @@
                                     Text="{u:I18n MaxFileSize}"
                                     StyleClass="box-footer-label" />
                             </StackLayout>
+                            <Label
+                                Text="{u:I18n TypeFileInfo}"
+                                StyleClass="box-label"
+                                Margin="0,5,0,0" />
                         </StackLayout>
                         <StackLayout StyleClass="box-row-header">
                             <Label Text="{u:I18n Options, Header=True}"
@@ -309,7 +321,7 @@
                         <StackLayout StyleClass="box-row, box-row-switch">
                             <Label
                                 Text="{u:I18n DisableSend}"
-                                StyleClass="box-label"
+                                StyleClass="text-sm"
                                 VerticalOptions="Center"
                                 HorizontalOptions="StartAndExpand" />
                             <Switch
@@ -320,7 +332,7 @@
                         <StackLayout StyleClass="box-row, box-row-switch">
                             <Label
                                 Text="{u:I18n ShareOnSave}"
-                                StyleClass="box-label"
+                                StyleClass="text-sm"
                                 VerticalOptions="Center"
                                 HorizontalOptions="StartAndExpand" />
                             <Switch

--- a/src/App/Pages/Send/SendAddEditPage.xaml
+++ b/src/App/Pages/Send/SendAddEditPage.xaml
@@ -118,6 +118,8 @@
                                         AutomationProperties.Name="{u:I18n File}"
                                         Grid.Column="1">
                                     <VisualStateManager.VisualStateGroups>
+                                        <!-- Rider users, if the x:Name values below are red, it's a known issue: -->
+                                        <!-- https://youtrack.jetbrains.com/issue/RSRP-479388 -->
                                         <VisualStateGroup x:Name="CommonStates">
                                             <VisualState x:Name="Normal">
                                                 <VisualState.Setters>
@@ -146,7 +148,7 @@
                                 StyleClass="box-value" />
                             <Label
                                 Text="{u:I18n NameInfo}"
-                                StyleClass="box-label"
+                                StyleClass="box-footer-label"
                                 Margin="0,5,0,0" />
                         </StackLayout>
                         <StackLayout StyleClass="box-row"
@@ -163,12 +165,12 @@
                             <BoxView StyleClass="box-row-separator" IsVisible="{Binding ShowEditorSeparators}" />
                             <Label
                                 Text="{u:I18n TypeTextInfo}"
-                                StyleClass="box-label"
-                                Margin="0,5,0,0" />
+                                StyleClass="box-footer-label"
+                                Margin="0,5,0,10" />
                             <StackLayout StyleClass="box-row, box-row-switch">
                                 <Label
                                     Text="{u:I18n HideTextByDefault}"
-                                    StyleClass="box-label"
+                                    StyleClass="box-label-regular"
                                     VerticalOptions="Center"
                                     HorizontalOptions="StartAndExpand" />
                                 <Switch
@@ -215,14 +217,14 @@
                             </StackLayout>
                             <Label
                                 Text="{u:I18n TypeFileInfo}"
-                                StyleClass="box-label"
+                                StyleClass="box-footer-label"
                                 Margin="0,5,0,0" />
                         </StackLayout>
                         <StackLayout StyleClass="box-row-header">
                             <Label Text="{u:I18n Options, Header=True}"
                                    StyleClass="box-header, box-header-platform" />
                         </StackLayout>
-                        <StackLayout StyleClass="box-row">
+                        <StackLayout StyleClass="box-row" Margin="0,10,0,0">
                             <Label
                                 Text="{u:I18n DeletionDate}"
                                 StyleClass="box-label" />
@@ -256,10 +258,10 @@
                             </Grid>
                             <Label
                                 Text="{u:I18n DeletionDateInfo}"
-                                StyleClass="box-label"
+                                StyleClass="box-footer-label"
                                 Margin="0,5,0,0" />
                         </StackLayout>
-                        <StackLayout StyleClass="box-row">
+                        <StackLayout StyleClass="box-row" Margin="0,5,0,0">
                             <Label
                                 Text="{u:I18n ExpirationDate}"
                                 StyleClass="box-label" />
@@ -296,20 +298,19 @@
                             <StackLayout Orientation="Horizontal" Margin="0,5,0,0">
                                 <Label
                                     Text="{u:I18n ExpirationDateInfo}"
-                                    StyleClass="box-label"
-                                    HorizontalOptions="StartAndExpand"
-                                    VerticalOptions="Center" />
+                                    StyleClass="box-footer-label"
+                                    HorizontalOptions="StartAndExpand" />
                                 <Button
                                     Text="{u:I18n Clear}"
                                     IsVisible="{Binding EditMode}"
                                     WidthRequest="110"
+                                    HeightRequest="{Binding SegmentedButtonHeight}"
+                                    FontSize="{Binding SegmentedButtonFontSize}"
                                     StyleClass="box-row-button"
                                     Clicked="ClearExpirationDate_Clicked" />
                             </StackLayout>
                         </StackLayout>
-                        <BoxView StyleClass="box-row-separator"
-                                 Margin="0, 5, 0, 0" />
-                        <StackLayout StyleClass="box-row">
+                        <StackLayout StyleClass="box-row" Margin="0,5,0,0">
                             <Label
                                 Text="{u:I18n MaximumAccessCount}"
                                 StyleClass="box-label" />
@@ -329,25 +330,26 @@
                             </StackLayout>
                             <Label
                                 Text="{u:I18n MaximumAccessCountInfo}"
-                                StyleClass="box-label"
-                                Margin="0,5" />
+                                StyleClass="box-footer-label" />
                             <StackLayout
                                 IsVisible="{Binding EditMode}"
                                 StyleClass="box-row"
                                 Orientation="Horizontal">
                                 <Label
                                     Text="{u:I18n CurrentAccessCount}"
-                                    StyleClass="box-label"
-                                    HorizontalOptions="StartAndExpand"
+                                    StyleClass="box-footer-label"
+                                    VerticalTextAlignment="Center" />
+                                <Label
+                                    Text=": "
+                                    StyleClass="box-footer-label"
                                     VerticalTextAlignment="Center" />
                                 <Label
                                     Text="{Binding Send.AccessCount, Mode=OneWay}"
                                     StyleClass="box-label"
-                                    HorizontalOptions="End" />
+                                    VerticalTextAlignment="Center" />
                             </StackLayout>
                         </StackLayout>
-                        <BoxView StyleClass="box-row-separator" />
-                        <StackLayout StyleClass="box-row" Margin="0,5">
+                        <StackLayout StyleClass="box-row" Margin="0,5,0,0">
                             <Label
                                 Text="{u:I18n NewPassword}"
                                 StyleClass="box-label" />
@@ -369,11 +371,10 @@
                             </StackLayout>
                             <Label
                                 Text="{u:I18n PasswordInfo}"
-                                StyleClass="box-label"
+                                StyleClass="box-footer-label"
                                 Margin="0,5,0,0" />
                         </StackLayout>
-                        <BoxView StyleClass="box-row-separator" />
-                        <StackLayout StyleClass="box-row" Margin="0,5">
+                        <StackLayout StyleClass="box-row" Margin="0,5,0,0">
                             <Label
                                 Text="{u:I18n Notes}"
                                 StyleClass="box-label" />
@@ -385,14 +386,13 @@
                             <BoxView StyleClass="box-row-separator" IsVisible="{Binding ShowEditorSeparators}" />
                             <Label
                                 Text="{u:I18n NotesInfo}"
-                                StyleClass="box-label"
+                                StyleClass="box-footer-label"
                                 Margin="0,5,0,0" />
                         </StackLayout>
-                        <BoxView StyleClass="box-row-separator" />
-                        <StackLayout StyleClass="box-row, box-row-switch">
+                        <StackLayout StyleClass="box-row, box-row-switch" Margin="0,5,0,0">
                             <Label
                                 Text="{u:I18n DisableSend}"
-                                StyleClass="box-label"
+                                StyleClass="box-label-regular"
                                 VerticalOptions="Center"
                                 HorizontalOptions="StartAndExpand" />
                             <Switch
@@ -403,7 +403,7 @@
                         <StackLayout StyleClass="box-row, box-row-switch">
                             <Label
                                 Text="{u:I18n ShareOnSave}"
-                                StyleClass="box-label"
+                                StyleClass="box-label-regular"
                                 VerticalOptions="Center"
                                 HorizontalOptions="StartAndExpand" />
                             <Switch
@@ -411,7 +411,6 @@
                                 HorizontalOptions="End"
                                 Margin="10,0,0,0" />
                         </StackLayout>
-                        <BoxView StyleClass="box-row-separator" />
 
                     </StackLayout>
                 </StackLayout>

--- a/src/App/Pages/Send/SendAddEditPage.xaml
+++ b/src/App/Pages/Send/SendAddEditPage.xaml
@@ -52,9 +52,9 @@
                          IsDestructive="True"
                          x:Name="_deleteItem"
                          x:Key="deleteItem" />
-            
+
             <Style x:Key="segmentedButtonBase" TargetType="Button">
-                <Setter Property="HeightRequest" Value="{Binding SegmentedButtonHeight}" />              
+                <Setter Property="HeightRequest" Value="{Binding SegmentedButtonHeight}" />
                 <Setter Property="FontSize" Value="{Binding SegmentedButtonFontSize}" />
                 <Setter Property="CornerRadius" Value="0" />
             </Style>
@@ -64,7 +64,7 @@
                 <Setter Property="BackgroundColor" Value="Transparent" />
                 <Setter Property="BorderColor" Value="{StaticResource PrimaryColor}" />
                 <Setter Property="BorderWidth" Value="1" />
-                
+
             </Style>
             <Style x:Key="segmentedButtonDisabled" BaseResourceKey="segmentedButtonBase" TargetType="Button">
                 <Setter Property="TextColor" Value="{StaticResource TitleTextColor}" />
@@ -72,7 +72,7 @@
                 <Setter Property="BackgroundColor" Value="{StaticResource PrimaryColor}" />
                 <Setter Property="BorderWidth" Value="0" />
             </Style>
-            
+
             <ScrollView x:Key="scrollView" x:Name="_scrollView">
                 <StackLayout Spacing="20">
                     <StackLayout StyleClass="box">
@@ -86,7 +86,7 @@
                                     <ColumnDefinition Width="*" />
                                     <ColumnDefinition Width="*" />
                                 </Grid.ColumnDefinitions>
-                                <Button Text="{u:I18n TypeText}" 
+                                <Button Text="{u:I18n TypeText}"
                                         IsEnabled="{Binding IsFile}"
                                         Clicked="TextType_Clicked"
                                         AutomationProperties.IsInAccessibleTree="True"
@@ -96,20 +96,20 @@
                                         <VisualStateGroup x:Name="CommonStates">
                                             <VisualState x:Name="Normal">
                                                 <VisualState.Setters>
-                                                    <Setter Property="Style" 
+                                                    <Setter Property="Style"
                                                             Value="{StaticResource segmentedButtonNormal}" />
                                                 </VisualState.Setters>
                                             </VisualState>
                                             <VisualState x:Name="Disabled">
                                                 <VisualState.Setters>
-                                                    <Setter Property="Style" 
+                                                    <Setter Property="Style"
                                                             Value="{StaticResource segmentedButtonDisabled}" />
-                                                 </VisualState.Setters>
+                                                </VisualState.Setters>
                                             </VisualState>
                                         </VisualStateGroup>
                                     </VisualStateManager.VisualStateGroups>
                                 </Button>
-                                <Button Text="{u:I18n TypeFile}" 
+                                <Button Text="{u:I18n TypeFile}"
                                         IsEnabled="{Binding IsText}"
                                         Clicked="FileType_Clicked"
                                         AutomationProperties.IsInAccessibleTree="True"
@@ -119,15 +119,15 @@
                                         <VisualStateGroup x:Name="CommonStates">
                                             <VisualState x:Name="Normal">
                                                 <VisualState.Setters>
-                                                    <Setter Property="Style" 
+                                                    <Setter Property="Style"
                                                             Value="{StaticResource segmentedButtonNormal}" />
                                                 </VisualState.Setters>
                                             </VisualState>
                                             <VisualState x:Name="Disabled">
                                                 <VisualState.Setters>
-                                                    <Setter Property="Style" 
+                                                    <Setter Property="Style"
                                                             Value="{StaticResource segmentedButtonDisabled}" />
-                                                 </VisualState.Setters>
+                                                </VisualState.Setters>
                                             </VisualState>
                                         </VisualStateGroup>
                                     </VisualStateManager.VisualStateGroups>

--- a/src/App/Pages/Send/SendAddEditPage.xaml
+++ b/src/App/Pages/Send/SendAddEditPage.xaml
@@ -93,6 +93,8 @@
                                         AutomationProperties.Name="{u:I18n Text}"
                                         Grid.Column="0">
                                     <VisualStateManager.VisualStateGroups>
+                                        <!-- Rider users, if the x:Name values below are red, it's a known issue: -->
+                                        <!-- https://youtrack.jetbrains.com/issue/RSRP-479388 -->
                                         <VisualStateGroup x:Name="CommonStates">
                                             <VisualState x:Name="Normal">
                                                 <VisualState.Setters>

--- a/src/App/Pages/Send/SendAddEditPage.xaml.cs
+++ b/src/App/Pages/Send/SendAddEditPage.xaml.cs
@@ -28,6 +28,7 @@ namespace Bit.App.Pages
             _vm.SendId = sendId;
             _vm.Type = type;
             _vm.Init();
+            SetActivityIndicator();
             if (Device.RuntimePlatform == Device.Android)
             {
                 if (_vm.EditMode)
@@ -37,6 +38,9 @@ namespace Bit.App.Pages
                     ToolbarItems.Add(_shareLink);
                     ToolbarItems.Add(_deleteItem);
                 }
+                _vm.SegmentedButtonHeight = 36;
+                _vm.SegmentedButtonFontSize = 13;
+                _vm.SegmentedButtonMargins = new Thickness(0, 10, 0, 0);
                 _vm.EditorMargins = new Thickness(0, 5, 0, 0);
             }
             else if (Device.RuntimePlatform == Device.iOS)
@@ -46,14 +50,15 @@ namespace Bit.App.Pages
                 {
                     ToolbarItems.Add(_moreItem);
                 }
+                _vm.SegmentedButtonHeight = 30;
+                _vm.SegmentedButtonFontSize = 15;
+                _vm.SegmentedButtonMargins = new Thickness(0, 5, 0, 0);
                 _vm.ShowEditorSeparators = true;
                 _vm.EditorMargins = new Thickness(0, 10, 0, 5);
-                _typePicker.On<iOS>().SetUpdateMode(UpdateMode.WhenFinished);
                 _deletionDateTypePicker.On<iOS>().SetUpdateMode(UpdateMode.WhenFinished);
                 _expirationDateTypePicker.On<iOS>().SetUpdateMode(UpdateMode.WhenFinished);
             }
 
-            _typePicker.ItemDisplayBinding = new Binding("Key");
             _deletionDateTypePicker.ItemDisplayBinding = new Binding("Key");
             _expirationDateTypePicker.ItemDisplayBinding = new Binding("Key");
 
@@ -101,6 +106,16 @@ namespace Bit.App.Pages
             {
                 _broadcasterService.Unsubscribe(nameof(SendAddEditPage));
             }
+        }
+
+        private void TextType_Clicked(object sender, EventArgs eventArgs)
+        {
+            _vm.TypeChanged(SendType.Text);
+        }
+        
+        private void FileType_Clicked(object sender, EventArgs eventArgs)
+        {
+            _vm.TypeChanged(SendType.File);
         }
 
         private void OnMaxAccessCountTextChanged(object sender, TextChangedEventArgs e)

--- a/src/App/Pages/Send/SendAddEditPageViewModel.cs
+++ b/src/App/Pages/Send/SendAddEditPageViewModel.cs
@@ -21,10 +21,7 @@ namespace Bit.App.Pages
         private readonly ISendService _sendService;
         private bool _canAccessPremium;
         private SendView _send;
-        private bool _showEditorSeparators;
-        private Thickness _editorMargins;
         private bool _showPassword;
-        private int _typeSelectedIndex;
         private int _deletionDateTypeSelectedIndex;
         private int _expirationDateTypeSelectedIndex;
         private DateTime _deletionDate;
@@ -76,6 +73,11 @@ namespace Bit.App.Pages
 
         public Command TogglePasswordCommand { get; set; }
         public string SendId { get; set; }
+        public int SegmentedButtonHeight { get; set; }
+        public int SegmentedButtonFontSize { get; set; }
+        public Thickness SegmentedButtonMargins { get; set; }
+        public bool ShowEditorSeparators { get; set; }
+        public Thickness EditorMargins { get; set; }
         public SendType? Type { get; set; }
         public string FileName { get; set; }
         public byte[] FileData { get; set; }
@@ -84,17 +86,6 @@ namespace Bit.App.Pages
         public List<KeyValuePair<string, SendType>> TypeOptions { get; }
         public List<KeyValuePair<string, string>> DeletionTypeOptions { get; }
         public List<KeyValuePair<string, string>> ExpirationTypeOptions { get; }
-        public int TypeSelectedIndex
-        {
-            get => _typeSelectedIndex;
-            set
-            {
-                if (SetProperty(ref _typeSelectedIndex, value))
-                {
-                    TypeChanged();
-                }
-            }
-        }
         public int DeletionDateTypeSelectedIndex
         {
             get => _deletionDateTypeSelectedIndex;
@@ -165,16 +156,6 @@ namespace Bit.App.Pages
             get => _send;
             set => SetProperty(ref _send, value, additionalPropertyNames: _additionalSendProperties);
         }
-        public bool ShowEditorSeparators
-        {
-            get => _showEditorSeparators;
-            set => SetProperty(ref _showEditorSeparators, value);
-        }
-        public Thickness EditorMargins
-        {
-            get => _editorMargins;
-            set => SetProperty(ref _editorMargins, value);
-        }
         public bool ShowPassword
         {
             get => _showPassword;
@@ -223,7 +204,6 @@ namespace Bit.App.Pages
                     ExpirationDateTypeSelectedIndex = 0;
                 }
 
-                TypeSelectedIndex = TypeOptions.FindIndex(k => k.Value == Send.Type);
                 MaxAccessCount = Send.MaxAccessCount;
                 _isOverridingPickers = true;
                 DeletionDate = Send.DeletionDate.ToLocalTime();
@@ -389,16 +369,16 @@ namespace Bit.App.Pages
             return await AppHelpers.DeleteSendAsync(SendId);
         }
 
-        private async void TypeChanged()
+        public async void TypeChanged(SendType type)
         {
-            if (Send != null && TypeSelectedIndex > -1)
+            if (Send != null)
             {
-                if (!EditMode && TypeOptions[TypeSelectedIndex].Value == SendType.File && !_canAccessPremium)
+                if (!EditMode && type == SendType.File && !_canAccessPremium)
                 {
                     await _platformUtilsService.ShowDialogAsync(AppResources.PremiumRequired);
-                    TypeSelectedIndex = 0;
+                    type = SendType.Text;
                 }
-                Send.Type = TypeOptions[TypeSelectedIndex].Value;
+                Send.Type = type;
                 TriggerPropertyChanged(nameof(Send), _additionalSendProperties);
             }
         }

--- a/src/App/Pages/Settings/AutofillServicesPage.xaml
+++ b/src/App/Pages/Settings/AutofillServicesPage.xaml
@@ -19,7 +19,7 @@
                 <StackLayout StyleClass="box-row, box-row-switch">
                     <Label
                         Text="{u:I18n AutofillService}"
-                        StyleClass="box-label, box-label-regular"
+                        StyleClass="box-label-regular"
                         HorizontalOptions="StartAndExpand" />
                     <RelativeLayout HorizontalOptions="End">
                         <Switch
@@ -46,7 +46,7 @@
                 <StackLayout StyleClass="box-row, box-row-switch">
                     <Label
                         Text="{u:I18n InlineAutofill}"
-                        StyleClass="box-label, box-label-regular"
+                        StyleClass="box-label-regular"
                         IsEnabled="{Binding InlineAutofillEnabled}"
                         HorizontalOptions="StartAndExpand" />
                     <RelativeLayout HorizontalOptions="End">
@@ -75,7 +75,7 @@
                 <StackLayout StyleClass="box-row, box-row-switch">
                     <Label
                         Text="{u:I18n Accessibility}"
-                        StyleClass="box-label, box-label-regular"
+                        StyleClass="box-label-regular"
                         HorizontalOptions="StartAndExpand" />
                     <RelativeLayout HorizontalOptions="End">
                         <Switch
@@ -102,7 +102,7 @@
                 <StackLayout StyleClass="box-row, box-row-switch">
                     <Label
                         Text="{u:I18n DrawOver}"
-                        StyleClass="box-label, box-label-regular"
+                        StyleClass="box-label-regular"
                         IsEnabled="{Binding DrawOverEnabled}"
                         HorizontalOptions="StartAndExpand" />
                     <RelativeLayout HorizontalOptions="End">

--- a/src/App/Pages/Settings/OptionsPage.xaml
+++ b/src/App/Pages/Settings/OptionsPage.xaml
@@ -68,7 +68,7 @@
                 <StackLayout StyleClass="box-row, box-row-switch">
                     <Label
                         Text="{u:I18n DisableAutoTotpCopy}"
-                        StyleClass="box-label, box-label-regular"
+                        StyleClass="box-label-regular"
                         HorizontalOptions="StartAndExpand" />
                     <Switch
                         IsToggled="{Binding DisableAutoTotpCopy}"
@@ -83,7 +83,7 @@
                 <StackLayout StyleClass="box-row, box-row-switch">
                     <Label
                         Text="{u:I18n DisableWebsiteIcons}"
-                        StyleClass="box-label, box-label-regular"
+                        StyleClass="box-label-regular"
                         HorizontalOptions="StartAndExpand" />
                     <Switch
                         IsToggled="{Binding DisableFavicon}"
@@ -102,7 +102,7 @@
                 <StackLayout StyleClass="box-row, box-row-switch">
                     <Label
                         Text="{u:I18n DisableSavePrompt}"
-                        StyleClass="box-label, box-label-regular"
+                        StyleClass="box-label-regular"
                         HorizontalOptions="StartAndExpand" />
                     <Switch
                         IsToggled="{Binding AutofillDisableSavePrompt}"

--- a/src/App/Pages/Settings/SyncPage.xaml
+++ b/src/App/Pages/Settings/SyncPage.xaml
@@ -22,7 +22,7 @@
                 <StackLayout StyleClass="box-row, box-row-switch">
                     <Label
                         Text="{u:I18n EnableSyncOnRefresh}"
-                        StyleClass="box-label, box-label-regular"
+                        StyleClass="box-label-regular"
                         HorizontalOptions="StartAndExpand" />
                     <Switch
                         IsToggled="{Binding EnableSyncOnRefresh}"

--- a/src/App/Pages/Vault/AddEditPage.xaml
+++ b/src/App/Pages/Vault/AddEditPage.xaml
@@ -523,7 +523,7 @@
                 <StackLayout StyleClass="box-row, box-row-switch">
                     <Label
                         Text="{u:I18n Favorite}"
-                        StyleClass="box-label, box-label-regular"
+                        StyleClass="box-label-regular"
                         HorizontalOptions="StartAndExpand" />
                     <Switch
                         IsToggled="{Binding Cipher.Favorite}"
@@ -674,7 +674,7 @@
                                 <StackLayout StyleClass="box-row, box-row-switch">
                                     <Label
                                         Text="{Binding Collection.Name}"
-                                        StyleClass="box-label, box-label-regular"
+                                        StyleClass="box-label-regular"
                                         HorizontalOptions="StartAndExpand" />
                                     <Switch
                                         IsToggled="{Binding Checked}"

--- a/src/App/Pages/Vault/CollectionsPage.xaml
+++ b/src/App/Pages/Vault/CollectionsPage.xaml
@@ -39,7 +39,7 @@
                                 <StackLayout StyleClass="box-row, box-row-switch">
                                     <Label
                                         Text="{Binding Collection.Name}"
-                                        StyleClass="box-label, box-label-regular"
+                                        StyleClass="box-label-regular"
                                         HorizontalOptions="StartAndExpand" />
                                     <Switch
                                         IsToggled="{Binding Checked}"

--- a/src/App/Pages/Vault/SharePage.xaml
+++ b/src/App/Pages/Vault/SharePage.xaml
@@ -66,7 +66,7 @@
                                 <StackLayout StyleClass="box-row, box-row-switch">
                                     <Label
                                         Text="{Binding Collection.Name}"
-                                        StyleClass="box-label, box-label-regular"
+                                        StyleClass="box-label-regular"
                                         HorizontalOptions="StartAndExpand" />
                                     <Switch
                                         IsToggled="{Binding Checked}"

--- a/src/App/Resources/AppResources.Designer.cs
+++ b/src/App/Resources/AppResources.Designer.cs
@@ -3201,9 +3201,21 @@ namespace Bit.App.Resources {
             }
         }
         
+        public static string NameInfo {
+            get {
+                return ResourceManager.GetString("NameInfo", resourceCulture);
+            }
+        }
+        
         public static string TypeText {
             get {
                 return ResourceManager.GetString("TypeText", resourceCulture);
+            }
+        }
+        
+        public static string TypeTextInfo {
+            get {
+                return ResourceManager.GetString("TypeTextInfo", resourceCulture);
             }
         }
         
@@ -3216,6 +3228,12 @@ namespace Bit.App.Resources {
         public static string TypeFile {
             get {
                 return ResourceManager.GetString("TypeFile", resourceCulture);
+            }
+        }
+        
+        public static string TypeFileInfo {
+            get {
+                return ResourceManager.GetString("TypeFileInfo", resourceCulture);
             }
         }
         

--- a/src/App/Resources/AppResources.resx
+++ b/src/App/Resources/AppResources.resx
@@ -1811,8 +1811,15 @@
     <value>Sends</value>
     <comment>'Send' is a noun and the name of a feature called 'Bitwarden Send'. It should not be translated.</comment>
   </data>
+  <data name="NameInfo" xml:space="preserve">
+    <value>A friendly name to describe this Send.</value>
+    <comment>'Send' is a noun and the name of a feature called 'Bitwarden Send'. It should not be translated.</comment>
+  </data>
   <data name="TypeText" xml:space="preserve">
     <value>Text</value>
+  </data>
+  <data name="TypeTextInfo" xml:space="preserve">
+    <value>The text you want to send.</value>
   </data>
   <data name="HideTextByDefault" xml:space="preserve">
     <value>When accessing the Send, hide the text by default</value>
@@ -1820,6 +1827,9 @@
   </data>
   <data name="TypeFile" xml:space="preserve">
     <value>File</value>
+  </data>
+  <data name="TypeFileInfo" xml:space="preserve">
+    <value>The file you want to send.</value>
   </data>
   <data name="DeletionDate" xml:space="preserve">
     <value>Deletion Date</value>

--- a/src/App/Styles/Base.xaml
+++ b/src/App/Styles/Base.xaml
@@ -320,6 +320,8 @@
            Class="box-label">
         <Setter Property="FontSize"
                 Value="Small" />
+        <Setter Property="FontAttributes"
+                Value="Bold" />
         <Setter Property="TextColor"
                 Value="{StaticResource MutedColor}" />
     </Style>


### PR DESCRIPTION
Additional adjustments based on [web PR 822](https://github.com/bitwarden/web/pull/822):

- Additional help text
- Replace Send type picker with segmented control (radio buttons can be iffy on mobile)

("copy on send" was already implemented as "share on send")

![Screen Shot 2021-02-11 at 12 26 21 PM](https://user-images.githubusercontent.com/59324545/107674619-2305a000-6c65-11eb-9139-dc2695dfdba1.png)
![Screen Shot 2021-02-11 at 12 26 42 PM](https://user-images.githubusercontent.com/59324545/107674632-24cf6380-6c65-11eb-825f-7c3c996d8fbf.png)
![Screen Shot 2021-02-11 at 12 27 08 PM](https://user-images.githubusercontent.com/59324545/107674637-26992700-6c65-11eb-8ec3-9acd380860b4.png)
![Screen Shot 2021-02-11 at 12 27 44 PM](https://user-images.githubusercontent.com/59324545/107674644-2862ea80-6c65-11eb-8d45-3947b5fd355d.png)
