### PR TITLE
Added disabled icon and make File default type for new Sends if premium

### DIFF
--- a/src/App/Controls/SendViewCell/SendViewCell.xaml
+++ b/src/App/Controls/SendViewCell/SendViewCell.xaml
@@ -46,6 +46,7 @@
                 <ColumnDefinition Width="Auto" />
                 <ColumnDefinition Width="Auto" />
                 <ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="Auto" />
                 <ColumnDefinition Width="*" />
             </Grid.ColumnDefinitions>
 
@@ -69,12 +70,23 @@
                 VerticalOptions="Center"
                 StyleClass="list-title-icon"
                 Margin="5, 0, 0, 0"
+                Text="&#xf071;"
+                IsVisible="{Binding Send.Disabled, Mode=OneWay}"
+                AutomationProperties.IsInAccessibleTree="True"
+                AutomationProperties.Name="{u:I18n Disabled}" />
+            <controls:FaLabel
+                Grid.Column="2"
+                Grid.Row="0"
+                HorizontalOptions="Start"
+                VerticalOptions="Center"
+                StyleClass="list-title-icon"
+                Margin="5, 0, 0, 0"
                 Text="&#xf084;"
                 IsVisible="{Binding Send.HasPassword, Mode=OneWay}"
                 AutomationProperties.IsInAccessibleTree="True"
                 AutomationProperties.Name="{u:I18n Password}" />
             <controls:FaLabel
-                Grid.Column="2"
+                Grid.Column="3"
                 Grid.Row="0"
                 HorizontalOptions="Start"
                 VerticalOptions="Center"
@@ -85,7 +97,7 @@
                 AutomationProperties.IsInAccessibleTree="True"
                 AutomationProperties.Name="{u:I18n MaxAccessCountReached}" />
             <controls:FaLabel
-                Grid.Column="3"
+                Grid.Column="4"
                 Grid.Row="0"
                 HorizontalOptions="Start"
                 VerticalOptions="Center"
@@ -96,7 +108,7 @@
                 AutomationProperties.IsInAccessibleTree="True"
                 AutomationProperties.Name="{u:I18n Expired}" />
             <controls:FaLabel
-                Grid.Column="4"
+                Grid.Column="5"
                 Grid.Row="0"
                 HorizontalOptions="Start"
                 VerticalOptions="Center"

--- a/src/App/Controls/SendViewCell/SendViewCell.xaml
+++ b/src/App/Controls/SendViewCell/SendViewCell.xaml
@@ -60,7 +60,7 @@
                 LineBreakMode="TailTruncation"
                 Grid.Column="0"
                 Grid.Row="1"
-                Grid.ColumnSpan="5"
+                Grid.ColumnSpan="6"
                 StyleClass="list-subtitle, list-subtitle-platform"
                 Text="{Binding Send.DisplayDate, Mode=OneWay}" />
             <controls:FaLabel

--- a/src/App/Pages/Send/SendAddEditPage.xaml
+++ b/src/App/Pages/Send/SendAddEditPage.xaml
@@ -86,11 +86,11 @@
                                     <ColumnDefinition Width="*" />
                                     <ColumnDefinition Width="*" />
                                 </Grid.ColumnDefinitions>
-                                <Button Text="{u:I18n TypeText}"
-                                        IsEnabled="{Binding IsFile}"
-                                        Clicked="TextType_Clicked"
+                                <Button Text="{u:I18n TypeFile}"
+                                        IsEnabled="{Binding IsText}"
+                                        Clicked="FileType_Clicked"
                                         AutomationProperties.IsInAccessibleTree="True"
-                                        AutomationProperties.Name="{u:I18n Text}"
+                                        AutomationProperties.Name="{u:I18n File}"
                                         Grid.Column="0">
                                     <VisualStateManager.VisualStateGroups>
                                         <!-- Rider users, if the x:Name values below are red, it's a known issue: -->
@@ -111,11 +111,11 @@
                                         </VisualStateGroup>
                                     </VisualStateManager.VisualStateGroups>
                                 </Button>
-                                <Button Text="{u:I18n TypeFile}"
-                                        IsEnabled="{Binding IsText}"
-                                        Clicked="FileType_Clicked"
+                                <Button Text="{u:I18n TypeText}"
+                                        IsEnabled="{Binding IsFile}"
+                                        Clicked="TextType_Clicked"
                                         AutomationProperties.IsInAccessibleTree="True"
-                                        AutomationProperties.Name="{u:I18n File}"
+                                        AutomationProperties.Name="{u:I18n Text}"
                                         Grid.Column="1">
                                     <VisualStateManager.VisualStateGroups>
                                         <!-- Rider users, if the x:Name values below are red, it's a known issue: -->

--- a/src/App/Pages/Send/SendAddEditPageViewModel.cs
+++ b/src/App/Pages/Send/SendAddEditPageViewModel.cs
@@ -195,9 +195,10 @@ namespace Bit.App.Pages
                 }
                 else
                 {
+                    var defaultType = _canAccessPremium ? SendType.File : SendType.Text;
                     Send = new SendView
                     {
-                        Type = Type.GetValueOrDefault(SendType.Text),
+                        Type = Type.GetValueOrDefault(defaultType),
                         DeletionDate = DateTime.Now.AddDays(7),
                     };
                     DeletionDateTypeSelectedIndex = 4;


### PR DESCRIPTION
- Added "disabled" state icon `fa-warning` in lieu of banner to save space in Sends list
- Swapped `File` and `Text` type buttons for new Sends
- Made `File` the default new Send type for premium users

![Screen Shot 2021-02-11 at 4 15 16 PM](https://user-images.githubusercontent.com/59324545/107699663-615e8780-6c84-11eb-9bb1-07f8cae10729.png)
![Screen Shot 2021-02-11 at 3 56 33 PM](https://user-images.githubusercontent.com/59324545/107698262-44c15000-6c82-11eb-989a-ffc4dba90429.png)
