### PR TITLE
Send bugfixes & tweaks

### DIFF
--- a/src/App/Pages/Send/SendAddEditPage.xaml
+++ b/src/App/Pages/Send/SendAddEditPage.xaml
@@ -76,6 +76,19 @@
             <ScrollView x:Key="scrollView" x:Name="_scrollView">
                 <StackLayout Spacing="20">
                     <StackLayout StyleClass="box">
+                        <StackLayout StyleClass="box-row">
+                            <Label
+                                Text="{u:I18n Name}"
+                                StyleClass="box-label" />
+                            <Entry
+                                x:Name="_nameEntry"
+                                Text="{Binding Send.Name}"
+                                StyleClass="box-value" />
+                            <Label
+                                Text="{u:I18n NameInfo}"
+                                StyleClass="box-footer-label"
+                                Margin="0,5,0,0" />
+                        </StackLayout>
                         <StackLayout StyleClass="box-row"
                                      IsVisible="{Binding EditMode, Converter={StaticResource inverseBool}}">
                             <Label
@@ -137,19 +150,6 @@
                                     </VisualStateManager.VisualStateGroups>
                                 </Button>
                             </Grid>
-                        </StackLayout>
-                        <StackLayout StyleClass="box-row">
-                            <Label
-                                Text="{u:I18n Name}"
-                                StyleClass="box-label" />
-                            <Entry
-                                x:Name="_nameEntry"
-                                Text="{Binding Send.Name}"
-                                StyleClass="box-value" />
-                            <Label
-                                Text="{u:I18n NameInfo}"
-                                StyleClass="box-footer-label"
-                                Margin="0,5,0,0" />
                         </StackLayout>
                         <StackLayout StyleClass="box-row"
                                      IsVisible="{Binding IsText}">
@@ -244,13 +244,13 @@
                                     <ColumnDefinition Width="*" />
                                 </Grid.ColumnDefinitions>
                                 <controls:ExtendedDatePicker
-                                    Date="{Binding DeletionDate}"
+                                    NullableDate="{Binding DeletionDate, Mode=TwoWay}"
                                     Format="d"
                                     AutomationProperties.IsInAccessibleTree="True"
                                     AutomationProperties.Name="{u:I18n DeletionDate}"
                                     Grid.Column="0" />
                                 <controls:ExtendedTimePicker
-                                    Time="{Binding DeletionTime}"
+                                    NullableTime="{Binding DeletionTime, Mode=TwoWay}"
                                     Format="t"
                                     AutomationProperties.IsInAccessibleTree="True"
                                     AutomationProperties.Name="{u:I18n DeletionTime}"

--- a/src/App/Pages/Send/SendAddEditPage.xaml.cs
+++ b/src/App/Pages/Send/SendAddEditPage.xaml.cs
@@ -111,11 +111,17 @@ namespace Bit.App.Pages
         private void TextType_Clicked(object sender, EventArgs eventArgs)
         {
             _vm.TypeChanged(SendType.Text);
+            _nameEntry.ReturnType = ReturnType.Next;
+            _nameEntry.ReturnCommand = new Command(() => _textEditor.Focus());
+            RequestFocus(_nameEntry);
         }
         
         private void FileType_Clicked(object sender, EventArgs eventArgs)
         {
             _vm.TypeChanged(SendType.File);
+            _nameEntry.ReturnType = ReturnType.Done;
+            _nameEntry.ReturnCommand = null;
+            RequestFocus(_nameEntry);
         }
 
         private void OnMaxAccessCountTextChanged(object sender, TextChangedEventArgs e)

--- a/src/App/Pages/Send/SendAddEditPage.xaml.cs
+++ b/src/App/Pages/Send/SendAddEditPage.xaml.cs
@@ -113,7 +113,10 @@ namespace Bit.App.Pages
             _vm.TypeChanged(SendType.Text);
             _nameEntry.ReturnType = ReturnType.Next;
             _nameEntry.ReturnCommand = new Command(() => _textEditor.Focus());
-            RequestFocus(_nameEntry);
+            if (string.IsNullOrWhiteSpace(_vm.Send.Name))
+            {
+                RequestFocus(_nameEntry);
+            }
         }
         
         private void FileType_Clicked(object sender, EventArgs eventArgs)
@@ -121,7 +124,10 @@ namespace Bit.App.Pages
             _vm.TypeChanged(SendType.File);
             _nameEntry.ReturnType = ReturnType.Done;
             _nameEntry.ReturnCommand = null;
-            RequestFocus(_nameEntry);
+            if (string.IsNullOrWhiteSpace(_vm.Send.Name))
+            {
+                RequestFocus(_nameEntry);
+            }
         }
 
         private void OnMaxAccessCountTextChanged(object sender, TextChangedEventArgs e)


### PR DESCRIPTION
- Fixed improper file field validation when editing a file Send
- Fixed "no file chosen" label after selecting file
- Fixed blank deletion date/time picker when current date is today or time is midnight
- Fixed all `Now` references to have minute-precision (strip seconds & milliseconds)
- Fixed `Name` field focus issue when switching between file and text types
- Moved `Name` field above Send type picker per discussion

![Screen Shot 2021-02-12 at 12 27 15 PM](https://user-images.githubusercontent.com/59324545/107801115-ae4a6880-6d2d-11eb-823a-6c7b4b313587.png)
![Screen Shot 2021-02-12 at 12 27 24 PM](https://user-images.githubusercontent.com/59324545/107801119-af7b9580-6d2d-11eb-8949-b8478c8382f1.png)
