### PR TITLE
Fixed launch url on Android 11

### DIFF
--- a/src/Android/Properties/AndroidManifest.xml
+++ b/src/Android/Properties/AndroidManifest.xml
@@ -64,4 +64,17 @@
     <!-- Support for LG "Dual Window" mode (for Android < 7.0 users) -->
     <meta-data android:name="com.lge.support.SPLIT_WINDOW" android:value="true" />
   </application>
+
+  <!-- Package visibility (for Android 11+) -->
+  <queries>
+      <intent>
+          <action android:name="android.intent.action.VIEW"/>
+          <data android:scheme="http"/>
+      </intent>
+      <intent>
+          <action android:name="android.intent.action.VIEW"/>
+          <data android:scheme="https"/>
+      </intent>
+  </queries>
+
 </manifest>


### PR DESCRIPTION
Added package visibility entries in the manifest so `Xamarin.Essentials.Browser` can open URLs on Android 11.

https://docs.microsoft.com/en-us/xamarin/essentials/open-browser?tabs=android