### PR TITLE
Use primary color for options label & chevron

### DIFF
--- a/src/App/Pages/Send/SendAddEditPage.xaml
+++ b/src/App/Pages/Send/SendAddEditPage.xaml
@@ -251,18 +251,21 @@
                                 Text="{u:I18n Options}"
                                 x:Name="_btnOptions"
                                 StyleClass="box-row-button"
+                                TextColor="{StaticResource PrimaryColor}"
                                 Margin="0"
                                 Clicked="ToggleOptions_Clicked" />
                             <controls:FaButton
                                 x:Name="_btnOptionsUp"
                                 Text="&#xf077;"
                                 StyleClass="box-row-button"
+                                TextColor="{StaticResource PrimaryColor}"
                                 Clicked="ToggleOptions_Clicked"
                                 IsVisible="{Binding ShowOptions}" />
                             <controls:FaButton
                                 x:Name="_btnOptionsDown"
                                 Text="&#xf078;"
                                 StyleClass="box-row-button"
+                                TextColor="{StaticResource PrimaryColor}"
                                 Clicked="ToggleOptions_Clicked"
                                 IsVisible="{Binding ShowOptions, Converter={StaticResource inverseBool}}" />
                         </StackLayout>


### PR DESCRIPTION
Use primary color for Send Options "button" so it stands out in dark themes the same way as light themes.

**Screenshots:**

![Screen Shot 2021-02-17 at 11 12 01 AM](https://user-images.githubusercontent.com/59324545/108233277-9b5edc00-7111-11eb-8100-dcd7212dd2f1.png)
![Screen Shot 2021-02-17 at 11 12 27 AM](https://user-images.githubusercontent.com/59324545/108233286-9d289f80-7111-11eb-8159-e2d0ee77142e.png)
