### PR TITLE
Support for Disable Send policy

### DIFF
--- a/src/Android/Renderers/SendViewCellRenderer.cs
+++ b/src/Android/Renderers/SendViewCellRenderer.cs
@@ -102,6 +102,7 @@ namespace Bit.Droid.Renderers
             Icon = view.FindViewById<TextView>(Resource.Id.SendCellIcon);
             Name = view.FindViewById<TextView>(Resource.Id.SendCellName);
             SubTitle = view.FindViewById<TextView>(Resource.Id.SendCellSubTitle);
+            DisabledIcon = view.FindViewById<TextView>(Resource.Id.SendCellDisabledIcon);
             HasPasswordIcon = view.FindViewById<TextView>(Resource.Id.SendCellHasPasswordIcon);
             MaxAccessCountReachedIcon = view.FindViewById<TextView>(Resource.Id.SendCellMaxAccessCountReachedIcon);
             ExpiredIcon = view.FindViewById<TextView>(Resource.Id.SendCellExpiredIcon);
@@ -110,6 +111,7 @@ namespace Bit.Droid.Renderers
             MoreButton.Click += MoreButton_Click;
 
             Icon.Typeface = _faTypeface;
+            DisabledIcon.Typeface = _faTypeface;
             HasPasswordIcon.Typeface = _faTypeface;
             MaxAccessCountReachedIcon.Typeface = _faTypeface;
             ExpiredIcon.Typeface = _faTypeface;
@@ -120,6 +122,7 @@ namespace Bit.Droid.Renderers
             Icon.SetTextSize(ComplexUnitType.Pt, 10);
             Name.SetTextSize(ComplexUnitType.Sp, (float)Device.GetNamedSize(NamedSize.Medium, typeof(Label)));
             SubTitle.SetTextSize(ComplexUnitType.Sp, small);
+            DisabledIcon.SetTextSize(ComplexUnitType.Sp, small);
             HasPasswordIcon.SetTextSize(ComplexUnitType.Sp, small);
             MaxAccessCountReachedIcon.SetTextSize(ComplexUnitType.Sp, small);
             ExpiredIcon.SetTextSize(ComplexUnitType.Sp, small);
@@ -140,6 +143,7 @@ namespace Bit.Droid.Renderers
         public TextView Icon { get; set; }
         public TextView Name { get; set; }
         public TextView SubTitle { get; set; }
+        public TextView DisabledIcon { get; set; }
         public TextView HasPasswordIcon { get; set; }
         public TextView MaxAccessCountReachedIcon { get; set; }
         public TextView ExpiredIcon { get; set; }
@@ -153,6 +157,7 @@ namespace Bit.Droid.Renderers
             var send = sendCell.Send;
             Name.Text = send.Name;
             SubTitle.Text = send.DisplayDate;
+            DisabledIcon.Visibility = send.Disabled ? ViewStates.Visible : ViewStates.Gone;
             HasPasswordIcon.Visibility = send.HasPassword ? ViewStates.Visible : ViewStates.Gone;
             MaxAccessCountReachedIcon.Visibility = send.MaxAccessCountReached ? ViewStates.Visible : ViewStates.Gone;
             ExpiredIcon.Visibility = send.Expired ? ViewStates.Visible : ViewStates.Gone;
@@ -177,6 +182,7 @@ namespace Bit.Droid.Renderers
             Name.SetTextColor(textColor);
             SubTitle.SetTextColor(mutedColor);
             Icon.SetTextColor(mutedColor);
+            DisabledIcon.SetTextColor(mutedColor);
             HasPasswordIcon.SetTextColor(mutedColor);
             MaxAccessCountReachedIcon.SetTextColor(mutedColor);
             ExpiredIcon.SetTextColor(mutedColor);

--- a/src/Android/Renderers/SendViewCellRenderer.cs
+++ b/src/Android/Renderers/SendViewCellRenderer.cs
@@ -81,6 +81,10 @@ namespace Bit.Droid.Renderers
             {
                 _cell.UpdateCell(sendCell);
             }
+            // else if (e.PropertyName == SendViewCell.ShowOptionsProperty.PropertyName)
+            // {
+            //     _cell.UpdateCell(sendCell);
+            // }
         }
     }
 
@@ -125,6 +129,11 @@ namespace Bit.Droid.Renderers
             ExpiredIcon.SetTextSize(ComplexUnitType.Sp, small);
             PendingDeleteIcon.SetTextSize(ComplexUnitType.Sp, small);
             MoreButton.SetTextSize(ComplexUnitType.Sp, 25);
+
+            if (!SendViewCell.ShowOptions)
+            {
+                MoreButton.Visibility = ViewStates.Gone;
+            }
 
             AddView(view);
         }

--- a/src/Android/Renderers/SendViewCellRenderer.cs
+++ b/src/Android/Renderers/SendViewCellRenderer.cs
@@ -81,10 +81,6 @@ namespace Bit.Droid.Renderers
             {
                 _cell.UpdateCell(sendCell);
             }
-            // else if (e.PropertyName == SendViewCell.ShowOptionsProperty.PropertyName)
-            // {
-            //     _cell.UpdateCell(sendCell);
-            // }
         }
     }
 

--- a/src/Android/Resources/layout/SendViewCell.axml
+++ b/src/Android/Resources/layout/SendViewCell.axml
@@ -44,6 +44,14 @@
                     android:ellipsize="end"
                     android:text="Name" />
                 <TextView
+                    android:id="@+id/SendCellDisabledIcon"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center_vertical"
+                    android:paddingLeft="5dp"
+                    android:singleLine="true"
+                    android:text="&#xf071;" />
+                <TextView
                     android:id="@+id/SendCellHasPasswordIcon"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"

--- a/src/App/Controls/SendViewCell/SendViewCell.xaml
+++ b/src/App/Controls/SendViewCell/SendViewCell.xaml
@@ -124,6 +124,7 @@
             Grid.Row="0"
             Grid.Column="2"
             Text="&#xe5d3;"
+            IsVisible="{Binding ShowOptions, Mode=OneWay}"
             StyleClass="list-row-button, list-row-button-platform, btn-disabled"
             Clicked="MoreButton_Clicked"
             VerticalOptions="CenterAndExpand"

--- a/src/App/Controls/SendViewCell/SendViewCell.xaml.cs
+++ b/src/App/Controls/SendViewCell/SendViewCell.xaml.cs
@@ -15,6 +15,9 @@ namespace Bit.App.Controls
 
         public static readonly BindableProperty ButtonCommandProperty = BindableProperty.Create(
             nameof(ButtonCommand), typeof(Command<SendView>), typeof(SendViewCell));
+        
+        public static readonly BindableProperty ShowOptionsProperty = BindableProperty.Create(
+            nameof(ShowOptions), typeof(bool), typeof(SendViewCell));
 
         private readonly IEnvironmentService _environmentService;
 
@@ -47,6 +50,12 @@ namespace Bit.App.Controls
             set => SetValue(ButtonCommandProperty, value);
         }
 
+        public bool ShowOptions
+        {
+            get => GetValue(ShowOptionsProperty) is bool && (bool)GetValue(ShowOptionsProperty);
+            set => SetValue(ShowOptionsProperty, value);
+        }
+
         protected override void OnPropertyChanged(string propertyName = null)
         {
             base.OnPropertyChanged(propertyName);
@@ -57,6 +66,10 @@ namespace Bit.App.Controls
             if (propertyName == SendProperty.PropertyName)
             {
                 _viewModel.Send = Send;
+            }
+            else if (propertyName == ShowOptionsProperty.PropertyName)
+            {
+                _viewModel.ShowOptions = ShowOptions;
             }
         }
 

--- a/src/App/Controls/SendViewCell/SendViewCellViewModel.cs
+++ b/src/App/Controls/SendViewCell/SendViewCellViewModel.cs
@@ -6,11 +6,18 @@ namespace Bit.App.Controls
     public class SendViewCellViewModel : ExtendedViewModel
     {
         private SendView _send;
+        private bool _showOptions;
 
         public SendView Send
         {
             get => _send;
             set => SetProperty(ref _send, value);
+        }
+
+        public bool ShowOptions
+        {
+            get => _showOptions;
+            set => SetProperty(ref _showOptions, value);
         }
     }
 }

--- a/src/App/Pages/Send/SendAddEditPage.xaml
+++ b/src/App/Pages/Send/SendAddEditPage.xaml
@@ -14,7 +14,8 @@
     </ContentPage.BindingContext>
 
     <ContentPage.ToolbarItems>
-        <ToolbarItem Text="{u:I18n Save}" Clicked="Save_Clicked" Order="Primary" />
+        <ToolbarItem Text="{u:I18n Save}" Clicked="Save_Clicked" Order="Primary"
+                     x:Key="saveItem" x:Name="_saveItem"/>
     </ContentPage.ToolbarItems>
 
     <ContentPage.Resources>
@@ -76,6 +77,18 @@
             <ScrollView x:Key="scrollView" x:Name="_scrollView">
                 <StackLayout Spacing="20">
                     <StackLayout StyleClass="box">
+                        <Frame
+                            IsVisible="{Binding SendEnabled, Converter={StaticResource inverseBool}}"
+                            Padding="10"
+                            Margin="0, 12, 0, 0"
+                            HasShadow="False"
+                            BackgroundColor="Transparent"
+                            BorderColor="Accent">
+                            <Label
+                                Text="{u:I18n SendDisabledWarning}"
+                                StyleClass="text-muted, text-sm, text-bold"
+                                HorizontalTextAlignment="Center" />
+                        </Frame>
                         <StackLayout StyleClass="box-row">
                             <Label
                                 Text="{u:I18n Name}"
@@ -83,6 +96,7 @@
                             <Entry
                                 x:Name="_nameEntry"
                                 Text="{Binding Send.Name}"
+                                IsEnabled="{Binding SendEnabled}"
                                 StyleClass="box-value" />
                             <Label
                                 Text="{u:I18n NameInfo}"
@@ -186,6 +200,7 @@
                                     HorizontalTextAlignment="Center" />
                                 <Button
                                     Text="{u:I18n ChooseFile}"
+                                    IsEnabled="{Binding SendEnabled}"
                                     StyleClass="box-button-row"
                                     Clicked="ChooseFile_Clicked" />
                                 <Label
@@ -210,6 +225,7 @@
                                 x:Name="_textEditor"
                                 AutoSize="TextChanges"
                                 Text="{Binding Send.Text.Text}"
+                                IsEnabled="{Binding SendEnabled}"
                                 StyleClass="box-value"
                                 Margin="{Binding EditorMargins}" />
                             <BoxView
@@ -229,6 +245,7 @@
                                     HorizontalOptions="StartAndExpand" />
                                 <Switch
                                     IsToggled="{Binding Send.Text.Hidden}"
+                                    IsEnabled="{Binding SendEnabled}"
                                     HorizontalOptions="End"
                                     Margin="10,0,0,0" />
                             </StackLayout>
@@ -241,6 +258,7 @@
                                 HorizontalOptions="StartAndExpand" />
                             <Switch
                                 IsToggled="{Binding ShareOnSave}"
+                                IsEnabled="{Binding SendEnabled}"
                                 HorizontalOptions="End"
                                 Margin="10,0,0,0" />
                         </StackLayout>
@@ -281,6 +299,7 @@
                                     IsVisible="{Binding EditMode, Converter={StaticResource inverseBool}}"
                                     ItemsSource="{Binding DeletionTypeOptions, Mode=OneTime}"
                                     SelectedIndex="{Binding DeletionDateTypeSelectedIndex}"
+                                    IsEnabled="{Binding SendEnabled}"
                                     StyleClass="box-value"
                                     AutomationProperties.IsInAccessibleTree="True"
                                     AutomationProperties.Name="{u:I18n DeletionTime}" />
@@ -294,12 +313,14 @@
                                     <controls:ExtendedDatePicker
                                         NullableDate="{Binding DeletionDate, Mode=TwoWay}"
                                         Format="d"
+                                        IsEnabled="{Binding SendEnabled}"
                                         AutomationProperties.IsInAccessibleTree="True"
                                         AutomationProperties.Name="{u:I18n DeletionDate}"
                                         Grid.Column="0" />
                                     <controls:ExtendedTimePicker
                                         NullableTime="{Binding DeletionTime, Mode=TwoWay}"
                                         Format="t"
+                                        IsEnabled="{Binding SendEnabled}"
                                         AutomationProperties.IsInAccessibleTree="True"
                                         AutomationProperties.Name="{u:I18n DeletionTime}"
                                         Grid.Column="1" />
@@ -318,6 +339,7 @@
                                     IsVisible="{Binding EditMode, Converter={StaticResource inverseBool}}"
                                     ItemsSource="{Binding ExpirationTypeOptions, Mode=OneTime}"
                                     SelectedIndex="{Binding ExpirationDateTypeSelectedIndex}"
+                                    IsEnabled="{Binding SendEnabled}"
                                     StyleClass="box-value"
                                     AutomationProperties.IsInAccessibleTree="True"
                                     AutomationProperties.Name="{u:I18n ExpirationTime}" />
@@ -332,6 +354,7 @@
                                         NullableDate="{Binding ExpirationDate, Mode=TwoWay}"
                                         PlaceHolder="mm/dd/yyyy"
                                         Format="d"
+                                        IsEnabled="{Binding SendEnabled}"
                                         AutomationProperties.IsInAccessibleTree="True"
                                         AutomationProperties.Name="{u:I18n ExpirationDate}"
                                         Grid.Column="0" />
@@ -339,6 +362,7 @@
                                         NullableTime="{Binding ExpirationTime, Mode=TwoWay}"
                                         PlaceHolder="--:-- --"
                                         Format="t"
+                                        IsEnabled="{Binding SendEnabled}"
                                         AutomationProperties.IsInAccessibleTree="True"
                                         AutomationProperties.Name="{u:I18n ExpirationTime}"
                                         Grid.Column="1" />
@@ -356,6 +380,7 @@
                                         WidthRequest="110"
                                         HeightRequest="{Binding SegmentedButtonHeight}"
                                         FontSize="{Binding SegmentedButtonFontSize}"
+                                        IsEnabled="{Binding SendEnabled}"
                                         StyleClass="box-row-button"
                                         Clicked="ClearExpirationDate_Clicked" />
                                 </StackLayout>
@@ -371,6 +396,7 @@
                                     Orientation="Horizontal">
                                     <Entry
                                         Text="{Binding MaxAccessCount}"
+                                        IsEnabled="{Binding SendEnabled}"
                                         StyleClass="box-value"
                                         Keyboard="Numeric"
                                         MaxLength="9"
@@ -380,6 +406,7 @@
                                         x:Name="_maxAccessCountStepper"
                                         Value="{Binding MaxAccessCount}"
                                         Maximum="999999999"
+                                        IsEnabled="{Binding SendEnabled}"
                                         Margin="10,0,0,0" />
                                 </StackLayout>
                                 <Label
@@ -413,11 +440,13 @@
                                     <Entry
                                         Text="{Binding NewPassword}"
                                         IsPassword="{Binding ShowPassword, Converter={StaticResource inverseBool}}"
+                                        IsEnabled="{Binding SendEnabled}"
                                         StyleClass="box-value"
                                         IsSpellCheckEnabled="False"
                                         IsTextPredictionEnabled="False"
                                         HorizontalOptions="FillAndExpand" />
                                     <controls:FaButton
+                                        IsEnabled="{Binding SendEnabled}"
                                         StyleClass="box-row-button, box-row-button-platform"
                                         Text="{Binding ShowPasswordIcon}"
                                         Command="{Binding TogglePasswordCommand}"
@@ -439,6 +468,7 @@
                                 <Editor
                                     AutoSize="TextChanges"
                                     Text="{Binding Send.Notes}"
+                                    IsEnabled="{Binding SendEnabled}"
                                     StyleClass="box-value"
                                     Margin="{Binding EditorMargins}" />
                                 <BoxView
@@ -459,6 +489,7 @@
                                     HorizontalOptions="StartAndExpand" />
                                 <Switch
                                     IsToggled="{Binding Send.Disabled}"
+                                    IsEnabled="{Binding SendEnabled}"
                                     HorizontalOptions="End"
                                     Margin="10,0,0,0" />
                             </StackLayout>

--- a/src/App/Pages/Send/SendAddEditPage.xaml.cs
+++ b/src/App/Pages/Send/SendAddEditPage.xaml.cs
@@ -27,7 +27,6 @@ namespace Bit.App.Pages
             _vm.Page = this;
             _vm.SendId = sendId;
             _vm.Type = type;
-            _vm.Init();
             SetActivityIndicator();
             if (Device.RuntimePlatform == Device.Android)
             {
@@ -42,7 +41,7 @@ namespace Bit.App.Pages
                 _vm.SegmentedButtonFontSize = 13;
                 _vm.SegmentedButtonMargins = new Thickness(0, 10, 0, 0);
                 _vm.EditorMargins = new Thickness(0, 5, 0, 0);
-                _btnOptions.WidthRequest = 62;
+                _btnOptions.WidthRequest = 70;
                 _btnOptionsDown.WidthRequest = 30;
                 _btnOptionsUp.WidthRequest = 30;
             }
@@ -75,6 +74,7 @@ namespace Bit.App.Pages
         protected override async void OnAppearing()
         {
             base.OnAppearing();
+            await _vm.InitAsync();
             _broadcasterService.Subscribe(nameof(SendAddEditPage), message =>
             {
                 if (message.Command == "selectFileResult")
@@ -99,6 +99,7 @@ namespace Bit.App.Pages
                 {
                     RequestFocus(_nameEntry);
                 }
+                AdjustToolbar();
             });
         }
 
@@ -113,7 +114,7 @@ namespace Bit.App.Pages
 
         private void TextType_Clicked(object sender, EventArgs eventArgs)
         {
-            _vm.TypeChanged(SendType.Text);
+            _vm.TypeChangedAsync(SendType.Text);
             _nameEntry.ReturnType = ReturnType.Next;
             _nameEntry.ReturnCommand = new Command(() => _textEditor.Focus());
             if (string.IsNullOrWhiteSpace(_vm.Send.Name))
@@ -124,7 +125,7 @@ namespace Bit.App.Pages
 
         private void FileType_Clicked(object sender, EventArgs eventArgs)
         {
-            _vm.TypeChanged(SendType.File);
+            _vm.TypeChangedAsync(SendType.File);
             _nameEntry.ReturnType = ReturnType.Done;
             _nameEntry.ReturnCommand = null;
             if (string.IsNullOrWhiteSpace(_vm.Send.Name))
@@ -219,12 +220,12 @@ namespace Bit.App.Pages
                 return;
             }
             var options = new List<string>();
-            if (_vm.Send.HasPassword)
+            if (_vm.SendEnabled && _vm.EditMode)
             {
-                options.Add(AppResources.RemovePassword);
-            }
-            if (_vm.EditMode)
-            {
+                if (_vm.Send.HasPassword)
+                {
+                    options.Add(AppResources.RemovePassword);
+                }
                 options.Add(AppResources.CopyLink);
                 options.Add(AppResources.ShareLink);
             }
@@ -257,6 +258,17 @@ namespace Bit.App.Pages
             if (DoOnce())
             {
                 await Navigation.PopModalAsync();
+            }
+        }
+
+        private void AdjustToolbar()
+        {
+            _saveItem.IsEnabled = _vm.SendEnabled;
+            if (!_vm.SendEnabled && _vm.EditMode && Device.RuntimePlatform == Device.Android)
+            {
+                ToolbarItems.Remove(_removePassword);
+                ToolbarItems.Remove(_copyLink);
+                ToolbarItems.Remove(_shareLink);
             }
         }
     }

--- a/src/App/Pages/Send/SendAddEditPage.xaml.cs
+++ b/src/App/Pages/Send/SendAddEditPage.xaml.cs
@@ -112,9 +112,9 @@ namespace Bit.App.Pages
             }
         }
 
-        private void TextType_Clicked(object sender, EventArgs eventArgs)
+        private async void TextType_Clicked(object sender, EventArgs eventArgs)
         {
-            _vm.TypeChangedAsync(SendType.Text);
+            await _vm.TypeChangedAsync(SendType.Text);
             _nameEntry.ReturnType = ReturnType.Next;
             _nameEntry.ReturnCommand = new Command(() => _textEditor.Focus());
             if (string.IsNullOrWhiteSpace(_vm.Send.Name))
@@ -123,9 +123,9 @@ namespace Bit.App.Pages
             }
         }
 
-        private void FileType_Clicked(object sender, EventArgs eventArgs)
+        private async void FileType_Clicked(object sender, EventArgs eventArgs)
         {
-            _vm.TypeChangedAsync(SendType.File);
+            await _vm.TypeChangedAsync(SendType.File);
             _nameEntry.ReturnType = ReturnType.Done;
             _nameEntry.ReturnCommand = null;
             if (string.IsNullOrWhiteSpace(_vm.Send.Name))

--- a/src/App/Pages/Send/SendAddEditPageViewModel.cs
+++ b/src/App/Pages/Send/SendAddEditPageViewModel.cs
@@ -394,7 +394,7 @@ namespace Bit.App.Pages
             return await AppHelpers.DeleteSendAsync(SendId);
         }
 
-        public async void TypeChangedAsync(SendType type)
+        public async Task TypeChangedAsync(SendType type)
         {
             if (Send != null)
             {

--- a/src/App/Pages/Send/SendAddEditPageViewModel.cs
+++ b/src/App/Pages/Send/SendAddEditPageViewModel.cs
@@ -356,7 +356,7 @@ namespace Bit.App.Pages
                     if (savedSend != null)
                     {
                         var savedSendView = await savedSend.DecryptAsync();
-                        await AppHelpers.ShareSendUrl(savedSendView);
+                        await AppHelpers.ShareSendUrlAsync(savedSendView);
                     }
                 }
 
@@ -381,14 +381,12 @@ namespace Bit.App.Pages
 
         public async Task CopyLinkAsync()
         {
-            await _platformUtilsService.CopyToClipboardAsync(AppHelpers.GetSendUrl(Send));
-            _platformUtilsService.ShowToast("info", null,
-                string.Format(AppResources.ValueHasBeenCopied, AppResources.ShareLink));
+            await AppHelpers.CopySendUrlAsync(Send);
         }
 
         public async Task ShareLinkAsync()
         {
-            await AppHelpers.ShareSendUrl(Send);
+            await AppHelpers.ShareSendUrlAsync(Send);
         }
 
         public async Task<bool> DeleteAsync()

--- a/src/App/Pages/Send/SendGroupingsPage/SendGroupingsPage.xaml
+++ b/src/App/Pages/Send/SendGroupingsPage/SendGroupingsPage.xaml
@@ -37,7 +37,8 @@
                           x:DataType="pages:SendGroupingsPageListItem">
                 <controls:SendViewCell
                     Send="{Binding Send}"
-                    ButtonCommand="{Binding BindingContext.SendOptionsCommand, Source={x:Reference _page}}" />
+                    ButtonCommand="{Binding BindingContext.SendOptionsCommand, Source={x:Reference _page}}"
+                    ShowOptions="{Binding ShowOptions}" />
             </DataTemplate>
 
             <DataTemplate x:Key="sendGroupTemplate"
@@ -72,6 +73,20 @@
                                                      GroupTemplate="{StaticResource sendGroupTemplate}" />
 
             <StackLayout x:Key="mainLayout" x:Name="_mainLayout">
+                <StackLayout StyleClass="box">
+                    <Frame
+                        IsVisible="{Binding SendEnabled, Converter={StaticResource inverseBool}}"
+                        Padding="10"
+                        Margin="0, 12, 0, 6"
+                        HasShadow="False"
+                        BackgroundColor="Transparent"
+                        BorderColor="Accent">
+                        <Label
+                            Text="{u:I18n SendDisabledWarning}"
+                            StyleClass="text-muted, text-sm, text-bold"
+                            HorizontalTextAlignment="Center" />
+                    </Frame>
+                </StackLayout>
                 <StackLayout
                     VerticalOptions="CenterAndExpand"
                     Padding="20, 0"
@@ -143,6 +158,7 @@
         <Button
             x:Name="_fab"
             Image="plus.png"
+            IsVisible="{Binding SendEnabled}"
             Clicked="AddButton_Clicked"
             Style="{StaticResource btn-fab}"
             AbsoluteLayout.LayoutFlags="PositionProportional"

--- a/src/App/Pages/Send/SendGroupingsPage/SendGroupingsPage.xaml.cs
+++ b/src/App/Pages/Send/SendGroupingsPage/SendGroupingsPage.xaml.cs
@@ -55,9 +55,10 @@ namespace Bit.App.Pages
 
         public ExtendedListView ListView { get; set; }
 
-        protected async override void OnAppearing()
+        protected override async void OnAppearing()
         {
             base.OnAppearing();
+            await _vm.InitAsync();
             if (_syncService.SyncInProgress)
             {
                 IsBusy = true;
@@ -107,6 +108,7 @@ namespace Bit.App.Pages
                 }
 
                 await ShowPreviousPageAsync();
+                AdjustToolbar();
             }, _mainContent);
         }
 
@@ -183,6 +185,11 @@ namespace Bit.App.Pages
                 await Navigation.PushModalAsync(new NavigationPage(new AddEditPage(_previousPage.SendId)));
             }
             _previousPage = null;
+        }
+        
+        private void AdjustToolbar()
+        {
+            _addItem.IsEnabled = _vm.SendEnabled;
         }
     }
 }

--- a/src/App/Pages/Send/SendGroupingsPage/SendGroupingsPageListItem.cs
+++ b/src/App/Pages/Send/SendGroupingsPage/SendGroupingsPageListItem.cs
@@ -12,6 +12,7 @@ namespace Bit.App.Pages
         public SendView Send { get; set; }
         public SendType? Type { get; set; }
         public string ItemCount { get; set; }
+        public bool ShowOptions { get; set; }
 
         public string Name
         {

--- a/src/App/Pages/Send/SendGroupingsPage/SendGroupingsPageViewModel.cs
+++ b/src/App/Pages/Send/SendGroupingsPage/SendGroupingsPageViewModel.cs
@@ -18,6 +18,7 @@ namespace Bit.App.Pages
 {
     public class SendGroupingsPageViewModel : BaseViewModel
     {
+        private bool _sendEnabled;
         private bool _refreshing;
         private bool _doingLoad;
         private bool _loading;
@@ -65,6 +66,11 @@ namespace Bit.App.Pages
         public bool HasSends { get; set; }
         public List<SendView> Sends { get; set; }
 
+        public bool SendEnabled
+        {
+            get => _sendEnabled;
+            set => SetProperty(ref _sendEnabled, value);
+        }
         public bool Refreshing
         {
             get => _refreshing;
@@ -110,6 +116,11 @@ namespace Bit.App.Pages
         public Command<SendView> SendOptionsCommand { get; set; }
         public bool LoadedOnce { get; set; }
 
+        public async Task InitAsync()
+        {
+            SendEnabled = ! await AppHelpers.IsSendDisabledByPolicyAsync();
+        }
+        
         public async Task LoadAsync()
         {
             if (_doingLoad)
@@ -167,7 +178,11 @@ namespace Bit.App.Pages
 
                 if (Sends?.Any() ?? false)
                 {
-                    var sendsListItems = Sends.Select(s => new SendGroupingsPageListItem { Send = s }).ToList();
+                    var sendsListItems = Sends.Select(s => new SendGroupingsPageListItem
+                    {
+                        Send = s,
+                        ShowOptions = SendEnabled
+                    }).ToList();
                     groupedSends.Add(new SendGroupingsPageListGroup(sendsListItems,
                         MainPage ? AppResources.AllSends : AppResources.Sends, sendsListItems.Count,
                         uppercaseGroupNames, !MainPage));

--- a/src/App/Pages/Send/SendsPage.xaml
+++ b/src/App/Pages/Send/SendsPage.xaml
@@ -72,7 +72,8 @@
                 <DataTemplate x:DataType="views:SendView">
                     <controls:SendViewCell
                         Send="{Binding .}"
-                        ButtonCommand="{Binding BindingContext.SendOptionsCommand, Source={x:Reference _page}}" />
+                        ButtonCommand="{Binding BindingContext.SendOptionsCommand, Source={x:Reference _page}}"
+                        ShowOptions="{Binding BindingContext.SendEnabled, Source={x:Reference _page}}" />
                 </DataTemplate>
             </ListView.ItemTemplate>
         </ListView>

--- a/src/App/Pages/Send/SendsPageViewModel.cs
+++ b/src/App/Pages/Send/SendsPageViewModel.cs
@@ -15,6 +15,7 @@ namespace Bit.App.Pages
         private readonly ISearchService _searchService;
 
         private CancellationTokenSource _searchCancellationTokenSource;
+        private bool _sendEnabled;
         private bool _showNoData;
         private bool _showList;
 
@@ -29,6 +30,12 @@ namespace Bit.App.Pages
         public ExtendedObservableCollection<SendView> Sends { get; set; }
         public Func<SendView, bool> Filter { get; set; }
 
+        public bool SendEnabled
+        {
+            get => _sendEnabled;
+            set => SetProperty(ref _sendEnabled, value);
+        }
+        
         public bool ShowNoData
         {
             get => _showNoData;
@@ -51,6 +58,7 @@ namespace Bit.App.Pages
 
         public async Task InitAsync()
         {
+            SendEnabled = ! await AppHelpers.IsSendDisabledByPolicyAsync();
             if (!string.IsNullOrWhiteSpace((Page as SendsPage).SearchBar.Text))
             {
                 Search((Page as SendsPage).SearchBar.Text, 200);

--- a/src/App/Resources/AppResources.Designer.cs
+++ b/src/App/Resources/AppResources.Designer.cs
@@ -3375,6 +3375,12 @@ namespace Bit.App.Resources {
             }
         }
         
+        public static string SendLink {
+            get {
+                return ResourceManager.GetString("SendLink", resourceCulture);
+            }
+        }
+        
         public static string SearchSends {
             get {
                 return ResourceManager.GetString("SearchSends", resourceCulture);

--- a/src/App/Resources/AppResources.Designer.cs
+++ b/src/App/Resources/AppResources.Designer.cs
@@ -3458,5 +3458,11 @@ namespace Bit.App.Resources {
                 return ResourceManager.GetString("ShareOnSave", resourceCulture);
             }
         }
+        
+        public static string SendDisabledWarning {
+            get {
+                return ResourceManager.GetString("SendDisabledWarning", resourceCulture);
+            }
+        }
     }
 }

--- a/src/App/Resources/AppResources.resx
+++ b/src/App/Resources/AppResources.resx
@@ -1908,11 +1908,11 @@
     <value>Share Link</value>
   </data>
   <data name="SendLink" xml:space="preserve">
-    <value>Send Link</value>
+    <value>Send link</value>
     <comment>'Send' is a noun and the name of a feature called 'Bitwarden Send'. It should not be translated.</comment>
   </data>
   <data name="SearchSends" xml:space="preserve">
-    <value>Search sends</value>
+    <value>Search Sends</value>
     <comment>'Send' is a noun and the name of a feature called 'Bitwarden Send'. It should not be translated.</comment>
   </data>
   <data name="EditSend" xml:space="preserve">

--- a/src/App/Resources/AppResources.resx
+++ b/src/App/Resources/AppResources.resx
@@ -1957,4 +1957,8 @@
     <value>Share this Send upon save.</value>
     <comment>'Send' is a noun and the name of a feature called 'Bitwarden Send'. It should not be translated.</comment>
   </data>
+  <data name="SendDisabledWarning" xml:space="preserve">
+    <value>Due to an enterprise policy, you are only able to delete an existing Send.</value>
+    <comment>'Send' is a noun and the name of a feature called 'Bitwarden Send'. It should not be translated.</comment>
+  </data>
 </root>

--- a/src/App/Resources/AppResources.resx
+++ b/src/App/Resources/AppResources.resx
@@ -1907,6 +1907,10 @@
   <data name="ShareLink" xml:space="preserve">
     <value>Share Link</value>
   </data>
+  <data name="SendLink" xml:space="preserve">
+    <value>Send Link</value>
+    <comment>'Send' is a noun and the name of a feature called 'Bitwarden Send'. It should not be translated.</comment>
+  </data>
   <data name="SearchSends" xml:space="preserve">
     <value>Search sends</value>
     <comment>'Send' is a noun and the name of a feature called 'Bitwarden Send'. It should not be translated.</comment>

--- a/src/App/Utilities/AppHelpers.cs
+++ b/src/App/Utilities/AppHelpers.cs
@@ -278,15 +278,14 @@ namespace Bit.App.Utilities
             
             var policies = await policyService.GetAll(PolicyType.DisableSend);
             var organizations = await userService.GetAllOrganizationAsync();
-            // return organizations.Any(o =>
-            // {
-            //     return o.Enabled &&
-            //            o.Status == OrganizationUserStatusType.Confirmed &&
-            //            o.UsePolicies &&
-            //            !o.canManagePolicies &&
-            //            policies.Any(p => p.OrganizationId == o.Id && p.Enabled);
-            // });
-            return true;
+            return organizations.Any(o =>
+            {
+                return o.Enabled &&
+                       o.Status == OrganizationUserStatusType.Confirmed &&
+                       o.UsePolicies &&
+                       !o.canManagePolicies &&
+                       policies.Any(p => p.OrganizationId == o.Id && p.Enabled);
+            });
         }
 
         public static async Task<bool> PerformUpdateTasksAsync(ISyncService syncService,

--- a/src/App/Utilities/AppHelpers.cs
+++ b/src/App/Utilities/AppHelpers.cs
@@ -10,6 +10,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Bit.App.Models;
+using Bit.Core.Enums;
 using Bit.Core.Exceptions;
 using Xamarin.Essentials;
 using Xamarin.Forms;
@@ -268,6 +269,24 @@ namespace Bit.App.Utilities
                 }
             }
             return false;
+        }
+
+        public static async Task<bool> IsSendDisabledByPolicyAsync()
+        {
+            var policyService = ServiceContainer.Resolve<IPolicyService>("policyService");
+            var userService = ServiceContainer.Resolve<IUserService>("userService");
+            
+            var policies = await policyService.GetAll(PolicyType.DisableSend);
+            var organizations = await userService.GetAllOrganizationAsync();
+            // return organizations.Any(o =>
+            // {
+            //     return o.Enabled &&
+            //            o.Status == OrganizationUserStatusType.Confirmed &&
+            //            o.UsePolicies &&
+            //            !o.canManagePolicies &&
+            //            policies.Any(p => p.OrganizationId == o.Id && p.Enabled);
+            // });
+            return true;
         }
 
         public static async Task<bool> PerformUpdateTasksAsync(ISyncService syncService,

--- a/src/Core/Enums/PolicyType.cs
+++ b/src/Core/Enums/PolicyType.cs
@@ -2,11 +2,12 @@
 {
     public enum PolicyType : byte
     {
-        TwoFactorAuthentication = 0,
-        MasterPassword = 1,
-        PasswordGenerator = 2,
-        OnlyOrg = 3,
-        RequireSso = 4,
-        PersonalOwnership = 5,
+        TwoFactorAuthentication = 0, // Requires users to have 2fa enabled
+        MasterPassword = 1, // Sets minimum requirements for master password complexity
+        PasswordGenerator = 2, // Sets minimum requirements/default type for generated passwords/passphrases
+        OnlyOrg = 3, // Allows users to only be apart of one organization
+        RequireSso = 4, // Requires users to authenticate with SSO
+        PersonalOwnership = 5, // Disables personal vault ownership for adding/cloning items
+        DisableSend = 6, // Disables the ability to create and edit Sends
     }
 }


### PR DESCRIPTION
**Overview**

Added support for disabling Send via enterprise policy.  Functionality is reduced to read and delete only.

_(Note that references to "options button" below is referring to the 3-dot overflow for each item in listviews, not the new expandable options button on the Send Add/Edit page)_

**Files Changes/Added**

Android:

- **SendviewCellRenderer.cs**: Support for toggling options button visibility, added missing disabled send icon
- **SendViewCell.axml**: Added missing disabled send icon

App:

- **SendviewCell.xaml**: Support for toggling options button visibility
- **SendViewCell.xaml.cs**: Support for toggling options button visibility
- **SendViewCellViewModel.cs**: Support for toggling options button visibility
- **SendGroupingsPage.xaml**: Support for toggling options button visibility, warning banner, and FAB visibility for Android
- **SendGroupingsPage.xaml.cs**: Added call to init viewmodel and post-load toolbar adjustments
- **SendGroupingsPageViewModel.cs**: Added SendEnabled property, set via new init method, and passed into sends list
- **SendGroupingsPageListItem.cs**: Added property for options button visibility
- **SendAddEditPage.xaml**: Support for disabling save button, warning banner, and bindings to disable editable components when Send is disabled
- **SendAddEditPage.xaml.cs**: Moved call to init to async, post-load toolbar adjustments, and adjustments to the "More" overflow menu based on `SendEnabled` (also tweaked button size for android hack and added missing "Async" suffix to "TypeChanged" method)
- **SendAddEditPageViewModel.cs**: Added `SendEnabled` property, made init method async, added `SendEnabled` check failsafe to `SubmitAsync`, use `CopySendUrlAsync` helper method, added missing `Async` suffix to `ShareSendUrl`
- **SendsPage.xaml**: Support for toggling options button visibility
- **SendsPageViewModel.cs**: Added `SendEnabled` property
- **AppResources.resx**: Added `SendLink` and `SendDisabledWarning` text
- **AppResources.Designer.cs**: System modified resources
- **AppHelpers.cs**: Added `IsSendDisabledByPolicyAsync` and `CopySendUrlAsync` helper methods, and added `IsSendDisabledByPolicyAsync` failsafe checks to `ShareSendUrlAsync` and `RemoveSendPasswordAsync`

Core:

- **PolicyType.cs**: Added `DisableSend` policy type

**Considerations**

- Warning banner design is based on pattern already established elsewhere (password generator policies come to mind)
- Some views lack an obvious "disabled" state change and it varies by platform.  it's something I hope to improve upon with styling & XF updates

**Screenshots**

![Screen Shot 2021-02-17 at 9 49 06 PM](https://user-images.githubusercontent.com/59324545/108304536-40ab9b80-7176-11eb-8ec4-63b97dbf19f1.png)
![Screen Shot 2021-02-17 at 9 54 53 PM](https://user-images.githubusercontent.com/59324545/108304547-43a68c00-7176-11eb-9fe6-c6a279cad1b9.png)
![Screen Shot 2021-02-17 at 9 55 13 PM](https://user-images.githubusercontent.com/59324545/108304557-46a17c80-7176-11eb-950a-f72fa87060ea.png)
