### PR TITLE
fix for send list refresh on android

### DIFF
--- a/src/App/Pages/Send/SendAddEditPageViewModel.cs
+++ b/src/App/Pages/Send/SendAddEditPageViewModel.cs
@@ -18,6 +18,7 @@ namespace Bit.App.Pages
     {
         private readonly IDeviceActionService _deviceActionService;
         private readonly IPlatformUtilsService _platformUtilsService;
+        private readonly IMessagingService _messagingService;
         private readonly IUserService _userService;
         private readonly ISendService _sendService;
         private bool _sendEnabled;
@@ -44,6 +45,7 @@ namespace Bit.App.Pages
         {
             _deviceActionService = ServiceContainer.Resolve<IDeviceActionService>("deviceActionService");
             _platformUtilsService = ServiceContainer.Resolve<IPlatformUtilsService>("platformUtilsService");
+            _messagingService = ServiceContainer.Resolve<IMessagingService>("messagingService");
             _userService = ServiceContainer.Resolve<IUserService>("userService");
             _sendService = ServiceContainer.Resolve<ISendService>("sendService");
             TogglePasswordCommand = new Command(TogglePassword);
@@ -349,6 +351,14 @@ namespace Bit.App.Pages
                 _platformUtilsService.ShowToast("success", null,
                     EditMode ? AppResources.SendUpdated : AppResources.NewSendCreated);
                 await Page.Navigation.PopModalAsync();
+
+                if (Device.RuntimePlatform == Device.Android && IsFile)
+                {
+                    // Workaround for https://github.com/xamarin/Xamarin.Forms/issues/5418
+                    // Exiting and returning (file picker) calls OnAppearing on list page instead of this modal, and
+                    // it doesn't get called again when the model is dismissed, so the list isn't updated.
+                    _messagingService.Send("sendUpdated");
+                }
 
                 if (ShareOnSave)
                 {

--- a/src/App/Pages/Send/SendGroupingsPage/SendGroupingsPage.xaml.cs
+++ b/src/App/Pages/Send/SendGroupingsPage/SendGroupingsPage.xaml.cs
@@ -70,7 +70,7 @@ namespace Bit.App.Pages
                 {
                     Device.BeginInvokeOnMainThread(() => IsBusy = true);
                 }
-                else if (message.Command == "syncCompleted")
+                else if (message.Command == "syncCompleted" || message.Command == "sendUpdated")
                 {
                     await Task.Delay(500);
                     Device.BeginInvokeOnMainThread(() =>


### PR DESCRIPTION
An Android-specific bug in Xamarin.Forms results in calling `OnAppearing` on a page when you exit and return to the app while a modal is showing, and it doesn't get called again when the modal is dismissed.  This results in new file Sends not showing up in the list since the file picker pushes the app to the background.  I'm using a simple broadcast message to refresh the list after saving is complete.