### PR TITLE
Send file model changes

### DIFF
--- a/src/Core/Models/Api/SendFileApi.cs
+++ b/src/Core/Models/Api/SendFileApi.cs
@@ -3,7 +3,6 @@ namespace Bit.Core.Models.Api
     public class SendFileApi
     {
         public string Id { get; set; }
-        public string Url { get; set; }
         public string FileName { get; set; }
         public string Key { get; set; }
         public string Size { get; set; }

--- a/src/Core/Models/Data/SendFileData.cs
+++ b/src/Core/Models/Data/SendFileData.cs
@@ -10,7 +10,6 @@ namespace Bit.Core.Models.Data
         public SendFileData(SendFileApi data)
         {
             Id = data.Id;
-            Url = data.Url;
             FileName = data.FileName;
             Key = data.Key;
             Size = data.Size;
@@ -18,7 +17,6 @@ namespace Bit.Core.Models.Data
         }
 
         public string Id { get; set; }
-        public string Url { get; set; }
         public string FileName { get; set; }
         public string Key { get; set; }
         public string Size { get; set; }

--- a/src/Core/Models/Domain/SendFile.cs
+++ b/src/Core/Models/Domain/SendFile.cs
@@ -8,7 +8,6 @@ namespace Bit.Core.Models.Domain
     public class SendFile : Domain
     {
         public string Id { get; set; }
-        public string Url { get; set; }
         public string Size { get; set; }
         public string SizeName { get; set; }
         public CipherString FileName { get; set; }
@@ -18,7 +17,7 @@ namespace Bit.Core.Models.Domain
         public SendFile(SendFileData file, bool alreadyEncrypted = false) : base()
         {
             Size = file.Size;
-            BuildDomainModel(this, file, new HashSet<string> { "Id", "Url", "SizeName", "FileName" }, alreadyEncrypted, new HashSet<string> { "Id", "Url", "SizeName" });
+            BuildDomainModel(this, file, new HashSet<string> { "Id", "SizeName", "FileName" }, alreadyEncrypted, new HashSet<string> { "Id", "SizeName" });
         }
 
         public Task<SendFileView> DecryptAsync(SymmetricCryptoKey key) =>

--- a/src/Core/Models/Request/SendRequest.cs
+++ b/src/Core/Models/Request/SendRequest.cs
@@ -8,6 +8,7 @@ namespace Bit.Core.Models.Request
     public class SendRequest
     {
         public SendType Type { get; set; }
+        public long? FileLength { get; set; }
         public string Name { get; set; }
         public string Notes { get; set; }
         public string Key { get; set; }
@@ -19,9 +20,10 @@ namespace Bit.Core.Models.Request
         public string Password { get; set; }
         public bool Disabled { get; set; }
 
-        public SendRequest(Send send)
+        public SendRequest(Send send, long? fileLength)
         {
-            Type = send.Type;
+            Type = send.Type ;
+            FileLength = fileLength;
             Name = send.Name?.EncryptedString;
             Notes = send.Notes?.EncryptedString;
             MaxAccessCount = send.MaxAccessCount;

--- a/src/Core/Models/View/SendFileView.cs
+++ b/src/Core/Models/View/SendFileView.cs
@@ -10,13 +10,11 @@ namespace Bit.Core.Models.View
         public SendFileView(SendFile file)
         {
             Id = file.Id;
-            Url = file.Url;
             Size = file.Size;
             SizeName = file.SizeName;
         }
 
         public string Id { get; set; }
-        public string Url { get; set; }
         public string Size { get; set; }
         public string SizeName { get; set; }
         public string FileName { get; set; }

--- a/src/Core/Services/SendService.cs
+++ b/src/Core/Services/SendService.cs
@@ -195,7 +195,7 @@ namespace Bit.Core.Services
 
         public async Task<string> SaveWithServerAsync(Send send, byte[] encryptedFileData)
         {
-            var request = new SendRequest(send);
+            var request = new SendRequest(send, encryptedFileData?.LongLength);
             SendResponse response;
             if (send.Id == null)
             {

--- a/test/Core.Test/Models/Request/SendRequestTests.cs
+++ b/test/Core.Test/Models/Request/SendRequestTests.cs
@@ -13,15 +13,16 @@ namespace Bit.Core.Test.Models.Request
     public class SendRequestTests
     {
         [Theory]
-        [InlineCustomAutoData(new[] { typeof(TextSendCustomization) })]
-        [InlineCustomAutoData(new[] { typeof(FileSendCustomization) })]
-        public void SendRequest_FromSend_Success(Send send)
+        [InlineCustomAutoData(new[] { typeof(TextSendCustomization) }, null)]
+        [InlineCustomAutoData(new[] { typeof(FileSendCustomization) }, 100)]
+        public void SendRequest_FromSend_Success(long? fileLength, Send send)
         {
-            var request = new SendRequest(send);
+            var request = new SendRequest(send, fileLength);
 
             TestHelper.AssertPropertyEqual(send, request, "Id", "AccessId", "UserId", "Name", "Notes", "File", "Text", "Key", "AccessCount", "RevisionDate");
             Assert.Equal(send.Name?.EncryptedString, request.Name);
             Assert.Equal(send.Notes?.EncryptedString, request.Notes);
+            Assert.Equal(fileLength, request.FileLength);
 
             switch (send.Type)
             {

--- a/test/Core.Test/Services/SendServiceTests.cs
+++ b/test/Core.Test/Services/SendServiceTests.cs
@@ -181,7 +181,7 @@ namespace Bit.Core.Test.Services
             Predicate<SendRequest> sendRequestPredicate = r =>
             {
                 // Note Send -> SendRequest tested in SendRequestTests
-                TestHelper.AssertPropertyEqual(new SendRequest(send), r);
+                TestHelper.AssertPropertyEqual(new SendRequest(send, fileContentBytes?.LongLength), r);
                 return true;
             };
 
@@ -215,7 +215,7 @@ namespace Bit.Core.Test.Services
             {
                 Assert.Equal(2, fd.Count()); // expect a request and file content
 
-                var expectedRequest = JsonConvert.SerializeObject(new SendRequest(send));
+                var expectedRequest = JsonConvert.SerializeObject(new SendRequest(send, fileContentBytes?.LongLength));
                 var actualRequest = fd.First().ReadAsStringAsync().GetAwaiter().GetResult();
                 Assert.Equal(expectedRequest, actualRequest);
 
@@ -249,7 +249,7 @@ namespace Bit.Core.Test.Services
             Predicate<SendRequest> sendRequestPredicate = r =>
             {
                 // Note Send -> SendRequest tested in SendRequestTests
-                TestHelper.AssertPropertyEqual(new SendRequest(send), r);
+                TestHelper.AssertPropertyEqual(new SendRequest(send, null), r);
                 return true;
             };
 


### PR DESCRIPTION
# Overview

Related to bitwarden/server#1175. Updates models to match new expected lack of URL in SendFile and file length hint in SendRequest.

# Files Changed
* **SendFileApi.cs/SendFileData.cs/SendFile.cs/SendFileView.cs**: Remove Url
* **SendRequest.cs/SendService.csc** Add and populate FileLength hint on initial Send Request
* **Tests**: Populate File Length. Verifies SendRequest file length is correctly populated.