### PR TITLE
Removed fast deployment hack for Android 11 emulation

### DIFF
--- a/src/Android/Android.csproj
+++ b/src/Android/Android.csproj
@@ -31,8 +31,6 @@
     <AndroidLinkMode>None</AndroidLinkMode>
     <AndroidSupportedAbis />
     <JavaMaximumHeapSize>1G</JavaMaximumHeapSize>
-    <AndroidUseSharedRuntime>false</AndroidUseSharedRuntime>
-    <EmbedAssembliesIntoApk>true</EmbedAssembliesIntoApk>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugSymbols>false</DebugSymbols>


### PR DESCRIPTION
Xamarin.Android 11.2 has finally been promoted to stable so this workaround is no longer necessary.  It also means:
- Debugging in Android 11 emulator is back to full speed
- No more 'removal of workaround' to debug on emulated Android versions < 11

Today is a good day - been waiting for this since October 👍 