### PR TITLE
fix for small gap at the top of send list when not disabled by policy

### DIFF
--- a/src/App/Pages/Send/SendGroupingsPage/SendGroupingsPage.xaml
+++ b/src/App/Pages/Send/SendGroupingsPage/SendGroupingsPage.xaml
@@ -73,9 +73,10 @@
                                                      GroupTemplate="{StaticResource sendGroupTemplate}" />
 
             <StackLayout x:Key="mainLayout" x:Name="_mainLayout">
-                <StackLayout StyleClass="box">
+                <StackLayout 
+                    IsVisible="{Binding SendEnabled, Converter={StaticResource inverseBool}}"
+                    StyleClass="box">
                     <Frame
-                        IsVisible="{Binding SendEnabled, Converter={StaticResource inverseBool}}"
                         Padding="10"
                         Margin="0, 12, 0, 6"
                         HasShadow="False"


### PR DESCRIPTION
There was a small but visible (on iOS) gap at the top of the Sends list when Send is _not_ disabled by org policy (so, when it's enabled normally).  `IsVisible` on the org policy warning banner was never moved to the wrapping `StackLayout` when it was added later.  Fixed.