### PR TITLE
Fix for editing existing personal vault items when non-personal org policy is active

### DIFF
--- a/src/App/Pages/Vault/AddEditPageViewModel.cs
+++ b/src/App/Pages/Vault/AddEditPageViewModel.cs
@@ -298,7 +298,8 @@ namespace Bit.App.Pages
                 if (org.Enabled && org.Status == OrganizationUserStatusType.Confirmed)
                 {
                     OwnershipOptions.Add(new KeyValuePair<string, string>(org.Name, org.Id));
-                    if (policies != null && org.UsePolicies && !org.canManagePolicies && AllowPersonal)
+                    if ((!EditMode || CloneMode) && policies != null && org.UsePolicies && !org.canManagePolicies &&
+                        AllowPersonal)
                     {
                         foreach (var policy in policies)
                         {


### PR DESCRIPTION
Fixed issue where users were unable to edit existing personal vault items while joined to an organization where personal vaults are prohibited.  Thanks to @vincentsalucci for key info.