### PR TITLE
Added missing filesize on Send edit screen

### DIFF
--- a/src/App/Pages/Send/SendAddEditPage.xaml
+++ b/src/App/Pages/Send/SendAddEditPage.xaml
@@ -177,10 +177,20 @@
                             <Label
                                 Text="{u:I18n TypeFile}"
                                 StyleClass="box-label" />
-                            <Label
-                                Text="{Binding Send.File.FileName, Mode=OneWay}"
+                            <StackLayout 
                                 IsVisible="{Binding EditMode}"
-                                StyleClass="box-value" />
+                                Orientation="Horizontal">
+                                <Label
+                                    Text="{Binding Send.File.FileName, Mode=OneWay}"
+                                    StyleClass="box-value"
+                                    VerticalTextAlignment="Center"
+                                    HorizontalOptions="StartAndExpand" />
+                                <Label
+                                    Text="{Binding Send.File.SizeName, Mode=OneWay}"
+                                    StyleClass="box-sub-label"
+                                    HorizontalTextAlignment="End"
+                                    VerticalTextAlignment="Center" />
+                            </StackLayout>
                             <StackLayout
                                 IsVisible="{Binding EditMode, Converter={StaticResource inverseBool}}"
                                 StyleClass="box-row">
@@ -212,6 +222,7 @@
                             </StackLayout>
                             <Label
                                 Text="{u:I18n TypeFileInfo}"
+                                IsVisible="{Binding EditMode, Converter={StaticResource inverseBool}}"
                                 StyleClass="box-footer-label"
                                 Margin="0,5,0,0" />
                         </StackLayout>


### PR DESCRIPTION
- Added filesize to Send edit screen
- Removed "The file you want to send" text underneath filename on edit screen since you can't edit the file anyway (requires creating a new Send)

![Screen Shot 2021-03-09 at 2 15 19 PM](https://user-images.githubusercontent.com/59324545/110524847-e8671a00-80e1-11eb-9438-7dad01f06b0d.png)
![Screen Shot 2021-03-09 at 2 13 19 PM](https://user-images.githubusercontent.com/59324545/110524681-b0f86d80-80e1-11eb-8906-c75efbb0d5b7.png)
