### PR TITLE
Fix for incorrect deletion/expiration times during Send creation

### DIFF
--- a/src/App/Resources/AppResources.resx
+++ b/src/App/Resources/AppResources.resx
@@ -1901,7 +1901,7 @@
     <comment>'Send' is a noun and the name of a feature called 'Bitwarden Send'. It should not be translated.</comment>
   </data>
   <data name="NoSends" xml:space="preserve">
-    <value>There are no sends in your account.</value>
+    <value>There are no Sends in your account.</value>
     <comment>'Send' is a noun and the name of a feature called 'Bitwarden Send'. It should not be translated.</comment>
   </data>
   <data name="CopyLink" xml:space="preserve">


### PR DESCRIPTION
When creating a new Send, the DateTimes created from the "simple" picker were being set to midnight instead of the current time.  Not really a showstopper until "one hour" is selected, resulting in a DateTime from the past ([today] at midnight).  Some investigation revealed that modifying the 'DeletionDate' property bound to `ExtendedDatePicker` was triggering property changes multiple times within the picker and resetting the time to midnight.  Those custom pickers are no fun, so for safety/sanity during this release I've given the "simple" pickers their own "simple" DateTimes to modify, isolating them from the values bound to the custom pickers.  I will revisit this later to come up with something more elegant.

Edit: Forgot to mention also fixed a missing "Send" capitalization
