### PR TITLE
[KnownUsernameField] Entries update (Amazon)

### DIFF
--- a/src/Android/Accessibility/AccessibilityHelpers.cs
+++ b/src/Android/Accessibility/AccessibilityHelpers.cs
@@ -182,7 +182,9 @@ namespace Bit.Droid.Accessibility
             new KnownUsernameField("amazon.in",              new (string, string)[] { ("contains:/ap/signin", "ap_email_login,ap_email") }),
             new KnownUsernameField("amazon.it",              new (string, string)[] { ("contains:/ap/signin", "ap_email_login,ap_email") }),
             new KnownUsernameField("amazon.nl",              new (string, string)[] { ("contains:/ap/signin", "ap_email_login,ap_email") }),
+            new KnownUsernameField("amazon.pl",              new (string, string)[] { ("contains:/ap/signin", "ap_email_login,ap_email") }),
             new KnownUsernameField("amazon.sa",              new (string, string)[] { ("contains:/ap/signin", "ap_email_login,ap_email") }),
+            new KnownUsernameField("amazon.se",              new (string, string)[] { ("contains:/ap/signin", "ap_email_login,ap_email") }),
             new KnownUsernameField("amazon.sg",              new (string, string)[] { ("contains:/ap/signin", "ap_email_login,ap_email") }),
 
             // Amazon Web Services


### PR DESCRIPTION
# This PR:
&nbsp;
- adds the freshly launched `amazon.pl` — see [the press release](https://www.aboutamazon.eu/press-release/amazon-pl-launches-in-poland). :bulb:

- adds the recently launched `amazon.se` — see [the press release](https://www.aboutamazon.eu/press-release/amazon-se-launches-in-sweden). :bulb:
&nbsp;

**Related:** https://github.com/bitwarden/server/pull/1219
&nbsp;
&nbsp;

# Technical details
<details>
<summary>Read me …</summary>
&nbsp;

**amazon.pl (desktop):**
```html
<input type="email" maxlength="128" id="ap_email" name="email" tabindex="1" class="a-input-text a-span12 auth-autofocus auth-required-field">
```

**amazon.pl (mobile):**
```html
<input type="email" maxlength="128" id="ap_email_login" placeholder="Adres e-mail (numer telefonu w przypadku kont mobilnych)" name="email" autocorrect="off" autocapitalize="none">
```

**amazon.se (desktop):**
```html
<input type="email" maxlength="128" id="ap_email" name="email" tabindex="1" class="a-input-text a-span12 auth-autofocus auth-required-field">
```

**amazon.se (mobile):**
```html
<input type="email" maxlength="128" id="ap_email_login" placeholder="E-post (mobilnummer fӧr mobilkonton)" name="email" autocorrect="off" autocapitalize="none">
```
&nbsp;
&nbsp;
:information_source: … and regarding the URL, `contains:/ap/signin` is OK for all. :thumbsup:
</details>