### PR TITLE
Hide email address in Sends

### DIFF
--- a/src/App/Pages/Send/SendAddEditPage.xaml
+++ b/src/App/Pages/Send/SendAddEditPage.xaml
@@ -89,6 +89,18 @@
                                 StyleClass="text-muted, text-sm, text-bold"
                                 HorizontalTextAlignment="Center" />
                         </Frame>
+                        <Frame
+                            IsVisible="{Binding SendOptionsPolicyInEffect}"
+                            Padding="10"
+                            Margin="0, 12, 0, 0"
+                            HasShadow="False"
+                            BackgroundColor="Transparent"
+                            BorderColor="Accent">
+                            <Label
+                                Text="{u:I18n SendOptionsPolicyInEffect}"
+                                StyleClass="text-muted, text-sm, text-bold"
+                                HorizontalTextAlignment="Center" />
+                        </Frame>
                         <StackLayout StyleClass="box-row">
                             <Label
                                 Text="{u:I18n Name}"
@@ -489,6 +501,20 @@
                                     Text="{u:I18n NotesInfo}"
                                     StyleClass="box-footer-label"
                                     Margin="0,5,0,0" />
+                            </StackLayout>
+                            <StackLayout
+                                StyleClass="box-row, box-row-switch"
+                                Margin="0,5,0,0">
+                                <Label
+                                    Text="{u:I18n HideEmail}"
+                                    StyleClass="box-label-regular"
+                                    VerticalOptions="Center"
+                                    HorizontalOptions="StartAndExpand" />
+                                <Switch
+                                    IsToggled="{Binding Send.HideEmail}"
+                                    IsEnabled="{Binding DisableHideEmailControl, Converter={StaticResource inverseBool}}"
+                                    HorizontalOptions="End"
+                                    Margin="10,0,0,0" />
                             </StackLayout>
                             <StackLayout
                                 StyleClass="box-row, box-row-switch"

--- a/src/App/Pages/Send/SendAddEditPageViewModel.cs
+++ b/src/App/Pages/Send/SendAddEditPageViewModel.cs
@@ -94,6 +94,7 @@ namespace Bit.App.Pages
         public byte[] FileData { get; set; }
         public string NewPassword { get; set; }
         public bool ShareOnSave { get; set; }
+        public bool DisableHideEmailControl { get; set; }
         public List<KeyValuePair<string, SendType>> TypeOptions { get; }
         public List<KeyValuePair<string, string>> DeletionTypeOptions { get; }
         public List<KeyValuePair<string, string>> ExpirationTypeOptions { get; }
@@ -197,12 +198,6 @@ namespace Bit.App.Pages
                     nameof(ShowPasswordIcon)
                 });
         }
-        public bool EditMode => !string.IsNullOrWhiteSpace(SendId);
-        public bool IsText => Send?.Type == SendType.Text;
-        public bool IsFile => Send?.Type == SendType.File;
-        public bool ShowDeletionCustomPickers => EditMode || DeletionDateTypeSelectedIndex == 6;
-        public bool ShowExpirationCustomPickers => EditMode || ExpirationDateTypeSelectedIndex == 7;
-        public string ShowPasswordIcon => ShowPassword ? "" : "";
         public bool DisableHideEmail
         {
             get => _disableHideEmail;
@@ -213,7 +208,12 @@ namespace Bit.App.Pages
             get => _sendOptionsPolicyInEffect;
             set => SetProperty(ref _sendOptionsPolicyInEffect, value);
         }
-        public bool DisableHideEmailControl { get; set; }
+        public bool EditMode => !string.IsNullOrWhiteSpace(SendId);
+        public bool IsText => Send?.Type == SendType.Text;
+        public bool IsFile => Send?.Type == SendType.File;
+        public bool ShowDeletionCustomPickers => EditMode || DeletionDateTypeSelectedIndex == 6;
+        public bool ShowExpirationCustomPickers => EditMode || ExpirationDateTypeSelectedIndex == 7;
+        public string ShowPasswordIcon => ShowPassword ? "" : "";
 
         public async Task InitAsync()
         {

--- a/src/App/Pages/Send/SendAddEditPageViewModel.cs
+++ b/src/App/Pages/Send/SendAddEditPageViewModel.cs
@@ -42,6 +42,9 @@ namespace Bit.App.Pages
             nameof(IsText),
             nameof(IsFile),
         };
+        private bool _disableHideEmail;
+        private bool _sendOptionsPolicyInEffect;
+        private bool _disableHideEmailControl;
 
         public SendAddEditPageViewModel()
         {
@@ -200,12 +203,25 @@ namespace Bit.App.Pages
         public bool ShowDeletionCustomPickers => EditMode || DeletionDateTypeSelectedIndex == 6;
         public bool ShowExpirationCustomPickers => EditMode || ExpirationDateTypeSelectedIndex == 7;
         public string ShowPasswordIcon => ShowPassword ? "" : "";
+        public bool DisableHideEmail
+        {
+            get => _disableHideEmail;
+            set => SetProperty(ref _disableHideEmail, value);
+        }
+        public bool SendOptionsPolicyInEffect
+        {
+            get => _sendOptionsPolicyInEffect;
+            set => SetProperty(ref _sendOptionsPolicyInEffect, value);
+        }
+        public bool DisableHideEmailControl { get; set; }
 
         public async Task InitAsync()
         {
             PageTitle = EditMode ? AppResources.EditSend : AppResources.AddSend;
             _canAccessPremium = await _userService.CanAccessPremiumAsync();
             SendEnabled = ! await AppHelpers.IsSendDisabledByPolicyAsync();
+            DisableHideEmail = await AppHelpers.IsHideEmailDisabledByPolicyAsync();
+            SendOptionsPolicyInEffect = SendEnabled && DisableHideEmail;
         }
 
         public async Task<bool> LoadAsync()
@@ -242,6 +258,10 @@ namespace Bit.App.Pages
                 MaxAccessCount = Send.MaxAccessCount;
                 _isOverridingPickers = false;
             }
+
+            DisableHideEmailControl = !SendEnabled ||
+                (!EditMode && DisableHideEmail) ||
+                (EditMode && DisableHideEmail && !Send.HideEmail);
 
             return true;
         }

--- a/src/App/Resources/AppResources.Designer.cs
+++ b/src/App/Resources/AppResources.Designer.cs
@@ -3484,5 +3484,17 @@ namespace Bit.App.Resources {
                 return ResourceManager.GetString("AboutSend", resourceCulture);
             }
         }
+        
+        public static string HideEmail {
+            get {
+                return ResourceManager.GetString("HideEmail", resourceCulture);
+            }
+        }
+        
+        public static string sendOptionsPolicyInEffect {
+            get {
+                return ResourceManager.GetString("sendOptionsPolicyInEffect", resourceCulture);
+            }
+        }
     }
 }

--- a/src/App/Resources/AppResources.Designer.cs
+++ b/src/App/Resources/AppResources.Designer.cs
@@ -3491,9 +3491,9 @@ namespace Bit.App.Resources {
             }
         }
         
-        public static string sendOptionsPolicyInEffect {
+        public static string SendOptionsPolicyInEffect {
             get {
-                return ResourceManager.GetString("sendOptionsPolicyInEffect", resourceCulture);
+                return ResourceManager.GetString("SendOptionsPolicyInEffect", resourceCulture);
             }
         }
     }

--- a/src/App/Resources/AppResources.resx
+++ b/src/App/Resources/AppResources.resx
@@ -1972,4 +1972,10 @@
     <value>About Send</value>
     <comment>'Send' is a noun and the name of a feature called 'Bitwarden Send'. It should not be translated.</comment>
   </data>
+  <data name="HideEmail" xml:space="preserve">
+    <value>Hide my email address from recipients</value>
+  </data>
+  <data name="sendOptionsPolicyInEffect" xml:space="preserve">
+    <value>One or more organization policies are affecting your Send options.</value>
+  </data>
 </root>

--- a/src/App/Resources/AppResources.resx
+++ b/src/App/Resources/AppResources.resx
@@ -1973,9 +1973,9 @@
     <comment>'Send' is a noun and the name of a feature called 'Bitwarden Send'. It should not be translated.</comment>
   </data>
   <data name="HideEmail" xml:space="preserve">
-    <value>Hide my email address from recipients</value>
+    <value>Hide my email address from recipients.</value>
   </data>
-  <data name="sendOptionsPolicyInEffect" xml:space="preserve">
+  <data name="SendOptionsPolicyInEffect" xml:space="preserve">
     <value>One or more organization policies are affecting your Send options.</value>
   </data>
 </root>

--- a/src/App/Resources/AppResources.resx
+++ b/src/App/Resources/AppResources.resx
@@ -1977,5 +1977,6 @@
   </data>
   <data name="SendOptionsPolicyInEffect" xml:space="preserve">
     <value>One or more organization policies are affecting your Send options.</value>
+    <comment>'Send' is a noun and the name of a feature called 'Bitwarden Send'. It should not be translated.</comment>
   </data>
 </root>

--- a/src/App/Utilities/AppHelpers.cs
+++ b/src/App/Utilities/AppHelpers.cs
@@ -311,6 +311,26 @@ namespace Bit.App.Utilities
             });
         }
 
+        public static async Task<bool> IsHideEmailDisabledByPolicyAsync()
+        {
+            var policyService = ServiceContainer.Resolve<IPolicyService>("policyService");
+            var userService = ServiceContainer.Resolve<IUserService>("userService");
+
+            var policies = await policyService.GetAll(PolicyType.SendOptions);
+            var organizations = await userService.GetAllOrganizationAsync();
+            return organizations.Any(o =>
+            {
+                return o.Enabled &&
+                       o.Status == OrganizationUserStatusType.Confirmed &&
+                       o.UsePolicies &&
+                       !o.canManagePolicies &&
+                       policies.Any(p => p.OrganizationId == o.Id &&
+                            p.Enabled &&
+                            p.Data.ContainsKey("disableHideEmail") &&
+                            (bool)p.Data["disableHideEmail"]);
+            });
+        }
+
         public static async Task<bool> PerformUpdateTasksAsync(ISyncService syncService,
             IDeviceActionService deviceActionService, IStorageService storageService)
         {

--- a/src/Core/Enums/PolicyType.cs
+++ b/src/Core/Enums/PolicyType.cs
@@ -9,5 +9,6 @@
         RequireSso = 4, // Requires users to authenticate with SSO
         PersonalOwnership = 5, // Disables personal vault ownership for adding/cloning items
         DisableSend = 6, // Disables the ability to create and edit Sends
+        SendOptions = 7, // Sets restrictions or defaults for Bitwarden Sends
     }
 }

--- a/src/Core/Models/Data/SendData.cs
+++ b/src/Core/Models/Data/SendData.cs
@@ -24,6 +24,7 @@ namespace Bit.Core.Models.Data
             DeletionDate = response.DeletionDate;
             Password = response.Password;
             Disabled = response.Disabled;
+            HideEmail = response.HideEmail.GetValueOrDefault();
 
             switch (Type)
             {
@@ -54,5 +55,6 @@ namespace Bit.Core.Models.Data
         public DateTime DeletionDate { get; set; }
         public string Password { get; set; }
         public bool Disabled { get; set; }
+        public bool HideEmail { get; set; }
     }
 }

--- a/src/Core/Models/Domain/Send.cs
+++ b/src/Core/Models/Domain/Send.cs
@@ -27,6 +27,7 @@ namespace Bit.Core.Models.Domain
         public DateTime DeletionDate { get; set; }
         public string Password { get; set; }
         public bool Disabled { get; set; }
+        public bool HideEmail { get; set; }
 
         public Send() : base() { }
 
@@ -49,6 +50,7 @@ namespace Bit.Core.Models.Domain
             RevisionDate = data.RevisionDate;
             DeletionDate = data.DeletionDate;
             ExpirationDate = data.ExpirationDate;
+            HideEmail = data.HideEmail;
 
             switch (Type)
             {

--- a/src/Core/Models/Request/SendRequest.cs
+++ b/src/Core/Models/Request/SendRequest.cs
@@ -19,6 +19,7 @@ namespace Bit.Core.Models.Request
         public SendFileApi File { get; set; }
         public string Password { get; set; }
         public bool Disabled { get; set; }
+        public bool HideEmail { get; set; }
 
         public SendRequest(Send send, long? fileLength)
         {
@@ -32,6 +33,7 @@ namespace Bit.Core.Models.Request
             Key = send.Key?.EncryptedString;
             Password = send.Password;
             Disabled = send.Disabled;
+            HideEmail = send.HideEmail;
 
             switch (Type)
             {

--- a/src/Core/Models/Response/SendResponse.cs
+++ b/src/Core/Models/Response/SendResponse.cs
@@ -21,5 +21,6 @@ namespace Bit.Core.Models.Response
         public DateTime DeletionDate { get; set; }
         public string Password { get; set; }
         public bool Disabled { get; set; }
+        public bool? HideEmail { get; set; }
     }
 }

--- a/src/Core/Models/View/SendView.cs
+++ b/src/Core/Models/View/SendView.cs
@@ -21,6 +21,7 @@ namespace Bit.Core.Models.View
             ExpirationDate = send.ExpirationDate;
             Disabled = send.Disabled;
             Password = send.Password;
+            HideEmail = send.HideEmail;
         }
 
         public string Id { get; set; }
@@ -45,5 +46,6 @@ namespace Bit.Core.Models.View
         public bool Expired => ExpirationDate.HasValue && ExpirationDate.Value <= DateTime.UtcNow;
         public bool PendingDelete => DeletionDate <= DateTime.UtcNow;
         public string DisplayDate => DeletionDate.ToLocalTime().ToString("MMM d, yyyy, h:mm tt");
+        public bool HideEmail { get; set; }
     }
 }

--- a/src/Core/Services/SendService.cs
+++ b/src/Core/Services/SendService.cs
@@ -97,6 +97,7 @@ namespace Bit.Core.Services
                 Key = await _cryptoService.EncryptAsync(model.Key, key),
                 Name = await _cryptoService.EncryptAsync(model.Name, model.CryptoKey),
                 Notes = await _cryptoService.EncryptAsync(model.Notes, model.CryptoKey),
+                HideEmail = model.HideEmail
             };
             byte[] encryptedFileData = null;
 


### PR DESCRIPTION
## Objective
Allow the creator of a Send to hide their email address from the recipient.

See the [web PR](https://github.com/bitwarden/web/pull/895) and [server PR](https://github.com/bitwarden/server/pull/1234) for more info and discussion.

## Code changes
* add "Hide my email address from recipients" toggle slider to the Send AddEdit page
* check and enforce new Send Options Policy > which can disable this new feature (`disableHideEmail`)
* add banner at the top of the Send AddEdit page if Send Options policy is in effect

## Screenshots

![Screen Shot 2021-03-26 at 3 44 29 pm](https://user-images.githubusercontent.com/31796059/112587912-34d48880-8e4a-11eb-9d09-a218e415a6c2.png)

![Screen Shot 2021-03-26 at 3 44 42 pm](https://user-images.githubusercontent.com/31796059/112587919-3900a600-8e4a-11eb-93e5-653ddbba733f.png)
