### PR TITLE
[SupportedBrowsers] Add support for Mull

### DIFF
--- a/src/Android/Accessibility/AccessibilityHelpers.cs
+++ b/src/Android/Accessibility/AccessibilityHelpers.cs
@@ -103,6 +103,7 @@ namespace Bit.Droid.Accessibility
             new Browser("org.torproject.torbrowser_alpha", "mozac_browser_toolbar_url_view,url_bar_title"), // 2nd = Legacy (before v10.0a8)
             new Browser("org.ungoogled.chromium.extensions.stable", "url_bar"),
             new Browser("org.ungoogled.chromium.stable", "url_bar"),
+            new Browser("us.spotco.fennec_dos", "mozac_browser_toolbar_url_view,url_bar_title"), // 2nd = Legacy
 
             // [Section B] Entries only present here
             //

--- a/src/Android/Autofill/AutofillHelpers.cs
+++ b/src/Android/Autofill/AutofillHelpers.cs
@@ -116,6 +116,7 @@ namespace Bit.Droid.Autofill
             "org.torproject.torbrowser_alpha",
             "org.ungoogled.chromium.extensions.stable",
             "org.ungoogled.chromium.stable",
+            "us.spotco.fennec_dos",
         };
 
         // The URLs are blacklisted from autofilling

--- a/src/Android/Resources/xml/autofillservice.xml
+++ b/src/Android/Resources/xml/autofillservice.xml
@@ -215,4 +215,7 @@
   <compatibility-package
     android:name="org.ungoogled.chromium.stable"
     android:maxLongVersionCode="10000000000"/>
+  <compatibility-package
+    android:name="us.spotco.fennec_dos"
+    android:maxLongVersionCode="10000000000"/>
 </autofill-service>


### PR DESCRIPTION
Mull is a hardened FOSS fork of Fenix.

Legacy support is also provided in the unlikely event any users are
running the legacy Fennec-based Mull.

Resolves:
https://github.com/Divested-Mobile/Mull-Fenix/issues/1
https://community.bitwarden.com/t/auto-fill-support-for-mull-browser-secure-firefox-android-fork/27454

Signed-off-by: Tad <tad@spotco.us>