### PR TITLE
Update ios Autofill page to match setting's name

### DIFF
--- a/src/App/Resources/AppResources.resx
+++ b/src/App/Resources/AppResources.resx
@@ -1278,7 +1278,7 @@
     <value>1. Go to the iOS "Settings" app</value>
   </data>
   <data name="AutofillTurnOn2" xml:space="preserve">
-    <value>2. Tap "Passwords &amp; Accounts"</value>
+    <value>2. Tap "Passwords"</value>
   </data>
   <data name="AutofillTurnOn3" xml:space="preserve">
     <value>3. Tap "AutoFill Passwords"</value>


### PR DESCRIPTION
The option in the ios menu to get to autofill settings is called "Passwords" instead of "Passwords & Accounts"

### Existing instructions in App:
<img src="https://user-images.githubusercontent.com/32627910/113486086-f446c180-947e-11eb-8af2-e0c5840d323f.png"  width="300"/>

### iOS Settings menu:
<img src="https://user-images.githubusercontent.com/32627910/113486102-088abe80-947f-11eb-9747-d23d5c814415.png"  width="300"/>
