### PR TITLE
Password reprompt

### DIFF
--- a/src/Android/Autofill/AutofillHelpers.cs
+++ b/src/Android/Autofill/AutofillHelpers.cs
@@ -137,13 +137,14 @@ namespace Bit.Droid.Autofill
                 {
                     var allCiphers = ciphers.Item1.ToList();
                     allCiphers.AddRange(ciphers.Item2.ToList());
-                    return allCiphers.Select(c => new FilledItem(c)).ToList();
+                    var nonPromptCiphers = allCiphers.Where(cipher => cipher.Reprompt == CipherRepromptType.None);
+                    return nonPromptCiphers.Select(c => new FilledItem(c)).ToList();
                 }
             }
             else if (parser.FieldCollection.FillableForCard)
             {
                 var ciphers = await cipherService.GetAllDecryptedAsync();
-                return ciphers.Where(c => c.Type == CipherType.Card).Select(c => new FilledItem(c)).ToList();
+                return ciphers.Where(c => c.Type == CipherType.Card && c.Reprompt == CipherRepromptType.None).Select(c => new FilledItem(c)).ToList();
             }
             return new List<FilledItem>();
         }

--- a/src/Android/MainApplication.cs
+++ b/src/Android/MainApplication.cs
@@ -101,7 +101,7 @@ namespace Bit.Droid
             var biometricService = new BiometricService();
             var cryptoFunctionService = new PclCryptoFunctionService(cryptoPrimitiveService);
             var cryptoService = new CryptoService(mobileStorageService, secureStorageService, cryptoFunctionService);
-            var passwordRepromptService = new MobilePasswordRepromptService(deviceActionService, platformUtilsService, cryptoService);
+            var passwordRepromptService = new MobilePasswordRepromptService(platformUtilsService, cryptoService);
 
             ServiceContainer.Register<IBroadcasterService>("broadcasterService", broadcasterService);
             ServiceContainer.Register<IMessagingService>("messagingService", messagingService);

--- a/src/Android/MainApplication.cs
+++ b/src/Android/MainApplication.cs
@@ -99,6 +99,9 @@ namespace Bit.Droid
             var platformUtilsService = new MobilePlatformUtilsService(deviceActionService, messagingService,
                 broadcasterService);
             var biometricService = new BiometricService();
+            var cryptoFunctionService = new PclCryptoFunctionService(cryptoPrimitiveService);
+            var cryptoService = new CryptoService(mobileStorageService, secureStorageService, cryptoFunctionService);
+            var passwordRepromptService = new MobilePasswordRepromptService(deviceActionService, platformUtilsService, cryptoService);
 
             ServiceContainer.Register<IBroadcasterService>("broadcasterService", broadcasterService);
             ServiceContainer.Register<IMessagingService>("messagingService", messagingService);
@@ -110,6 +113,9 @@ namespace Bit.Droid
             ServiceContainer.Register<IDeviceActionService>("deviceActionService", deviceActionService);
             ServiceContainer.Register<IPlatformUtilsService>("platformUtilsService", platformUtilsService);
             ServiceContainer.Register<IBiometricService>("biometricService", biometricService);
+            ServiceContainer.Register<ICryptoFunctionService>("cryptoFunctionService", cryptoFunctionService);
+            ServiceContainer.Register<ICryptoService>("cryptoService", cryptoService);
+            ServiceContainer.Register<IPasswordRepromptService>("passwordRepromptService", passwordRepromptService);
 
             // Push
 #if FDROID

--- a/src/Android/Services/DeviceActionService.cs
+++ b/src/Android/Services/DeviceActionService.cs
@@ -307,7 +307,7 @@ namespace Bit.Droid.Services
 
         public Task<string> DisplayPromptAync(string title = null, string description = null,
             string text = null, string okButtonText = null, string cancelButtonText = null,
-            bool numericKeyboard = false, bool autofocus = true)
+            bool numericKeyboard = false, bool autofocus = true, bool password = false)
         {
             var activity = (MainActivity)CrossCurrentActivity.Current.Activity;
             if (activity == null)
@@ -332,6 +332,10 @@ namespace Bit.Droid.Services
 #pragma warning disable CS0618 // Type or member is obsolete
                 input.KeyListener = DigitsKeyListener.GetInstance(false, false);
 #pragma warning restore CS0618 // Type or member is obsolete
+            }
+            if (password)
+            {
+                input.InputType = InputTypes.TextVariationPassword | InputTypes.ClassText;
             }
 
             input.ImeOptions = input.ImeOptions | (ImeAction)ImeFlags.NoPersonalizedLearning |

--- a/src/App/Abstractions/IDeviceActionService.cs
+++ b/src/App/Abstractions/IDeviceActionService.cs
@@ -19,7 +19,7 @@ namespace Bit.App.Abstractions
         Task SelectFileAsync();
         Task<string> DisplayPromptAync(string title = null, string description = null, string text = null,
             string okButtonText = null, string cancelButtonText = null, bool numericKeyboard = false,
-            bool autofocus = true);
+            bool autofocus = true, bool password = false);
         void RateApp();
         bool SupportsFaceBiometric();
         Task<bool> SupportsFaceBiometricAsync();

--- a/src/App/Abstractions/IPasswordRepromptService.cs
+++ b/src/App/Abstractions/IPasswordRepromptService.cs
@@ -1,0 +1,11 @@
+﻿using System.Threading.Tasks;
+
+namespace Bit.App.Abstractions
+{
+    public interface IPasswordRepromptService
+    {
+        string[] ProtectedFields { get; }
+
+        Task<bool> ShowPasswordPrompt();
+    }
+}

--- a/src/App/Abstractions/IPasswordRepromptService.cs
+++ b/src/App/Abstractions/IPasswordRepromptService.cs
@@ -6,6 +6,6 @@ namespace Bit.App.Abstractions
     {
         string[] ProtectedFields { get; }
 
-        Task<bool> ShowPasswordPrompt();
+        Task<bool> ShowPasswordPromptAsync();
     }
 }

--- a/src/App/Pages/Vault/AddEditPage.xaml
+++ b/src/App/Pages/Vault/AddEditPage.xaml
@@ -555,6 +555,16 @@
                         StyleClass="box-value"
                         HorizontalOptions="End" />
                 </StackLayout>
+                <StackLayout StyleClass="box-row, box-row-switch">
+                    <Label
+                        Text="{u:I18n PasswordPrompt}"
+                        StyleClass="box-label-regular"
+                        HorizontalOptions="StartAndExpand" />
+                    <Switch
+                        IsToggled="{Binding Cipher.PasswordPrompt}"
+                        StyleClass="box-value"
+                        HorizontalOptions="End" />
+                </StackLayout>
                 <BoxView StyleClass="box-row-separator" />
             </StackLayout>
             <StackLayout StyleClass="box">

--- a/src/App/Pages/Vault/AddEditPage.xaml
+++ b/src/App/Pages/Vault/AddEditPage.xaml
@@ -219,15 +219,40 @@
                             Text="{Binding Cipher.Card.CardholderName}"
                             StyleClass="box-value" />
                     </StackLayout>
-                    <StackLayout StyleClass="box-row, box-row-input">
+                    <Grid StyleClass="box-row, box-row-input">
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="*" />
+                        </Grid.RowDefinitions>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="Auto" />
+                        </Grid.ColumnDefinitions>
                         <Label
                             Text="{u:I18n Number}"
-                            StyleClass="box-label" />
-                        <Entry
+                            StyleClass="box-label"
+                            Grid.Row="0"
+                            Grid.Column="0" />
+                        <controls:MonoEntry
                             x:Name="_cardNumberEntry"
                             Text="{Binding Cipher.Card.Number}"
-                            StyleClass="box-value" />
-                    </StackLayout>
+                            StyleClass="box-value"
+                            Grid.Row="1"
+                            Grid.Column="0"
+                            Keyboard="Numeric"
+                            IsPassword="{Binding ShowCardNumber, Converter={StaticResource inverseBool}}"
+                            IsSpellCheckEnabled="False"
+                            IsTextPredictionEnabled="False" />
+                        <controls:FaButton 
+                            StyleClass="box-row-button, box-row-button-platform"
+                            Text="{Binding ShowCardNumberIcon}"
+                            Command="{Binding ToggleCardNumberCommand}"
+                            Grid.Row="0"
+                            Grid.Column="1"
+                            Grid.RowSpan="2"
+                            AutomationProperties.IsInAccessibleTree="True"
+                            AutomationProperties.Name="{u:I18n ToggleVisibility}" />
+                    </Grid>
                     <StackLayout StyleClass="box-row, box-row-input">
                         <Label
                             Text="{u:I18n Brand}"

--- a/src/App/Pages/Vault/AddEditPage.xaml
+++ b/src/App/Pages/Vault/AddEditPage.xaml
@@ -561,7 +561,8 @@
                         StyleClass="box-label-regular"
                         HorizontalOptions="StartAndExpand" />
                     <Switch
-                        IsToggled="{Binding Cipher.PasswordPrompt}"
+                        IsToggled="{Binding PasswordPrompt}"
+                        Toggled="PasswordPrompt_Toggled"
                         StyleClass="box-value"
                         HorizontalOptions="End" />
                 </StackLayout>

--- a/src/App/Pages/Vault/AddEditPage.xaml.cs
+++ b/src/App/Pages/Vault/AddEditPage.xaml.cs
@@ -376,5 +376,10 @@ namespace Bit.App.Pages
                 }
             }
         }
+
+        private void PasswordPrompt_Toggled(object sender, ToggledEventArgs e)
+        {
+            _vm.Cipher.Reprompt = e.Value ? CipherRepromptType.Password : CipherRepromptType.None;
+        }
     }
 }

--- a/src/App/Pages/Vault/AddEditPageViewModel.cs
+++ b/src/App/Pages/Vault/AddEditPageViewModel.cs
@@ -29,6 +29,7 @@ namespace Bit.App.Pages
         private CipherView _cipher;
         private bool _showNotesSeparator;
         private bool _showPassword;
+        private bool _showCardNumber;
         private bool _showCardCode;
         private int _typeSelectedIndex;
         private int _cardBrandSelectedIndex;
@@ -82,6 +83,7 @@ namespace Bit.App.Pages
             _policyService = ServiceContainer.Resolve<IPolicyService>("policyService");
             GeneratePasswordCommand = new Command(GeneratePassword);
             TogglePasswordCommand = new Command(TogglePassword);
+            ToggleCardNumberCommand = new Command(ToggleCardNumber);
             ToggleCardCodeCommand = new Command(ToggleCardCode);
             CheckPasswordCommand = new Command(CheckPasswordAsync);
             UriOptionsCommand = new Command<LoginUriView>(UriOptions);
@@ -141,6 +143,7 @@ namespace Bit.App.Pages
 
         public Command GeneratePasswordCommand { get; set; }
         public Command TogglePasswordCommand { get; set; }
+        public Command ToggleCardNumberCommand { get; set; }
         public Command ToggleCardCodeCommand { get; set; }
         public Command CheckPasswordCommand { get; set; }
         public Command UriOptionsCommand { get; set; }
@@ -246,6 +249,15 @@ namespace Bit.App.Pages
                     nameof(ShowPasswordIcon)
                 });
         }
+        public bool ShowCardNumber
+        {
+            get => _showCardNumber;
+            set => SetProperty(ref _showCardNumber, value,
+                additionalPropertyNames: new string[]
+                {
+                    nameof(ShowCardNumberIcon)
+                });
+        }
         public bool ShowCardCode
         {
             get => _showCardCode;
@@ -277,6 +289,7 @@ namespace Bit.App.Pages
         public bool ShowUris => IsLogin && Cipher.Login.HasUris;
         public bool ShowAttachments => Cipher.HasAttachments;
         public string ShowPasswordIcon => ShowPassword ? "" : "";
+        public string ShowCardNumberIcon => ShowCardNumber ? "" : "";
         public string ShowCardCodeIcon => ShowCardCode ? "" : "";
         public int PasswordFieldColSpan => Cipher.ViewPassword ? 1 : 4;
         public int TotpColumnSpan => Cipher.ViewPassword ? 1 : 2;
@@ -688,6 +701,16 @@ namespace Bit.App.Pages
             if (EditMode && ShowPassword)
             {
                 var task = _eventService.CollectAsync(EventType.Cipher_ClientToggledPasswordVisible, CipherId);
+            }
+        }
+
+        public void ToggleCardNumber()
+        {
+            ShowCardNumber = !ShowCardNumber;
+            if (EditMode && ShowCardNumber)
+            {
+                var task = _eventService.CollectAsync(
+                    Core.Enums.EventType.Cipher_ClientToggledCardNumberVisible, CipherId);
             }
         }
 

--- a/src/App/Pages/Vault/AddEditPageViewModel.cs
+++ b/src/App/Pages/Vault/AddEditPageViewModel.cs
@@ -294,6 +294,7 @@ namespace Bit.App.Pages
         public int PasswordFieldColSpan => Cipher.ViewPassword ? 1 : 4;
         public int TotpColumnSpan => Cipher.ViewPassword ? 1 : 2;
         public bool AllowPersonal { get; set; }
+        public bool PasswordPrompt => Cipher.Reprompt != CipherRepromptType.None;
 
         public void Init()
         {

--- a/src/App/Pages/Vault/AutofillCiphersPageViewModel.cs
+++ b/src/App/Pages/Vault/AutofillCiphersPageViewModel.cs
@@ -23,6 +23,7 @@ namespace Bit.App.Pages
         private readonly IDeviceActionService _deviceActionService;
         private readonly ICipherService _cipherService;
         private readonly IStateService _stateService;
+        private readonly IPasswordRepromptService _passwordRepromptService;
 
         private AppOptions _appOptions;
         private bool _showList;
@@ -35,6 +36,7 @@ namespace Bit.App.Pages
             _cipherService = ServiceContainer.Resolve<ICipherService>("cipherService");
             _deviceActionService = ServiceContainer.Resolve<IDeviceActionService>("deviceActionService");
             _stateService = ServiceContainer.Resolve<IStateService>("stateService");
+            _passwordRepromptService = ServiceContainer.Resolve<IPasswordRepromptService>("passwordRepromptService");
 
             GroupedItems = new ExtendedObservableCollection<GroupingsPageListGroup>();
             CipherOptionsCommand = new Command<CipherView>(CipherOptionsAsync);
@@ -118,7 +120,7 @@ namespace Bit.App.Pages
             }
             if (_deviceActionService.SystemMajorVersion() < 21)
             {
-                await AppHelpers.CipherListOptions(Page, cipher);
+                await AppHelpers.CipherListOptions(Page, cipher, _passwordRepromptService);
             }
             else
             {
@@ -175,7 +177,7 @@ namespace Bit.App.Pages
         {
             if ((Page as BaseContentPage).DoOnce())
             {
-                await AppHelpers.CipherListOptions(Page, cipher);
+                await AppHelpers.CipherListOptions(Page, cipher, _passwordRepromptService);
             }
         }
     }

--- a/src/App/Pages/Vault/AutofillCiphersPageViewModel.cs
+++ b/src/App/Pages/Vault/AutofillCiphersPageViewModel.cs
@@ -124,6 +124,10 @@ namespace Bit.App.Pages
             }
             else
             {
+                if (cipher.Reprompt != CipherRepromptType.None && !await _passwordRepromptService.ShowPasswordPrompt())
+                {
+                    return;
+                }
                 var autofillResponse = AppResources.Yes;
                 if (fuzzy)
                 {

--- a/src/App/Pages/Vault/AutofillCiphersPageViewModel.cs
+++ b/src/App/Pages/Vault/AutofillCiphersPageViewModel.cs
@@ -124,7 +124,7 @@ namespace Bit.App.Pages
             }
             else
             {
-                if (cipher.Reprompt != CipherRepromptType.None && !await _passwordRepromptService.ShowPasswordPrompt())
+                if (cipher.Reprompt != CipherRepromptType.None && !await _passwordRepromptService.ShowPasswordPromptAsync())
                 {
                     return;
                 }

--- a/src/App/Pages/Vault/CiphersPageViewModel.cs
+++ b/src/App/Pages/Vault/CiphersPageViewModel.cs
@@ -22,6 +22,7 @@ namespace Bit.App.Pages
         private readonly ISearchService _searchService;
         private readonly IDeviceActionService _deviceActionService;
         private readonly IStateService _stateService;
+        private readonly IPasswordRepromptService _passwordRepromptService;
         private CancellationTokenSource _searchCancellationTokenSource;
 
         private bool _showNoData;
@@ -35,6 +36,7 @@ namespace Bit.App.Pages
             _searchService = ServiceContainer.Resolve<ISearchService>("searchService");
             _deviceActionService = ServiceContainer.Resolve<IDeviceActionService>("deviceActionService");
             _stateService = ServiceContainer.Resolve<IStateService>("stateService");
+            _passwordRepromptService = ServiceContainer.Resolve<IPasswordRepromptService>("passwordRepromptService");
 
             Ciphers = new ExtendedObservableCollection<CipherView>();
             CipherOptionsCommand = new Command<CipherView>(CipherOptionsAsync);
@@ -182,7 +184,7 @@ namespace Bit.App.Pages
                 }
                 if (_deviceActionService.SystemMajorVersion() < 21)
                 {
-                    await Utilities.AppHelpers.CipherListOptions(Page, cipher);
+                    await Utilities.AppHelpers.CipherListOptions(Page, cipher, _passwordRepromptService);
                 }
                 else
                 {
@@ -195,7 +197,7 @@ namespace Bit.App.Pages
         {
             if ((Page as BaseContentPage).DoOnce())
             {
-                await Utilities.AppHelpers.CipherListOptions(Page, cipher);
+                await Utilities.AppHelpers.CipherListOptions(Page, cipher, _passwordRepromptService);
             }
         }
     }

--- a/src/App/Pages/Vault/GroupingsPage/GroupingsPageViewModel.cs
+++ b/src/App/Pages/Vault/GroupingsPage/GroupingsPageViewModel.cs
@@ -46,6 +46,7 @@ namespace Bit.App.Pages
         private readonly IMessagingService _messagingService;
         private readonly IStateService _stateService;
         private readonly IStorageService _storageService;
+        private readonly IPasswordRepromptService _passwordRepromptService;
 
         public GroupingsPageViewModel()
         {
@@ -60,6 +61,7 @@ namespace Bit.App.Pages
             _messagingService = ServiceContainer.Resolve<IMessagingService>("messagingService");
             _stateService = ServiceContainer.Resolve<IStateService>("stateService");
             _storageService = ServiceContainer.Resolve<IStorageService>("storageService");
+            _passwordRepromptService = ServiceContainer.Resolve<IPasswordRepromptService>("passwordRepromptService");
 
             Loading = true;
             PageTitle = AppResources.MyVault;
@@ -514,7 +516,7 @@ namespace Bit.App.Pages
         {
             if ((Page as BaseContentPage).DoOnce())
             {
-                await AppHelpers.CipherListOptions(Page, cipher);
+                await AppHelpers.CipherListOptions(Page, cipher, _passwordRepromptService);
             }
         }
     }

--- a/src/App/Pages/Vault/ViewPage.xaml
+++ b/src/App/Pages/Vault/ViewPage.xaml
@@ -224,24 +224,41 @@
                                 <Grid.ColumnDefinitions>
                                     <ColumnDefinition Width="*" />
                                     <ColumnDefinition Width="Auto" />
+                                    <ColumnDefinition Width="Auto" />
                                 </Grid.ColumnDefinitions>
                                 <Label
                                     Text="{u:I18n Number}"
                                     StyleClass="box-label"
                                     Grid.Row="0"
                                     Grid.Column="0" />
-                                <Label
+                                <controls:MonoLabel
+                                    Text="{Binding Cipher.Card.MaskedNumber, Mode=OneWay}"
+                                    StyleClass="box-value"
+                                    Grid.Row="1"
+                                    Grid.Column="0"
+                                    IsVisible="{Binding ShowCardNumber, Converter={StaticResource inverseBool}}" />
+                                <controls:MonoLabel
                                     Text="{Binding Cipher.Card.Number, Mode=OneWay}"
                                     StyleClass="box-value"
                                     Grid.Row="1"
-                                    Grid.Column="0" />
+                                    Grid.Column="0"
+                                    IsVisible="{Binding ShowCardNumber}" />
+                                <controls:FaButton 
+                                    StyleClass="box-row-button, box-row-button-platform"
+                                    Text="{Binding ShowCardNumberIcon}"
+                                    Command="{Binding ToggleCardNumberCommand}"
+                                    Grid.Row="0"
+                                    Grid.Column="1"
+                                    Grid.RowSpan="2"
+                                    AutomationProperties.IsInAccessibleTree="True"
+                                    AutomationProperties.Name="{u:I18n ToggleVisibility}" />
                                 <controls:FaButton 
                                     StyleClass="box-row-button, box-row-button-platform"
                                     Text="&#xf24d;"
                                     Command="{Binding CopyCommand}"
                                     CommandParameter="CardNumber"
                                     Grid.Row="0"
-                                    Grid.Column="1"
+                                    Grid.Column="2"
                                     Grid.RowSpan="2"
                                     AutomationProperties.IsInAccessibleTree="True"
                                     AutomationProperties.Name="{u:I18n CopyNumber}" />

--- a/src/App/Pages/Vault/ViewPage.xaml.cs
+++ b/src/App/Pages/Vault/ViewPage.xaml.cs
@@ -146,6 +146,10 @@ namespace Bit.App.Pages
         {
             if (DoOnce())
             {
+                if (!await _vm.PromptPasswordAsync())
+                {
+                    return;
+                }
                 var page = new AttachmentsPage(_vm.CipherId);
                 await Navigation.PushModalAsync(new NavigationPage(page));
             }
@@ -155,6 +159,10 @@ namespace Bit.App.Pages
         {
             if (DoOnce())
             {
+                if (!await _vm.PromptPasswordAsync())
+                {
+                    return;
+                }
                 var page = new SharePage(_vm.CipherId);
                 await Navigation.PushModalAsync(new NavigationPage(page));
             }
@@ -164,6 +172,10 @@ namespace Bit.App.Pages
         {
             if (DoOnce())
             {
+                if (!await _vm.PromptPasswordAsync())
+                {
+                    return;
+                }
                 if (await _vm.DeleteAsync())
                 {
                     await Navigation.PopModalAsync();
@@ -175,6 +187,10 @@ namespace Bit.App.Pages
         {
             if (DoOnce())
             {
+                if (!await _vm.PromptPasswordAsync())
+                {
+                    return;
+                }
                 var page = new CollectionsPage(_vm.CipherId);
                 await Navigation.PushModalAsync(new NavigationPage(page));
             }
@@ -184,6 +200,10 @@ namespace Bit.App.Pages
         {
             if (DoOnce())
             {
+                if (!await _vm.PromptPasswordAsync())
+                {
+                    return;
+                }
                 var page = new AddEditPage(_vm.CipherId, cloneMode: true, viewPage: this);
                 await Navigation.PushModalAsync(new NavigationPage(page));
             }

--- a/src/App/Pages/Vault/ViewPage.xaml.cs
+++ b/src/App/Pages/Vault/ViewPage.xaml.cs
@@ -128,6 +128,10 @@ namespace Bit.App.Pages
                 }
                 else
                 {
+                    if (!await _vm.PromptPasswordAsync())
+                    {
+                        return;
+                    }
                     await Navigation.PushModalAsync(new NavigationPage(new AddEditPage(_vm.CipherId)));
                 }
             }

--- a/src/App/Pages/Vault/ViewPageViewModel.cs
+++ b/src/App/Pages/Vault/ViewPageViewModel.cs
@@ -27,6 +27,7 @@ namespace Bit.App.Pages
         private List<ViewPageFieldViewModel> _fields;
         private bool _canAccessPremium;
         private bool _showPassword;
+        private bool _showCardNumber;
         private bool _showCardCode;
         private string _totpCode;
         private string _totpCodeFormatted;
@@ -52,6 +53,7 @@ namespace Bit.App.Pages
             CopyFieldCommand = new Command<FieldView>(CopyField);
             LaunchUriCommand = new Command<LoginUriView>(LaunchUri);
             TogglePasswordCommand = new Command(TogglePassword);
+            ToggleCardNumberCommand = new Command(ToggleCardNumber);
             ToggleCardCodeCommand = new Command(ToggleCardCode);
             CheckPasswordCommand = new Command(CheckPasswordAsync);
             DownloadAttachmentCommand = new Command<AttachmentView>(DownloadAttachmentAsync);
@@ -64,6 +66,7 @@ namespace Bit.App.Pages
         public Command CopyFieldCommand { get; set; }
         public Command LaunchUriCommand { get; set; }
         public Command TogglePasswordCommand { get; set; }
+        public Command ToggleCardNumberCommand { get; set; }
         public Command ToggleCardCodeCommand { get; set; }
         public Command CheckPasswordCommand { get; set; }
         public Command DownloadAttachmentCommand { get; set; }
@@ -107,6 +110,15 @@ namespace Bit.App.Pages
                 additionalPropertyNames: new string[]
                 {
                     nameof(ShowPasswordIcon)
+                });
+        }
+        public bool ShowCardNumber
+        {
+            get => _showCardNumber;
+            set => SetProperty(ref _showCardNumber, value,
+                additionalPropertyNames: new string[]
+                {
+                    nameof(ShowCardNumberIcon)
                 });
         }
         public bool ShowCardCode
@@ -188,6 +200,7 @@ namespace Bit.App.Pages
         public bool ShowTotp => IsLogin && !string.IsNullOrWhiteSpace(Cipher.Login.Totp) &&
             !string.IsNullOrWhiteSpace(TotpCodeFormatted);
         public string ShowPasswordIcon => ShowPassword ? "" : "";
+        public string ShowCardNumberIcon => ShowCardNumber ? "" : "";
         public string ShowCardCodeIcon => ShowCardCode ? "" : "";
         public string TotpCodeFormatted
         {
@@ -265,6 +278,16 @@ namespace Bit.App.Pages
             if (ShowPassword)
             {
                 var task = _eventService.CollectAsync(Core.Enums.EventType.Cipher_ClientToggledPasswordVisible, CipherId);
+            }
+        }
+
+        public void ToggleCardNumber()
+        {
+            ShowCardNumber = !ShowCardNumber;
+            if (ShowCardNumber)
+            {
+                var task = _eventService.CollectAsync(
+                    Core.Enums.EventType.Cipher_ClientToggledCardNumberVisible, CipherId);
             }
         }
 

--- a/src/App/Pages/Vault/ViewPageViewModel.cs
+++ b/src/App/Pages/Vault/ViewPageViewModel.cs
@@ -2,6 +2,7 @@
 using Bit.App.Resources;
 using Bit.App.Utilities;
 using Bit.Core.Abstractions;
+using Bit.Core.Enums;
 using Bit.Core.Exceptions;
 using Bit.Core.Models.View;
 using Bit.Core.Utilities;
@@ -685,7 +686,7 @@ namespace Bit.App.Pages
 
         internal async Task<bool> PromptPasswordAsync()
         {
-            if (!Cipher.PasswordPrompt || _passwordReprompted)
+            if (Cipher.Reprompt == CipherRepromptType.None || _passwordReprompted)
             {
                 return true;
             }

--- a/src/App/Pages/Vault/ViewPageViewModel.cs
+++ b/src/App/Pages/Vault/ViewPageViewModel.cs
@@ -691,7 +691,7 @@ namespace Bit.App.Pages
                 return true;
             }
 
-            return _passwordReprompted = await _passwordRepromptService.ShowPasswordPrompt();
+            return _passwordReprompted = await _passwordRepromptService.ShowPasswordPromptAsync();
         }
     }
 

--- a/src/App/Resources/AppResources.Designer.cs
+++ b/src/App/Resources/AppResources.Designer.cs
@@ -3508,5 +3508,25 @@ namespace Bit.App.Resources {
                 return ResourceManager.GetString("SendFileEmailVerificationRequired", resourceCulture);
             }
         }
+        public static string PasswordPrompt
+        {
+            get
+            {
+                return ResourceManager.GetString("PasswordPrompt", resourceCulture);
+            }
+        }
+        public static string PasswordConfirmation
+        {
+            get
+            {
+                return ResourceManager.GetString("PasswordConfirmation", resourceCulture);
+            }
+        }public static string PasswordConfirmationDesc
+        {
+            get
+            {
+                return ResourceManager.GetString("PasswordConfirmationDesc", resourceCulture);
+            }
+        }
     }
 }

--- a/src/App/Resources/AppResources.resx
+++ b/src/App/Resources/AppResources.resx
@@ -1987,4 +1987,13 @@
     <value>You must verify your email to use files with Send.</value>
     <comment>'Send' is a noun and the name of a feature called 'Bitwarden Send'. It should not be translated.</comment>
   </data>
+  <data name="PasswordPrompt" xml:space="preserve">
+    <value>Master password re-prompt</value>
+  </data>
+  <data name="PasswordConfirmation" xml:space="preserve">
+    <value>Master password confirmation</value>
+  </data>
+  <data name="PasswordConfirmationDesc" xml:space="preserve">
+    <value>This action is protected, to continue please re-enter your master password to verify your identity.</value>
+  </data>
 </root>

--- a/src/App/Services/MobilePasswordRepromptService.cs
+++ b/src/App/Services/MobilePasswordRepromptService.cs
@@ -2,50 +2,45 @@
 using Bit.Core.Abstractions;
 using Bit.App.Abstractions;
 using Bit.App.Resources;
+using System;
 
 namespace Bit.App.Services
 {
     public class MobilePasswordRepromptService : IPasswordRepromptService
     {
-        private readonly IDeviceActionService _deviceActionService;
         private readonly IPlatformUtilsService _platformUtilsService;
         private readonly ICryptoService _cryptoService;
 
-        public MobilePasswordRepromptService(
-            IDeviceActionService deviceActionService,
-            IPlatformUtilsService platformUtilsService,
-            ICryptoService cryptoService)
+        public MobilePasswordRepromptService(IPlatformUtilsService platformUtilsService, ICryptoService cryptoService)
         {
-            _deviceActionService = deviceActionService;
             _platformUtilsService = platformUtilsService;
             _cryptoService = cryptoService;
         }
 
         public string[] ProtectedFields { get; } = { "LoginTotp", "LoginPassword", "H_FieldValue", "CardNumber", "CardCode" };
 
-        public async Task<bool> ShowPasswordPrompt()
+        public async Task<bool> ShowPasswordPromptAsync()
         {
-            var password = await _deviceActionService.DisplayPromptAync(AppResources.PasswordConfirmation,
-                    AppResources.PasswordConfirmationDesc, null, AppResources.Submit, AppResources.Cancel, password: true);
-
-            // Assume user has canceled.
-            if (string.IsNullOrWhiteSpace(password))
+            Func<string, Task<bool>> validator = async (string password) =>
             {
-                return false;
+                // Assume user has canceled.
+                if (string.IsNullOrWhiteSpace(password))
+                {
+                    return false;
+                };
+
+                var keyHash = await _cryptoService.HashPasswordAsync(password, null);
+                var storedKeyHash = await _cryptoService.GetKeyHashAsync();
+
+                if (storedKeyHash == null || keyHash == null || storedKeyHash != keyHash)
+                {
+                    return false;
+                }
+
+                return true;
             };
 
-            var keyHash = await _cryptoService.HashPasswordAsync(password, null);
-            var storedKeyHash = await _cryptoService.GetKeyHashAsync();
-
-            if (storedKeyHash == null || keyHash == null || storedKeyHash != keyHash)
-            {
-                var retry = await _platformUtilsService.ShowDialogAsync(
-                       AppResources.InvalidMasterPassword, null, AppResources.Ok);
-
-                return false;
-            }
-
-            return true;
+            return await _platformUtilsService.ShowPasswordDialogAsync(AppResources.PasswordConfirmation, AppResources.PasswordConfirmationDesc, validator);
         }
     }
 }

--- a/src/App/Services/MobilePasswordRepromptService.cs
+++ b/src/App/Services/MobilePasswordRepromptService.cs
@@ -1,0 +1,51 @@
+﻿using System.Threading.Tasks;
+using Bit.Core.Abstractions;
+using Bit.App.Abstractions;
+using Bit.App.Resources;
+
+namespace Bit.App.Services
+{
+    public class MobilePasswordRepromptService : IPasswordRepromptService
+    {
+        private readonly IDeviceActionService _deviceActionService;
+        private readonly IPlatformUtilsService _platformUtilsService;
+        private readonly ICryptoService _cryptoService;
+
+        public MobilePasswordRepromptService(
+            IDeviceActionService deviceActionService,
+            IPlatformUtilsService platformUtilsService,
+            ICryptoService cryptoService)
+        {
+            _deviceActionService = deviceActionService;
+            _platformUtilsService = platformUtilsService;
+            _cryptoService = cryptoService;
+        }
+
+        public string[] ProtectedFields { get; } = { "LoginTotp", "LoginPassword", "H_FieldValue", "CardNumber", "CardCode" };
+
+        public async Task<bool> ShowPasswordPrompt()
+        {
+            var password = await _deviceActionService.DisplayPromptAync(AppResources.PasswordConfirmation,
+                    AppResources.PasswordConfirmationDesc, null, AppResources.Submit, AppResources.Cancel, password: true);
+
+            // Assume user has canceled.
+            if (string.IsNullOrWhiteSpace(password))
+            {
+                return false;
+            };
+
+            var keyHash = await _cryptoService.HashPasswordAsync(password, null);
+            var storedKeyHash = await _cryptoService.GetKeyHashAsync();
+
+            if (storedKeyHash == null || keyHash == null || storedKeyHash != keyHash)
+            {
+                var retry = await _platformUtilsService.ShowDialogAsync(
+                       AppResources.InvalidMasterPassword, null, AppResources.Ok);
+
+                return false;
+            }
+
+            return true;
+        }
+    }
+}

--- a/src/App/Services/MobilePlatformUtilsService.cs
+++ b/src/App/Services/MobilePlatformUtilsService.cs
@@ -171,6 +171,21 @@ namespace Bit.App.Services
             return tcs.Task;
         }
 
+        public async Task<bool> ShowPasswordDialogAsync(string title, string body, Func<string, Task<bool>> validator)
+        {
+            var password = await _deviceActionService.DisplayPromptAync(AppResources.PasswordConfirmation,
+                AppResources.PasswordConfirmationDesc, null, AppResources.Submit, AppResources.Cancel, password: true);
+
+            var valid = await validator(password);
+
+            if (!valid)
+            {
+                await ShowDialogAsync(AppResources.InvalidMasterPassword, null, AppResources.Ok);
+            }
+
+            return valid;
+        }
+
         public bool IsDev()
         {
             return Core.Utilities.CoreHelpers.InDebugMode();

--- a/src/App/Utilities/AppHelpers.cs
+++ b/src/App/Utilities/AppHelpers.cs
@@ -92,7 +92,7 @@ namespace Bit.App.Utilities
             }
             else if (selection == AppResources.CopyPassword)
             {
-                if (cipher.PasswordPrompt && await passwordRepromptService.ShowPasswordPrompt())
+                if (cipher.Reprompt == CipherRepromptType.None || await passwordRepromptService.ShowPasswordPrompt())
                 {
                     await platformUtilsService.CopyToClipboardAsync(cipher.Login.Password);
                     platformUtilsService.ShowToast("info", null,
@@ -102,7 +102,7 @@ namespace Bit.App.Utilities
             }
             else if (selection == AppResources.CopyTotp)
             {
-                if (cipher.PasswordPrompt && await passwordRepromptService.ShowPasswordPrompt())
+                if (cipher.Reprompt == CipherRepromptType.None || await passwordRepromptService.ShowPasswordPrompt())
                 {
                     var totpService = ServiceContainer.Resolve<ITotpService>("totpService");
                     var totp = await totpService.GetCodeAsync(cipher.Login.Totp);
@@ -120,7 +120,7 @@ namespace Bit.App.Utilities
             }
             else if (selection == AppResources.CopyNumber)
             {
-                if (cipher.PasswordPrompt && await passwordRepromptService.ShowPasswordPrompt())
+                if (cipher.Reprompt == CipherRepromptType.None || await passwordRepromptService.ShowPasswordPrompt())
                 {
                     await platformUtilsService.CopyToClipboardAsync(cipher.Card.Number);
                     platformUtilsService.ShowToast("info", null,
@@ -129,7 +129,7 @@ namespace Bit.App.Utilities
             }
             else if (selection == AppResources.CopySecurityCode)
             {
-                if (cipher.PasswordPrompt && await passwordRepromptService.ShowPasswordPrompt())
+                if (cipher.Reprompt == CipherRepromptType.None || await passwordRepromptService.ShowPasswordPrompt())
                 {
                     await platformUtilsService.CopyToClipboardAsync(cipher.Card.Code);
                     platformUtilsService.ShowToast("info", null,

--- a/src/App/Utilities/AppHelpers.cs
+++ b/src/App/Utilities/AppHelpers.cs
@@ -92,7 +92,7 @@ namespace Bit.App.Utilities
             }
             else if (selection == AppResources.CopyPassword)
             {
-                if (cipher.Reprompt == CipherRepromptType.None || await passwordRepromptService.ShowPasswordPrompt())
+                if (cipher.Reprompt == CipherRepromptType.None || await passwordRepromptService.ShowPasswordPromptAsync())
                 {
                     await platformUtilsService.CopyToClipboardAsync(cipher.Login.Password);
                     platformUtilsService.ShowToast("info", null,
@@ -102,7 +102,7 @@ namespace Bit.App.Utilities
             }
             else if (selection == AppResources.CopyTotp)
             {
-                if (cipher.Reprompt == CipherRepromptType.None || await passwordRepromptService.ShowPasswordPrompt())
+                if (cipher.Reprompt == CipherRepromptType.None || await passwordRepromptService.ShowPasswordPromptAsync())
                 {
                     var totpService = ServiceContainer.Resolve<ITotpService>("totpService");
                     var totp = await totpService.GetCodeAsync(cipher.Login.Totp);
@@ -120,7 +120,7 @@ namespace Bit.App.Utilities
             }
             else if (selection == AppResources.CopyNumber)
             {
-                if (cipher.Reprompt == CipherRepromptType.None || await passwordRepromptService.ShowPasswordPrompt())
+                if (cipher.Reprompt == CipherRepromptType.None || await passwordRepromptService.ShowPasswordPromptAsync())
                 {
                     await platformUtilsService.CopyToClipboardAsync(cipher.Card.Number);
                     platformUtilsService.ShowToast("info", null,
@@ -129,7 +129,7 @@ namespace Bit.App.Utilities
             }
             else if (selection == AppResources.CopySecurityCode)
             {
-                if (cipher.Reprompt == CipherRepromptType.None || await passwordRepromptService.ShowPasswordPrompt())
+                if (cipher.Reprompt == CipherRepromptType.None || await passwordRepromptService.ShowPasswordPromptAsync())
                 {
                     await platformUtilsService.CopyToClipboardAsync(cipher.Card.Code);
                     platformUtilsService.ShowToast("info", null,

--- a/src/App/Utilities/AppHelpers.cs
+++ b/src/App/Utilities/AppHelpers.cs
@@ -19,7 +19,7 @@ namespace Bit.App.Utilities
 {
     public static class AppHelpers
     {
-        public static async Task<string> CipherListOptions(ContentPage page, CipherView cipher)
+        public static async Task<string> CipherListOptions(ContentPage page, CipherView cipher, IPasswordRepromptService passwordRepromptService)
         {
             var platformUtilsService = ServiceContainer.Resolve<IPlatformUtilsService>("platformUtilsService");
             var eventService = ServiceContainer.Resolve<IEventService>("eventService");
@@ -92,20 +92,26 @@ namespace Bit.App.Utilities
             }
             else if (selection == AppResources.CopyPassword)
             {
-                await platformUtilsService.CopyToClipboardAsync(cipher.Login.Password);
-                platformUtilsService.ShowToast("info", null,
-                    string.Format(AppResources.ValueHasBeenCopied, AppResources.Password));
-                var task = eventService.CollectAsync(Core.Enums.EventType.Cipher_ClientCopiedPassword, cipher.Id);
+                if (cipher.PasswordPrompt && await passwordRepromptService.ShowPasswordPrompt())
+                {
+                    await platformUtilsService.CopyToClipboardAsync(cipher.Login.Password);
+                    platformUtilsService.ShowToast("info", null,
+                        string.Format(AppResources.ValueHasBeenCopied, AppResources.Password));
+                    var task = eventService.CollectAsync(Core.Enums.EventType.Cipher_ClientCopiedPassword, cipher.Id);
+                }
             }
             else if (selection == AppResources.CopyTotp)
             {
-                var totpService = ServiceContainer.Resolve<ITotpService>("totpService");
-                var totp = await totpService.GetCodeAsync(cipher.Login.Totp);
-                if (!string.IsNullOrWhiteSpace(totp))
+                if (cipher.PasswordPrompt && await passwordRepromptService.ShowPasswordPrompt())
                 {
-                    await platformUtilsService.CopyToClipboardAsync(totp);
-                    platformUtilsService.ShowToast("info", null,
-                        string.Format(AppResources.ValueHasBeenCopied, AppResources.VerificationCodeTotp));
+                    var totpService = ServiceContainer.Resolve<ITotpService>("totpService");
+                    var totp = await totpService.GetCodeAsync(cipher.Login.Totp);
+                    if (!string.IsNullOrWhiteSpace(totp))
+                    {
+                        await platformUtilsService.CopyToClipboardAsync(totp);
+                        platformUtilsService.ShowToast("info", null,
+                            string.Format(AppResources.ValueHasBeenCopied, AppResources.VerificationCodeTotp));
+                    }
                 }
             }
             else if (selection == AppResources.Launch)
@@ -114,16 +120,22 @@ namespace Bit.App.Utilities
             }
             else if (selection == AppResources.CopyNumber)
             {
-                await platformUtilsService.CopyToClipboardAsync(cipher.Card.Number);
-                platformUtilsService.ShowToast("info", null,
-                    string.Format(AppResources.ValueHasBeenCopied, AppResources.Number));
+                if (cipher.PasswordPrompt && await passwordRepromptService.ShowPasswordPrompt())
+                {
+                    await platformUtilsService.CopyToClipboardAsync(cipher.Card.Number);
+                    platformUtilsService.ShowToast("info", null,
+                        string.Format(AppResources.ValueHasBeenCopied, AppResources.Number));
+                }
             }
             else if (selection == AppResources.CopySecurityCode)
             {
-                await platformUtilsService.CopyToClipboardAsync(cipher.Card.Code);
-                platformUtilsService.ShowToast("info", null,
-                    string.Format(AppResources.ValueHasBeenCopied, AppResources.SecurityCode));
-                var task = eventService.CollectAsync(Core.Enums.EventType.Cipher_ClientCopiedCardCode, cipher.Id);
+                if (cipher.PasswordPrompt && await passwordRepromptService.ShowPasswordPrompt())
+                {
+                    await platformUtilsService.CopyToClipboardAsync(cipher.Card.Code);
+                    platformUtilsService.ShowToast("info", null,
+                        string.Format(AppResources.ValueHasBeenCopied, AppResources.SecurityCode));
+                    var task = eventService.CollectAsync(Core.Enums.EventType.Cipher_ClientCopiedCardCode, cipher.Id);
+                }
             }
             else if (selection == AppResources.CopyNotes)
             {

--- a/src/Core/Abstractions/IPlatformUtilsService.cs
+++ b/src/Core/Abstractions/IPlatformUtilsService.cs
@@ -22,6 +22,7 @@ namespace Bit.Core.Abstractions
         void SaveFile();
         Task<bool> ShowDialogAsync(string text, string title = null, string confirmText = null,
             string cancelText = null, string type = null);
+        Task<bool> ShowPasswordDialogAsync(string title, string body, Func<string, Task<bool>> validator);
         void ShowToast(string type, string title, string text, Dictionary<string, object> options = null);
         void ShowToast(string type, string title, string[] text, Dictionary<string, object> options = null);
         bool SupportsU2f();

--- a/src/Core/Enums/CipherRepromptType.cs
+++ b/src/Core/Enums/CipherRepromptType.cs
@@ -1,0 +1,8 @@
+﻿namespace Bit.Core.Enums
+{
+    public enum CipherRepromptType : byte
+    {
+        None = 0,
+        Password = 1,
+    }
+}

--- a/src/Core/Enums/EventType.cs
+++ b/src/Core/Enums/EventType.cs
@@ -28,6 +28,7 @@
         Cipher_ClientAutofilled = 1114,
         Cipher_SoftDeleted = 1115,
         Cipher_Restored = 1116,
+        Cipher_ClientToggledCardNumberVisible = 1117,
 
         Collection_Created = 1300,
         Collection_Updated = 1301,

--- a/src/Core/Models/Data/CipherData.cs
+++ b/src/Core/Models/Data/CipherData.cs
@@ -20,6 +20,7 @@ namespace Bit.Core.Models.Data
             ViewPassword = response.ViewPassword;
             OrganizationUseTotp = response.OrganizationUseTotp;
             Favorite = response.Favorite;
+            PasswordPrompt = response.PasswordPrompt;
             RevisionDate = response.RevisionDate;
             Type = response.Type;
             Name = response.Name;
@@ -71,6 +72,7 @@ namespace Bit.Core.Models.Data
         public bool ViewPassword { get; set; } = true; // Fallback for old server versions
         public bool OrganizationUseTotp { get; set; }
         public bool Favorite { get; set; }
+        public bool PasswordPrompt { get; set; }
         public DateTime RevisionDate { get; set; }
         public Enums.CipherType Type { get; set; }
         public string Name { get; set; }

--- a/src/Core/Models/Data/CipherData.cs
+++ b/src/Core/Models/Data/CipherData.cs
@@ -1,4 +1,5 @@
-﻿using Bit.Core.Models.Response;
+﻿using Bit.Core.Enums;
+using Bit.Core.Models.Response;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -20,7 +21,7 @@ namespace Bit.Core.Models.Data
             ViewPassword = response.ViewPassword;
             OrganizationUseTotp = response.OrganizationUseTotp;
             Favorite = response.Favorite;
-            PasswordPrompt = response.PasswordPrompt;
+            Reprompt = response.Reprompt;
             RevisionDate = response.RevisionDate;
             Type = response.Type;
             Name = response.Name;
@@ -72,7 +73,7 @@ namespace Bit.Core.Models.Data
         public bool ViewPassword { get; set; } = true; // Fallback for old server versions
         public bool OrganizationUseTotp { get; set; }
         public bool Favorite { get; set; }
-        public bool PasswordPrompt { get; set; }
+        public CipherRepromptType Reprompt { get; set; }
         public DateTime RevisionDate { get; set; }
         public Enums.CipherType Type { get; set; }
         public string Name { get; set; }

--- a/src/Core/Models/Domain/Cipher.cs
+++ b/src/Core/Models/Domain/Cipher.cs
@@ -24,6 +24,7 @@ namespace Bit.Core.Models.Domain
 
             Type = obj.Type;
             Favorite = obj.Favorite;
+            PasswordPrompt = obj.PasswordPrompt;
             OrganizationUseTotp = obj.OrganizationUseTotp;
             Edit = obj.Edit;
             ViewPassword = obj.ViewPassword;
@@ -62,6 +63,7 @@ namespace Bit.Core.Models.Domain
         public CipherString Notes { get; set; }
         public Enums.CipherType Type { get; set; }
         public bool Favorite { get; set; }
+        public bool PasswordPrompt { get; set; }
         public bool OrganizationUseTotp { get; set; }
         public bool Edit { get; set; }
         public bool ViewPassword { get; set; }
@@ -164,6 +166,7 @@ namespace Bit.Core.Models.Domain
                 Edit = Edit,
                 OrganizationUseTotp = OrganizationUseTotp,
                 Favorite = Favorite,
+                PasswordPrompt = PasswordPrompt,
                 RevisionDate = RevisionDate,
                 Type = Type,
                 CollectionIds = CollectionIds.ToList(),

--- a/src/Core/Models/Domain/Cipher.cs
+++ b/src/Core/Models/Domain/Cipher.cs
@@ -1,4 +1,5 @@
-﻿using Bit.Core.Models.Data;
+﻿using Bit.Core.Enums;
+using Bit.Core.Models.Data;
 using Bit.Core.Models.View;
 using System;
 using System.Collections.Generic;
@@ -24,7 +25,7 @@ namespace Bit.Core.Models.Domain
 
             Type = obj.Type;
             Favorite = obj.Favorite;
-            PasswordPrompt = obj.PasswordPrompt;
+            Reprompt = obj.Reprompt;
             OrganizationUseTotp = obj.OrganizationUseTotp;
             Edit = obj.Edit;
             ViewPassword = obj.ViewPassword;
@@ -63,7 +64,7 @@ namespace Bit.Core.Models.Domain
         public CipherString Notes { get; set; }
         public Enums.CipherType Type { get; set; }
         public bool Favorite { get; set; }
-        public bool PasswordPrompt { get; set; }
+        public CipherRepromptType Reprompt { get; set; }
         public bool OrganizationUseTotp { get; set; }
         public bool Edit { get; set; }
         public bool ViewPassword { get; set; }
@@ -166,7 +167,7 @@ namespace Bit.Core.Models.Domain
                 Edit = Edit,
                 OrganizationUseTotp = OrganizationUseTotp,
                 Favorite = Favorite,
-                PasswordPrompt = PasswordPrompt,
+                Reprompt = Reprompt,
                 RevisionDate = RevisionDate,
                 Type = Type,
                 CollectionIds = CollectionIds.ToList(),

--- a/src/Core/Models/Request/CipherRequest.cs
+++ b/src/Core/Models/Request/CipherRequest.cs
@@ -17,6 +17,7 @@ namespace Bit.Core.Models.Request
             Name = cipher.Name?.EncryptedString;
             Notes = cipher.Notes?.EncryptedString;
             Favorite = cipher.Favorite;
+            PasswordPrompt = cipher.PasswordPrompt;
             LastKnownRevisionDate = cipher.RevisionDate;
 
             switch (Type)
@@ -112,6 +113,7 @@ namespace Bit.Core.Models.Request
         public string Name { get; set; }
         public string Notes { get; set; }
         public bool Favorite { get; set; }
+        public bool PasswordPrompt { get; set; }
         public LoginApi Login { get; set; }
         public SecureNoteApi SecureNote { get; set; }
         public CardApi Card { get; set; }

--- a/src/Core/Models/Request/CipherRequest.cs
+++ b/src/Core/Models/Request/CipherRequest.cs
@@ -17,7 +17,7 @@ namespace Bit.Core.Models.Request
             Name = cipher.Name?.EncryptedString;
             Notes = cipher.Notes?.EncryptedString;
             Favorite = cipher.Favorite;
-            PasswordPrompt = cipher.PasswordPrompt;
+            Reprompt = cipher.Reprompt;
             LastKnownRevisionDate = cipher.RevisionDate;
 
             switch (Type)
@@ -113,7 +113,7 @@ namespace Bit.Core.Models.Request
         public string Name { get; set; }
         public string Notes { get; set; }
         public bool Favorite { get; set; }
-        public bool PasswordPrompt { get; set; }
+        public CipherRepromptType Reprompt { get; set; }
         public LoginApi Login { get; set; }
         public SecureNoteApi SecureNote { get; set; }
         public CardApi Card { get; set; }

--- a/src/Core/Models/Response/CipherResponse.cs
+++ b/src/Core/Models/Response/CipherResponse.cs
@@ -1,4 +1,5 @@
-﻿using Bit.Core.Models.Api;
+﻿using Bit.Core.Enums;
+using Bit.Core.Models.Api;
 using System;
 using System.Collections.Generic;
 
@@ -18,7 +19,7 @@ namespace Bit.Core.Models.Response
         public IdentityApi Identity { get; set; }
         public SecureNoteApi SecureNote { get; set; }
         public bool Favorite { get; set; }
-        public bool PasswordPrompt { get; set; }
+        public CipherRepromptType Reprompt { get; set; }
         public bool Edit { get; set; }
         public bool ViewPassword { get; set; } = true; // Fallback for old server versions
         public bool OrganizationUseTotp { get; set; }

--- a/src/Core/Models/Response/CipherResponse.cs
+++ b/src/Core/Models/Response/CipherResponse.cs
@@ -18,6 +18,7 @@ namespace Bit.Core.Models.Response
         public IdentityApi Identity { get; set; }
         public SecureNoteApi SecureNote { get; set; }
         public bool Favorite { get; set; }
+        public bool PasswordPrompt { get; set; }
         public bool Edit { get; set; }
         public bool ViewPassword { get; set; } = true; // Fallback for old server versions
         public bool OrganizationUseTotp { get; set; }

--- a/src/Core/Models/View/CardView.cs
+++ b/src/Core/Models/View/CardView.cs
@@ -18,6 +18,7 @@ namespace Bit.Core.Models.View
         public string ExpYear { get; set; }
         public string Code { get; set; }
         public string MaskedCode => Code != null ? new string('•', Code.Length) : null;
+        public string MaskedNumber => Number != null ? new string('•', Number.Length) : null;
 
         public string Brand
         {

--- a/src/Core/Models/View/CipherView.cs
+++ b/src/Core/Models/View/CipherView.cs
@@ -16,6 +16,7 @@ namespace Bit.Core.Models.View
             OrganizationId = c.OrganizationId;
             FolderId = c.FolderId;
             Favorite = c.Favorite;
+            PasswordPrompt = c.PasswordPrompt;
             OrganizationUseTotp = c.OrganizationUseTotp;
             Edit = c.Edit;
             ViewPassword = c.ViewPassword;
@@ -33,6 +34,7 @@ namespace Bit.Core.Models.View
         public string Notes { get; set; }
         public CipherType Type { get; set; }
         public bool Favorite { get; set; }
+        public bool PasswordPrompt { get; set; }
         public bool OrganizationUseTotp { get; set; }
         public bool Edit { get; set; }
         public bool ViewPassword { get; set; } = true;

--- a/src/Core/Models/View/CipherView.cs
+++ b/src/Core/Models/View/CipherView.cs
@@ -16,7 +16,7 @@ namespace Bit.Core.Models.View
             OrganizationId = c.OrganizationId;
             FolderId = c.FolderId;
             Favorite = c.Favorite;
-            PasswordPrompt = c.PasswordPrompt;
+            Reprompt = c.Reprompt;
             OrganizationUseTotp = c.OrganizationUseTotp;
             Edit = c.Edit;
             ViewPassword = c.ViewPassword;
@@ -34,7 +34,7 @@ namespace Bit.Core.Models.View
         public string Notes { get; set; }
         public CipherType Type { get; set; }
         public bool Favorite { get; set; }
-        public bool PasswordPrompt { get; set; }
+        public CipherRepromptType Reprompt { get; set; }
         public bool OrganizationUseTotp { get; set; }
         public bool Edit { get; set; }
         public bool ViewPassword { get; set; } = true;

--- a/src/Core/Services/CipherService.cs
+++ b/src/Core/Services/CipherService.cs
@@ -177,6 +177,7 @@ namespace Bit.Core.Services
                 Id = model.Id,
                 FolderId = model.FolderId,
                 Favorite = model.Favorite,
+                PasswordPrompt = model.PasswordPrompt,
                 OrganizationId = model.OrganizationId,
                 Type = model.Type,
                 CollectionIds = model.CollectionIds,

--- a/src/Core/Services/CipherService.cs
+++ b/src/Core/Services/CipherService.cs
@@ -177,7 +177,7 @@ namespace Bit.Core.Services
                 Id = model.Id,
                 FolderId = model.FolderId,
                 Favorite = model.Favorite,
-                PasswordPrompt = model.PasswordPrompt,
+                Reprompt = model.Reprompt,
                 OrganizationId = model.OrganizationId,
                 Type = model.Type,
                 CollectionIds = model.CollectionIds,

--- a/src/Core/Utilities/ServiceContainer.cs
+++ b/src/Core/Utilities/ServiceContainer.cs
@@ -23,14 +23,13 @@ namespace Bit.Core.Utilities
             var platformUtilsService = Resolve<IPlatformUtilsService>("platformUtilsService");
             var storageService = Resolve<IStorageService>("storageService");
             var secureStorageService = Resolve<IStorageService>("secureStorageService");
-            var cryptoPrimitiveService = Resolve<ICryptoPrimitiveService>("cryptoPrimitiveService");
             var i18nService = Resolve<II18nService>("i18nService");
             var messagingService = Resolve<IMessagingService>("messagingService");
+            var cryptoFunctionService = Resolve<ICryptoFunctionService>("cryptoFunctionService");
+            var cryptoService = Resolve<ICryptoService>("cryptoService");
             SearchService searchService = null;
 
             var stateService = new StateService();
-            var cryptoFunctionService = new PclCryptoFunctionService(cryptoPrimitiveService);
-            var cryptoService = new CryptoService(storageService, secureStorageService, cryptoFunctionService);
             var tokenService = new TokenService(storageService);
             var apiService = new ApiService(tokenService, platformUtilsService, (bool expired) =>
             {
@@ -75,8 +74,6 @@ namespace Bit.Core.Utilities
             var eventService = new EventService(storageService, apiService, userService, cipherService);
 
             Register<IStateService>("stateService", stateService);
-            Register<ICryptoFunctionService>("cryptoFunctionService", cryptoFunctionService);
-            Register<ICryptoService>("cryptoService", cryptoService);
             Register<ITokenService>("tokenService", tokenService);
             Register<IApiService>("apiService", apiService);
             Register<IAppIdService>("appIdService", appIdService);

--- a/src/iOS.Autofill/LoginListViewController.cs
+++ b/src/iOS.Autofill/LoginListViewController.cs
@@ -9,6 +9,7 @@ using Bit.iOS.Autofill.Utilities;
 using Bit.iOS.Core.Utilities;
 using Bit.Core.Utilities;
 using Bit.Core.Abstractions;
+using Bit.App.Abstractions;
 
 namespace Bit.iOS.Autofill
 {
@@ -18,10 +19,12 @@ namespace Bit.iOS.Autofill
             : base(handle)
         {
             DismissModalAction = Cancel;
+            PasswordRepromptService = ServiceContainer.Resolve<IPasswordRepromptService>("passwordRepromptService");
         }
 
         public Context Context { get; set; }
         public CredentialProviderViewController CPViewController { get; set; }
+        public IPasswordRepromptService PasswordRepromptService { get; private set; }
 
         public async override void ViewDidLoad()
         {
@@ -109,7 +112,7 @@ namespace Bit.iOS.Autofill
             public async override void RowSelected(UITableView tableView, NSIndexPath indexPath)
             {
                 await AutofillHelpers.TableRowSelectedAsync(tableView, indexPath, this,
-                    _controller.CPViewController, _controller, "loginAddSegue");
+                    _controller.CPViewController, _controller, _controller.PasswordRepromptService, "loginAddSegue");
             }
         }
     }

--- a/src/iOS.Autofill/LoginSearchViewController.cs
+++ b/src/iOS.Autofill/LoginSearchViewController.cs
@@ -7,6 +7,8 @@ using Bit.App.Resources;
 using Bit.iOS.Core.Views;
 using Bit.iOS.Autofill.Utilities;
 using Bit.iOS.Core.Utilities;
+using Bit.App.Abstractions;
+using Bit.Core.Utilities;
 
 namespace Bit.iOS.Autofill
 {
@@ -16,11 +18,13 @@ namespace Bit.iOS.Autofill
             : base(handle)
         {
             DismissModalAction = Cancel;
+            PasswordRepromptService = ServiceContainer.Resolve<IPasswordRepromptService>("passwordRepromptService");
         }
 
         public Context Context { get; set; }
         public CredentialProviderViewController CPViewController { get; set; }
         public bool FromList { get; set; }
+        public IPasswordRepromptService PasswordRepromptService { get; private set; }
 
         public async override void ViewDidLoad()
         {
@@ -107,7 +111,8 @@ namespace Bit.iOS.Autofill
             public async override void RowSelected(UITableView tableView, NSIndexPath indexPath)
             {
                 await AutofillHelpers.TableRowSelectedAsync(tableView, indexPath, this,
-                    _controller.CPViewController, _controller, "loginAddFromSearchSegue");
+                    _controller.CPViewController, _controller, _controller.PasswordRepromptService,
+                    "loginAddFromSearchSegue");
             }
         }
     }

--- a/src/iOS.Autofill/Utilities/AutofillHelpers.cs
+++ b/src/iOS.Autofill/Utilities/AutofillHelpers.cs
@@ -1,5 +1,6 @@
 ﻿using System.Linq;
 using System.Threading.Tasks;
+using Bit.App.Abstractions;
 using Bit.App.Resources;
 using Bit.Core.Abstractions;
 using Bit.Core.Utilities;
@@ -14,7 +15,8 @@ namespace Bit.iOS.Autofill.Utilities
     {
         public async static Task TableRowSelectedAsync(UITableView tableView, NSIndexPath indexPath,
             ExtensionTableSource tableSource, CredentialProviderViewController cpViewController,
-            UITableViewController controller, string loginAddSegue)
+            UITableViewController controller, IPasswordRepromptService passwordRepromptService,
+            string loginAddSegue)
         {
             tableView.DeselectRow(indexPath, true);
             tableView.EndEditing(true);
@@ -28,6 +30,11 @@ namespace Bit.iOS.Autofill.Utilities
             if (item == null)
             {
                 cpViewController.CompleteRequest();
+                return;
+            }
+
+            if (item.Reprompt != Bit.Core.Enums.CipherRepromptType.None && !await passwordRepromptService.ShowPasswordPrompt())
+            {
                 return;
             }
 

--- a/src/iOS.Autofill/Utilities/AutofillHelpers.cs
+++ b/src/iOS.Autofill/Utilities/AutofillHelpers.cs
@@ -33,7 +33,7 @@ namespace Bit.iOS.Autofill.Utilities
                 return;
             }
 
-            if (item.Reprompt != Bit.Core.Enums.CipherRepromptType.None && !await passwordRepromptService.ShowPasswordPrompt())
+            if (item.Reprompt != Bit.Core.Enums.CipherRepromptType.None && !await passwordRepromptService.ShowPasswordPromptAsync())
             {
                 return;
             }

--- a/src/iOS.Core/Models/CipherViewModel.cs
+++ b/src/iOS.Core/Models/CipherViewModel.cs
@@ -18,6 +18,7 @@ namespace Bit.iOS.Core.Models
             Totp = cipher.Login?.Totp;
             Uris = cipher.Login?.Uris?.Select(u => new LoginUriModel(u)).ToList();
             Fields = cipher.Fields?.Select(f => new Tuple<string, string>(f.Name, f.Value)).ToList();
+            Reprompt = cipher.Reprompt;
         }
 
         public string Id { get; set; }
@@ -28,6 +29,7 @@ namespace Bit.iOS.Core.Models
         public string Totp { get; set; }
         public List<Tuple<string, string>> Fields { get; set; }
         public CipherView CipherView { get; set; }
+        public CipherRepromptType Reprompt { get; set; }
 
         public class LoginUriModel
         {

--- a/src/iOS.Core/Services/DeviceActionService.cs
+++ b/src/iOS.Core/Services/DeviceActionService.cs
@@ -201,7 +201,7 @@ namespace Bit.iOS.Core.Services
 
         public Task<string> DisplayPromptAync(string title = null, string description = null,
             string text = null, string okButtonText = null, string cancelButtonText = null,
-            bool numericKeyboard = false, bool autofocus = true)
+            bool numericKeyboard = false, bool autofocus = true, bool password = false)
         {
             var result = new TaskCompletionSource<string>();
             var alert = UIAlertController.Create(title ?? string.Empty, description, UIAlertControllerStyle.Alert);
@@ -223,6 +223,9 @@ namespace Bit.iOS.Core.Services
                 if (numericKeyboard)
                 {
                     input.KeyboardType = UIKeyboardType.NumberPad;
+                }
+                if (password) {
+                    input.InputType = InputTypes.TextVariationPassword | InputTypes.ClassText;
                 }
                 if (!ThemeHelpers.LightTheme)
                 {

--- a/src/iOS.Core/Services/DeviceActionService.cs
+++ b/src/iOS.Core/Services/DeviceActionService.cs
@@ -225,7 +225,7 @@ namespace Bit.iOS.Core.Services
                     input.KeyboardType = UIKeyboardType.NumberPad;
                 }
                 if (password) {
-                    input.InputType = InputTypes.TextVariationPassword | InputTypes.ClassText;
+                    input.SecureTextEntry = true;
                 }
                 if (!ThemeHelpers.LightTheme)
                 {

--- a/src/iOS.Core/Utilities/iOSCoreHelpers.cs
+++ b/src/iOS.Core/Utilities/iOSCoreHelpers.cs
@@ -55,6 +55,9 @@ namespace Bit.iOS.Core.Utilities
             var platformUtilsService = new MobilePlatformUtilsService(deviceActionService, messagingService,
                 broadcasterService);
             var biometricService = new BiometricService(mobileStorageService);
+            var cryptoFunctionService = new PclCryptoFunctionService(cryptoPrimitiveService);
+            var cryptoService = new CryptoService(mobileStorageService, secureStorageService, cryptoFunctionService);
+            var passwordRepromptService = new MobilePasswordRepromptService(deviceActionService, platformUtilsService, cryptoService);
 
             ServiceContainer.Register<IBroadcasterService>("broadcasterService", broadcasterService);
             ServiceContainer.Register<IMessagingService>("messagingService", messagingService);
@@ -66,6 +69,9 @@ namespace Bit.iOS.Core.Utilities
             ServiceContainer.Register<IDeviceActionService>("deviceActionService", deviceActionService);
             ServiceContainer.Register<IPlatformUtilsService>("platformUtilsService", platformUtilsService);
             ServiceContainer.Register<IBiometricService>("biometricService", biometricService);
+            ServiceContainer.Register<ICryptoFunctionService>("cryptoFunctionService", cryptoFunctionService);
+            ServiceContainer.Register<ICryptoService>("cryptoService", cryptoService);
+            ServiceContainer.Register<IPasswordRepromptService>("passwordRepromptService", passwordRepromptService);
         }
 
         public static void Bootstrap(Func<Task> postBootstrapFunc = null)

--- a/src/iOS.Core/Utilities/iOSCoreHelpers.cs
+++ b/src/iOS.Core/Utilities/iOSCoreHelpers.cs
@@ -57,7 +57,7 @@ namespace Bit.iOS.Core.Utilities
             var biometricService = new BiometricService(mobileStorageService);
             var cryptoFunctionService = new PclCryptoFunctionService(cryptoPrimitiveService);
             var cryptoService = new CryptoService(mobileStorageService, secureStorageService, cryptoFunctionService);
-            var passwordRepromptService = new MobilePasswordRepromptService(deviceActionService, platformUtilsService, cryptoService);
+            var passwordRepromptService = new MobilePasswordRepromptService(platformUtilsService, cryptoService);
 
             ServiceContainer.Register<IBroadcasterService>("broadcasterService", broadcasterService);
             ServiceContainer.Register<IMessagingService>("messagingService", messagingService);


### PR DESCRIPTION
## Objective
Adds support for requiring master password re-prompt before accessing hidden fields on ciphers. Also marks card numbers as a secret to ensure it's protected.

### Code Changes
- **src/{Android, iOS}/Services/DeviceActionService.cs**: Add support for prompting password.
- **src/App/Pages/Vault/AddEditPage.xaml, src/App/Pages/Vault/AddEditPage.xaml.cs**: Change card number to be hidden, add toggle for password prompt.
- **src/App/Pages/Vault/AddEditPageViewModel.cs**: Hook up toggle for card number, password prompts.
- **src/App/Pages/Vault/AutofillCiphersPageViewModel.cs, src/App/Pages/Vault/CiphersPageViewModel.cs, src/App/Pages/Vault/GroupingsPage/GroupingsPageViewModel.cs**: Hook in password reprompt service to CipherListOptions.
- **src/App/Pages/Vault/ViewPage.xaml**: Change card number to be hidden.
- **src/App/Pages/Vault/ViewPage.xaml.cs**: Prompt for password before showing/copying secrets.
- **src/App/Pages/Vault/ViewPageViewModel.cs**: Card number toggle and password prompts.
- **src/App/Services/MobilePasswordRepromptService.cs**: Service for prompting for passwords.
- **src/App/Utilities/AppHelpers.cs**: Prompt for password before allowing access to protected items.

### Testing Considerations
We should verify all expected values are protected and cannot be accessed without prompting for master password. Especially for autofill.
