### PR TITLE
Update csv export lib

### DIFF
--- a/src/Core/Core.csproj
+++ b/src/Core/Core.csproj
@@ -23,7 +23,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="CsvHelper" Version="15.0.5" />
+    <PackageReference Include="CsvHelper" Version="26.1.0" />
     <PackageReference Include="LiteDB" Version="5.0.8" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="PCLCrypto" Version="2.0.147" />


### PR DESCRIPTION
Update to our csv export lib.  Release notes indicate this may fix our mystery export failure on iOS.  (@clayadams5226 has a device that can repro it)

* It's a big version jump with lots of breaking changes (none of which affected us).  My prelim test results indicate it's working fine and the output matches the export output from the portal.