### PR TITLE
Expand package visibility for Android 11+

### DIFF
--- a/src/Android/Properties/AndroidManifest.xml
+++ b/src/Android/Properties/AndroidManifest.xml
@@ -68,12 +68,7 @@
   <!-- Package visibility (for Android 11+) -->
   <queries>
       <intent>
-          <action android:name="android.intent.action.VIEW"/>
-          <data android:scheme="http"/>
-      </intent>
-      <intent>
-          <action android:name="android.intent.action.VIEW"/>
-          <data android:scheme="https"/>
+          <action android:name="*"/>
       </intent>
   </queries>
 


### PR DESCRIPTION
The previous fix to open URIs in Android 11+ did not take into account app (i.e. non-web) URIs.  In order for `PackageManager.GetLaunchIntentForPackage(..)` to function in Android 11+, the package has to be visible to us.  Visibility can be specified by exact package name or types of actions with filters.  Since neither is practical when the user can specify any and all current and future apps, we've gone the wildcard route with the `name` and removed the optional `scheme`.  This gives us enough app visibility to build launch intents using known package names without requiring the `QUERY_ALL_PACKAGES` permission.

Additional reading:  https://developer.android.com/training/package-visibility