### PR TITLE
Limit file upload sizes to 100MB

### DIFF
--- a/src/App/Pages/Send/SendAddEditPageViewModel.cs
+++ b/src/App/Pages/Send/SendAddEditPageViewModel.cs
@@ -356,7 +356,7 @@ namespace Bit.App.Pages
                             AppResources.AnErrorHasOccurred);
                         return false;
                     }
-                    if (FileData.Length > 524288000) // 500 MB
+                    if (FileData.Length > 104857600) // 100 MB
                     {
                         await _platformUtilsService.ShowDialogAsync(AppResources.MaxFileSize,
                             AppResources.AnErrorHasOccurred);

--- a/src/App/Pages/Vault/AttachmentsPageViewModel.cs
+++ b/src/App/Pages/Vault/AttachmentsPageViewModel.cs
@@ -102,7 +102,7 @@ namespace Bit.App.Pages
                     AppResources.AnErrorHasOccurred);
                 return false;
             }
-            if (FileData.Length > 524288000) // 500 MB
+            if (FileData.Length > 104857600) // 100 MB
             {
                 await _platformUtilsService.ShowDialogAsync(AppResources.MaxFileSize,
                     AppResources.AnErrorHasOccurred);

--- a/src/App/Resources/AppResources.resx
+++ b/src/App/Resources/AppResources.resx
@@ -926,7 +926,7 @@
     <value>Feature Unavailable</value>
   </data>
   <data name="MaxFileSize" xml:space="preserve">
-    <value>Maximum file size is 500 MB.</value>
+    <value>Maximum file size is 100 MB.</value>
   </data>
   <data name="UpdateKey" xml:space="preserve">
     <value>You cannot use this feature until you update your encryption key.</value>


### PR DESCRIPTION
# Overview 

Both iOS and Android are having trouble with the current method of loading the entire file to memory, encrypting it, and sending to azure in one go.

We will need to come up with a chunking scheme to support larger files in the future

# Files Changed
* **SendAddEditPageViewModel**: Validate file is not longer that 100MB
* **AttachmentsPageViewModel**: Validate file is not longer than 100MB
* **AppResources**: Revert size limit text to 100 MB