### PR TITLE
Explain how to verify email for file Sends

### DIFF
--- a/src/App/Pages/Send/SendAddEditPageViewModel.cs
+++ b/src/App/Pages/Send/SendAddEditPageViewModel.cs
@@ -45,6 +45,7 @@ namespace Bit.App.Pages
         };
         private bool _disableHideEmail;
         private bool _sendOptionsPolicyInEffect;
+        private bool _disableHideEmailControl;
 
         public SendAddEditPageViewModel()
         {
@@ -343,7 +344,7 @@ namespace Bit.App.Pages
                 }
                 if (!_emailVerified)
                 {
-                    verifyEmailPrompt();
+                    await _platformUtilsService.ShowDialogAsync(AppResources.SendFileEmailVerificationRequired);
                     return false;
                 }
                 if (!EditMode)
@@ -474,7 +475,7 @@ namespace Bit.App.Pages
                     }
                     else if (!_emailVerified)
                     {
-                        verifyEmailPrompt();
+                        await _platformUtilsService.ShowDialogAsync(AppResources.SendFileEmailVerificationRequired);
                     }
                     
                     if (IsAddFromShare && Device.RuntimePlatform == Device.Android)
@@ -607,16 +608,6 @@ namespace Bit.App.Pages
                 0,
                 DateTimeKind.Local
             );
-        }
-
-        private async void verifyEmailPrompt()
-        {
-            var confirmed = await _platformUtilsService.ShowDialogAsync(AppResources.SendFileEmailVerificationRequired, null,
-                AppResources.Yes, AppResources.Cancel);
-            if (confirmed)
-            {
-                _platformUtilsService.LaunchUri("https://bitwarden.com/help/article/create-bitwarden-account/#verify-your-email");
-            }
         }
     }
 }

--- a/src/App/Pages/Send/SendAddEditPageViewModel.cs
+++ b/src/App/Pages/Send/SendAddEditPageViewModel.cs
@@ -45,7 +45,6 @@ namespace Bit.App.Pages
         };
         private bool _disableHideEmail;
         private bool _sendOptionsPolicyInEffect;
-        private bool _disableHideEmailControl;
 
         public SendAddEditPageViewModel()
         {
@@ -344,7 +343,7 @@ namespace Bit.App.Pages
                 }
                 if (!_emailVerified)
                 {
-                    await _platformUtilsService.ShowDialogAsync(AppResources.SendFileEmailVerificationRequired);
+                    verifyEmailPrompt();
                     return false;
                 }
                 if (!EditMode)
@@ -475,7 +474,7 @@ namespace Bit.App.Pages
                     }
                     else if (!_emailVerified)
                     {
-                        await _platformUtilsService.ShowDialogAsync(AppResources.SendFileEmailVerificationRequired);
+                        verifyEmailPrompt();
                     }
                     
                     if (IsAddFromShare && Device.RuntimePlatform == Device.Android)
@@ -608,6 +607,16 @@ namespace Bit.App.Pages
                 0,
                 DateTimeKind.Local
             );
+        }
+
+        private async void verifyEmailPrompt()
+        {
+            var confirmed = await _platformUtilsService.ShowDialogAsync(AppResources.SendFileEmailVerificationRequired, null,
+                AppResources.Yes, AppResources.Cancel);
+            if (confirmed)
+            {
+                _platformUtilsService.LaunchUri("https://bitwarden.com/help/article/create-bitwarden-account/#verify-your-email");
+            }
         }
     }
 }

--- a/src/App/Pages/Send/SendAddEditPageViewModel.cs
+++ b/src/App/Pages/Send/SendAddEditPageViewModel.cs
@@ -45,7 +45,6 @@ namespace Bit.App.Pages
         };
         private bool _disableHideEmail;
         private bool _sendOptionsPolicyInEffect;
-        private bool _disableHideEmailControl;
 
         public SendAddEditPageViewModel()
         {

--- a/src/App/Resources/AppResources.resx
+++ b/src/App/Resources/AppResources.resx
@@ -1984,7 +1984,7 @@
     <comment>'Send' is a noun and the name of a feature called 'Bitwarden Send'. It should not be translated.</comment>
   </data>
   <data name="SendFileEmailVerificationRequired" xml:space="preserve">
-    <value>You must verify your email to use files with Send.</value>
+    <value>You must verify your email to use files with Send. You can verify your email in the bitwarden.com web vault. Do you want to visit the website now?</value>
     <comment>'Send' is a noun and the name of a feature called 'Bitwarden Send'. It should not be translated.</comment>
   </data>
 </root>

--- a/src/App/Resources/AppResources.resx
+++ b/src/App/Resources/AppResources.resx
@@ -1984,7 +1984,7 @@
     <comment>'Send' is a noun and the name of a feature called 'Bitwarden Send'. It should not be translated.</comment>
   </data>
   <data name="SendFileEmailVerificationRequired" xml:space="preserve">
-    <value>You must verify your email to use files with Send.</value>
+    <value>You must verify your email to use files with Send. You can verify your email in the web vault.</value>
     <comment>'Send' is a noun and the name of a feature called 'Bitwarden Send'. It should not be translated.</comment>
   </data>
 </root>

--- a/src/App/Resources/AppResources.resx
+++ b/src/App/Resources/AppResources.resx
@@ -1984,7 +1984,7 @@
     <comment>'Send' is a noun and the name of a feature called 'Bitwarden Send'. It should not be translated.</comment>
   </data>
   <data name="SendFileEmailVerificationRequired" xml:space="preserve">
-    <value>You must verify your email to use files with Send. You can verify your email in the bitwarden.com web vault. Do you want to visit the website now?</value>
+    <value>You must verify your email to use files with Send.</value>
     <comment>'Send' is a noun and the name of a feature called 'Bitwarden Send'. It should not be translated.</comment>
   </data>
 </root>


### PR DESCRIPTION
## Objective

Users are required to verify their email before creating a file Send, however the current message doesn't provide any explanation about how to do this. This is especially a problem because you can't verify your email in the mobile app, so it's not obvious that you have to go somewhere else to do it.

## Code changes

I've used the same UX flow as settings that can only be changed in the web vault:
* explain to the user that this can only be done on the "bitwarden.com web vault" (may be inaccurate for self hosted, but I've stuck to the current pattern)
* offer to take the user there now, which takes the user to the relevant help documentation

I'll replicate these changes for desktop and browser tomorrow.

Bonus: deleted unused private var I left there from the 'hide email' feature.