### PR TITLE
Explain how to verify email for file Sends

### DIFF
--- a/src/App/Pages/Send/SendAddEditPageViewModel.cs
+++ b/src/App/Pages/Send/SendAddEditPageViewModel.cs
@@ -45,7 +45,6 @@ namespace Bit.App.Pages
         };
         private bool _disableHideEmail;
         private bool _sendOptionsPolicyInEffect;
-        private bool _disableHideEmailControl;
 
         public SendAddEditPageViewModel()
         {

--- a/src/App/Resources/AppResources.resx
+++ b/src/App/Resources/AppResources.resx
@@ -1984,7 +1984,7 @@
     <comment>'Send' is a noun and the name of a feature called 'Bitwarden Send'. It should not be translated.</comment>
   </data>
   <data name="SendFileEmailVerificationRequired" xml:space="preserve">
-    <value>You must verify your email to use files with Send.</value>
+    <value>You must verify your email to use files with Send. You can verify your email in the web vault.</value>
     <comment>'Send' is a noun and the name of a feature called 'Bitwarden Send'. It should not be translated.</comment>
   </data>
 </root>


### PR DESCRIPTION
## Objective

Users are required to verify their email before creating a file Send, however the current message doesn't provide any explanation about how to do this. This is especially a problem because you can't verify your email in the mobile app, so it's not obvious that you have to go somewhere else to do it.

## Code changes

I've used the same UX flow as settings that can only be changed in the web vault:
* explain to the user that this can only be done on the "bitwarden.com web vault" (may be inaccurate for self hosted, but I've stuck to the current pattern)
* offer to take the user there now, which takes the user to the relevant help documentation

I'll replicate these changes for desktop and browser tomorrow.

Bonus: deleted unused private var I left there from the 'hide email' feature.