### PR TITLE
Encode exports as UTF8

### DIFF
--- a/src/App/Pages/Settings/ExportVaultPageViewModel.cs
+++ b/src/App/Pages/Settings/ExportVaultPageViewModel.cs
@@ -128,7 +128,7 @@ namespace Bit.App.Pages
                 fileFormat = fileFormat == "encrypted_json" ? "json" : fileFormat;
 
                 _defaultFilename = _exportService.GetFileName(null, fileFormat);
-                _exportResult = Encoding.ASCII.GetBytes(data);
+                _exportResult = Encoding.UTF8.GetBytes(data);
 
                 if (!_deviceActionService.SaveFile(_exportResult, null, _defaultFilename, null))
                 {


### PR DESCRIPTION
# Overview

Fixes #1401. Exports should be saved as UTF-8, not ASCII-encoded strings.