### PR TITLE
Updated MyVault string for spanish

### DIFF
--- a/src/App/Resources/AppResources.es.resx
+++ b/src/App/Resources/AppResources.es.resx
@@ -284,7 +284,7 @@
     <comment>Text to define that there are more options things to see.</comment>
   </data>
   <data name="MyVault" xml:space="preserve">
-    <value>Mi caja fuerte</value>
+    <value>Caja fuerte</value>
     <comment>The title for the vault page.</comment>
   </data>
   <data name="Name" xml:space="preserve">


### PR DESCRIPTION
The string for MyVault in spanish was too long, so I've changed from "Mi caja fuerte" to "Caja fuerte".  This solves the issue where the title on the navbar appears cutted.