### PR TITLE
fix for activity exporting and workaround for task affinity

### DIFF
--- a/src/Android/MainActivity.cs
+++ b/src/Android/MainActivity.cs
@@ -27,6 +27,7 @@ namespace Bit.Droid
         Icon = "@mipmap/ic_launcher",
         Theme = "@style/LaunchTheme",
         MainLauncher = true,
+        TaskAffinity = "",
         ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation |
                                ConfigChanges.Keyboard | ConfigChanges.KeyboardHidden |
                                ConfigChanges.Navigation)]

--- a/src/Android/WebAuthCallbackActivity.cs
+++ b/src/Android/WebAuthCallbackActivity.cs
@@ -3,7 +3,10 @@ using Android.Content.PM;
 
 namespace Bit.Droid
 {
-    [Activity(NoHistory = true, LaunchMode = LaunchMode.SingleTop)]
+    [Activity(
+        Exported = false,
+        NoHistory = true, 
+        LaunchMode = LaunchMode.SingleTop)]
     [IntentFilter(new[] { Android.Content.Intent.ActionView },
         Categories = new[] { Android.Content.Intent.CategoryDefault, Android.Content.Intent.CategoryBrowsable },
         DataScheme = "bitwarden")]


### PR DESCRIPTION
- Android: make sure `WebAuthCallbackActivity` isn't exported
- Android: make TaskAffinity for `MainActivity` empty to address strandhogg v1 & v2 vulnerability

**Things to consider:**

These changes have the potential to affect established app behavior, and as such will require regression with a focus on autofill, accessibility, and the SSO authentication flow.