### PR TITLE
replaced blank taskaffinity with singletask launchmode

### DIFF
--- a/src/Android/MainActivity.cs
+++ b/src/Android/MainActivity.cs
@@ -27,7 +27,7 @@ namespace Bit.Droid
         Icon = "@mipmap/ic_launcher",
         Theme = "@style/LaunchTheme",
         MainLauncher = true,
-        TaskAffinity = "",
+        LaunchMode = LaunchMode.SingleTask,
         ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation |
                                ConfigChanges.Keyboard | ConfigChanges.KeyboardHidden |
                                ConfigChanges.Navigation)]

--- a/src/Android/WebAuthCallbackActivity.cs
+++ b/src/Android/WebAuthCallbackActivity.cs
@@ -4,7 +4,6 @@ using Android.Content.PM;
 namespace Bit.Droid
 {
     [Activity(
-        Exported = false,
         NoHistory = true, 
         LaunchMode = LaunchMode.SingleTop)]
     [IntentFilter(new[] { Android.Content.Intent.ActionView },


### PR DESCRIPTION
[These changes](https://github.com/bitwarden/mobile/commit/e61bcd278548b7d8bb3925d8dc89f616c17b1c7d) broke the SSO auth flow (`Xamarin.Essentials.WebAuthenticatorCallbackActivity` can't deliver a callback to an activity with a different TaskAffinity).  Using `SingleTask` launch mode in our main activity still fixes the issue reported to us while maintaining TaskAffinity with other activities.  In addition `WebAuthCallbackActivity` must remain exported for this to work.