### PR TITLE
add `auth-email` header to auth request

### DIFF
--- a/src/Core/Models/Request/TokenRequest.cs
+++ b/src/Core/Models/Request/TokenRequest.cs
@@ -1,6 +1,7 @@
 ﻿using Bit.Core.Enums;
 using System;
 using System.Collections.Generic;
+using System.Net.Http.Headers;
 using System.Text;
 
 namespace Bit.Core.Models.Request
@@ -77,6 +78,14 @@ namespace Bit.Core.Models.Request
                 obj.Add("twoFactorRemember", Remember.GetValueOrDefault() ? "1" : "0");
             }
             return obj;
+        }
+
+        public void AlterIdentityTokenHeaders(HttpRequestHeaders headers)
+        {
+            if (MasterPasswordHash != null && Email != null)
+            {
+                headers.Add("Auth-Email", Email);
+            }
         }
     }
 }

--- a/src/Core/Services/ApiService.cs
+++ b/src/Core/Services/ApiService.cs
@@ -91,6 +91,7 @@ namespace Bit.Core.Services
                 Content = new FormUrlEncodedContent(request.ToIdentityToken(_platformUtilsService.IdentityClientId))
             };
             requestMessage.Headers.Add("Accept", "application/json");
+            request.AlterIdentityTokenHeaders(requestMessage.Headers);
 
             HttpResponseMessage response;
             try


### PR DESCRIPTION
Adds a new request header, `auth-email`, to auth requests that includes the same value as the `username` post parameter. This will enable us to rate limit auth requested based on username to prevent things like 2FA brute forcing.