### PR TITLE
Track failed unlock attempts in storage

### DIFF
--- a/src/App/Pages/Accounts/LoginPageViewModel.cs
+++ b/src/App/Pages/Accounts/LoginPageViewModel.cs
@@ -6,6 +6,7 @@ using Bit.Core.Exceptions;
 using Bit.Core.Utilities;
 using System;
 using System.Threading.Tasks;
+using Bit.App.Utilities;
 using Xamarin.Forms;
 
 namespace Bit.App.Pages
@@ -125,6 +126,7 @@ namespace Bit.App.Pages
                 {
                     await _storageService.RemoveAsync(Keys_RememberedEmail);
                 }
+                await AppHelpers.ResetInvalidUnlockAttemptsAsync();
                 await _deviceActionService.HideLoadingAsync();
                 if (response.TwoFactor)
                 {

--- a/src/App/Pages/Accounts/LoginSsoPageViewModel.cs
+++ b/src/App/Pages/Accounts/LoginSsoPageViewModel.cs
@@ -5,6 +5,7 @@ using Bit.Core.Abstractions;
 using Bit.Core.Utilities;
 using System;
 using System.Threading.Tasks;
+using Bit.App.Utilities;
 using Bit.Core.Enums;
 using Bit.Core.Exceptions;
 using Bit.Core.Models.Domain;
@@ -182,6 +183,7 @@ namespace Bit.App.Pages
             try
             {
                 var response = await _authService.LogInSsoAsync(code, codeVerifier, redirectUri);
+                await AppHelpers.ResetInvalidUnlockAttemptsAsync();
                 if (RememberOrgIdentifier)
                 {
                     await _storageService.SaveAsync(Keys_RememberedOrgIdentifier, OrgIdentifier);

--- a/src/App/Services/MobileStorageService.cs
+++ b/src/App/Services/MobileStorageService.cs
@@ -39,6 +39,7 @@ namespace Bit.App.Services
             Constants.iOSExtensionBiometricIntegrityKey,
             Constants.EnvironmentUrlsKey,
             Constants.InlineAutofillEnabledKey,
+            Constants.InvalidUnlockAttempts,
         };
 
         private readonly HashSet<string> _migrateToPreferences = new HashSet<string>

--- a/src/App/Utilities/AppHelpers.cs
+++ b/src/App/Utilities/AppHelpers.cs
@@ -440,5 +440,20 @@ namespace Bit.App.Utilities
             }
             return previousPage;
         }
+
+        public static async Task<int> IncrementInvalidUnlockAttemptsAsync()
+        {
+            var storageService = ServiceContainer.Resolve<IStorageService>("storageService");
+            var invalidUnlockAttempts = await storageService.GetAsync<int>(Constants.InvalidUnlockAttempts); 
+            invalidUnlockAttempts++;
+            await storageService.SaveAsync(Constants.InvalidUnlockAttempts, invalidUnlockAttempts);
+            return invalidUnlockAttempts;
+        }
+        
+        public static async Task ResetInvalidUnlockAttemptsAsync()
+        {
+            var storageService = ServiceContainer.Resolve<IStorageService>("storageService");
+            await storageService.RemoveAsync(Constants.InvalidUnlockAttempts);
+        }
     }
 }

--- a/src/Core/Constants.cs
+++ b/src/Core/Constants.cs
@@ -40,6 +40,7 @@
         public static string EventCollectionKey = "eventCollection";
         public static string PreviousPageKey = "previousPage";
         public static string InlineAutofillEnabledKey = "inlineAutofillEnabled";
+        public static string InvalidUnlockAttempts = "invalidUnlockAttempts";
         public const int SelectFileRequestCode = 42;
         public const int SelectFilePermissionRequestCode = 43;
         public const int SaveFileRequestCode = 44;


### PR DESCRIPTION
Track failed unlock attempts in device storage instead of memory to prevent brute-force attacks for PIN or master password on unlock screen.  (HackerOne report # 1217914)