### PR TITLE
Use type to ensure transmitted data is encrypted

### DIFF
--- a/src/Core/Abstractions/IFileUploadService.cs
+++ b/src/Core/Abstractions/IFileUploadService.cs
@@ -4,7 +4,7 @@ using Bit.Core.Models.Response;
 
 namespace Bit.Core.Abstractions {
     public interface IFileUploadService {
-        Task UploadCipherAttachmentFileAsync(AttachmentUploadDataResponse uploadData, string fileName, EncByteArray encryptedFileData);
+        Task UploadCipherAttachmentFileAsync(AttachmentUploadDataResponse uploadData, EncString fileName, EncByteArray encryptedFileData);
         Task UploadSendFileAsync(SendFileUploadDataResponse uploadData, EncString fileName, EncByteArray encryptedFileData);
     }
 }

--- a/src/Core/Services/CipherService.cs
+++ b/src/Core/Services/CipherService.cs
@@ -574,7 +574,7 @@ namespace Bit.Core.Services
 
                 var uploadDataResponse = await _apiService.PostCipherAttachmentAsync(cipher.Id, request);
                 response = uploadDataResponse.CipherResponse;
-                await _fileUploadService.UploadCipherAttachmentFileAsync(uploadDataResponse, encFileName.EncryptedString, encFileData);
+                await _fileUploadService.UploadCipherAttachmentFileAsync(uploadDataResponse, encFileName, encFileData);
             }
             catch (ApiException e) when (e.Error.StatusCode == System.Net.HttpStatusCode.NotFound || e.Error.StatusCode == System.Net.HttpStatusCode.MethodNotAllowed)
             {

--- a/src/Core/Services/FileUploadService.cs
+++ b/src/Core/Services/FileUploadService.cs
@@ -20,14 +20,14 @@ namespace Bit.Core.Services {
         private readonly ApiService _apiService;
 
         public async Task UploadCipherAttachmentFileAsync(AttachmentUploadDataResponse uploadData,
-            string encryptedFileName, EncByteArray encryptedFileData)
+            EncString encryptedFileName, EncByteArray encryptedFileData)
         {
             try
             {
                 switch (uploadData.FileUploadType)
                 {
                     case FileUploadType.Direct:
-                        await _bitwardenFileUploadService.Upload(encryptedFileName, encryptedFileData,
+                        await _bitwardenFileUploadService.Upload(encryptedFileName.EncryptedString, encryptedFileData,
                             fd => _apiService.PostAttachmentFileAsync(uploadData.CipherResponse.Id, uploadData.AttachmentId, fd));
                         break;
                     case FileUploadType.Azure:

--- a/test/Core.Test/Services/CipherServiceTests.cs
+++ b/test/Core.Test/Services/CipherServiceTests.cs
@@ -24,8 +24,9 @@ namespace Bit.Core.Test.Services
         public async Task SaveWithServerAsync_PrefersFileUploadService(SutProvider<CipherService> sutProvider,
             Cipher cipher, string fileName, EncByteArray data, AttachmentUploadDataResponse uploadDataResponse, EncString encKey)
         {
+            var encFileName = new EncString(fileName);
             sutProvider.GetDependency<ICryptoService>().EncryptAsync(fileName, Arg.Any<SymmetricCryptoKey>())
-                .Returns(new EncString(fileName));
+                .Returns(encFileName);
             sutProvider.GetDependency<ICryptoService>().EncryptToBytesAsync(data.Buffer, Arg.Any<SymmetricCryptoKey>())
                 .Returns(data);
             sutProvider.GetDependency<ICryptoService>().MakeEncKeyAsync(Arg.Any<SymmetricCryptoKey>()).Returns(new Tuple<SymmetricCryptoKey, EncString>(null, encKey));
@@ -35,7 +36,7 @@ namespace Bit.Core.Test.Services
             await sutProvider.Sut.SaveAttachmentRawWithServerAsync(cipher, fileName, data.Buffer);
 
             await sutProvider.GetDependency<IFileUploadService>().Received(1)
-                .UploadCipherAttachmentFileAsync(uploadDataResponse, fileName, data);
+                .UploadCipherAttachmentFileAsync(uploadDataResponse, encFileName, data);
         }
 
         [Theory]


### PR DESCRIPTION
# Overview

See bitwarden/jslib#403. The issue wasn't present here, but the type change still is a good idea to protect against that kind of typo