### PR TITLE
Fix selecting ciphers in search not working

### DIFF
--- a/src/App/Pages/Send/SendsPage.xaml.cs
+++ b/src/App/Pages/Send/SendsPage.xaml.cs
@@ -1,4 +1,5 @@
-using System;
+﻿using System;
+using System.Linq;
 using Bit.App.Controls;
 using Bit.App.Resources;
 using Bit.Core.Models.View;
@@ -96,7 +97,7 @@ namespace Bit.App.Pages
                 return;
             }
 
-            if (e.CurrentSelection is SendView send)
+            if (e.CurrentSelection?.FirstOrDefault() is SendView send)
             {
                 await _vm.SelectSendAsync(send);
             }

--- a/src/App/Pages/Vault/CiphersPage.xaml.cs
+++ b/src/App/Pages/Vault/CiphersPage.xaml.cs
@@ -3,6 +3,7 @@ using Bit.App.Resources;
 using Bit.Core.Models.View;
 using Bit.Core.Utilities;
 using System;
+using System.Linq;
 using Bit.App.Controls;
 using Xamarin.Forms;
 
@@ -128,7 +129,7 @@ namespace Bit.App.Pages
                 return;
             }
 
-            if (e.CurrentSelection is CipherView cipher)
+            if (e.CurrentSelection?.FirstOrDefault() is CipherView cipher)
             {
                 await _vm.SelectCipherAsync(cipher);
             }


### PR DESCRIPTION
## Objective
It seems https://github.com/bitwarden/mobile-maui/pull/1374 broke selecting ciphers and sends when searching. When looking at the other pages which implements the same logic I noticed we forgot to add `FirstOrDefault()`.