### PR TITLE
Add a 250ms sleep before prompting for password

### DIFF
--- a/src/iOS.Autofill/CredentialProviderViewController.cs
+++ b/src/iOS.Autofill/CredentialProviderViewController.cs
@@ -246,6 +246,7 @@ namespace Bit.iOS.Autofill
                 }
                 else if (!await storageService.GetAsync<bool>(Bit.Core.Constants.PasswordVerifiedAutofillKey))
                 {
+                    // Add a timeout to resolve keyboard not always showing up.
                     await Task.Delay(250);
                     var passwordRepromptService = ServiceContainer.Resolve<IPasswordRepromptService>("passwordRepromptService");
                     if (!await passwordRepromptService.ShowPasswordPromptAsync())


### PR DESCRIPTION
Add a sleep in an attempt to resolve keyboard not showing up somtimes.