### PR TITLE
Fix for EMM system configuration for mobile

### DIFF
--- a/src/Android/MainActivity.cs
+++ b/src/Android/MainActivity.cs
@@ -166,7 +166,9 @@ namespace Bit.Droid
                 }
                 catch { }
             }
-            var setRestrictions = AndroidHelpers.SetPreconfiguredRestrictionSettingsAsync(this);
+            AndroidHelpers.SetPreconfiguredRestrictionSettingsAsync(this)
+                .GetAwaiter()
+                .GetResult();
         }
 
         protected override void OnNewIntent(Intent intent)

--- a/src/App/Utilities/AppHelpers.cs
+++ b/src/App/Utilities/AppHelpers.cs
@@ -381,7 +381,7 @@ namespace Bit.App.Utilities
 
         public static async Task SetPreconfiguredSettingsAsync(IDictionary<string, string> configSettings)
         {
-            if (configSettings?.Any() ?? true)
+            if (configSettings?.Any() != true)
             {
                 return;
             }
@@ -403,7 +403,7 @@ namespace Bit.App.Utilities
                                 Icons = environmentService.IconsUrl
                             });
                         }
-                        break;
+                        return;
                     default:
                         break;
                 }


### PR DESCRIPTION
## Overview
There have been some reports of the EMM / MDM configuration for centrally mobile deployments where the custom, self-hosted URL for Bitwarden needs to be pre-set in corporate distributions. This capability is supported in Xamarin and this capability was added a while back, but it would appear it isn't working (just nobody told us this or truly needed it until now).

## Changes
* **MainActivity.cs** - `SetPreconfiguredRestrictionSettingsAsync` is an `async` method and was being called synchronously, assigning the delegate task (unexecuted) to `var setRestrictions` only to be lost in the aether. Added the `.GetAwaiter().GetResult()` call to force synchronous execution in the synchronous context it's needed
* **AppHelpers.cs** - It would seem that from the calling methods to `SetPreconfiguredSettingsAsync()`, the `configSettings` parameter generally did have values added to it, however the way the `if` block logic was written it would bail out of this method early if any values were provided in this case, which seems perhaps misplaced. I've not tested this theory, but this change felt right.

Reference from original PR: https://github.com/bitwarden/mobile/pull/727.