### PR TITLE
Add support for Mull browser

### DIFF
--- a/src/Android/Accessibility/AccessibilityHelpers.cs
+++ b/src/Android/Accessibility/AccessibilityHelpers.cs
@@ -109,6 +109,7 @@ namespace Bit.Droid.Accessibility
             new Browser("org.torproject.torbrowser_alpha", "mozac_browser_toolbar_url_view,url_bar_title"), // 2nd = Legacy (before v10.0a8)
             new Browser("org.ungoogled.chromium.extensions.stable", "url_bar"),
             new Browser("org.ungoogled.chromium.stable", "url_bar"),
+            new Browser("us.spotco.fennec_dos", "mozac_browser_toolbar_url_view,url_bar_title"), // 2nd = Legacy
 
             // [Section B] Entries only present here
             //

--- a/src/Android/Autofill/AutofillHelpers.cs
+++ b/src/Android/Autofill/AutofillHelpers.cs
@@ -122,6 +122,7 @@ namespace Bit.Droid.Autofill
             "org.torproject.torbrowser_alpha",
             "org.ungoogled.chromium.extensions.stable",
             "org.ungoogled.chromium.stable",
+            "us.spotco.fennec_dos",
         };
 
         // The URLs are blacklisted from autofilling

--- a/src/Android/Resources/xml/autofillservice.xml
+++ b/src/Android/Resources/xml/autofillservice.xml
@@ -233,4 +233,7 @@
   <compatibility-package
     android:name="org.ungoogled.chromium.stable"
     android:maxLongVersionCode="10000000000"/>
+  <compatibility-package
+    android:name="us.spotco.fennec_dos"
+    android:maxLongVersionCode="10000000000"/>
 </autofill-service>


### PR DESCRIPTION
This adds support for Mull browser, a privacy oriented and deblobbed web browser based on Mozilla's Firefox for Android. 

Also adds support for legacy version of Mull based on the Fennec architecture.

Resolves #1288 