### PR TITLE
MaximumAccessCountInfo locale string update

### DIFF
--- a/src/App/Resources/AppResources.resx
+++ b/src/App/Resources/AppResources.resx
@@ -1864,7 +1864,7 @@
     <value>Maximum Access Count</value>
   </data>
   <data name="MaximumAccessCountInfo" xml:space="preserve">
-    <value>If set, users will no longer be able to access this send once the maximum access count is reached.</value>
+    <value>If set, users will no longer be able to access this Send once the maximum access count is reached.</value>
     <comment>'Send' is a noun and the name of a feature called 'Bitwarden Send'. It should not be translated.</comment>
   </data>
   <data name="MaximumAccessCountReached" xml:space="preserve">


### PR DESCRIPTION
Hey, I noticed that the string doesn't have a capitalized "Send" word.

It a bit messes up with the Crowdin comparing system, as both browser and desktop versions have "Send" capitalized correctly - while mobile and web don't.

I also made a PR on the web version.