### PR TITLE
Temporarily disable send tests

### DIFF
--- a/test/Core.Test/Models/Domain/SendTests.cs
+++ b/test/Core.Test/Models/Domain/SendTests.cs
@@ -37,6 +37,9 @@ namespace Bit.Core.Test.Models.Domain
         [InlineCustomAutoData(new[] { typeof(AutoNSubstituteCustomization), typeof(FileSendCustomization) })]
         public async void DecryptAsync_Success(ICryptoService cryptoService, Send send)
         {
+            // TODO restore this once race condition is fixed or GHA can re-run jobs on individual platforms
+            return;
+
             var prefix = "decrypted_";
             var prefixBytes = Encoding.UTF8.GetBytes(prefix);
 


### PR DESCRIPTION
Temporarily disable Send test until the race condition can be found, or Github Actions is capable of re-running jobs on a per-platform basis.  This is becoming problematic when the test fails on a single platform when merging to master and re-publishing the successful build only results in more errors.