### PR TITLE
Workaround for off-screen draw bug in XF4.5+

### DIFF
--- a/src/App/Pages/Vault/AddEditPage.xaml
+++ b/src/App/Pages/Vault/AddEditPage.xaml
@@ -710,7 +710,10 @@
                     </StackLayout>
                     <BoxView StyleClass="box-row-separator" />
                 </StackLayout>
-                <controls:RepeaterView ItemsSource="{Binding Collections}" IsVisible="{Binding HasCollections}">
+                <controls:RepeaterView 
+                    x:Name="_collectionsRepeaterView" 
+                    ItemsSource="{Binding Collections}"
+                    IsVisible="{Binding HasCollections}">
                     <controls:RepeaterView.ItemTemplate>
                         <DataTemplate x:DataType="pages:CollectionViewModel">
                             <StackLayout Spacing="0" Padding="0">

--- a/src/App/Pages/Vault/AddEditPage.xaml.cs
+++ b/src/App/Pages/Vault/AddEditPage.xaml.cs
@@ -47,6 +47,7 @@ namespace Bit.App.Pages
             _vm.CipherId = cipherId;
             _vm.FolderId = folderId == "none" ? null : folderId;
             _vm.CollectionIds = collectionId != null ? new HashSet<string>(new List<string> { collectionId }) : null;
+            _vm.CollectionsRepeaterView = _collectionsRepeaterView;
             _vm.Type = type;
             _vm.DefaultName = name ?? appOptions?.SaveName;
             _vm.DefaultUri = uri ?? appOptions?.Uri;
@@ -158,6 +159,7 @@ namespace Bit.App.Pages
                 {
                     RequestFocus(_nameEntry);
                 }
+                _scrollView.Scrolled += (sender, args) => _vm.HandleScroll();
             });
         }
 

--- a/src/App/Pages/Vault/AddEditPageViewModel.cs
+++ b/src/App/Pages/Vault/AddEditPageViewModel.cs
@@ -1,4 +1,5 @@
-﻿using Bit.App.Abstractions;
+﻿using System;
+using Bit.App.Abstractions;
 using Bit.App.Models;
 using Bit.App.Resources;
 using Bit.Core.Abstractions;
@@ -9,6 +10,7 @@ using Bit.Core.Utilities;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Bit.App.Controls;
 using Xamarin.Forms;
 using View = Xamarin.Forms.View;
 
@@ -39,6 +41,7 @@ namespace Bit.App.Pages
         private int _ownershipSelectedIndex;
         private bool _hasCollections;
         private string _previousCipherId;
+        private DateTime _lastHandledScrollTime;
         private List<Core.Models.View.CollectionView> _writeableCollections;
         private string[] _additionalCipherProperties = new string[]
         {
@@ -166,6 +169,7 @@ namespace Bit.App.Pages
         public ExtendedObservableCollection<LoginUriView> Uris { get; set; }
         public ExtendedObservableCollection<AddEditPageFieldViewModel> Fields { get; set; }
         public ExtendedObservableCollection<CollectionViewModel> Collections { get; set; }
+        public RepeaterView CollectionsRepeaterView { get; set; }
         public int TypeSelectedIndex
         {
             get => _typeSelectedIndex;
@@ -798,15 +802,32 @@ namespace Bit.App.Pages
             }
             if (Cipher.OrganizationId != null)
             {
+                HasCollections = true;
                 var cols = _writeableCollections.Where(c => c.OrganizationId == Cipher.OrganizationId)
                     .Select(c => new CollectionViewModel { Collection = c }).ToList();
                 Collections.ResetWithRange(cols);
+                Collections = new ExtendedObservableCollection<CollectionViewModel>(cols);
             }
             else
             {
+                HasCollections = false;
                 Collections.ResetWithRange(new List<CollectionViewModel>());
+                Collections = new ExtendedObservableCollection<CollectionViewModel>(new List<CollectionViewModel>());
             }
-            HasCollections = Collections.Any();
+        }
+
+        public void HandleScroll()
+        {
+            // workaround for https://github.com/xamarin/Xamarin.Forms/issues/13607
+            // required for org ownership/collections to render properly in XF4.5+
+            if (!HasCollections ||
+                EditMode ||
+                (DateTime.Now - _lastHandledScrollTime < TimeSpan.FromMilliseconds(200)))
+            {
+                return;
+            }
+            CollectionsRepeaterView.ItemsSource = Collections;
+            _lastHandledScrollTime = DateTime.Now;
         }
 
         private void TriggerCipherChanged()

--- a/src/App/Pages/Vault/AddEditPageViewModel.cs
+++ b/src/App/Pages/Vault/AddEditPageViewModel.cs
@@ -802,9 +802,9 @@ namespace Bit.App.Pages
             }
             if (Cipher.OrganizationId != null)
             {
-                HasCollections = true;
                 var cols = _writeableCollections.Where(c => c.OrganizationId == Cipher.OrganizationId)
                     .Select(c => new CollectionViewModel { Collection = c }).ToList();
+                HasCollections = cols.Any();
                 Collections.ResetWithRange(cols);
                 Collections = new ExtendedObservableCollection<CollectionViewModel>(cols);
             }


### PR DESCRIPTION
An issue where a BindableLayout that is modified off-screen isn't re-drawn to reflect the modification (Xamarin Forms 4.5+) broke the way we render organization & collection selection when adding new vault items.  This PR works around that in an _interesting_ way.

- `HasCollections` is set to `true` in order to make the layout visible before modifying the content
- After `Collections` is updated with the new content, it is set to a new instance of `ExtendedObservableCollection` containing the values already established in `ResetWithRange` (which must still occur or this has no effect)
- Upon scrolling the screen, the collections `RepeaterView.ItemsSource` is repeatedly set to `Collections` (limited by a timer to prevent scroll events from max'ing out the thread pool)

Things to consider:
- All of these seemingly useless steps are required to force collections to draw like they did before we updated to Forms 5.x. A lot of whittling took place to narrow this down.
- Android exhibits this bug far more consistently than iOS, but I didn't restrict the workaround since I witnessed it happen a few times in iOS.
- When the owner is changed to an organization and you begin to scroll, you may experience an initial lag in the scroll action as the workaround does its "magic".

Note to my future self: Please for the love of ham, revert this when that bug is fixed