### PR TITLE
Fix for export password handling

### DIFF
--- a/src/App/Pages/Settings/ExportVaultPageViewModel.cs
+++ b/src/App/Pages/Settings/ExportVaultPageViewModel.cs
@@ -103,10 +103,9 @@ namespace Bit.App.Pages
                 return;
             }
 
-            MasterPassword = string.Empty;
-
             var passwordValid = await _cryptoService.CompareAndUpdateKeyHashAsync(_masterPassword, null);
-            if (passwordValid)
+            MasterPassword = string.Empty;
+            if (!passwordValid)
             {
                 await _platformUtilsService.ShowDialogAsync(_i18nService.T("InvalidMasterPassword"));
                 return;


### PR DESCRIPTION
Fix for password handling in vault export:

- Don't clear `MasterPassword` property until after sending the backing var to `CompareAndUpdateKeyHashAsync`
- Negate `passwordValid` for proper error flow
