### PR TITLE
Fix for resuming autofill when back button was previously used to exit

### DIFF
--- a/src/App/Pages/Vault/AutofillCiphersPage.xaml.cs
+++ b/src/App/Pages/Vault/AutofillCiphersPage.xaml.cs
@@ -46,6 +46,15 @@ namespace Bit.App.Pages
             }, _mainContent);
         }
 
+        protected override bool OnBackButtonPressed()
+        {
+            if (Device.RuntimePlatform == Device.Android)
+            {
+                _appOptions.Uri = null;
+            }
+            return base.OnBackButtonPressed();
+        }
+
         private async void RowSelected(object sender, SelectionChangedEventArgs e)
         {
             ((ExtendedCollectionView)sender).SelectedItem = null;


### PR DESCRIPTION
The autofill cipher list screen would re-appear when resuming the app after exiting via the back button (I believe this could be due to the change to SingleTask LaunchMode).  By clearing the autofill `Uri` when using the back button, resuming the app behaves as expected by opening to the main tabbed screen.