### PR TITLE
Fix for password unlock for autofill and share-to-send on Android

### DIFF
--- a/src/Android/Autofill/AutofillService.cs
+++ b/src/Android/Autofill/AutofillService.cs
@@ -57,6 +57,7 @@ namespace Bit.Droid.Autofill
             }
 
             List<FilledItem> items = null;
+            await _vaultTimeoutService.CheckVaultTimeoutAsync();
             var locked = await _vaultTimeoutService.IsLockedAsync();
             if (!locked)
             {

--- a/src/App/Pages/Send/SendAddEditPageViewModel.cs
+++ b/src/App/Pages/Send/SendAddEditPageViewModel.cs
@@ -398,7 +398,7 @@ namespace Bit.App.Pages
 
                 if (IsAddFromShare && Device.RuntimePlatform == Device.Android)
                 {
-                    _deviceActionService.CloseMainApp();
+                    CloseMainApp();
                 }
                 else
                 {
@@ -427,6 +427,14 @@ namespace Bit.App.Pages
                 }
             }
             return false;
+        }
+
+        public void CloseMainApp()
+        {
+            if (Device.RuntimePlatform == Device.Android)
+            {
+                _deviceActionService.CloseMainApp();   
+            }
         }
 
         public async Task<bool> RemovePasswordAsync()

--- a/src/App/Pages/Vault/AddEditPage.xaml.cs
+++ b/src/App/Pages/Vault/AddEditPage.xaml.cs
@@ -20,6 +20,7 @@ namespace Bit.App.Pages
         private readonly AppOptions _appOptions;
         private readonly IStorageService _storageService;
         private readonly IDeviceActionService _deviceActionService;
+        private readonly IVaultTimeoutService _vaultTimeoutService;
 
         private AddEditPageViewModel _vm;
         private bool _fromAutofill;
@@ -38,6 +39,7 @@ namespace Bit.App.Pages
         {
             _storageService = ServiceContainer.Resolve<IStorageService>("storageService");
             _deviceActionService = ServiceContainer.Resolve<IDeviceActionService>("deviceActionService");
+            _vaultTimeoutService = ServiceContainer.Resolve<IVaultTimeoutService>("vaultTimeoutService");
             _appOptions = appOptions;
             _fromAutofill = fromAutofill;
             FromAutofillFramework = _appOptions?.FromAutofillFramework ?? false;
@@ -145,6 +147,11 @@ namespace Bit.App.Pages
         protected override async void OnAppearing()
         {
             base.OnAppearing();
+            await _vaultTimeoutService.CheckVaultTimeoutAsync();
+            if (await _vaultTimeoutService.IsLockedAsync())
+            {
+                return;
+            }
             await LoadOnAppearedAsync(_scrollView, true, async () =>
             {
                 var success = await _vm.LoadAsync(_appOptions);

--- a/src/App/Pages/Vault/AutofillCiphersPage.xaml.cs
+++ b/src/App/Pages/Vault/AutofillCiphersPage.xaml.cs
@@ -15,6 +15,7 @@ namespace Bit.App.Pages
     {
         private readonly AppOptions _appOptions;
         private readonly IPlatformUtilsService _platformUtilsService;
+        private readonly IVaultTimeoutService _vaultTimeoutService;
 
         private AutofillCiphersPageViewModel _vm;
 
@@ -27,11 +28,17 @@ namespace Bit.App.Pages
             _vm.Init(appOptions);
 
             _platformUtilsService = ServiceContainer.Resolve<IPlatformUtilsService>("platformUtilsService");
+            _vaultTimeoutService = ServiceContainer.Resolve<IVaultTimeoutService>("vaultTimeoutService");
         }
 
         protected async override void OnAppearing()
         {
             base.OnAppearing();
+            await _vaultTimeoutService.CheckVaultTimeoutAsync();
+            if (await _vaultTimeoutService.IsLockedAsync())
+            {
+                return;
+            }
             await LoadOnAppearedAsync(_mainLayout, false, async () =>
             {
                 try


### PR DESCRIPTION
Recent changes to the order of operations for vault timeout created a bug specific to activities that are launched by an intent other than the system app launcher and when the user isn't using biometrics (race condition between showing the lock screen and clearing data needed to unlock).  This PR fixes that as well as a few other bugs discovered along the way.

- **AutofillService.cs**: calls `CheckVaultTimeoutAsync` before checking the lock status to make sure the timeout is taken into account before providing creds to the autofill service
- **SendAddEditPage.xaml.cs** and **SendAddEditPageViewModel.cs**: calls `CheckVaultTimeoutAsync` and checks lock status when appearing to prevent attempts to load anything before unlock can occur, and handle back button to close activity properly (recently done for **AutofillCiphersPage.xaml.cs** as well)
- **AddEditPage.xaml.cs**: calls `CheckVaultTimeoutAsync` and checks lock status when appearing to prevent attempts to load anything before unlock can occur
- **AutofillCiphersPage.xaml.cs**: calls `CheckVaultTimeoutAsync` and checks lock status when appearing to prevent attempts to load anything before unlock can occur

