### PR TITLE
Workaround for off-screen draw bug in XF4.5+ part 2 (Send)

### DIFF
--- a/src/App/Pages/Send/SendAddEditPage.xaml
+++ b/src/App/Pages/Send/SendAddEditPage.xaml
@@ -294,24 +294,23 @@
                                 x:Name="_btnOptions"
                                 StyleClass="box-row-button"
                                 TextColor="{StaticResource PrimaryColor}"
-                                Margin="0"
-                                Clicked="ToggleOptions_Clicked" />
+                                Margin="0" />
                             <controls:FaButton
                                 x:Name="_btnOptionsUp"
                                 Text="&#xf077;"
                                 StyleClass="box-row-button"
                                 TextColor="{StaticResource PrimaryColor}"
                                 Clicked="ToggleOptions_Clicked"
-                                IsVisible="{Binding ShowOptions}" />
+                                IsVisible="False" />
                             <controls:FaButton
                                 x:Name="_btnOptionsDown"
                                 Text="&#xf078;"
                                 StyleClass="box-row-button"
                                 TextColor="{StaticResource PrimaryColor}"
                                 Clicked="ToggleOptions_Clicked"
-                                IsVisible="{Binding ShowOptions, Converter={StaticResource inverseBool}}" />
+                                IsVisible="False" />
                         </StackLayout>
-                        <StackLayout IsVisible="{Binding ShowOptions}">
+                        <StackLayout IsVisible="True">
                             <StackLayout
                                 StyleClass="box-row"
                                 Margin="0,10,0,0">


### PR DESCRIPTION
The same issue we had to work around in #1447 also occurred in the collapsible `Options` panel when adding/editing a Send.  Thankfully this one was easier to work around simply by locking the panel open so it's drawn initially and never needs to be re-drawn.  (This should also be reverted once the Forms bug is fixed)