### PR TITLE
Bugfixes for lock block when setting timeout to immediate

### DIFF
--- a/src/Android/MainActivity.cs
+++ b/src/Android/MainActivity.cs
@@ -327,6 +327,11 @@ namespace Bit.Droid
         {
             if (intent.Action == Intent.ActionSend && intent.Type != null)
             {
+                if ((intent.Flags & ActivityFlags.LaunchedFromHistory) == ActivityFlags.LaunchedFromHistory)
+                {
+                    // don't re-deliver intent if resuming from app switcher
+                    return null;
+                }
                 var type = intent.Type;
                 if (type.Contains("text/"))
                 {

--- a/src/App/Pages/Send/SendAddEditPage.xaml.cs
+++ b/src/App/Pages/Send/SendAddEditPage.xaml.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Bit.App.Models;
 using Bit.App.Resources;
+using Bit.App.Utilities;
 using Bit.Core.Abstractions;
 using Bit.Core.Enums;
 using Bit.Core.Utilities;
@@ -81,7 +82,10 @@ namespace Bit.App.Pages
         protected override async void OnAppearing()
         {
             base.OnAppearing();
-            await _vaultTimeoutService.CheckVaultTimeoutAsync();
+            if (!await AppHelpers.IsVaultTimeoutImmediateAsync())
+            {
+                await _vaultTimeoutService.CheckVaultTimeoutAsync();
+            }
             if (await _vaultTimeoutService.IsLockedAsync())
             {
                 return;
@@ -121,7 +125,6 @@ namespace Bit.App.Pages
             if (_vm.IsAddFromShare && Device.RuntimePlatform == Device.Android)
             {
                 _appOptions.CreateSend = null;
-                _vm.CloseMainApp();
             }
             return base.OnBackButtonPressed();
         }

--- a/src/App/Pages/Send/SendAddEditPageViewModel.cs
+++ b/src/App/Pages/Send/SendAddEditPageViewModel.cs
@@ -398,7 +398,7 @@ namespace Bit.App.Pages
 
                 if (IsAddFromShare && Device.RuntimePlatform == Device.Android)
                 {
-                    CloseMainApp();
+                    _deviceActionService.CloseMainApp();
                 }
                 else
                 {
@@ -427,14 +427,6 @@ namespace Bit.App.Pages
                 }
             }
             return false;
-        }
-
-        public void CloseMainApp()
-        {
-            if (Device.RuntimePlatform == Device.Android)
-            {
-                _deviceActionService.CloseMainApp();   
-            }
         }
 
         public async Task<bool> RemovePasswordAsync()

--- a/src/App/Pages/Vault/AddEditPage.xaml.cs
+++ b/src/App/Pages/Vault/AddEditPage.xaml.cs
@@ -147,7 +147,10 @@ namespace Bit.App.Pages
         protected override async void OnAppearing()
         {
             base.OnAppearing();
-            await _vaultTimeoutService.CheckVaultTimeoutAsync();
+            if (!await AppHelpers.IsVaultTimeoutImmediateAsync())
+            {
+                await _vaultTimeoutService.CheckVaultTimeoutAsync();
+            }
             if (await _vaultTimeoutService.IsLockedAsync())
             {
                 return;

--- a/src/App/Pages/Vault/AutofillCiphersPage.xaml.cs
+++ b/src/App/Pages/Vault/AutofillCiphersPage.xaml.cs
@@ -7,6 +7,7 @@ using System;
 using System.Linq;
 using System.Threading.Tasks;
 using Bit.App.Controls;
+using Bit.App.Utilities;
 using Xamarin.Forms;
 
 namespace Bit.App.Pages
@@ -34,7 +35,10 @@ namespace Bit.App.Pages
         protected async override void OnAppearing()
         {
             base.OnAppearing();
-            await _vaultTimeoutService.CheckVaultTimeoutAsync();
+            if (!await AppHelpers.IsVaultTimeoutImmediateAsync())
+            {
+                await _vaultTimeoutService.CheckVaultTimeoutAsync();
+            }
             if (await _vaultTimeoutService.IsLockedAsync())
             {
                 return;

--- a/src/App/Utilities/AppHelpers.cs
+++ b/src/App/Utilities/AppHelpers.cs
@@ -458,5 +458,17 @@ namespace Bit.App.Utilities
             var storageService = ServiceContainer.Resolve<IStorageService>("storageService");
             await storageService.RemoveAsync(Constants.InvalidUnlockAttempts);
         }
+
+        public static async Task<bool> IsVaultTimeoutImmediateAsync()
+        {
+            var storageService = ServiceContainer.Resolve<IStorageService>("storageService");
+            
+            var vaultTimeoutMinutes = await storageService.GetAsync<int?>(Constants.VaultTimeoutKey);
+            if (vaultTimeoutMinutes.GetValueOrDefault(-1) == 0)
+            {
+                return true;
+            }
+            return false;
+        }
     }
 }


### PR DESCRIPTION
Recent changes caused the app to lock instantly when adding a new cipher or Send from within the app when the vault timeout is set to immediate.  As locking is handled on sleep instead of on resume when the timeout is set to immediate, some additional intelligence was needed to make sure activities that support launching via intent (autofill and Send) don't perform lock checks on launch if the timeout is set to immediate (as the app will already be locked when the user exited previously).

While working on this, a previous fix regarding back button handling in Send stopped working.  Further investigation revealed the launch intent was being re-delivered when resuming from the app switcher.  A simple check for the intent's `ActivityFlags.LaunchedFromHistory` allows us to skip delivery if it's not triggered via the original share action.  This seems to be more reliable and eliminates the need for a dedicated `CloseMainApp()` method, so that was reverted.
