### PR TITLE
Bugfix for incorrect type and nullable for some org vars

### DIFF
--- a/src/Core/Models/Data/OrganizationData.cs
+++ b/src/Core/Models/Data/OrganizationData.cs
@@ -43,8 +43,8 @@ namespace Bit.Core.Models.Data
         public bool UsePolicies { get; set; }
         public bool SelfHost { get; set; }
         public bool UsersGetPremium { get; set; }
-        public int Seats { get; set; }
-        public int MaxCollections { get; set; }
+        public int? Seats { get; set; }
+        public short? MaxCollections { get; set; }
         public short? MaxStorageGb { get; set; }
         public Permissions Permissions { get; set; } = new Permissions();
     }

--- a/src/Core/Models/Domain/Organization.cs
+++ b/src/Core/Models/Domain/Organization.cs
@@ -43,8 +43,8 @@ namespace Bit.Core.Models.Domain
         public bool UsePolicies { get; set; }
         public bool SelfHost { get; set; }
         public bool UsersGetPremium { get; set; }
-        public int Seats { get; set; }
-        public int MaxCollections { get; set; }
+        public int? Seats { get; set; }
+        public short? MaxCollections { get; set; }
         public short? MaxStorageGb { get; set; }
         public Permissions Permissions { get; set; } = new Permissions();
 

--- a/src/Core/Models/Response/ProfileOrganizationResponse.cs
+++ b/src/Core/Models/Response/ProfileOrganizationResponse.cs
@@ -16,8 +16,8 @@ namespace Bit.Core.Models.Response
         public bool UsePolicies { get; set; }
         public bool UsersGetPremium { get; set; }
         public bool SelfHost { get; set; }
-        public int Seats { get; set; }
-        public int MaxCollections { get; set; }
+        public int? Seats { get; set; }
+        public short? MaxCollections { get; set; }
         public short? MaxStorageGb { get; set; }
         public string Key { get; set; }
         public OrganizationUserStatusType Status { get; set; }


### PR DESCRIPTION
Two fixes to Organization vars that were preventing sync from working with a particular set of data:

- `Seats`: made nullable to match server
- `MaxCollections`: made nullable `short` to match server
