### PR TITLE
lib updates and app version bump

### DIFF
--- a/src/Android/Android.csproj
+++ b/src/Android/Android.csproj
@@ -85,6 +85,7 @@
       <Version>122.0.0</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Google.Android.Material" Version="1.3.0.1" />
+    <PackageReference Include="Xamarin.AndroidX.Core" Version="1.6.0" />
     <PackageReference Include="Xamarin.AndroidX.AppCompat" Version="1.3.0" />
     <PackageReference Include="Xamarin.AndroidX.Legacy.Support.V4" Version="1.0.0.7" />
     <PackageReference Include="Xamarin.AndroidX.CardView" Version="1.0.0.8" />

--- a/src/Android/Android.csproj
+++ b/src/Android/Android.csproj
@@ -79,18 +79,18 @@
     </PackageReference>
     <PackageReference Include="Xamarin.AndroidX.AutoFill" Version="1.1.0.6" />
     <PackageReference Include="Xamarin.Essentials">
-      <Version>1.6.1</Version>
+      <Version>1.7.0</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Firebase.Messaging">
-      <Version>121.0.1</Version>
+      <Version>122.0.0</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Google.Android.Material" Version="1.3.0.1" />
-    <PackageReference Include="Xamarin.AndroidX.AppCompat" Version="1.2.0.7" />
+    <PackageReference Include="Xamarin.AndroidX.AppCompat" Version="1.3.0" />
     <PackageReference Include="Xamarin.AndroidX.Legacy.Support.V4" Version="1.0.0.7" />
     <PackageReference Include="Xamarin.AndroidX.CardView" Version="1.0.0.8" />
-    <PackageReference Include="Xamarin.AndroidX.MediaRouter" Version="1.2.2.1" />
+    <PackageReference Include="Xamarin.AndroidX.MediaRouter" Version="1.2.4" />
     <PackageReference Include="Xamarin.AndroidX.Migration" Version="1.0.8" />
-    <PackageReference Include="Xamarin.Google.Dagger" Version="2.27.0" />
+    <PackageReference Include="Xamarin.Google.Dagger" Version="2.37.0" />
     <PackageReference Include="Xamarin.GooglePlayServices.SafetyNet">
       <Version>117.0.0</Version>
     </PackageReference>

--- a/src/Android/Properties/AndroidManifest.xml
+++ b/src/Android/Properties/AndroidManifest.xml
@@ -3,7 +3,7 @@
   xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:tools="http://schemas.android.com/tools"
   android:versionCode="1"
-  android:versionName="2.11.1"
+  android:versionName="2.11.2"
   android:installLocation="internalOnly"
   package="com.x8bit.bitwarden">
 

--- a/src/App/App.csproj
+++ b/src/App/App.csproj
@@ -13,11 +13,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AppCenter.Crashes" Version="4.2.0" />
+    <PackageReference Include="Microsoft.AppCenter.Crashes" Version="4.3.0" />
     <PackageReference Include="Plugin.Fingerprint" Version="2.1.4" />
-    <PackageReference Include="Xamarin.Essentials" Version="1.6.1" />
+    <PackageReference Include="Xamarin.Essentials" Version="1.7.0" />
     <PackageReference Include="Xamarin.FFImageLoading.Forms" Version="2.4.11.982" />
-    <PackageReference Include="Xamarin.Forms" Version="5.0.0.2012" />
+    <PackageReference Include="Xamarin.Forms" Version="5.0.0.2083" />
     <PackageReference Include="ZXing.Net.Mobile" Version="2.4.1" />
     <PackageReference Include="ZXing.Net.Mobile.Forms" Version="2.4.1" />
   </ItemGroup>

--- a/src/iOS.Autofill/Info.plist
+++ b/src/iOS.Autofill/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIdentifier</key>
 	<string>com.8bit.bitwarden.autofill</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.11.1</string>
+	<string>2.11.2</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>CFBundleLocalizations</key>

--- a/src/iOS.Autofill/iOS.Autofill.csproj
+++ b/src/iOS.Autofill/iOS.Autofill.csproj
@@ -253,7 +253,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AppCenter.Crashes">
-      <Version>4.2.0</Version>
+      <Version>4.3.0</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/iOS.Extension/Info.plist
+++ b/src/iOS.Extension/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIdentifier</key>
 	<string>com.8bit.bitwarden.find-login-action-extension</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.11.1</string>
+	<string>2.11.2</string>
 	<key>CFBundleLocalizations</key>
 	<array>
 		<string>en</string>

--- a/src/iOS.Extension/iOS.Extension.csproj
+++ b/src/iOS.Extension/iOS.Extension.csproj
@@ -231,7 +231,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AppCenter.Crashes">
-      <Version>4.2.0</Version>
+      <Version>4.3.0</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.AppExtension.CSharp.targets" />

--- a/src/iOS/Info.plist
+++ b/src/iOS/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIdentifier</key>
 	<string>com.8bit.bitwarden</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.11.1</string>
+	<string>2.11.2</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>CFBundleIconName</key>

--- a/src/iOS/iOS.csproj
+++ b/src/iOS/iOS.csproj
@@ -163,7 +163,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Xamarin.Essentials">
-      <Version>1.6.1</Version>
+      <Version>1.7.0</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />

--- a/store/google/Publisher/Publisher.csproj
+++ b/store/google/Publisher/Publisher.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Apis.AndroidPublisher.v3" Version="1.51.0.2310" />
+    <PackageReference Include="Google.Apis.AndroidPublisher.v3" Version="1.52.0.2350" />
   </ItemGroup>
 
 </Project>

--- a/test/Common/Common.csproj
+++ b/test/Common/Common.csproj
@@ -15,7 +15,7 @@
     </PackageReference>
     <PackageReference Include="AutoFixture.Xunit2" Version="4.17.0" />
     <PackageReference Include="AutoFixture.AutoNSubstitute" Version="4.17.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
   </ItemGroup>
 
 </Project>

--- a/test/Core.Test/Core.Test.csproj
+++ b/test/Core.Test/Core.Test.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
     <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
     <PackageReference Include="NSubstitute" Version="4.2.2" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">


### PR DESCRIPTION
- App version bump to 2.11.2
- Bumped to latest Xamarin libs to squash Android fragment view crash
- Updated other libs since this release will be regression tested
- Keep `Xamarin.Google.Android.Material` at `1.3.0.1` due to [this issue](https://github.com/xamarin/AndroidX/issues/335)
- Added explicit `Xamarin.AndroidX.Core` dependency due to [this issue](https://github.com/xamarin/Xamarin.Forms/issues/14417) (will create Asana ticket for future removal)