### PR TITLE
Move remaining primary buttons in login flow

### DIFF
--- a/src/App/Pages/Accounts/LoginSsoPage.xaml
+++ b/src/App/Pages/Accounts/LoginSsoPage.xaml
@@ -35,10 +35,10 @@
                         ReturnCommand="{Binding LogInCommand}" />
                 </StackLayout>
             </StackLayout>
-		    <StackLayout Padding="10, 0">
-				<Button Text="{u:I18n LogIn}"
-				    Clicked="LogIn_Clicked"></Button>
-			</StackLayout>
+            <StackLayout Padding="10, 0">
+                <Button Text="{u:I18n LogIn}"
+                    Clicked="LogIn_Clicked"></Button>
+            </StackLayout>
         </StackLayout>
     </ScrollView>
 

--- a/src/App/Pages/Accounts/TwoFactorPageViewModel.cs
+++ b/src/App/Pages/Accounts/TwoFactorPageViewModel.cs
@@ -76,10 +76,10 @@ namespace Bit.App.Pages
         public bool ShowTryAgain => YubikeyMethod && Device.RuntimePlatform == Device.iOS;
 
         public bool ShowContinue
-	    {
-	        get => _showContinue;
-	        set => SetProperty(ref _showContinue, value);
-	    }
+        {
+            get => _showContinue;
+            set => SetProperty(ref _showContinue, value);
+        }
 
         public bool EnableContinue
         {


### PR DESCRIPTION
## Objective

Some work to finish off #1427.

On the 2FA page:
* Fix QA feedback that the "Continue" button was not properly showing/hiding based on the selected 2FA method. This was because we weren't using `setProperty` in the `ShowContinue` getter, so the bindings weren't being updated.
* Fix an unrelated bug where clicking off the "Use another method" modal (without selecting an option or clicking cancel) would act as if the user had selected an unsupported 2FA method.

On the SSO page:
* Move Log In button to be consistent with the other login pages.

![Screen Shot 2021-07-21 at 9 50 49 pm](https://user-images.githubusercontent.com/31796059/126484232-9d88e6ad-bb0c-4b69-a947-f4fc3e90e6eb.png)