### PR TITLE
Move remaining primary buttons in login flow

### DIFF
--- a/src/App/Pages/Accounts/LoginSsoPage.xaml
+++ b/src/App/Pages/Accounts/LoginSsoPage.xaml
@@ -14,7 +14,6 @@
 
     <ContentPage.ToolbarItems>
         <ToolbarItem Text="{u:I18n Close}" Clicked="Close_Clicked" Order="Primary" Priority="-1" />
-        <ToolbarItem Text="{u:I18n LogIn}" Clicked="LogIn_Clicked" />
     </ContentPage.ToolbarItems>
 
     <ScrollView>
@@ -36,6 +35,10 @@
                         ReturnCommand="{Binding LogInCommand}" />
                 </StackLayout>
             </StackLayout>
+		    <StackLayout Padding="10, 0">
+				<Button Text="{u:I18n LogIn}"
+				    Clicked="LogIn_Clicked"></Button>
+			</StackLayout>
         </StackLayout>
     </ScrollView>
 

--- a/src/App/Pages/Accounts/LoginSsoPage.xaml
+++ b/src/App/Pages/Accounts/LoginSsoPage.xaml
@@ -35,10 +35,10 @@
                         ReturnCommand="{Binding LogInCommand}" />
                 </StackLayout>
             </StackLayout>
-		    <StackLayout Padding="10, 0">
-				<Button Text="{u:I18n LogIn}"
-				    Clicked="LogIn_Clicked"></Button>
-			</StackLayout>
+            <StackLayout Padding="10, 0">
+                <Button Text="{u:I18n LogIn}"
+                    Clicked="LogIn_Clicked"></Button>
+            </StackLayout>
         </StackLayout>
     </ScrollView>
 

--- a/src/App/Pages/Accounts/TwoFactorPageViewModel.cs
+++ b/src/App/Pages/Accounts/TwoFactorPageViewModel.cs
@@ -33,6 +33,7 @@ namespace Bit.App.Pages
         private string _webVaultUrl = "https://vault.bitwarden.com";
         private bool _authingWithSso = false;
         private bool _enableContinue = false;
+        private bool _showContinue = true;
 
         public TwoFactorPageViewModel()
         {
@@ -74,7 +75,11 @@ namespace Bit.App.Pages
 
         public bool ShowTryAgain => YubikeyMethod && Device.RuntimePlatform == Device.iOS;
 
-        public bool ShowContinue { get; set; }
+        public bool ShowContinue
+	    {
+	        get => _showContinue;
+	        set => SetProperty(ref _showContinue, value);
+	    }
 
         public bool EnableContinue
         {

--- a/src/App/Pages/Accounts/TwoFactorPageViewModel.cs
+++ b/src/App/Pages/Accounts/TwoFactorPageViewModel.cs
@@ -252,7 +252,7 @@ namespace Bit.App.Pages
             {
                 _platformUtilsService.LaunchUri("https://help.bitwarden.com/article/lost-two-step-device/");
             }
-            else if (method != AppResources.Cancel)
+            else if (method != AppResources.Cancel && method != null)
             {
                 var selected = supportedProviders.FirstOrDefault(p => p.Name == method)?.Type;
                 if (selected == SelectedProviderType)

--- a/src/App/Pages/Accounts/TwoFactorPageViewModel.cs
+++ b/src/App/Pages/Accounts/TwoFactorPageViewModel.cs
@@ -76,10 +76,10 @@ namespace Bit.App.Pages
         public bool ShowTryAgain => YubikeyMethod && Device.RuntimePlatform == Device.iOS;
 
         public bool ShowContinue
-	    {
-	        get => _showContinue;
-	        set => SetProperty(ref _showContinue, value);
-	    }
+        {
+            get => _showContinue;
+            set => SetProperty(ref _showContinue, value);
+        }
 
         public bool EnableContinue
         {


### PR DESCRIPTION
## Objective

Some work to finish off #1427.

On the 2FA page:
* Fix QA feedback that the "Continue" button was not properly showing/hiding based on the selected 2FA method. This was because we weren't using `setProperty` in the `ShowContinue` getter, so the bindings weren't being updated.
* Fix an unrelated bug where clicking off the "Use another method" modal (without selecting an option or clicking cancel) would act as if the user had selected an unsupported 2FA method.

On the SSO page:
* Move Log In button to be consistent with the other login pages.

![Screen Shot 2021-07-21 at 9 50 49 pm](https://user-images.githubusercontent.com/31796059/126484232-9d88e6ad-bb0c-4b69-a947-f4fc3e90e6eb.png)