### PR TITLE
Fix for Android crash when toggling system light/dark theme

### DIFF
--- a/src/Android/Android.csproj
+++ b/src/Android/Android.csproj
@@ -28,7 +28,6 @@
     <DefineConstants>DEBUG;</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>3</WarningLevel>
-    <AndroidLinkMode>None</AndroidLinkMode>
     <AndroidSupportedAbis />
     <JavaMaximumHeapSize>1G</JavaMaximumHeapSize>
   </PropertyGroup>
@@ -77,20 +76,22 @@
     <PackageReference Include="Portable.BouncyCastle">
       <Version>1.8.10</Version>
     </PackageReference>
+    <PackageReference Include="Xamarin.AndroidX.Core" Version="1.5.0" />
+    <PackageReference Include="Xamarin.AndroidX.AppCompat.AppCompatResources" Version="1.3.0" />
+    <PackageReference Include="Xamarin.AndroidX.AppCompat" Version="1.3.0" />
     <PackageReference Include="Xamarin.AndroidX.AutoFill" Version="1.1.0.6" />
+    <PackageReference Include="Xamarin.AndroidX.CardView" Version="1.0.0.8" />
+    <PackageReference Include="Xamarin.AndroidX.Legacy.Support.V4" Version="1.0.0.7" />
+    <PackageReference Include="Xamarin.AndroidX.MediaRouter" Version="1.2.4" />
+    <PackageReference Include="Xamarin.AndroidX.Migration" Version="1.0.8" />
     <PackageReference Include="Xamarin.Essentials">
-      <Version>1.6.1</Version>
+      <Version>1.7.0</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Firebase.Messaging">
-      <Version>121.0.1</Version>
+      <Version>122.0.0</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Google.Android.Material" Version="1.3.0.1" />
-    <PackageReference Include="Xamarin.AndroidX.AppCompat" Version="1.2.0.7" />
-    <PackageReference Include="Xamarin.AndroidX.Legacy.Support.V4" Version="1.0.0.7" />
-    <PackageReference Include="Xamarin.AndroidX.CardView" Version="1.0.0.8" />
-    <PackageReference Include="Xamarin.AndroidX.MediaRouter" Version="1.2.2.1" />
-    <PackageReference Include="Xamarin.AndroidX.Migration" Version="1.0.8" />
-    <PackageReference Include="Xamarin.Google.Dagger" Version="2.27.0" />
+    <PackageReference Include="Xamarin.Google.Dagger" Version="2.37.0" />
     <PackageReference Include="Xamarin.GooglePlayServices.SafetyNet">
       <Version>117.0.0</Version>
     </PackageReference>

--- a/src/App/App.csproj
+++ b/src/App/App.csproj
@@ -13,11 +13,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AppCenter.Crashes" Version="4.2.0" />
+    <PackageReference Include="Microsoft.AppCenter.Crashes" Version="4.3.0" />
     <PackageReference Include="Plugin.Fingerprint" Version="2.1.4" />
-    <PackageReference Include="Xamarin.Essentials" Version="1.6.1" />
+    <PackageReference Include="Xamarin.Essentials" Version="1.7.0" />
     <PackageReference Include="Xamarin.FFImageLoading.Forms" Version="2.4.11.982" />
-    <PackageReference Include="Xamarin.Forms" Version="5.0.0.2012" />
+    <PackageReference Include="Xamarin.Forms" Version="5.0.0.2083" />
     <PackageReference Include="ZXing.Net.Mobile" Version="2.4.1" />
     <PackageReference Include="ZXing.Net.Mobile.Forms" Version="2.4.1" />
   </ItemGroup>

--- a/src/iOS.Autofill/iOS.Autofill.csproj
+++ b/src/iOS.Autofill/iOS.Autofill.csproj
@@ -253,7 +253,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AppCenter.Crashes">
-      <Version>4.2.0</Version>
+      <Version>4.3.0</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/iOS.Extension/iOS.Extension.csproj
+++ b/src/iOS.Extension/iOS.Extension.csproj
@@ -231,7 +231,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AppCenter.Crashes">
-      <Version>4.2.0</Version>
+      <Version>4.3.0</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.AppExtension.CSharp.targets" />

--- a/src/iOS/iOS.csproj
+++ b/src/iOS/iOS.csproj
@@ -163,7 +163,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Xamarin.Essentials">
-      <Version>1.6.1</Version>
+      <Version>1.7.0</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />

--- a/store/google/Publisher/Publisher.csproj
+++ b/store/google/Publisher/Publisher.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Apis.AndroidPublisher.v3" Version="1.51.0.2310" />
+    <PackageReference Include="Google.Apis.AndroidPublisher.v3" Version="1.52.0.2350" />
   </ItemGroup>
 
 </Project>

--- a/test/Common/Common.csproj
+++ b/test/Common/Common.csproj
@@ -15,7 +15,7 @@
     </PackageReference>
     <PackageReference Include="AutoFixture.Xunit2" Version="4.17.0" />
     <PackageReference Include="AutoFixture.AutoNSubstitute" Version="4.17.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
   </ItemGroup>
 
 </Project>

--- a/test/Core.Test/Core.Test.csproj
+++ b/test/Core.Test/Core.Test.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
     <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
     <PackageReference Include="NSubstitute" Version="4.2.2" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">


### PR DESCRIPTION
- Bumped to latest Xamarin Forms to fix Android crash when toggling light/dark mode
- Keep `Xamarin.Google.Android.Material` at `1.3.0.1` due to [this issue](https://github.com/xamarin/AndroidX/issues/335)
- Added explicit `Xamarin.AndroidX.Core` dependency due to [this issue](https://github.com/xamarin/Xamarin.Forms/issues/14417) (will create Asana ticket for future removal)
- Restricted `Xamarin.AndroidX.Core` to `1.5.0` and added `Xamarin.AndroidX.AppCompat.AppCompatResources` due to [this issue](https://github.com/xamarin/Xamarin.Forms/issues/14424)
- Removed `<AndroidLinkMode>` from debug builds to fallback to default (same as release, which is `SdkOnly` instead of `None`) to catch library issues sneaking past developers.  This will add a few seconds to the build time, but potentially save hours of debugging after the fact.
- Updated other libs since this release will be regression tested
- Some `<PackageReference>` cleanup in `Android.cs.proj`