### PR TITLE
Temporarily disable send test

### DIFF
--- a/test/Core.Test/Services/SendServiceTests.cs
+++ b/test/Core.Test/Services/SendServiceTests.cs
@@ -147,6 +147,9 @@ namespace Bit.Core.Test.Services
         [InlineCustomAutoData(new[] { typeof(SutProviderCustomization), typeof(FileSendCustomization) })]
         public async Task GetAllDecryptedAsync_Success(SutProvider<SendService> sutProvider, string userId, IEnumerable<SendData> sendDatas)
         {
+            // TODO restore this once race condition is fixed or GHA can re-run jobs on individual platforms
+            return;
+            
             var sendDataDict = sendDatas.ToDictionary(d => d.Id, d => d);
             sutProvider.GetDependency<ICryptoService>().HasKeyAsync().Returns(true);
             ServiceContainer.Register("cryptoService", sutProvider.GetDependency<ICryptoService>());


### PR DESCRIPTION
Temporarily disable Send test until the race condition can be found, or Github Actions is capable of re-running jobs on a per-platform basis (missed this one back when #1443 was merged, and it failed today with the same `System.Exception : Service cryptoService is not registered` message)