### PR TITLE
Add Kiwi Browser

### DIFF
--- a/src/Android/Resources/xml/autofillservice.xml
+++ b/src/Android/Resources/xml/autofillservice.xml
@@ -236,4 +236,7 @@
   <compatibility-package
     android:name="us.spotco.fennec_dos"
     android:maxLongVersionCode="10000000000"/>
+<compatibility-package
+    android:name="com.kiwibrowser.browser"
+    android:maxLongVersionCode="10000000000"/>
 </autofill-service>


### PR DESCRIPTION
Kiwi Browser is Chromium-based and will likely work with Bitwarden's autofill service without any modifications to Bitwarden.
Kiwi's Play Store page: https://play.google.com/store/apps/details?id=com.kiwibrowser.browser