### PR TITLE
Fix iphone captcha throws

### DIFF
--- a/src/App/Pages/CaptchaProtectedViewModel.cs
+++ b/src/App/Pages/CaptchaProtectedViewModel.cs
@@ -30,7 +30,7 @@ namespace Bit.App.Pages
                 captchaRequiredText = AppResources.CaptchaRequired,
             });
 
-            var url = environmentService.WebVaultUrl + "/captcha-mobile-connector.html?" + "data=" + data +
+            var url = environmentService.GetWebVaultUrl() + "/captcha-mobile-connector.html?" + "data=" + data +
                 "&parent=" + Uri.EscapeDataString(callbackUri) + "&v=1";
 
             WebAuthenticatorResult authResult = null;

--- a/src/Core/Models/Response/ErrorResponse.cs
+++ b/src/Core/Models/Response/ErrorResponse.cs
@@ -29,7 +29,7 @@ namespace Bit.Core.Models.Response
             {
                 var model = errorModel.ToObject<ErrorModel>();
                 Message = model.Message;
-                ValidationErrors = model.ValidationErrors;
+                ValidationErrors = model.ValidationErrors ?? new Dictionary<string, List<string>>();
                 CaptchaSiteKey = ValidationErrors.ContainsKey("HCaptcha_SiteKey") ?
                     ValidationErrors["HCaptcha_SiteKey"]?.FirstOrDefault() :
                     null;

--- a/src/iOS.Core/Services/DeviceActionService.cs
+++ b/src/iOS.Core/Services/DeviceActionService.cs
@@ -106,7 +106,9 @@ namespace Bit.iOS.Core.Services
             if (_progressAlert == null)
             {
                 result.TrySetResult(0);
+                return result.Task;
             }
+
             _progressAlert.DismissViewController(false, () => result.TrySetResult(0));
             _progressAlert.Dispose();
             _progressAlert = null;


### PR DESCRIPTION
# Overview

Fixes: https://app.asana.com/0/0/1200771124135716/f

Two iphone crashes were found due to captcha. The first is a null exception dismissing progress view if it doesn't exist. The second with grabbing validation errors on a message that has none.

# Files Changed
* **CaptchaProtectedModel.cs**: Use helper method to ensure we have the right webvault url
* **ErrorResponse**: Handle the case when no validationErrors are returned
* **DeviceActionService**: Return if _progress is null. This seems to just be an oversight of the null check.