### PR TITLE
Adding stub for crowdin sync testing

### DIFF
--- a/.github/workflows/crowdin-sync.yml
+++ b/.github/workflows/crowdin-sync.yml
@@ -1,0 +1,19 @@
+name: Crowdin Sync
+
+on:
+  workflow_dispatch:
+    inputs: {}
+  #schedule:
+  #  - cron: '0 0 * * *'
+
+jobs:
+  crowdin-sync:
+    name: Autosync
+    runs-on: ubuntu-20.04
+    env:
+      CROWDIN_BASE_URL: "https://api.crowdin.com/api/v2/projects"
+      CROWDIN_PROJECT_ID: "269690"
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f  # v2.3.4
+


### PR DESCRIPTION
## Summary

In order to test the new Crowdin Sync workflow, the workflow needs to first exist in `master`