### PR TITLE
friendly message for webauthn errors

### DIFF
--- a/src/App/Pages/Accounts/TwoFactorPageViewModel.cs
+++ b/src/App/Pages/Accounts/TwoFactorPageViewModel.cs
@@ -240,15 +240,8 @@ namespace Bit.App.Pages
             else
             {
                 await _deviceActionService.HideLoadingAsync();
-                if (authResult != null && authResult.Properties.TryGetValue("error", out var resultError))
-                {
-                    await _platformUtilsService.ShowDialogAsync(resultError, AppResources.AnErrorHasOccurred);
-                }
-                else
-                {
-                    await _platformUtilsService.ShowDialogAsync(AppResources.Fido2SomethingWentWrong,
+                await _platformUtilsService.ShowDialogAsync(AppResources.Fido2SomethingWentWrong,
                         AppResources.AnErrorHasOccurred);
-                }
             }
         }
 

--- a/src/App/Pages/Accounts/TwoFactorPageViewModel.cs
+++ b/src/App/Pages/Accounts/TwoFactorPageViewModel.cs
@@ -240,8 +240,16 @@ namespace Bit.App.Pages
             else
             {
                 await _deviceActionService.HideLoadingAsync();
-                await _platformUtilsService.ShowDialogAsync(AppResources.Fido2SomethingWentWrong,
+                if (authResult != null && authResult.Properties.TryGetValue("error", out var resultError))
+                {
+                    var message = AppResources.Fido2SomethingWentWrong + "\n\n" + resultError;
+                    await _platformUtilsService.ShowDialogAsync(message, AppResources.AnErrorHasOccurred);
+                }
+                else
+                {
+                    await _platformUtilsService.ShowDialogAsync(AppResources.Fido2SomethingWentWrong,
                         AppResources.AnErrorHasOccurred);
+                }
             }
         }
 

--- a/src/App/Pages/Accounts/TwoFactorPageViewModel.cs
+++ b/src/App/Pages/Accounts/TwoFactorPageViewModel.cs
@@ -242,12 +242,12 @@ namespace Bit.App.Pages
                 await _deviceActionService.HideLoadingAsync();
                 if (authResult != null && authResult.Properties.TryGetValue("error", out var resultError))
                 {
-                    var message = AppResources.Fido2SomethingWentWrong + "\n\n" + resultError;
+                    var message = AppResources.Fido2CheckBrowser + "\n\n" + resultError;
                     await _platformUtilsService.ShowDialogAsync(message, AppResources.AnErrorHasOccurred);
                 }
                 else
                 {
-                    await _platformUtilsService.ShowDialogAsync(AppResources.Fido2SomethingWentWrong,
+                    await _platformUtilsService.ShowDialogAsync(AppResources.Fido2CheckBrowser,
                         AppResources.AnErrorHasOccurred);
                 }
             }

--- a/src/App/Resources/AppResources.Designer.cs
+++ b/src/App/Resources/AppResources.Designer.cs
@@ -3585,9 +3585,9 @@ namespace Bit.App.Resources {
             }
         }
         
-        public static string Fido2SomethingWentWrong {
+        public static string Fido2CheckBrowser {
             get {
-                return ResourceManager.GetString("Fido2SomethingWentWrong", resourceCulture);
+                return ResourceManager.GetString("Fido2CheckBrowser", resourceCulture);
             }
         }
         

--- a/src/App/Resources/AppResources.resx
+++ b/src/App/Resources/AppResources.resx
@@ -2028,8 +2028,8 @@
   <data name="Fido2AuthenticateWebAuthn" xml:space="preserve">
     <value>Authenticate WebAuthn</value>
   </data>
-  <data name="Fido2SomethingWentWrong" xml:space="preserve">
-    <value>Something Went Wrong. Please make sure your default browser supports WebAuthn and try again.</value>
+  <data name="Fido2CheckBrowser" xml:space="preserve">
+    <value>Please make sure your default browser supports WebAuthn and try again.</value>
   </data>
   <data name="ResetPasswordAutoEnrollInviteWarning" xml:space="preserve">
     <value>This organization has an enterprise policy that will automatically enroll you in password reset. Enrollment will allow organization administrators to change your master password.</value>

--- a/src/App/Resources/AppResources.resx
+++ b/src/App/Resources/AppResources.resx
@@ -2029,7 +2029,7 @@
     <value>Authenticate WebAuthn</value>
   </data>
   <data name="Fido2SomethingWentWrong" xml:space="preserve">
-    <value>Something Went Wrong. Try again.</value>
+    <value>Something Went Wrong. Please make sure your default browser supports WebAuthn and try again.</value>
   </data>
   <data name="ResetPasswordAutoEnrollInviteWarning" xml:space="preserve">
     <value>This organization has an enterprise policy that will automatically enroll you in password reset. Enrollment will allow organization administrators to change your master password.</value>


### PR DESCRIPTION
_Edited with final screenshots_

Prepend WebAuthn error messages with a friendly/helpful message to hopefully cut down on support requests.

Key points conveyed:

1. User's browser must support WebAuthn, and 
2. It has to be set as the default browser (per WebAuthenticator requirements) 

New message:

![device-2021-09-08-183325](https://user-images.githubusercontent.com/59324545/132594579-c8420013-cacf-41d2-a761-13acbaf85b9e.png)

Old message:

![before2](https://user-images.githubusercontent.com/59324545/132591150-34ae7796-1c35-49ec-ae42-8797c90c3226.png)
