### PR TITLE
[SSO Auto Enroll] Auto Enroll status retrieval

### DIFF
--- a/src/App/Pages/Accounts/SetPasswordPageViewModel.cs
+++ b/src/App/Pages/Accounts/SetPasswordPageViewModel.cs
@@ -102,7 +102,7 @@ namespace Bit.App.Pages
             {
                 var response = await _apiService.GetOrganizationAutoEnrollStatusAsync(OrgIdentifier);
                 OrgId = response.Id;
-                ResetPasswordAutoEnroll = response.AutoEnrollEnabled;
+                ResetPasswordAutoEnroll = response.ResetPasswordEnrolled;
             }
             catch (ApiException e)
             {

--- a/src/App/Pages/Accounts/SetPasswordPageViewModel.cs
+++ b/src/App/Pages/Accounts/SetPasswordPageViewModel.cs
@@ -97,12 +97,21 @@ namespace Bit.App.Pages
         public async Task InitAsync()
         {
             await CheckPasswordPolicy();
-            
-            var org = await _userService.GetOrganizationByIdentifierAsync(OrgIdentifier);
-            OrgId = org?.Id;
-            var policyList = await _policyService.GetAll(PolicyType.ResetPassword);
-            var policyResult = _policyService.GetResetPasswordPolicyOptions(policyList, OrgId);
-            ResetPasswordAutoEnroll = policyResult.Item2 && policyResult.Item1.AutoEnrollEnabled;
+
+            try
+            {
+                var response = await _apiService.GetOrganizationAutoEnrollStatusAsync(OrgIdentifier);
+                OrgId = response.Id;
+                ResetPasswordAutoEnroll = response.AutoEnrollEnabled;
+            }
+            catch (ApiException e)
+            {
+                if (e?.Error != null)
+                {
+                    await _platformUtilsService.ShowDialogAsync(e.Error.GetSingleMessage(),
+                        AppResources.AnErrorHasOccurred);
+                }
+            }
         }
 
         public async Task SubmitAsync()

--- a/src/Core/Abstractions/IApiService.cs
+++ b/src/Core/Abstractions/IApiService.cs
@@ -59,6 +59,7 @@ namespace Bit.Core.Abstractions
         Task PutDeviceTokenAsync(string identifier, DeviceTokenRequest request);
         Task PostEventsCollectAsync(IEnumerable<EventRequest> request);
         Task<OrganizationKeysResponse> GetOrganizationKeysAsync(string id);
+        Task<OrganizationAutoEnrollStatusResponse> GetOrganizationAutoEnrollStatusAsync(string identifier);
         Task PutOrganizationUserResetPasswordEnrollmentAsync(string orgId, string userId,
             OrganizationUserResetPasswordEnrollmentRequest request);
 

--- a/src/Core/Models/Response/OrganizationAutoEnrollStatusResponse.cs
+++ b/src/Core/Models/Response/OrganizationAutoEnrollStatusResponse.cs
@@ -1,0 +1,8 @@
+namespace Bit.Core.Models.Response
+{
+    public class OrganizationAutoEnrollStatusResponse
+    {
+        public string Id { get; set; }
+        public bool AutoEnrollEnabled { get; set; }
+    }
+}

--- a/src/Core/Models/Response/OrganizationAutoEnrollStatusResponse.cs
+++ b/src/Core/Models/Response/OrganizationAutoEnrollStatusResponse.cs
@@ -3,6 +3,6 @@ namespace Bit.Core.Models.Response
     public class OrganizationAutoEnrollStatusResponse
     {
         public string Id { get; set; }
-        public bool AutoEnrollEnabled { get; set; }
+        public bool ResetPasswordEnrolled { get; set; }
     }
 }

--- a/src/Core/Services/ApiService.cs
+++ b/src/Core/Services/ApiService.cs
@@ -410,6 +410,12 @@ namespace Bit.Core.Services
         {
             return SendAsync<object, OrganizationKeysResponse>(HttpMethod.Get, $"/organizations/{id}/keys", null, true, true);
         }
+
+        public Task<OrganizationAutoEnrollStatusResponse> GetOrganizationAutoEnrollStatusAsync(string identifier)
+        {
+            return SendAsync<object, OrganizationAutoEnrollStatusResponse>(HttpMethod.Get,
+                $"/organizations/{identifier}/auto-enroll-status", null, true, true);
+        }
         
         #endregion
         


### PR DESCRIPTION
## Objective
> Add the latest `Auto Enroll` status `API` and updated the flow for information retrieval in regards to the `Organization ID` and `AutoEnrollEnabled` boolean.

## Code Changes
- **SetPasswordPageViewModel**: Update the flow to use the newly available `API`
- **api.service**: Added new `GetOrganizationAutoEnrollStatus` method
- **OrganizationAutoEnrollStatusResponse**: Added response object for newly created `API`

## Dependency
- [Server - Add Auto Enroll status API](https://github.com/bitwarden/server/pull/1583)