### PR TITLE
Update XF to remove AndroidX dependency hack

### DIFF
--- a/src/Android/Android.csproj
+++ b/src/Android/Android.csproj
@@ -76,13 +76,11 @@
     <PackageReference Include="Portable.BouncyCastle">
       <Version>1.8.10</Version>
     </PackageReference>
-    <PackageReference Include="Xamarin.AndroidX.Core" Version="1.5.0" />
-    <PackageReference Include="Xamarin.AndroidX.AppCompat.AppCompatResources" Version="1.3.0" />
-    <PackageReference Include="Xamarin.AndroidX.AppCompat" Version="1.3.0" />
-    <PackageReference Include="Xamarin.AndroidX.AutoFill" Version="1.1.0.6" />
-    <PackageReference Include="Xamarin.AndroidX.CardView" Version="1.0.0.8" />
-    <PackageReference Include="Xamarin.AndroidX.Legacy.Support.V4" Version="1.0.0.7" />
-    <PackageReference Include="Xamarin.AndroidX.MediaRouter" Version="1.2.4" />
+    <PackageReference Include="Xamarin.AndroidX.AppCompat" Version="1.3.1.1" />
+    <PackageReference Include="Xamarin.AndroidX.AutoFill" Version="1.1.0.7" />
+    <PackageReference Include="Xamarin.AndroidX.CardView" Version="1.0.0.9" />
+    <PackageReference Include="Xamarin.AndroidX.Legacy.Support.V4" Version="1.0.0.8" />
+    <PackageReference Include="Xamarin.AndroidX.MediaRouter" Version="1.2.5" />
     <PackageReference Include="Xamarin.AndroidX.Migration" Version="1.0.8" />
     <PackageReference Include="Xamarin.Essentials">
       <Version>1.7.0</Version>
@@ -90,10 +88,10 @@
     <PackageReference Include="Xamarin.Firebase.Messaging">
       <Version>122.0.0</Version>
     </PackageReference>
-    <PackageReference Include="Xamarin.Google.Android.Material" Version="1.3.0.1" />
+    <PackageReference Include="Xamarin.Google.Android.Material" Version="1.4.0.2" />
     <PackageReference Include="Xamarin.Google.Dagger" Version="2.37.0" />
     <PackageReference Include="Xamarin.GooglePlayServices.SafetyNet">
-      <Version>117.0.0</Version>
+      <Version>117.0.1</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/Android/Renderers/CustomTabbedRenderer.cs
+++ b/src/Android/Renderers/CustomTabbedRenderer.cs
@@ -49,7 +49,7 @@ namespace Bit.Droid.Renderers
             return null;
         }
 
-        async void BottomNavigationView.IOnNavigationItemReselectedListener.OnNavigationItemReselected(IMenuItem item)
+        public async void OnNavigationItemReselected(IMenuItem item)
         {
             if (_page?.CurrentPage?.Navigation != null && _page.CurrentPage.Navigation.NavigationStack.Count > 0)
             {

--- a/src/Android/Renderers/CustomTabbedRenderer.cs
+++ b/src/Android/Renderers/CustomTabbedRenderer.cs
@@ -49,11 +49,11 @@ namespace Bit.Droid.Renderers
             return null;
         }
 
-        public async void OnNavigationItemReselected(IMenuItem item)
+        public void OnNavigationItemReselected(IMenuItem item)
         {
             if (_page?.CurrentPage?.Navigation != null && _page.CurrentPage.Navigation.NavigationStack.Count > 0)
             {
-                await _page.CurrentPage.Navigation.PopToRootAsync();
+                Device.BeginInvokeOnMainThread(async () => await _page.CurrentPage.Navigation.PopToRootAsync());
             }
         }
     }

--- a/src/App/App.csproj
+++ b/src/App/App.csproj
@@ -13,11 +13,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AppCenter.Crashes" Version="4.3.0" />
+    <PackageReference Include="Microsoft.AppCenter.Crashes" Version="4.4.0" />
     <PackageReference Include="Plugin.Fingerprint" Version="2.1.4" />
     <PackageReference Include="Xamarin.Essentials" Version="1.7.0" />
     <PackageReference Include="Xamarin.FFImageLoading.Forms" Version="2.4.11.982" />
-    <PackageReference Include="Xamarin.Forms" Version="5.0.0.2083" />
+    <PackageReference Include="Xamarin.Forms" Version="5.0.0.2125" />
     <PackageReference Include="ZXing.Net.Mobile" Version="2.4.1" />
     <PackageReference Include="ZXing.Net.Mobile.Forms" Version="2.4.1" />
   </ItemGroup>

--- a/src/Core/Core.csproj
+++ b/src/Core/Core.csproj
@@ -24,7 +24,7 @@
 
   <ItemGroup>
     <PackageReference Include="CsvHelper" Version="27.1.1" />
-    <PackageReference Include="LiteDB" Version="5.0.10" />
+    <PackageReference Include="LiteDB" Version="5.0.11" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="PCLCrypto" Version="2.0.147" />
     <PackageReference Include="zxcvbn-core" Version="7.0.92" />

--- a/src/iOS.Autofill/iOS.Autofill.csproj
+++ b/src/iOS.Autofill/iOS.Autofill.csproj
@@ -253,7 +253,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AppCenter.Crashes">
-      <Version>4.3.0</Version>
+      <Version>4.4.0</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/iOS.Extension/iOS.Extension.csproj
+++ b/src/iOS.Extension/iOS.Extension.csproj
@@ -231,7 +231,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AppCenter.Crashes">
-      <Version>4.3.0</Version>
+      <Version>4.4.0</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.AppExtension.CSharp.targets" />

--- a/test/Common/Common.csproj
+++ b/test/Common/Common.csproj
@@ -15,7 +15,7 @@
     </PackageReference>
     <PackageReference Include="AutoFixture.Xunit2" Version="4.17.0" />
     <PackageReference Include="AutoFixture.AutoNSubstitute" Version="4.17.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
   </ItemGroup>
 
 </Project>

--- a/test/Core.Test/Core.Test.csproj
+++ b/test/Core.Test/Core.Test.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
     <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="NSubstitute" Version="4.2.2" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">


### PR DESCRIPTION
The SR5 release of Xamarin Forms (5.0.0.2125) fixed the broken AndroidX & Material dependencies of the previous release, allowing us to remove the extra dependencies added in #1471 and update others to the latest without breaking the build.  This will close [this Asana task](https://app.asana.com/0/1169444489336079/1200632790235501/f).

(Note this does not yet fix [this Asana task](https://app.asana.com/0/1169444489336079/1200531933783245/f) which we worked around in #1447 and #1454)

Also updated LiteDB, AppCenter, and .NET Test SDK to the latest.