### PR TITLE
Exclude deleted items from folder counts

### DIFF
--- a/src/App/Pages/Vault/GroupingsPage/GroupingsPageViewModel.cs
+++ b/src/App/Pages/Vault/GroupingsPage/GroupingsPageViewModel.cs
@@ -485,6 +485,11 @@ namespace Bit.App.Pages
                     }
                 }
 
+                if (c.IsDeleted)
+                {
+                    continue;
+                }
+
                 var fId = c.FolderId ?? "none";
                 if (_folderCounts.ContainsKey(fId))
                 {


### PR DESCRIPTION
Prevents grouped pages from counting deleted items in the folder/collection counts. We were including these deleted items when doing type, folder, and collection counts on grouped pages (except the main page which had code to prevent it).
