### PR TITLE
Set cursor position after toggle password visibility

### DIFF
--- a/src/App/Pages/Accounts/LockPageViewModel.cs
+++ b/src/App/Pages/Accounts/LockPageViewModel.cs
@@ -318,6 +318,7 @@ namespace Bit.App.Pages
             var page = (Page as LockPage);
             var entry = PinLock ? page.PinEntry : page.MasterPasswordEntry;
             entry.Focus();
+            entry.CursorPosition = PinLock ? Pin.Length : MasterPassword.Length;
         }
 
         public async Task PromptBiometricAsync()

--- a/src/App/Pages/Accounts/LoginPageViewModel.cs
+++ b/src/App/Pages/Accounts/LoginPageViewModel.cs
@@ -185,7 +185,9 @@ namespace Bit.App.Pages
         public void TogglePassword()
         {
             ShowPassword = !ShowPassword;
-            (Page as LoginPage).MasterPasswordEntry.Focus();
+            var entry = (Page as LoginPage).MasterPasswordEntry;
+            entry.Focus();
+            entry.CursorPosition = MasterPassword.Length;
         }
     }
 }

--- a/src/App/Pages/Accounts/RegisterPageViewModel.cs
+++ b/src/App/Pages/Accounts/RegisterPageViewModel.cs
@@ -201,13 +201,17 @@ namespace Bit.App.Pages
         public void TogglePassword()
         {
             ShowPassword = !ShowPassword;
-            (Page as RegisterPage).MasterPasswordEntry.Focus();
+            var entry = (Page as RegisterPage).MasterPasswordEntry;
+            entry.Focus();
+            entry.CursorPosition = MasterPassword.Length;
         }
 
         public void ToggleConfirmPassword()
         {
             ShowPassword = !ShowPassword;
-            (Page as RegisterPage).ConfirmMasterPasswordEntry.Focus();
+            var entry = (Page as RegisterPage).ConfirmMasterPasswordEntry;
+            entry.Focus();
+            entry.CursorPosition = ConfirmMasterPassword.Length;
         }
     }
 }


### PR DESCRIPTION
## Issue
On Android, the cursor for passwords was being reset to the beginning of the text after the visibility was toggled with the eye icon.

## Fix
Set the cursor position to the end of the text after visibility toggle for the following pages:
- Lock page
- Login page
- Register page

Closes #1139