### PR TITLE
Website favicon only shows if hostname is first element

### DIFF
--- a/src/App/Controls/CipherViewCell/CipherViewCell.xaml
+++ b/src/App/Controls/CipherViewCell/CipherViewCell.xaml
@@ -46,7 +46,7 @@
         WidthRequest="22"
         HeightRequest="22"
         IsVisible="{Binding ShowIconImage}"
-        Source="{Binding Cipher, Converter={StaticResource iconImageConverter}}"
+        Source="{Binding IconImageSource, Mode=OneTime}"
         AutomationProperties.IsInAccessibleTree="False" />
 
     <Grid RowSpacing="0" ColumnSpacing="0" Grid.Row="0" Grid.Column="1" VerticalOptions="Center" Padding="0, 7">

--- a/src/App/Controls/CipherViewCell/CipherViewCellViewModel.cs
+++ b/src/App/Controls/CipherViewCell/CipherViewCellViewModel.cs
@@ -1,4 +1,5 @@
-﻿using Bit.Core.Models.View;
+﻿using Bit.App.Utilities;
+using Bit.Core.Models.View;
 using Bit.Core.Utilities;
 
 namespace Bit.App.Controls
@@ -7,6 +8,7 @@ namespace Bit.App.Controls
     {
         private CipherView _cipher;
         private bool _websiteIconsEnabled;
+        private string _iconImageSource = string.Empty;
 
         public CipherViewCellViewModel(CipherView cipherView, bool websiteIconsEnabled)
         {
@@ -28,8 +30,22 @@ namespace Bit.App.Controls
 
         public bool ShowIconImage
         {
-            get => WebsiteIconsEnabled && !string.IsNullOrWhiteSpace(Cipher.Login?.Uri) &&
-                   Cipher.Login.Uri.StartsWith("http");
+            get => WebsiteIconsEnabled
+                && !string.IsNullOrWhiteSpace(Cipher.Login?.Uri)
+                && IconImageSource != null;
+        }
+
+        public string IconImageSource
+        {
+            get
+            {
+                if (_iconImageSource == string.Empty) // default value since icon source can return null
+                {
+                    _iconImageSource = IconImageHelper.GetLoginIconImage(Cipher);
+                }
+                return _iconImageSource;
+            }
+
         }
     }
 }


### PR DESCRIPTION
# Overview
Website Icon (favicon) only shows if website url (hostname) is in the first url element.
If the first url is an app link (eg. androidapp:// ) and the website url as second element, the favicon will not show.

This fix iterates through the list of urls and looks for the first website url for the icon. If no website is found, it defaults to the android, apple, or globe icon.

Closes #1120

# Changes

- **IconImageConverter.cs** - Create static class for uri logic (keeping converter for future)
- **CipherViewCellViewModel.cs** - Create new property in viewmodel for icon source, making sure to cache result
    - Check if icons are enabled and source for icon before showing default glyph
- **CipherViewCell.xaml** - Bind source to new property in viewmodel