### PR TITLE
Fix app crash when 'show password' clicked on empty field

### DIFF
--- a/src/App/Pages/Accounts/LockPageViewModel.cs
+++ b/src/App/Pages/Accounts/LockPageViewModel.cs
@@ -317,8 +317,9 @@ namespace Bit.App.Pages
             ShowPassword = !ShowPassword;
             var page = (Page as LockPage);
             var entry = PinLock ? page.PinEntry : page.MasterPasswordEntry;
+            var str = PinLock ? Pin : MasterPassword;
             entry.Focus();
-            entry.CursorPosition = PinLock ? Pin.Length : MasterPassword.Length;
+            entry.CursorPosition = String.IsNullOrEmpty(str) ? 0 : str.Length;
         }
 
         public async Task PromptBiometricAsync()

--- a/src/App/Pages/Accounts/LoginPageViewModel.cs
+++ b/src/App/Pages/Accounts/LoginPageViewModel.cs
@@ -187,7 +187,7 @@ namespace Bit.App.Pages
             ShowPassword = !ShowPassword;
             var entry = (Page as LoginPage).MasterPasswordEntry;
             entry.Focus();
-            entry.CursorPosition = MasterPassword.Length;
+            entry.CursorPosition = String.IsNullOrEmpty(MasterPassword) ? 0 : MasterPassword.Length;
         }
     }
 }

--- a/src/App/Pages/Accounts/RegisterPageViewModel.cs
+++ b/src/App/Pages/Accounts/RegisterPageViewModel.cs
@@ -203,7 +203,7 @@ namespace Bit.App.Pages
             ShowPassword = !ShowPassword;
             var entry = (Page as RegisterPage).MasterPasswordEntry;
             entry.Focus();
-            entry.CursorPosition = MasterPassword.Length;
+            entry.CursorPosition = String.IsNullOrEmpty(MasterPassword) ? 0 : MasterPassword.Length;
         }
 
         public void ToggleConfirmPassword()
@@ -211,7 +211,7 @@ namespace Bit.App.Pages
             ShowPassword = !ShowPassword;
             var entry = (Page as RegisterPage).ConfirmMasterPasswordEntry;
             entry.Focus();
-            entry.CursorPosition = ConfirmMasterPassword.Length;
+            entry.CursorPosition = String.IsNullOrEmpty(ConfirmMasterPassword) ? 0 : ConfirmMasterPassword.Length;
         }
     }
 }


### PR DESCRIPTION
Check password for null before setting cursor position

closes #1578