### PR TITLE
fix gap in background color application resulting in flashing during transitions

### DIFF
--- a/src/Android/MainActivity.cs
+++ b/src/Android/MainActivity.cs
@@ -385,6 +385,7 @@ namespace Bit.Droid
         private void AppearanceAdjustments()
         {
             Window?.SetStatusBarColor(ThemeHelpers.NavBarBackgroundColor);
+            Window?.DecorView.SetBackgroundColor(ThemeHelpers.BackgroundColor);
             ThemeHelpers.SetAppearance(ThemeManager.GetTheme(true), ThemeManager.OsDarkModeEnabled());
         }
 

--- a/src/Android/Utilities/ThemeHelpers.cs
+++ b/src/Android/Utilities/ThemeHelpers.cs
@@ -16,6 +16,10 @@ namespace Bit.Droid.Utilities
         {
             get => ThemeManager.GetResourceColor("MutedColor").ToAndroid();
         }
+        public static Color BackgroundColor
+        {
+            get => ThemeManager.GetResourceColor("BackgroundColor").ToAndroid();
+        }
         public static Color NavBarBackgroundColor
         {
             get => ThemeManager.GetResourceColor("NavigationBarBackgroundColor").ToAndroid();


### PR DESCRIPTION
There was a gap in the application of background color (Android only) when activities are first created, resulting in unpleasant transitions between screens when selecting non-item things (types, folders, collections).  In addition due to the way our splash screen is implemented you could also see our logo during the gap, making the experience even less pleasant.  This was previously covered by the app restarting on theme change, which is no longer the case.