### PR TITLE
fix for crash when terminating iOS app

### DIFF
--- a/src/iOS/AppDelegate.cs
+++ b/src/iOS/AppDelegate.cs
@@ -188,6 +188,12 @@ namespace Bit.iOS
             _storageService.SaveAsync(Constants.LastActiveTimeKey, _deviceActionService.GetActiveTime());
             _messagingService.Send("slept");
 
+            if (UIApplication.SharedApplication.KeyWindow == null)
+            {
+                // Despite IDE warning, KeyWindow is null here during app termination in iOS 15
+                return;
+            }
+
             var view = new UIView(UIApplication.SharedApplication.KeyWindow.Frame)
             {
                 Tag = 4321


### PR DESCRIPTION
App crashes on iOS 15 when terminating because the KeyWindow is null where (to my knowledge) it shouldn't be.  I added a null check before we attempt to draw the splash screen over top of the main window when backgrounding the app.

I originally thought this was fixed in 15.0.1 but it's still happening in 15.0.2.  I can find no mention of this being the expected behavior, but it does look like KeyWindow was deprecated in iOS 13, and the work needed to update this (transition to scenes?) is currently over my head.  For now this simple approach will stop the super annoying crash without breaking our existing behavior for normal backgrounding.