### PR TITLE
Fix for crash when checking for running accessibility service without activity

### DIFF
--- a/src/Android/Services/DeviceActionService.cs
+++ b/src/Android/Services/DeviceActionService.cs
@@ -640,8 +640,7 @@ namespace Bit.Droid.Services
 
         public bool AutofillAccessibilityServiceRunning()
         {
-            var activity = (MainActivity)CrossCurrentActivity.Current.Activity;
-            var enabledServices = Settings.Secure.GetString(activity.ContentResolver,
+            var enabledServices = Settings.Secure.GetString(Application.Context.ContentResolver,
                 Settings.Secure.EnabledAccessibilityServices);
             return Application.Context.PackageName != null &&
                    (enabledServices?.Contains(Application.Context.PackageName) ?? false);


### PR DESCRIPTION
When checking if our accessibility service is running while outside of the app (Use of the autofill quick-tile) the app can crash if `MainActivity`'s context can't be obtained.  Using application context is a safer approach here.

This code was [recently updated](https://github.com/bitwarden/mobile/pull/1556/files#diff-baae9aac90018239aa3d5e2d0404727c3c15613ef10fb5f917bb01281bc5fa5bR643) to work within additional restrictions in recent versions of Android.  The original code was wrapped in a try/catch, so if there were any issues obtaining context it would just fail without crashing, resulting in the "Bitwarden needs attention" toast showing when attempting to use the autofill quick tile even if accessibility is already enabled.  I don't believe restoring the try/catch is necessary now that we're using application context.