### PR TITLE
Turn off autofill compatibility mode on the latest Firefox and Beta

### DIFF
--- a/src/Android/Resources/xml/autofillservice.xml
+++ b/src/Android/Resources/xml/autofillservice.xml
@@ -211,10 +211,10 @@
     android:maxLongVersionCode="10000000000"/>
   <compatibility-package
     android:name="org.mozilla.firefox"
-    android:maxLongVersionCode="10000000000"/>
+    android:maxLongVersionCode="2015836711"/>
   <compatibility-package
     android:name="org.mozilla.firefox_beta"
-    android:maxLongVersionCode="10000000000"/>
+    android:maxLongVersionCode="2015849447"/>
   <compatibility-package
     android:name="org.mozilla.reference.browser"
     android:maxLongVersionCode="10000000000"/>


### PR DESCRIPTION
Firefox (after Fenix) has native support of Android's autofill framework. So it is unnecessary to turn on autofill compatibility mode for autofill service. But Bitwarden still seems to enable it for Firefox.

This compatibility mode walks through the all virtual nodes using accessibility API, so application supports both (autofill native support and accessibility API), it has multiple virtual nodes for same element. And this mode also cause performance issue as browser since accessing accessibility  nodes is too slow.

Also, this mode causes another bug. This mode steals focus by accessibility API.  See https://bugzilla.mozilla.org/show_bug.cgi?id=1715549#c6 for more details. As long as debugging Firefox Nightly, Bitwarden seems not to turn on this mode.

So I would like to request to turn off this mode on the latest Firefox. (This version code for this fix is 93.1.0 and 94 beta 3).  I believe that this fix resolves a lot of strange bugs on Bitwarden + Firefox.