### PR TITLE
fix gap in background color application resulting in flashing during transitions, part 2

### DIFF
--- a/src/App/Pages/Send/SendGroupingsPage/SendGroupingsPage.xaml.cs
+++ b/src/App/Pages/Send/SendGroupingsPage/SendGroupingsPage.xaml.cs
@@ -161,7 +161,7 @@ namespace Bit.App.Pages
             if (DoOnce())
             {
                 var page = new SendsPage(_vm.Filter, _vm.Type != null);
-                await Navigation.PushModalAsync(new NavigationPage(page), false);
+                await Navigation.PushModalAsync(new NavigationPage(page));
             }
         }
 

--- a/src/App/Pages/Vault/GroupingsPage/GroupingsPage.xaml.cs
+++ b/src/App/Pages/Vault/GroupingsPage/GroupingsPage.xaml.cs
@@ -234,7 +234,7 @@ namespace Bit.App.Pages
             {
                 var page = new CiphersPage(_vm.Filter, _vm.FolderId != null, _vm.CollectionId != null,
                     _vm.Type != null, deleted: _vm.Deleted);
-                await Navigation.PushModalAsync(new NavigationPage(page), false);
+                await Navigation.PushModalAsync(new NavigationPage(page));
             }
         }
 


### PR DESCRIPTION
I missed two transitions in the [original PR](https://github.com/bitwarden/mobile/pull/1588) that cause the splash background/logo to flash when clicking the search icon on the `Vault` and `Send` groupings page.