### PR TITLE
Autofill support for upcoming changes to google search

### DIFF
--- a/src/Android/Autofill/AutofillHelpers.cs
+++ b/src/Android/Autofill/AutofillHelpers.cs
@@ -35,6 +35,7 @@ namespace Bit.Droid.Autofill
         public static HashSet<string> TrustedBrowsers = new HashSet<string>
         {
             "com.duckduckgo.mobile.android",
+            "com.google.android.googlequicksearchbox",
             "org.mozilla.focus",
             "org.mozilla.klar",
         };


### PR DESCRIPTION
Added `com.google.android.googlequicksearchbox` to native autofill trust list to support upcoming changes in the Google app