### PR TITLE
utilize iOS safe area in UI

### DIFF
--- a/src/App/Pages/BaseContentPage.cs
+++ b/src/App/Pages/BaseContentPage.cs
@@ -23,6 +23,7 @@ namespace Bit.App.Pages
         {
             if (Device.RuntimePlatform == Device.iOS)
             {
+                On<iOS>().SetUseSafeArea(true);
                 On<iOS>().SetModalPresentationStyle(UIModalPresentationStyle.FullScreen);
             }
         }


### PR DESCRIPTION
Added iOS safe-area support to prevent content from hiding behind notches in landscape mode.

Before:

![before](https://user-images.githubusercontent.com/59324545/138466229-ceeb6c5d-25f6-4e50-88c9-08e54b62dd06.png)

After:

![after](https://user-images.githubusercontent.com/59324545/138466259-4229dcde-f7ef-45f8-87e3-b8b056ac02f7.png)
