### PR TITLE
Fixed long secure notes edition scrolling issue when focused (#1257)

### DIFF
--- a/src/App/App.csproj
+++ b/src/App/App.csproj
@@ -124,6 +124,7 @@
 
   <ItemGroup>
     <Folder Include="Resources\" />
+    <Folder Include="Behaviors\" />
   </ItemGroup>
 
   <ItemGroup>
@@ -411,4 +412,7 @@
     </EmbeddedResource>
   </ItemGroup>
 
+  <ItemGroup>
+    <None Remove="Behaviors\" />
+  </ItemGroup>
 </Project>

--- a/src/App/Behaviors/EditorPreventAutoBottomScrollingOnFocusedBehavior.cs
+++ b/src/App/Behaviors/EditorPreventAutoBottomScrollingOnFocusedBehavior.cs
@@ -1,0 +1,43 @@
+﻿using Xamarin.Essentials;
+using Xamarin.Forms;
+
+namespace Bit.App.Behaviors
+{
+    /// <summary>
+    /// This behavior prevents the Editor to be automatically scrolled to the bottom on focus.
+    /// This is needed due to this Xamarin Forms issue: https://github.com/xamarin/Xamarin.Forms/issues/2233
+    /// </summary>
+    public class EditorPreventAutoBottomScrollingOnFocusedBehavior : Behavior<Editor>
+    {
+        public static readonly BindableProperty ParentScrollViewProperty
+            = BindableProperty.Create(nameof(ParentScrollView), typeof(ScrollView), typeof(EditorPreventAutoBottomScrollingOnFocusedBehavior));
+
+        public ScrollView ParentScrollView
+        {
+            get => (ScrollView)GetValue(ParentScrollViewProperty);
+            set => SetValue(ParentScrollViewProperty, value);
+        }
+
+        protected override void OnAttachedTo(Editor bindable)
+        {
+            base.OnAttachedTo(bindable);
+
+            bindable.Focused += OnFocused;
+        }
+
+        private void OnFocused(object sender, FocusEventArgs e)
+        {
+            if (DeviceInfo.Platform.Equals(DevicePlatform.iOS) && ParentScrollView != null)
+            {
+                ParentScrollView.ScrollToAsync(ParentScrollView.ScrollX, ParentScrollView.ScrollY, true);
+            }
+        }
+
+        protected override void OnDetachingFrom(Editor bindable)
+        {
+            bindable.Focused -= OnFocused;
+
+            base.OnDetachingFrom(bindable);
+        }
+    }
+}

--- a/src/App/Controls/ExtendedEditor.cs
+++ b/src/App/Controls/ExtendedEditor.cs
@@ -1,0 +1,16 @@
+﻿using Xamarin.Forms;
+
+namespace Bit.App.Controls
+{
+    public class ExtendedEditor : Editor
+    {
+        public static readonly BindableProperty IsScrollEnabledProperty = BindableProperty.Create(
+               nameof(IsScrollEnabled), typeof(bool), typeof(ExtendedEditor), true);
+
+        public bool IsScrollEnabled
+        {
+            get => (bool)GetValue(IsScrollEnabledProperty);
+            set => SetValue(IsScrollEnabledProperty, value);
+        }
+    }
+}

--- a/src/App/Pages/Vault/AddEditPage.xaml
+++ b/src/App/Pages/Vault/AddEditPage.xaml
@@ -7,6 +7,7 @@
     xmlns:u="clr-namespace:Bit.App.Utilities"
     xmlns:controls="clr-namespace:Bit.App.Controls"
     xmlns:views="clr-namespace:Bit.Core.Models.View;assembly=BitwardenCore"
+    xmlns:behaviors="clr-namespace:Bit.App.Behaviors"
     x:DataType="pages:AddEditPageViewModel"
     x:Name="_page"
     Title="{Binding PageTitle}">
@@ -581,11 +582,16 @@
                            StyleClass="box-header, box-header-platform" />
                 </StackLayout>
                 <StackLayout StyleClass="box-row, box-row-input">
-                    <Editor
+                    <controls:ExtendedEditor
                         x:Name="_notesEditor"
                         AutoSize="TextChanges"
-                        Text="{Binding Cipher.Notes}"
-                        StyleClass="box-value" />
+                        IsScrollEnabled="False"
+                        StyleClass="box-value"
+                        Text="{Binding Cipher.Notes}">
+                        <controls:ExtendedEditor.Behaviors>
+                            <behaviors:EditorPreventAutoBottomScrollingOnFocusedBehavior ParentScrollView="{x:Reference _scrollView}" />
+                        </controls:ExtendedEditor.Behaviors>
+                    </controls:ExtendedEditor>
                 </StackLayout>
                 <BoxView StyleClass="box-row-separator" IsVisible="{Binding ShowNotesSeparator}" />
             </StackLayout>

--- a/src/iOS.Core/Renderers/ExtendedEditorRenderer.cs
+++ b/src/iOS.Core/Renderers/ExtendedEditorRenderer.cs
@@ -1,0 +1,21 @@
+﻿using Bit.App.Controls;
+using Bit.iOS.Core.Renderers;
+using Xamarin.Forms;
+using Xamarin.Forms.Platform.iOS;
+
+[assembly: ExportRenderer(typeof(ExtendedEditor), typeof(ExtendedEditorRenderer))]
+namespace Bit.iOS.Core.Renderers
+{
+    public class ExtendedEditorRenderer : EditorRenderer
+    {
+        protected override void OnElementChanged(ElementChangedEventArgs<Editor> e)
+        {
+            base.OnElementChanged(e);
+
+            if (Control != null && Element is ExtendedEditor view)
+            {
+                Control.ScrollEnabled = view.IsScrollEnabled;
+            }
+        }
+    }
+}

--- a/src/iOS.Core/iOS.Core.csproj
+++ b/src/iOS.Core/iOS.Core.csproj
@@ -189,6 +189,7 @@
     <Compile Include="Views\SwitchTableViewCell.cs" />
     <Compile Include="Views\Toast.cs" />
     <Compile Include="Renderers\SelectableLabelRenderer.cs" />
+    <Compile Include="Renderers\ExtendedEditorRenderer.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\App\App.csproj">


### PR DESCRIPTION
When editing Secure Notes and the field was long and the user tapped, the scroll will go to the bottom and not the place where the user tapped or selected. So fixed this so that scrolling doesn't happen and the scroll remains at the cursor of the notes field.