### PR TITLE
Hotfix: Adding the missing flag for sed in the fdroid build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -229,7 +229,7 @@ jobs:
           echo "##### Setting Version Code $BUILD_NUMBER"
           echo "########################################"
 
-          sed "s/android:versionCode=\"1\"/android:versionCode=\"$BUILD_NUMBER\"/" \
+          sed -i "s/android:versionCode=\"1\"/android:versionCode=\"$BUILD_NUMBER\"/" \
             ./src/Android/Properties/AndroidManifest.xml
         shell: bash
 


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [x] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
Fixing the `sed` issue in the Fdroid build pipeline.



## Code changes
- adding missing flag for `sed` in the fdroid build job.