### PR TITLE
fix for bug stopping vault timeout to never

### DIFF
--- a/src/App/Pages/Settings/SettingsPage/SettingsPageViewModel.cs
+++ b/src/App/Pages/Settings/SettingsPage/SettingsPageViewModel.cs
@@ -57,7 +57,7 @@ namespace Bit.App.Pages
             };
 
         private Policy _vaultTimeoutPolicy;
-        private int _vaultTimeout;
+        private int? _vaultTimeout;
 
         public SettingsPageViewModel()
         {
@@ -220,7 +220,7 @@ namespace Bit.App.Pages
             await _vaultTimeoutService.LockAsync(true, true);
         }
 
-        public async Task VaultTimeoutAsync(bool promptOptions = true, int newTimeout = 0)
+        public async Task VaultTimeoutAsync(bool promptOptions = true, int? newTimeout = 0)
         {
             var oldTimeout = _vaultTimeout;
 
@@ -237,7 +237,7 @@ namespace Bit.App.Pages
                 var cleanSelection = selection.Replace("✓ ", string.Empty);
                 var selectionOption = _vaultTimeouts.FirstOrDefault(o => o.Key == cleanSelection);
                 _vaultTimeoutDisplayValue = selectionOption.Key;
-                newTimeout = selectionOption.Value.GetValueOrDefault();
+                newTimeout = selectionOption.Value;
             }
 
             if (_vaultTimeoutPolicy != null)
@@ -438,7 +438,7 @@ namespace Bit.App.Pages
                 securityItems.Insert(1, new SettingsPageListItem
                 {
                     Name = AppResources.Custom,
-                    Time = TimeSpan.FromMinutes(Math.Abs((double)_vaultTimeout)),
+                    Time = TimeSpan.FromMinutes(Math.Abs((double)_vaultTimeout.GetValueOrDefault())),
                 });
             }
             if (_vaultTimeoutPolicy != null)

--- a/src/Core/Abstractions/IVaultTimeoutService.cs
+++ b/src/Core/Abstractions/IVaultTimeoutService.cs
@@ -17,6 +17,6 @@ namespace Bit.Core.Abstractions
         Task LockAsync(bool allowSoftLock = false, bool userInitiated = false);
         Task LogOutAsync();
         Task SetVaultTimeoutOptionsAsync(int? timeout, string action);
-        Task<int> GetVaultTimeout();
+        Task<int?> GetVaultTimeout();
     }
 }

--- a/src/Core/Services/VaultTimeoutService.cs
+++ b/src/Core/Services/VaultTimeoutService.cs
@@ -86,7 +86,7 @@ namespace Bit.Core.Services
                 return;
             }
             var vaultTimeoutMinutes = await GetVaultTimeout();
-            if (vaultTimeoutMinutes < 0)
+            if (vaultTimeoutMinutes < 0 || vaultTimeoutMinutes == null)
             {
                 return;
             }
@@ -178,8 +178,8 @@ namespace Bit.Core.Services
             await _storageService.RemoveAsync(Constants.ProtectedPin);
         }
 
-        public async Task<int> GetVaultTimeout() {
-            var vaultTimeout = (await _storageService.GetAsync<int?>(Constants.VaultTimeoutKey)).GetValueOrDefault(-1);
+        public async Task<int?> GetVaultTimeout() {
+            var vaultTimeout = await _storageService.GetAsync<int?>(Constants.VaultTimeoutKey);
 
             if (await _policyService.PolicyAppliesToUser(PolicyType.MaximumVaultTimeout)) {
                 var policy = (await _policyService.GetAll(PolicyType.MaximumVaultTimeout)).First();
@@ -190,7 +190,7 @@ namespace Bit.Core.Services
                     return vaultTimeout;
                 }
 
-                var timeout = Math.Min(vaultTimeout, policyTimeout.Value);
+                var timeout = vaultTimeout.HasValue ? Math.Min(vaultTimeout.Value, policyTimeout.Value) : policyTimeout.Value;
 
                 if (timeout < 0) {
                     timeout = policyTimeout.Value;


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
When switching to the settings screen and selecting a timeout option of "Never", if you left the screen and returned the value reverted back to "Immediately". 

The timeout preference option of "Never" is being saved as null in storage, but when we made the call to storage for the value we defaulted it back to "Immediately" if the value was null.

This fix removes the default value and instead allows the returned value to be null if the user selected "Never" as a timeout option. 

Closes #1615
Asana Task: https://app.asana.com/0/1169444489336079/1201287480797899/f

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **src/App/Pages/Settings/SettingsPage/SettingsPageViewModel.cs:** Allow _vaultTimeout to be nullable, remove the `GetValueorDefault()` while selecting value.
* **src/Core/Abstractions/IVaultTimeoutService.cs:** Allow returned int to be nullable
* **src/Core/Services/VaultTimeoutService.cs:** Allow returned int to be nullable, add additional null checks, and refactor timeout policy to work with null value

## Screenshots
<!--Required for any UI changes. Delete if not applicable-->



## Testing requirements
<!--What functionality requires testing by QA? This includes testing new behavior and regression testing-->
 - Setting VaultTimeout to "Never" shouldn't revert back to "Immediately" after changing screens
 - Correct VaultTimeout should persist between uses


## Before you submit
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
