### PR TITLE
[SupportedBrowsers] Add Captive Login and drop Alook

### DIFF
--- a/src/Android/Accessibility/AccessibilityHelpers.cs
+++ b/src/Android/Accessibility/AccessibilityHelpers.cs
@@ -31,7 +31,6 @@ namespace Bit.Droid.Accessibility
             // So keep them in sync with:
             //   - AutofillHelpers.{TrustedBrowsers,CompatBrowsers}
             //   - Resources/xml/autofillservice.xml
-            new Browser("alook.browser", "search_fragment_input_view"),
             new Browser("com.amazon.cloud9", "url"),
             new Browser("com.android.browser", "url"),
             new Browser("com.android.chrome", "url_bar"),
@@ -52,6 +51,7 @@ namespace Bit.Droid.Accessibility
             new Browser("com.ecosia.android", "url_bar"),
             new Browser("com.google.android.apps.chrome", "url_bar"),
             new Browser("com.google.android.apps.chrome_dev", "url_bar"),
+            // Rem. for "com.google.android.captiveportallogin": URL displayed in ActionBar subtitle without viewId.
             new Browser("com.jamal2367.styx", "search"),
             new Browser("com.kiwibrowser.browser", "url_bar"),
             new Browser("com.microsoft.emmx", "url_bar"),

--- a/src/Android/Autofill/AutofillHelpers.cs
+++ b/src/Android/Autofill/AutofillHelpers.cs
@@ -49,7 +49,6 @@ namespace Bit.Droid.Autofill
         //   - ... to keep this list in sync with values in AccessibilityHelpers.SupportedBrowsers [Section A], too.
         public static HashSet<string> CompatBrowsers = new HashSet<string>
         {
-            "alook.browser",
             "com.amazon.cloud9",
             "com.android.browser",
             "com.android.chrome",
@@ -69,6 +68,7 @@ namespace Bit.Droid.Autofill
             "com.ecosia.android",
             "com.google.android.apps.chrome",
             "com.google.android.apps.chrome_dev",
+            "com.google.android.captiveportallogin",
             "com.jamal2367.styx",
             "com.kiwibrowser.browser",
             "com.microsoft.emmx",

--- a/src/Android/Resources/xml/autofillservice.xml
+++ b/src/Android/Resources/xml/autofillservice.xml
@@ -12,9 +12,6 @@
 <autofill-service xmlns:android="http://schemas.android.com/apk/res/android"
     android:supportsInlineSuggestions="true">
   <compatibility-package
-    android:name="alook.browser"
-    android:maxLongVersionCode="10000000000"/>
-  <compatibility-package
     android:name="com.amazon.cloud9"
     android:maxLongVersionCode="10000000000"/>
   <compatibility-package
@@ -70,6 +67,9 @@
     android:maxLongVersionCode="10000000000"/>
   <compatibility-package
     android:name="com.google.android.apps.chrome_dev"
+    android:maxLongVersionCode="10000000000"/>
+  <compatibility-package
+    android:name="com.google.android.captiveportallogin"
     android:maxLongVersionCode="10000000000"/>
   <compatibility-package
     android:name="com.jamal2367.styx"


### PR DESCRIPTION
## Captive Login

Some android systems show captive login activity (`com.google.android.captiveportallogin`) when connecting to wireless network. This activity shows URL in its ActionBar subtitle, so there is no view ID.

See: https://cs.android.com/android/platform/superproject/+/master:packages/modules/CaptivePortalLogin/src/com/android/captiveportallogin/CaptivePortalLoginActivity.java;l=600

## Alook

This browser was added in https://github.com/bitwarden/mobile/pull/1281, but the developer seems to be unwilling to add auto-fill compatibility. Auto-fill was partially functioning before adding the support, but afterwards it was completely broken (or it might be subject to browser version). Dropping the support might be a good choice.