### PR TITLE
Supress lock and logout when showing fileswitcher on Android

### DIFF
--- a/src/App/App.xaml.cs
+++ b/src/App/App.xaml.cs
@@ -176,8 +176,9 @@ namespace Bit.App
             if (Device.RuntimePlatform == Device.Android)
             {
                 await _vaultTimeoutService.CheckVaultTimeoutAsync();
+                // Reset delay on every start
+                _vaultTimeoutService.DelayLockAndLogoutMs = null;
             }
-            _vaultTimeoutService.SuppressLockLogout = false;
             _messagingService.Send("startEventTimer");
         }
 
@@ -205,12 +206,11 @@ namespace Bit.App
             {
                 ResumedAsync();
             }
-            _vaultTimeoutService.SuppressLockLogout = false;
         }
 
         private async Task SleptAsync()
         {
-            await HandleVaultTimeoutAsync();
+            await _vaultTimeoutService.CheckVaultTimeoutAsync();
             _messagingService.Send("stopEventTimer");
         }
 
@@ -278,33 +278,6 @@ namespace Bit.App
             else
             {
                 Current.MainPage = new HomePage(Options);
-            }
-        }
-
-        private async Task HandleVaultTimeoutAsync()
-        {
-            if (await _vaultTimeoutService.IsLockedAsync())
-            {
-                return;
-            }
-            var authed = await _userService.IsAuthenticatedAsync();
-            if (!authed)
-            {
-                return;
-            }
-            var vaultTimeout = await _storageService.GetAsync<int?>(Constants.VaultTimeoutKey);
-            vaultTimeout = vaultTimeout.GetValueOrDefault(-1);
-            if (vaultTimeout == 0)
-            {
-                var action = await _storageService.GetAsync<string>(Constants.VaultTimeoutActionKey);
-                if (action == "logOut")
-                {
-                    await _vaultTimeoutService.LogOutAsync();
-                }
-                else
-                {
-                    await _vaultTimeoutService.LockAsync(true);
-                }
             }
         }
 

--- a/src/App/Pages/Vault/AttachmentsPageViewModel.cs
+++ b/src/App/Pages/Vault/AttachmentsPageViewModel.cs
@@ -140,7 +140,7 @@ namespace Bit.App.Pages
             // Prevent Android from locking if vault timeout set to "immediate"
             if (Device.RuntimePlatform == Device.Android)
             {
-                _timeoutService.SuppressLockLogout = true;
+                _timeoutService.DelayLockAndLogoutMs = 60000;
             }
             await _deviceActionService.SelectFileAsync();
         }

--- a/src/Core/Abstractions/IVaultTimeoutService.cs
+++ b/src/Core/Abstractions/IVaultTimeoutService.cs
@@ -8,7 +8,7 @@ namespace Bit.Core.Abstractions
     {
         EncString PinProtectedKey { get; set; }
         bool BiometricLocked { get; set; }
-        bool SuppressLockLogout { get; set; }
+        long? DelayLockAndLogoutMs { get; set; }
 
         Task CheckVaultTimeoutAsync();
         Task ClearAsync();


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
If vault timeout was set to "Immediate", the file picker on Android was locking and logging out Bitwarden. This meant you could never choose a file.

This fix adds a `DelayLockAndLogoutMs` long to the VaultTimeoutService and sets it to 60 seconds while choosing an attachment on Android.

I also removed the extraneous logic for lock/logout from App.xaml.cs. I consolidated this logic in `CheckVaultTimeoutAsync()` inside the VaultTimeoutService.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **IVaultTimeoutService.cs:** Add DelayLockAndLogoutMs long to TimeoutService
* **VaultTimeoutService.cs:** Add logic to check for DelayLockAndLogoutMs when checking VaultTimeout settings
* **AttachmentsPageViewModel.cs:** If Android, set DelayLockAndLogoutMs to 60s before showing filepicker
* **App.xaml.cs:** Reset DelayLockAndLogoutMs and move lock/logout logic to VaultTimeoutService

## Screenshots
<!--Required for any UI changes. Delete if not applicable-->



## Testing requirements
<!--What functionality requires testing by QA? This includes testing new behavior and regression testing-->
- User can pick an attachment while the VaultTimeout option is set to "Immediate"
- Functionality of VaultTimeout still works


## Before you submit
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
