### PR TITLE
Add support for Pluma Browser for Android

### DIFF
--- a/src/Android/Accessibility/AccessibilityHelpers.cs
+++ b/src/Android/Accessibility/AccessibilityHelpers.cs
@@ -67,6 +67,7 @@ namespace Bit.Droid.Accessibility
             new Browser("com.opera.mini.native", "url_field"),
             new Browser("com.opera.mini.native.beta", "url_field"),
             new Browser("com.opera.touch", "addressbarEdit"),
+            new Browser("com.qflair.browserq", "url"),
             new Browser("com.qwant.liberty", "mozac_browser_toolbar_url_view,url_bar_title"), // 2nd = Legacy (before v4)
             new Browser("com.sec.android.app.sbrowser", "location_bar_edit_text"),
             new Browser("com.sec.android.app.sbrowser.beta", "location_bar_edit_text"),

--- a/src/Android/Autofill/AutofillHelpers.cs
+++ b/src/Android/Autofill/AutofillHelpers.cs
@@ -84,6 +84,7 @@ namespace Bit.Droid.Autofill
             "com.opera.mini.native",
             "com.opera.mini.native.beta",
             "com.opera.touch",
+            "com.qflair.browserq",
             "com.qwant.liberty",
             "com.sec.android.app.sbrowser",
             "com.sec.android.app.sbrowser.beta",

--- a/src/Android/Resources/xml/autofillservice.xml
+++ b/src/Android/Resources/xml/autofillservice.xml
@@ -117,6 +117,9 @@
     android:name="com.opera.touch"
     android:maxLongVersionCode="10000000000"/>
   <compatibility-package
+    android:name="com.qflair.browserq"
+    android:maxLongVersionCode="10000000000"/>
+  <compatibility-package
     android:name="com.qwant.liberty"
     android:maxLongVersionCode="10000000000"/>
   <compatibility-package


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [X] Other

## Objective
Add support for Bitwarden auto-fill in Pluma: [Play Store link](https://play.google.com/store/apps/details?id=com.qflair.browserq).

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->



## Code changes
Add the corresponding package name in the expected places. Followed other PRs that achieve the same for other browsers, such as https://github.com/bitwarden/mobile/pull/846.

## Testing requirements
Ensure that Bitwarden auto-fill suggestions target the site that Pluma is currently displaying (as opposed to the package name for Pluma).

## Before you submit
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
