### PR TITLE
Show SSO login if using key-connector without bio or pin

### DIFF
--- a/src/iOS.Core/Controllers/LockPasswordViewController.cs
+++ b/src/iOS.Core/Controllers/LockPasswordViewController.cs
@@ -11,6 +11,9 @@ using System.Threading.Tasks;
 using Bit.App.Utilities;
 using Bit.Core.Models.Domain;
 using Bit.Core.Enums;
+using Bit.App.Pages;
+using Bit.App.Models;
+using Xamarin.Forms;
 
 namespace Bit.iOS.Core.Controllers
 {
@@ -24,6 +27,7 @@ namespace Bit.iOS.Core.Controllers
         private IStorageService _secureStorageService;
         private IPlatformUtilsService _platformUtilsService;
         private IBiometricService _biometricService;
+        private IKeyConnectorService _keyConnectorService;
         private Tuple<bool, bool> _pinSet;
         private bool _pinLock;
         private bool _biometricLock;
@@ -57,6 +61,7 @@ namespace Bit.iOS.Core.Controllers
             _secureStorageService = ServiceContainer.Resolve<IStorageService>("secureStorageService");
             _platformUtilsService = ServiceContainer.Resolve<IPlatformUtilsService>("platformUtilsService");
             _biometricService = ServiceContainer.Resolve<IBiometricService>("biometricService");
+            _keyConnectorService = ServiceContainer.Resolve<IKeyConnectorService>("keyConnectorService");
 
             // We re-use the lock screen for autofill extension to verify master password
             // when trying to access protected items.
@@ -123,13 +128,20 @@ namespace Bit.iOS.Core.Controllers
             }
         }
 
-        public override void ViewDidAppear(bool animated)
+        public override async void ViewDidAppear(bool animated)
         {
             base.ViewDidAppear(animated);
             if (!_biometricLock || !_biometricIntegrityValid)
             {
                 MasterPasswordCell.TextField.BecomeFirstResponder();
             }
+
+            // Users with key connector and without biometric or pin has no MP to unlock with
+            if (await _keyConnectorService.GetUsesKeyConnector() && !(_pinLock || _biometricLock))
+            {
+                PromptSSO();
+            }
+
         }
 
         protected async Task CheckPasswordAsync()
@@ -222,12 +234,7 @@ namespace Bit.iOS.Core.Controllers
                     }
                     await AppHelpers.ResetInvalidUnlockAttemptsAsync();
                     await SetKeyAndContinueAsync(key2, true);
-                    
-                    // Re-enable biometrics
-                    if (_biometricLock & !_biometricIntegrityValid)
-                    {
-                        await _biometricService.SetupBiometricAsync(BiometricIntegrityKey);
-                    }
+                    await EnableBiometrics();
                 }
                 else
                 {
@@ -258,6 +265,7 @@ namespace Bit.iOS.Core.Controllers
             {
                 await _storageService.SaveAsync(Bit.Core.Constants.PasswordVerifiedAutofillKey, true);
             }
+            await EnableBiometrics();
             _vaultTimeoutService.BiometricLocked = false;
             MasterPasswordCell.TextField.ResignFirstResponder();
             Success();
@@ -277,6 +285,33 @@ namespace Bit.iOS.Core.Controllers
             {
                 DoContinue();
             }
+        }
+
+        private async Task EnableBiometrics()
+        {
+            // Re-enable biometrics
+            if (_biometricLock & !_biometricIntegrityValid)
+            {
+                await _biometricService.SetupBiometricAsync(BiometricIntegrityKey);
+            }
+        }
+
+        public void PromptSSO()
+        {
+            var loginPage = new LoginSsoPage();
+            var app = new App.App(new AppOptions { IosExtension = true });
+            ThemeManager.SetTheme(false, app.Resources);
+            ThemeManager.ApplyResourcesToPage(loginPage);
+            if (loginPage.BindingContext is LoginSsoPageViewModel vm)
+            {
+                vm.SsoAuthSuccessAction = () => DoContinue();
+                vm.CloseAction = Cancel;
+            }
+
+            var navigationPage = new NavigationPage(loginPage);
+            var loginController = navigationPage.CreateViewController();
+            loginController.ModalPresentationStyle = UIModalPresentationStyle.FullScreen;
+            PresentViewController(loginController, true, null);
         }
 
         private void InvalidValue()


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Use SSO if using key connector without bio or pin on autofill
Asana Task: https://app.asana.com/0/1201363553288890/1201363818962345/f
https://app.asana.com/0/1201363553288890/1201363818962343/f


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **src/iOS.Core/Controllers/LockPasswordViewController.cs:** Add call to SSO login page if using key connector



## Testing requirements
<!--What functionality requires testing by QA? This includes testing new behavior and regression testing-->
- Autofill authentication with key connector
- Extension authentication with key connector


## Before you submit
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
