### PR TITLE
Fixed missing FavIcons on Android #1640

### DIFF
--- a/src/Android/Android.csproj
+++ b/src/Android/Android.csproj
@@ -68,6 +68,7 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Xml" />
+    <Reference Include="System.Net.Http" Condition="'$(Configuration)'=='FDroid'" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Plugin.CurrentActivity">

--- a/src/Android/MainApplication.cs
+++ b/src/Android/MainApplication.cs
@@ -17,7 +17,6 @@ using Plugin.CurrentActivity;
 using Plugin.Fingerprint;
 using Xamarin.Android.Net;
 using System.Net.Http;
-using Android.Net.Http;
 using System.Net;
 #if !FDROID
 using Android.Gms.Security;

--- a/src/Android/MainApplication.cs
+++ b/src/Android/MainApplication.cs
@@ -16,6 +16,9 @@ using Bit.Droid.Utilities;
 using Plugin.CurrentActivity;
 using Plugin.Fingerprint;
 using Xamarin.Android.Net;
+using System.Net.Http;
+using Android.Net.Http;
+using System.Net;
 #if !FDROID
 using Android.Gms.Security;
 #endif
@@ -78,7 +81,8 @@ namespace Bit.Droid
                 FFImageLoading.ImageService.Instance.Initialize(new FFImageLoading.Config.Configuration
                 {
                     FadeAnimationEnabled = false,
-                    FadeAnimationForCachedImages = false
+                    FadeAnimationForCachedImages = false,
+                    HttpClient = new HttpClient(new AndroidClientHandler() { AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate })
                 });
                 ZXing.Net.Mobile.Forms.Android.Platform.Init();
             });


### PR DESCRIPTION
## Type of change
- [X] Bug fix #1640 
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Favicons were missed on the vault because of an SSL issue due to not setting AndroidClientHandler on the image library, FFImageLoading.

Discussion of the issue: https://github.com/xamarin/xamarin-android/issues/6351

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

**MainApplication.cs:** Set AndroidClientHandler as the handler for the HttpClient to be used in the FFImageLoading service.

## Screenshots
<!--Required for any UI changes. Delete if not applicable-->



## Testing requirements
<!--What functionality requires testing by QA? This includes testing new behavior and regression testing-->
Specially on Android API < 7.1.1 we should test that the vault icons are being loaded correctly.


## Before you submit
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
