### PR TITLE
[Key Connector] Hide MP input in iOS extensions

### DIFF
--- a/src/iOS.Core/Controllers/LockPasswordViewController.cs
+++ b/src/iOS.Core/Controllers/LockPasswordViewController.cs
@@ -109,11 +109,31 @@ namespace Bit.iOS.Core.Controllers
                 _usesKeyConnector = await _keyConnectorService.GetUsesKeyConnector();
                 _biometricUnlockOnly = _usesKeyConnector && !_pinLock && _biometricLock;
             }
+
+            if (_pinLock)
+            {
+                BaseNavItem.Title = AppResources.VerifyPIN;
+            }
+            else if (_biometricUnlockOnly)
+            {
+                BaseNavItem.Title = AppResources.UnlockVault;
+            }
+            else
+            {
+                BaseNavItem.Title = AppResources.VerifyMasterPassword;
+            }
             
-            BaseNavItem.Title = _pinLock ? AppResources.VerifyPIN : AppResources.VerifyMasterPassword;
             BaseCancelButton.Title = AppResources.Cancel;
 
-            BaseSubmitButton.Title = AppResources.Submit;
+            if (_biometricUnlockOnly)
+            {
+                BaseSubmitButton.Title = null;
+                BaseSubmitButton.Enabled = false;
+            }
+            else
+            {
+                BaseSubmitButton.Title = AppResources.Submit;
+            }
 
             var descriptor = UIFontDescriptor.PreferredBody;
 


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

Implements https://github.com/bitwarden/mobile/pull/1654 for the iOS extension & autofill projects:

> If a key connector user has biometrics set up on the lock screen, we want to hide the master password prompt. [...]
>
> If the user is using a PIN with biometrics, the screen should remain the same and prompt for PIN input.

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **src/iOS.Core/Controllers/LockPasswordViewController.cs**:
  * hide the Submit button if using biometric unlock only (this is done by setting text to `null` and disabling it)
  * change the title text to "Unlock Vault" if using biometric unlock only
  * skip setup for the `MasterPasswordCell` if using biometric unlock only
  * if using biometric unlock only, move the "biometric cell" up to the first row, and adjust the length of the grid accordingly. To assist this, I've extracted the 'builder' logic for the biometric cell into a getter.

Please pay particular attention to the conditional logic involved - there are quite a few different combinations, and I'd like simpler logic, but I think this works.

## Screenshots
<!--Required for any UI changes. Delete if not applicable-->

<img width="561" alt="Screen Shot 2021-11-22 at 2 04 39 pm" src="https://user-images.githubusercontent.com/31796059/142799506-bb24feef-28f6-4725-93b0-8e4ca8fb54b5.png">

## Testing requirements
<!--What functionality requires testing by QA? This includes testing new behavior and regression testing-->

* confirm that the iOS unlock page conforms to the Figma and behaves as expected
* full regression on iOS extension ("share") and autofill unlock page

## Before you submit
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
