### PR TITLE
Add workaround to Android entry renderer

### DIFF
--- a/src/Android/Renderers/CustomEntryRenderer.cs
+++ b/src/Android/Renderers/CustomEntryRenderer.cs
@@ -29,7 +29,16 @@ namespace Bit.Droid.Renderers
                     Control.PaddingBottom + 20);
                 Control.ImeOptions = Control.ImeOptions | (ImeAction)ImeFlags.NoPersonalizedLearning |
                     (ImeAction)ImeFlags.NoExtractUi;
-            }
+            }   
+        }
+
+        // Workaround for bug preventing long-press -> copy/paste on Android 11
+        // See https://issuetracker.google.com/issues/37095917
+        protected override void OnAttachedToWindow()
+        {
+            base.OnAttachedToWindow();
+            Control.Enabled = false;
+            Control.Enabled = true;
         }
 
         // Workaround for failure to disable text prediction on non-password fields


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Android has a known bug preventing the copy/paste functionality on a TextView inside a scrollable RecyclerView: https://issuetracker.google.com/issues/37095917

While running on Android 11, Bitwarden entry fields are encountering the same problem. After loading a page with entry fields, you can't long-press to show copy/paste menu unless you first input text. 

This workaround re-enables the entry after displaying, and allows users to utilize the clipboard without putting in text first.

Asana Task: https://app.asana.com/0/1169444489336079/1199543494650934/f
Closes #1215


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **src/Android/Renderers/CustomEntryRenderer.cs:** Workaround for Android clipboard bug




## Testing requirements
<!--What functionality requires testing by QA? This includes testing new behavior and regression testing-->
- Regression testing of clipboard functionality for entry fields throughout the application on Android 11


## Before you submit
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
