### PR TITLE
only prompt for sso if using key connector

### DIFF
--- a/src/iOS.Core/Controllers/LockPasswordViewController.cs
+++ b/src/iOS.Core/Controllers/LockPasswordViewController.cs
@@ -185,9 +185,13 @@ namespace Bit.iOS.Core.Controllers
             base.ViewDidAppear(animated);
 
             // Users with key connector and without biometric or pin has no MP to unlock with
-            if (_usesKeyConnector && (!(_pinLock || _biometricLock)) || ( _biometricLock && !_biometricIntegrityValid))
+            if (_usesKeyConnector)
             {
-                PromptSSO();
+                if (!(_pinLock || _biometricLock) ||
+                    (_biometricLock && !_biometricIntegrityValid))
+                {
+                    PromptSSO();
+                }
             }
             else if (!_biometricLock || !_biometricIntegrityValid)
             {


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Key Connector changes for autofill on iOS were showing the SSO login flow even when a user wasn't a SSO user. This was a logic error, we weren't checking for key connector use while seeing if the user was using biometric without being validated. 

Needs to be cherry picked to `rc`
Asana Task: https://app.asana.com/0/1201363553288890/1201432735007902/f


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **src/iOS.Core/Controllers/LockPasswordViewController.cs:** Add check for key connector before sso login flow to autofill




## Testing requirements
<!--What functionality requires testing by QA? This includes testing new behavior and regression testing-->
- iOS autofill with/without key connector & biometric authentication


## Before you submit
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
