### PR TITLE
Fix Crash produced when adding a custom field on a Secure Note

### DIFF
--- a/src/App/Pages/Vault/AddEditPageViewModel.cs
+++ b/src/App/Pages/Vault/AddEditPageViewModel.cs
@@ -929,7 +929,7 @@ namespace Bit.App.Pages
 
         public List<KeyValuePair<string, LinkedIdType>> LinkedFieldOptions
         {
-            get => _cipher.LinkedFieldOptions
+            get => _cipher.LinkedFieldOptions?
                 .Select(kvp => new KeyValuePair<string, LinkedIdType>(_i18nService.T(kvp.Key), kvp.Value))
                 .ToList();
         }


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Fix crash produced when adding a custom field on a Secure Note, because it tries to load Linked field picker even if the type of the custom field is not Linked. This happens because the Linked picker is on the same view.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **AddEditPageViewModel.cs:** Added null check to avoid crash when loading LInkedFieldOptions on SecureNote on other type of custom fields.

## Screenshots
<!--Required for any UI changes. Delete if not applicable-->



## Testing requirements
<!--What functionality requires testing by QA? This includes testing new behavior and regression testing-->
Try to add each type of custom field on Secure Notes; and also a Linked custom field on some other Cypher.


## Before you submit
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
