### PR TITLE
move splash screen logic to OnResignActivation

### DIFF
--- a/src/iOS/AppDelegate.cs
+++ b/src/iOS/AppDelegate.cs
@@ -183,17 +183,8 @@ namespace Bit.iOS
             return base.FinishedLaunching(app, options);
         }
 
-        public override void DidEnterBackground(UIApplication uiApplication)
+        public override void OnResignActivation(UIApplication uiApplication)
         {
-            _storageService.SaveAsync(Constants.LastActiveTimeKey, _deviceActionService.GetActiveTime());
-            _messagingService.Send("slept");
-
-            if (UIApplication.SharedApplication.KeyWindow == null)
-            {
-                // Despite IDE warning, KeyWindow is null here during app termination in iOS 15
-                return;
-            }
-
             var view = new UIView(UIApplication.SharedApplication.KeyWindow.Frame)
             {
                 Tag = 4321
@@ -213,6 +204,13 @@ namespace Bit.iOS
             UIApplication.SharedApplication.KeyWindow.BringSubviewToFront(view);
             UIApplication.SharedApplication.KeyWindow.EndEditing(true);
             UIApplication.SharedApplication.SetStatusBarHidden(true, false);
+            base.OnResignActivation(uiApplication);
+        }
+
+        public override void DidEnterBackground(UIApplication uiApplication)
+        {
+            _storageService.SaveAsync(Constants.LastActiveTimeKey, _deviceActionService.GetActiveTime());
+            _messagingService.Send("slept");
             base.DidEnterBackground(uiApplication);
         }
 


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
iOS will occasionally crash while backgrounding or killing the application. This was due to us referencing a `KeyWindow` object that becomes null during backgrounding. If the timing was off we would get a null pointer exception. 

This fix moves all the logic for backgrounding to OnResignActivation, which is called right before we move to the background. `KeyWindow` shouldn't be null yet and we can handle the splash screen without timing issues.

This opens up an old task: https://app.asana.com/0/1169444489336079/1201190971681077/f

We might eventually need to refactor how we accomplish this, as `KeyWindow` is deprecated in iOS 15.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **src/iOS/AppDelegate.cs:** Move splash screen logic to OnResignActivation




## Testing requirements
<!--What functionality requires testing by QA? This includes testing new behavior and regression testing-->
- Testing around backgrounding and killing of app. Splash screen should show when backgrounding and there should be no crash.


## Before you submit
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
