### PR TITLE
Fix Progress dialog crash on tombstoning

### DIFF
--- a/src/Android/Android.csproj
+++ b/src/Android/Android.csproj
@@ -189,6 +189,7 @@
     <AndroidResource Include="Resources\drawable-v23\splash_screen.xml" />
     <AndroidResource Include="Resources\drawable-v23\splash_screen_dark.xml" />
     <AndroidResource Include="Resources\drawable\switch_thumb.xml" />
+    <AndroidResource Include="Resources\layout\progress_dialog_layout.xml" />
     <AndroidResource Include="Resources\layout\Tabbar.axml" />
     <AndroidResource Include="Resources\layout\Toolbar.axml" />
     <AndroidResource Include="Resources\mipmap-anydpi-v26\ic_launcher.xml" />

--- a/src/Android/Resources/layout/progress_dialog_layout.xml
+++ b/src/Android/Resources/layout/progress_dialog_layout.xml
@@ -1,0 +1,27 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="80dp"
+        android:layout_centerInParent="true"
+        android:orientation="horizontal">
+
+        <ProgressBar
+            android:id="@+id/progressBar"
+            style="?android:attr/progressBarStyle"
+            android:layout_width="wrap_content"
+            android:layout_height="match_parent"
+            android:layout_marginLeft="10dp" />
+
+        <TextView
+            android:id="@+id/txtLoading"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_marginLeft="15dp"
+            android:gravity="center|left"
+            android:textSize="18sp" />
+    </LinearLayout>
+</RelativeLayout>

--- a/src/Android/Services/DeviceActionService.cs
+++ b/src/Android/Services/DeviceActionService.cs
@@ -13,6 +13,7 @@ using Android.OS;
 using Android.Provider;
 using Android.Text;
 using Android.Text.Method;
+using Android.Views;
 using Android.Views.Autofill;
 using Android.Views.InputMethods;
 using Android.Webkit;
@@ -27,6 +28,7 @@ using Bit.Core.Enums;
 using Bit.Core.Models.View;
 using Bit.Core.Utilities;
 using Bit.Droid.Autofill;
+using Bit.Droid.Utilities;
 using Plugin.CurrentActivity;
 
 namespace Bit.Droid.Services
@@ -37,7 +39,9 @@ namespace Bit.Droid.Services
         private readonly IMessagingService _messagingService;
         private readonly IBroadcasterService _broadcasterService;
         private readonly Func<IEventService> _eventServiceFunc;
-        private ProgressDialog _progressDialog;
+        private AlertDialog _progressDialog;
+        object _progressDialogLock = new object();
+
         private bool _cameraPermissionsDenied;
         private Toast _toast;
         private string _userAgent;
@@ -108,22 +112,102 @@ namespace Bit.Droid.Services
             {
                 await HideLoadingAsync();
             }
-            var activity = (MainActivity)CrossCurrentActivity.Current.Activity;
-            _progressDialog = new ProgressDialog(activity);
-            _progressDialog.SetMessage(text);
-            _progressDialog.SetCancelable(false);
+
+            var activity = CrossCurrentActivity.Current.Activity;
+            var inflater = (LayoutInflater)activity.GetSystemService(Context.LayoutInflaterService);
+            var dialogView = inflater.Inflate(Resource.Layout.progress_dialog_layout, null);
+            
+            var txtLoading = dialogView.FindViewById<TextView>(Resource.Id.txtLoading);
+            txtLoading.Text = text;
+            txtLoading.SetTextColor(ThemeHelpers.TextColor);
+
+            _progressDialog = new AlertDialog.Builder(activity)
+                .SetView(dialogView)
+                .SetCancelable(false)
+                .Create();
             _progressDialog.Show();
         }
 
         public Task HideLoadingAsync()
         {
-            if (_progressDialog != null)
+            // Based on https://github.com/redth-org/AndHUD/blob/master/AndHUD/AndHUD.cs
+            lock (_progressDialogLock)
             {
-                _progressDialog.Dismiss();
-                _progressDialog.Dispose();
-                _progressDialog = null;
+                if (_progressDialog is null)
+                {
+                    return Task.CompletedTask;
+                }
+
+                void actionDismiss()
+                {
+                    try
+                    {
+                        if (IsAlive(_progressDialog) && IsAlive(_progressDialog.Window))
+                        {
+                            _progressDialog.Hide();
+                            _progressDialog.Dismiss();
+                        }
+                    }
+                    catch
+                    {
+                        // ignore
+                    }
+
+                    _progressDialog = null;
+                }
+
+                // First try the SynchronizationContext
+                if (Application.SynchronizationContext != null)
+                {
+                    Application.SynchronizationContext.Send(state => actionDismiss(), null);
+                    return Task.CompletedTask;
+                }
+
+                // Otherwise try OwnerActivity on dialog
+                var ownerActivity = _progressDialog?.OwnerActivity;
+                if (IsAlive(ownerActivity))
+                {
+                    ownerActivity.RunOnUiThread(actionDismiss);
+                    return Task.CompletedTask;
+                }
+
+                // Otherwise try get it from the Window Context
+                if (_progressDialog?.Window?.Context is Activity windowActivity && IsAlive(windowActivity))
+                {
+                    windowActivity.RunOnUiThread(actionDismiss);
+                    return Task.CompletedTask;
+                }
+
+                // Finally if all else fails, let's see if current activity is MainActivity
+                if (CrossCurrentActivity.Current.Activity is MainActivity activity && IsAlive(activity))
+                {
+                    activity.RunOnUiThread(actionDismiss);
+                    return Task.CompletedTask;
+                }
+
+                return Task.CompletedTask;
             }
-            return Task.FromResult(0);
+        }
+
+        bool IsAlive(Java.Lang.Object @object)
+        {
+            if (@object == null)
+                return false;
+
+            if (@object.Handle == IntPtr.Zero)
+                return false;
+
+            if (@object is Activity activity)
+            {
+                if (activity.IsFinishing)
+                    return false;
+
+                if (Build.VERSION.SdkInt >= BuildVersionCodes.JellyBeanMr1 &&
+                    activity.IsDestroyed)
+                    return false;
+            }
+
+            return true;
         }
 
         public bool OpenFile(byte[] fileData, string id, string fileName)

--- a/src/Android/Utilities/ThemeHelpers.cs
+++ b/src/Android/Utilities/ThemeHelpers.cs
@@ -36,6 +36,10 @@ namespace Bit.Droid.Utilities
         {
             get => ThemeManager.GetResourceColor("SwitchThumbColor").ToAndroid();
         }
+        public static Color TextColor
+        {
+            get => ThemeManager.GetResourceColor("TextColor").ToAndroid();
+        }
         
         public static void SetAppearance(string theme, bool osDarkModeEnabled)
         {

--- a/src/App/Pages/Vault/AddEditPageViewModel.cs
+++ b/src/App/Pages/Vault/AddEditPageViewModel.cs
@@ -12,7 +12,9 @@ using System.Linq;
 using System.Threading.Tasks;
 using Bit.App.Controls;
 using Xamarin.Forms;
-using View = Xamarin.Forms.View;
+#if !FDROID
+using Microsoft.AppCenter.Crashes;
+#endif
 
 namespace Bit.App.Pages
 {
@@ -493,9 +495,12 @@ namespace Bit.App.Pages
             try
             {
                 await _deviceActionService.ShowLoadingAsync(AppResources.Saving);
+
                 await _cipherService.SaveWithServerAsync(cipher);
                 Cipher.Id = cipher.Id;
+
                 await _deviceActionService.HideLoadingAsync();
+
                 _platformUtilsService.ShowToast("success", null,
                     EditMode && !CloneMode ? AppResources.ItemUpdated : AppResources.NewItemCreated);
                 _messagingService.Send(EditMode && !CloneMode ? "editedCipher" : "addedCipher", Cipher.Id);
@@ -511,18 +516,29 @@ namespace Bit.App.Pages
                     {
                         ViewPage?.UpdateCipherId(this.Cipher.Id);
                     }
-                    await Page.Navigation.PopModalAsync();
+                    // if the app is tombstoned then PopModalAsync would throw index out of bounds
+                    if (Page.Navigation?.ModalStack?.Count > 0)
+                    {
+                        await Page.Navigation.PopModalAsync();
+                    }
                 }
                 return true;
             }
-            catch (ApiException e)
+            catch (ApiException apiEx)
             {
                 await _deviceActionService.HideLoadingAsync();
-                if (e?.Error != null)
+                if (apiEx?.Error != null)
                 {
-                    await _platformUtilsService.ShowDialogAsync(e.Error.GetSingleMessage(),
+                    await _platformUtilsService.ShowDialogAsync(apiEx.Error.GetSingleMessage(),
                         AppResources.AnErrorHasOccurred);
                 }
+            }
+            catch(Exception genex)
+            {
+#if !FDROID
+                Crashes.TrackError(genex);
+#endif
+                await _deviceActionService.HideLoadingAsync();
             }
             return false;
         }


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Android: Fix crash produced by the Progress dialog on tombstoning and also to change it because it was deprecated for the new way.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **DeviceActionService.cs:** Changed `ProgressDialog` for `AlertDialog` with a custom layout for the progress and improved the `HideLoadingAsync` to take care of more situations so that the dismissal is done correctly and doesn't crash the app
* **AddEditPageViewModel.cs:** Added a check before popping the modal because it could lead to a crash on tombstoning


## Testing requirements
<!--What functionality requires testing by QA? This includes testing new behavior and regression testing-->
Check that the UI of the loading hasn't been affected dramatically, check that the loading is done correctly in different screens, e.g. logging in or saving a cypher.
Also test that while loading (without letting the loading finish) tombstone the app (a simpler way, but not the same, is to set `Don't keep activities` in Developer options of the settings of the phone before opening the app) and then go back to the app and check that it doesn't crash.


## Before you submit
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
