### PR TITLE
Fix by workaround crash on LabelRenderer and when changing themes #1689

### DIFF
--- a/src/iOS.Core/Renderers/CustomLabelRenderer.cs
+++ b/src/iOS.Core/Renderers/CustomLabelRenderer.cs
@@ -1,4 +1,5 @@
-﻿using System.ComponentModel;
+﻿using System;
+using System.ComponentModel;
 using Bit.iOS.Core.Renderers;
 using Bit.iOS.Core.Utilities;
 using UIKit;
@@ -9,34 +10,49 @@ using Xamarin.Forms.Platform.iOS;
 namespace Bit.iOS.Core.Renderers
 {
     public class CustomLabelRenderer : LabelRenderer
-    {
-        protected override void OnElementChanged(ElementChangedEventArgs<Label> e)
-        {
-            base.OnElementChanged(e);
-            if (Control != null && e.NewElement is Label)
-            {
-                UpdateFont();
-            }
-        }
+	{
+		protected override void OnElementChanged(ElementChangedEventArgs<Label> e)
+		{
+			base.OnElementChanged(e);
+			if (Control != null && e.NewElement is Label)
+			{
+				UpdateFont();
+			}
+		}
 
-        protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
-        {
-            base.OnElementPropertyChanged(sender, e);
-            if (e.PropertyName == Label.FontProperty.PropertyName ||
-                e.PropertyName == Label.TextProperty.PropertyName ||
-                e.PropertyName == Label.FormattedTextProperty.PropertyName)
+		protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
+		{
+            try
             {
-                UpdateFont();
-            }
-        }
+				base.OnElementPropertyChanged(sender, e);
+			}
+			catch (NullReferenceException)
+			{
+				// Do nothing...
+				// There is an issue on Xamarin Forms which throws a null reference
+				// https://appcenter.ms/users/kspearrin/apps/bitwarden/crashes/errors/534094859u/overview
+				// TODO: Maybe something like this https://github.com/matteobortolazzo/HtmlLabelPlugin/pull/113 can be implemented to avoid this
+				// on html labels.
+			}
 
-        private void UpdateFont()
-        {
-            var pointSize = iOSHelpers.GetAccessibleFont<Label>(Element.FontSize);
-            if (pointSize != null)
-            {
-                Control.Font = UIFont.FromDescriptor(Element.Font.ToUIFont().FontDescriptor, pointSize.Value);
-            }
-        }
-    }
+			if (e.PropertyName == Label.FontProperty.PropertyName ||
+				e.PropertyName == Label.TextProperty.PropertyName ||
+				e.PropertyName == Label.FormattedTextProperty.PropertyName)
+			{
+				UpdateFont();
+			}
+		}
+
+		private void UpdateFont()
+		{
+			if (Element is null || Control is null)
+				return;
+
+			var pointSize = iOSHelpers.GetAccessibleFont<Label>(Element.FontSize);
+			if (pointSize != null)
+			{
+				Control.Font = UIFont.FromDescriptor(Element.Font.ToUIFont().FontDescriptor, pointSize.Value);
+			}
+		}
+	}
 }


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Fix crash on iOS LabelRenderer when changing themes on password generator screen and password generator history. These are **workarounds** only

I think this may need to be further tested and check what happens on certain scenarios before going to PRD. I saw that when the app is supposed to crash, but now it doesn't because of the try...catch, there are certain elements that don't update the style, so maybe I could spend more time in it trying to make everything work correctly

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **CustomLabelRenderer.cs:** Added try...catch when calling base so that we can ignore the exception if it happens, it's the only workardound I could find so far (already submitted PR on Xamarin Forms to fix this https://github.com/xamarin/Xamarin.Forms/pull/14982)
* **ThemeManager.cs:** Sometimes the app crashes when closing a view when coming from background having changed the theme, so I've added a try...catch as a workaround here as well.

## Screenshots
<!--Required for any UI changes. Delete if not applicable-->



## Testing requirements
<!--What functionality requires testing by QA? This includes testing new behavior and regression testing-->

Scenario 1:
- Go to a cypher -> Edit -> tap on the icon for regenerate password
- Put the app on background
- Change light/dark mode
- Go back to the app
- Without waiting the password label to be updated tap on Select
- The app crashes, and now it shouldn't

Scenario 2:
- Go to Password generator -> Password history (on the toolbar menu three dots)
- Put the app on background
- Change light/dark mode
- Go back to the app
- The app crashes, and now it shouldn't (sometimes it doesn't crash, it needs a few attempts)


## Before you submit
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
