### PR TITLE
Fix Unsafe deserialization of Parcel data Intent

### DIFF
--- a/src/Android/Accessibility/AccessibilityActivity.cs
+++ b/src/Android/Accessibility/AccessibilityActivity.cs
@@ -6,6 +6,7 @@ using Android.Views;
 using System;
 using Bit.Core.Abstractions;
 using Bit.Core.Utilities;
+using Bit.Droid.Utilities;
 
 namespace Bit.Droid.Accessibility
 {
@@ -17,6 +18,7 @@ namespace Bit.Droid.Accessibility
 
         protected override void OnCreate(Bundle bundle)
         {
+            Intent?.Validate();
             base.OnCreate(bundle);
             HandleIntent(Intent, 932473);
         }

--- a/src/Android/Android.csproj
+++ b/src/Android/Android.csproj
@@ -150,6 +150,7 @@
     <Compile Include="WebAuthCallbackActivity.cs" />
     <Compile Include="Renderers\SelectableLabelRenderer.cs" />
     <Compile Include="Services\ClipboardService.cs" />
+    <Compile Include="Utilities\IntentExtensions.cs" />
   </ItemGroup>
   <ItemGroup>
     <AndroidAsset Include="Assets\FontAwesome.ttf" />

--- a/src/Android/MainActivity.cs
+++ b/src/Android/MainActivity.cs
@@ -62,7 +62,7 @@ namespace Bit.Droid
             ToolbarResource = Resource.Layout.Toolbar;
 
             // this needs to be called here before base.OnCreate(...)
-            Intent?.ValidateIntent();
+            Intent?.Validate();
 
             base.OnCreate(savedInstanceState);
             if (!CoreHelpers.InDebugMode())

--- a/src/Android/MainActivity.cs
+++ b/src/Android/MainActivity.cs
@@ -19,6 +19,7 @@ using System.Threading.Tasks;
 using AndroidX.Core.Content;
 using Bit.App.Utilities;
 using ZXing.Net.Mobile.Android;
+using Android.Util;
 
 namespace Bit.Droid
 {
@@ -59,6 +60,9 @@ namespace Bit.Droid
 
             TabLayoutResource = Resource.Layout.Tabbar;
             ToolbarResource = Resource.Layout.Toolbar;
+
+            // this needs to be called here before base.OnCreate(...)
+            Intent?.ValidateIntent();
 
             base.OnCreate(savedInstanceState);
             if (!CoreHelpers.InDebugMode())

--- a/src/Android/Utilities/IntentExtensions.cs
+++ b/src/Android/Utilities/IntentExtensions.cs
@@ -1,0 +1,22 @@
+﻿using Android.Content;
+using Android.OS;
+
+namespace Bit.Droid.Utilities
+{
+    public static class IntentExtensions
+    {
+        public static void ValidateIntent(this Intent intent)
+        {
+            try
+            {
+                // Check if getting the bundle of the extras causes any exception when unparcelling
+                // Note: getting the bundle like this will cause to call unparcel() internally
+                var b = intent?.Extras?.GetBundle("trashstringwhichhasnousebuttocheckunparcel");
+            }
+            catch (BadParcelableException)
+            {
+                intent.ReplaceExtras((Bundle)null);
+            }
+        }
+    }
+}

--- a/src/Android/Utilities/IntentExtensions.cs
+++ b/src/Android/Utilities/IntentExtensions.cs
@@ -5,7 +5,7 @@ namespace Bit.Droid.Utilities
 {
     public static class IntentExtensions
     {
-        public static void ValidateIntent(this Intent intent)
+        public static void Validate(this Intent intent)
         {
             try
             {

--- a/src/Android/WebAuthCallbackActivity.cs
+++ b/src/Android/WebAuthCallbackActivity.cs
@@ -1,5 +1,7 @@
 ﻿using Android.App;
 using Android.Content.PM;
+using Android.OS;
+using Bit.Droid.Utilities;
 
 namespace Bit.Droid
 {
@@ -9,5 +11,12 @@ namespace Bit.Droid
     [IntentFilter(new[] { Android.Content.Intent.ActionView },
         Categories = new[] { Android.Content.Intent.CategoryDefault, Android.Content.Intent.CategoryBrowsable },
         DataScheme = "bitwarden")]
-    public class WebAuthCallbackActivity : Xamarin.Essentials.WebAuthenticatorCallbackActivity { }
+    public class WebAuthCallbackActivity : Xamarin.Essentials.WebAuthenticatorCallbackActivity
+    {
+        protected override void OnCreate(Bundle savedInstanceState)
+        {
+            Intent?.Validate();
+            base.OnCreate(savedInstanceState);
+        }
+    }
 }


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Fix crash produced by unsafe deserialization of parcel data intent attack.

The problem lies in that when creating the activity this is called and if there are any extras then a bundle is requested in [FcmLifecycleCallbacks](https://github.com/firebase/firebase-android-sdk/blob/21a9f912862bfbd801690a9f88dce22366bec8ac/firebase-messaging/src/main/java/com/google/firebase/messaging/FcmLifecycleCallbacks.java#L40) that will cause to call the [Bundle.getBundle(...)](https://cs.android.com/android/platform/superproject/+/nougat-cts-release:frameworks/base/core/java/android/os/Bundle.java;l=817) which calls `unparcel()` and if the attacker planted a parcelable class that can't be found in the app then it will make the app crash.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **MainActivity.cs:** Call ValidateIntent to check whether the extras can be unparcelled.

## Testing requirements
<!--What functionality requires testing by QA? This includes testing new behavior and regression testing-->


## Before you submit
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
