### PR TITLE
Possible fix for iOS crash after long time idling

### DIFF
--- a/src/iOS/AppDelegate.cs
+++ b/src/iOS/AppDelegate.cs
@@ -201,8 +201,8 @@ namespace Bit.iOS
 
         public override void DidEnterBackground(UIApplication uiApplication)
         {
-            _storageService.SaveAsync(Constants.LastActiveTimeKey, _deviceActionService.GetActiveTime());
-            _messagingService.Send("slept");
+            _storageService?.SaveAsync(Constants.LastActiveTimeKey, _deviceActionService.GetActiveTime());
+            _messagingService?.Send("slept");
             base.DidEnterBackground(uiApplication);
         }
 
@@ -220,7 +220,7 @@ namespace Bit.iOS
 
         public override void WillEnterForeground(UIApplication uiApplication)
         {
-            _messagingService.Send("resumed");
+            _messagingService?.Send("resumed");
             base.WillEnterForeground(uiApplication);
         }
 


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Fix crash produced on iOS after long time in the background


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **AppDelegate.cs:** Added null checks on some services that were being called on the app lifecycle and may have been disposed before.

I'm not sure yet what is the root cause of the problem, so this'd be a baindaid for the problem, if it keeps appearing we'd need to dig in more to check which is the flow or root cause that leads to the blink crash.

## Testing requirements
<!--What functionality requires testing by QA? This includes testing new behavior and regression testing-->
Steps to reproduce:

- Open the Bitwarden app on iOS
- Stop using the phone for a while leaving it on background (no idea yet how long, to make sure of my testing I left it on the background until the next day)
- Open the Bitwarden app again. On the first try, the app will just blink (opening then closed suddenly).
- It will open successfully on the second try.

The app shouldn't crash when opened again.

## Before you submit
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
