### PR TITLE
Expand Settings TimePicker tap recognition to entire row

### DIFF
--- a/src/App/Pages/Settings/SettingsPage/SettingsPage.xaml
+++ b/src/App/Pages/Settings/SettingsPage/SettingsPage.xaml
@@ -45,20 +45,47 @@
                            VerticalOptions="CenterAndExpand"
                            TextColor="{Binding SubLabelColor}"
                            StyleClass="list-sub" />
-                    <TimePicker IsVisible="{Binding ShowTimeInput}"
-                                Time="{Binding Time}" Format="HH:mm"
+                </controls:ExtendedStackLayout>
+            </DataTemplate>
+            <DataTemplate
+                x:Key="timePickerTemplate"
+                x:DataType="pages:SettingsPageListItem">
+                <controls:ExtendedStackLayout Orientation="Horizontal"
+                             StyleClass="list-row, list-row-platform">
+                    <Frame
+                        IsVisible="{Binding UseFrame}"
+                        Padding="10"
+                        HasShadow="False"
+                        BackgroundColor="Transparent"
+                        BorderColor="Accent">
+                        <Label
+                            Text="{Binding Name, Mode=OneWay}"
+                            StyleClass="text-muted, text-sm, text-bold"
+                            HorizontalTextAlignment="Center" />
+                    </Frame>
+                    <Label IsVisible="{Binding UseFrame, Converter={StaticResource inverseBool}}"
+                           Text="{Binding Name, Mode=OneWay}"
+                           LineBreakMode="{Binding LineBreakMode}"
+                           HorizontalOptions="StartAndExpand"
+                           VerticalOptions="CenterAndExpand"
+                           StyleClass="list-title"/>
+                    <TimePicker Time="{Binding Time}" Format="HH:mm"
                                 PropertyChanged="OnTimePickerPropertyChanged"
                                 HorizontalOptions="End"
                                 VerticalOptions="Center"
                                 FontSize="Small"
                                 TextColor="{Binding SubLabelColor}"
-                                StyleClass="list-sub" Margin="-5" />
+                                StyleClass="list-sub" Margin="-5"/>
+                    <controls:ExtendedStackLayout.GestureRecognizers>
+			            <TapGestureRecognizer Tapped="ActivateTimePicker"/>
+		            </controls:ExtendedStackLayout.GestureRecognizers>
                 </controls:ExtendedStackLayout>
-            </DataTemplate>
+	        </DataTemplate>
 
             <pages:SettingsPageListItemSelector
                 x:Key="listItemDataTemplateSelector"
-                RegularTemplate="{StaticResource regularTemplate}" />
+                RegularTemplate="{StaticResource regularTemplate}"
+                TimePickerTemplate="{StaticResource timePickerTemplate}" />
         </ResourceDictionary>
     </ContentPage.Resources>
 

--- a/src/App/Pages/Settings/SettingsPage/SettingsPage.xaml.cs
+++ b/src/App/Pages/Settings/SettingsPage/SettingsPage.xaml.cs
@@ -1,4 +1,5 @@
-﻿using System.ComponentModel;
+﻿using System;
+using System.ComponentModel;
 using System.Linq;
 using System.Threading.Tasks;
 using Bit.App.Abstractions;
@@ -43,6 +44,17 @@ namespace Bit.App.Pages
                 return true;
             }
             return base.OnBackButtonPressed();
+        }
+
+        void ActivateTimePicker(object sender, EventArgs args)
+        {
+            var stackLayout = (ExtendedStackLayout)sender;
+            SettingsPageListItem item = (SettingsPageListItem)stackLayout.BindingContext;
+            if (item.ShowTimeInput)
+            {
+                var timePicker = stackLayout.Children.Where(x => x is TimePicker).FirstOrDefault();
+                ((TimePicker)timePicker).Focus();
+            }
         }
 
         async void OnTimePickerPropertyChanged(object sender, PropertyChangedEventArgs args)

--- a/src/App/Pages/Settings/SettingsPage/SettingsPage.xaml.cs
+++ b/src/App/Pages/Settings/SettingsPage/SettingsPage.xaml.cs
@@ -53,7 +53,7 @@ namespace Bit.App.Pages
             if (item.ShowTimeInput)
             {
                 var timePicker = stackLayout.Children.Where(x => x is TimePicker).FirstOrDefault();
-                ((TimePicker)timePicker).Focus();
+                ((TimePicker)timePicker)?.Focus();
             }
         }
 

--- a/src/App/Pages/Settings/SettingsPage/SettingsPageListItemSelector.cs
+++ b/src/App/Pages/Settings/SettingsPage/SettingsPageListItemSelector.cs
@@ -5,12 +5,20 @@ namespace Bit.App.Pages
     public class SettingsPageListItemSelector : DataTemplateSelector
     {
         public DataTemplate RegularTemplate { get; set; }
+        public DataTemplate TimePickerTemplate { get; set; }
 
         protected override DataTemplate OnSelectTemplate(object item, BindableObject container)
         {
             if (item is SettingsPageListItem listItem)
             {
-                return RegularTemplate;
+                if (listItem.ShowTimeInput)
+                {
+                    return TimePickerTemplate;
+                }
+                else
+                {
+                    return RegularTemplate;
+                }
             }
             return null;
         }


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Every option in settings allows you to tap anywhere within the row to enable the action. Every option except "Custom" timeouts. This fix pulls the option into its own data template and adds a tap recognizer on the entire row for the TimePicker.

Asana: https://app.asana.com/0/1169444489336079/1201172188894451/f

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **file.ext:** Description of what was changed and why
* **src/App/Pages/Settings/SettingsPage/SettingsPage.xaml:** Create new DataTemplate for Custom option in Settings. Include DataTemplate in the DataTemplateSelector
* **src/App/Pages/Settings/SettingsPage/SettingsPage.xaml.cs:** If TapGestureRecognizer is triggered, find the TimePicker from the StackLayout and trigger.
* **src/App/Pages/Settings/SettingsPage/SettingsPageListItemSelector.cs:** Return new DataTemplate for Custom option

## Screenshots
<!--Required for any UI changes. Delete if not applicable-->

https://user-images.githubusercontent.com/24985544/148834516-153919be-d983-43e6-b247-2a8352507515.mov




## Testing requirements
<!--What functionality requires testing by QA? This includes testing new behavior and regression testing-->
- Test functionality of Settings options


## Before you submit
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
