### PR TITLE
Check for disable save prompt option before sending fill request in Android Autofill

### DIFF
--- a/src/Android/Autofill/AutofillHelpers.cs
+++ b/src/Android/Autofill/AutofillHelpers.cs
@@ -160,7 +160,7 @@ namespace Bit.Droid.Autofill
             return new List<FilledItem>();
         }
 
-        public static FillResponse BuildFillResponse(Parser parser, List<FilledItem> items, bool locked,
+        public static FillResponse.Builder CreateFillResponse(Parser parser, List<FilledItem> items, bool locked,
             bool inlineAutofillEnabled, FillRequest fillRequest = null)
         {
             // Acquire inline presentation specs on Android 11+
@@ -211,9 +211,8 @@ namespace Bit.Droid.Autofill
             }
             responseBuilder.AddDataset(BuildVaultDataset(parser.ApplicationContext, parser.FieldCollection,
                 parser.Uri, locked, inlinePresentationSpecs));
-            AddSaveInfo(parser, fillRequest, responseBuilder, parser.FieldCollection);
             responseBuilder.SetIgnoredIds(parser.FieldCollection.IgnoreAutofillIds.ToArray());
-            return responseBuilder.Build();
+            return responseBuilder;
         }
 
         public static Dataset BuildDataset(Context context, FieldCollection fields, FilledItem filledItem,

--- a/src/Android/Autofill/AutofillService.cs
+++ b/src/Android/Autofill/AutofillService.cs
@@ -11,8 +11,8 @@ using Bit.Core.Enums;
 using Bit.Core.Utilities;
 #if !FDROID
 using Microsoft.AppCenter.Crashes;
-using System;
 #endif
+using System;
 using System.Collections.Generic;
 using System.Linq;
 

--- a/src/Android/Autofill/AutofillService.cs
+++ b/src/Android/Autofill/AutofillService.cs
@@ -69,8 +69,13 @@ namespace Bit.Droid.Autofill
             }
 
             // build response
-            var response = AutofillHelpers.BuildFillResponse(parser, items, locked, inlineAutofillEnabled, request);
-            callback.OnSuccess(response);
+            var response = AutofillHelpers.CreateFillResponse(parser, items, locked, inlineAutofillEnabled, request);
+            var disableSavePrompt = await _storageService.GetAsync<bool?>(Constants.AutofillDisableSavePromptKey);
+            if (!disableSavePrompt.GetValueOrDefault())
+            {
+                AutofillHelpers.AddSaveInfo(parser, request, response, parser.FieldCollection);
+            }
+            callback.OnSuccess(response.Build());
         }
 
         public async override void OnSaveRequest(SaveRequest request, SaveCallback callback)


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
closes #1017 
Asana: https://app.asana.com/0/1169444489336079/1185097609703843/f

We're having reports of some applications and browsers repeatedly asking if the user would like to save login information. While this is most likely an issue with the Autofill service or the application itself, our option to "Disable Save Prompts" isn't working correctly to stop all prompts.

This change moves the check for "Disable Save Prompts" to before sending the fill package. That way, we can determine if the we need to include Save Information in the `FillResponse` before the prompt shows.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **file.ext:** Description of what was changed and why
* **src/Android/Autofill/AutofillHelpers.cs:** Change `BuildFillResponse` to `CreateFillResponse` as we are only returning the `FillResponse.Builder` now in order to add save info later on.
* **src/Android/Autofill/AutofillService.cs:** Move `AddSaveInfo` call to the `AutofillService` as we now check the DisableSavePrompts before calling it.

## Screenshots
<!--Required for any UI changes. Delete if not applicable-->



## Testing requirements
<!--What functionality requires testing by QA? This includes testing new behavior and regression testing-->
- Testing around Android Autofill Service and the "Disable Save Prompts" option
    - When enabled, there shouldn't be a prompt to save the login


## Before you submit
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
