### PR TITLE
Fix for initial login token storage paradox

### DIFF
--- a/src/Core/Abstractions/ITokenService.cs
+++ b/src/Core/Abstractions/ITokenService.cs
@@ -23,7 +23,7 @@ namespace Bit.Core.Abstractions
         Task<string> GetTwoFactorTokenAsync(string email);
         string GetUserId();
         Task SetRefreshTokenAsync(string refreshToken);
-        Task SetAccessTokenAsync(string token);
+        Task SetAccessTokenAsync(string token, bool forDecodeOnly = false);
         Task SetTokensAsync(string accessToken, string refreshToken);
         Task SetTwoFactorTokenAsync(string token, string email);
         bool TokenNeedsRefresh(int minutes = 5);

--- a/src/Core/Services/AuthService.cs
+++ b/src/Core/Services/AuthService.cs
@@ -352,7 +352,7 @@ namespace Bit.Core.Services
             {
                 await _tokenService.SetTwoFactorTokenAsync(tokenResponse.TwoFactorToken, email);
             }
-            await _tokenService.SetTokensAsync(tokenResponse.AccessToken, tokenResponse.RefreshToken);
+            await _tokenService.SetAccessTokenAsync(tokenResponse.AccessToken, true);
             await _stateService.AddAccountAsync(
                 new Account(
                     new Account.AccountProfile()

--- a/src/Core/Services/TokenService.cs
+++ b/src/Core/Services/TokenService.cs
@@ -27,11 +27,14 @@ namespace Bit.Core.Services
                 SetRefreshTokenAsync(refreshToken));
         }
 
-        public async Task SetAccessTokenAsync(string accessToken)
+        public async Task SetAccessTokenAsync(string accessToken, bool forDecodeOnly = false)
         {
             _accessTokenForDecoding = accessToken;
             _decodedAccessToken = null;
-            await _stateService.SetAccessTokenAsync(accessToken, await SkipTokenStorage());
+            if (!forDecodeOnly)
+            {
+                await _stateService.SetAccessTokenAsync(accessToken, await SkipTokenStorage());
+            }
         }
 
         public async Task<string> GetTokenAsync()


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Fix NPE on login with account that has never logged in before (recent change in the way skipping token storage is handled combined with a fresh install)


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **TokenService.cs:** Added `forDecodeOnly` bool to `SetAccessTokenAsync` method to allow token decoding without saving to the account state (which doesn't exist until the next step in the auth process, which requires values from the decoded token)
* **AuthService.cs:** Utilize the new bool


## Testing requirements
<!--What functionality requires testing by QA? This includes testing new behavior and regression testing-->
Login with a fresh install and boom.  Apparently it's been awhile since I cleared app data.


## Before you submit
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
