### PR TITLE
Fix Account Switching crash on log out

### DIFF
--- a/src/App/Controls/ExtendedToolbarItem.cs
+++ b/src/App/Controls/ExtendedToolbarItem.cs
@@ -13,7 +13,6 @@ namespace Bit.App.Controls
         // that we don't have access to, and that we should in order to properly prevent memory leaks
         // So as a hack solution we have this OnAppearing/OnDisappearing actions and methods to be called on page lifecycle
         // to subscribe/unsubscribe indirectly on the CustomNavigationRenderer
-        #region HACKSubscription
         public Action OnAppearingAction { get; set; }
         public Action OnDisappearingAction { get; set; }
 
@@ -26,6 +25,5 @@ namespace Bit.App.Controls
         {
             OnDisappearingAction?.Invoke();
         }
-        #endregion
     }
 }

--- a/src/iOS.Core/Renderers/CustomNavigationRenderer.cs
+++ b/src/iOS.Core/Renderers/CustomNavigationRenderer.cs
@@ -68,7 +68,17 @@ namespace Bit.iOS.Core.Renderers
                         var uiBarButtonItem = uiBarButtonItems[index];
 
                         DispatchQueue.MainQueue.DispatchAsync(() =>
-                            uiBarButtonItem.Image = uiBarButtonItem.Image.ImageWithRenderingMode(UIImageRenderingMode.AlwaysOriginal));
+                        {
+                            try
+                            {
+                                uiBarButtonItem.Image = uiBarButtonItem.Image.ImageWithRenderingMode(UIImageRenderingMode.AlwaysOriginal);
+                            }
+                            catch (ObjectDisposedException)
+                            {
+                                // Do nothing, we can't access the proper place to properly dispose this, so here
+                                // we can just catch and ignore the exception. This should only happen when logging out a user.
+                            }
+                        });
                     }
                 };
             }


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Fix crash when having two or more users and one of them logs out on Account Switching.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **CustomNavigationRenderer.cs:** Added try....catch of the `ObjectDisposedException` given that we don't have a clearer way to check whether the Toolbar item has been disposed or change the approach on (un)subscription for the `PropertyChanged`

## Testing requirements
<!--What functionality requires testing by QA? This includes testing new behavior and regression testing-->
The app shouldn't crash when logging out a user

## Before you submit
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
