### PR TITLE
Account switching migration service

### DIFF
--- a/src/Android/MainApplication.cs
+++ b/src/Android/MainApplication.cs
@@ -114,6 +114,8 @@ namespace Bit.Droid
             var cryptoPrimitiveService = new CryptoPrimitiveService();
             var mobileStorageService = new MobileStorageService(preferencesStorage, liteDbStorage);
             var stateService = new StateService(mobileStorageService, secureStorageService);
+            var stateMigrationService =
+                new StateMigrationService(liteDbStorage, preferencesStorage, secureStorageService);
             var deviceActionService = new DeviceActionService(stateService, messagingService,
                 broadcasterService, () => ServiceContainer.Resolve<IEventService>("eventService"));
             var platformUtilsService = new MobilePlatformUtilsService(deviceActionService, messagingService,
@@ -131,6 +133,7 @@ namespace Bit.Droid
             ServiceContainer.Register<IStorageService>("storageService", mobileStorageService);
             ServiceContainer.Register<IStorageService>("secureStorageService", secureStorageService);
             ServiceContainer.Register<IStateService>("stateService", stateService);
+            ServiceContainer.Register<IStateMigrationService>("stateMigrationService", stateMigrationService);
             ServiceContainer.Register<IClipboardService>("clipboardService", new ClipboardService(stateService));
             ServiceContainer.Register<IDeviceActionService>("deviceActionService", deviceActionService);
             ServiceContainer.Register<IPlatformUtilsService>("platformUtilsService", platformUtilsService);

--- a/src/App/Pages/Accounts/LockPage.xaml.cs
+++ b/src/App/Pages/Accounts/LockPage.xaml.cs
@@ -66,16 +66,8 @@ namespace Bit.App.Pages
 
             _accountAvatar?.OnAppearing();
 
-            if (await ShowAccountSwitcherAsync())
-            {
-                _vm.AvatarImageSource = await GetAvatarImageSourceAsync();
-            }
-            else
-            {
-                // TODO: this is currently not working because of xamarin bug on Priority = -1,
-                // check if we can hide it by putting a same backgroundcolor icon
-                ToolbarItems.Remove(_accountAvatar);
-            }
+            _vm.AvatarImageSource = await GetAvatarImageSourceAsync();
+
             await _vm.InitAsync();
             if (!_vm.BiometricLock)
             {

--- a/src/App/Pages/BaseContentPage.cs
+++ b/src/App/Pages/BaseContentPage.cs
@@ -124,7 +124,7 @@ namespace Bit.App.Pages
 
         protected async Task<bool> ShowAccountSwitcherAsync()
         {
-            return await _stateService.HasMultipleAccountsAsync();
+            return await _stateService.GetActiveUserIdAsync() != null;
         }
 
         protected async Task RefreshAccountViewsAsync(Xamarin.Forms.ListView accountListView, bool allowAddAccountRow)

--- a/src/App/Pages/Vault/GroupingsPage/GroupingsPage.xaml.cs
+++ b/src/App/Pages/Vault/GroupingsPage/GroupingsPage.xaml.cs
@@ -109,7 +109,6 @@ namespace Bit.App.Pages
                 }
             });
 
-            var migratedFromV1 = await _stateService.GetMigratedFromV1Async();
             await LoadOnAppearedAsync(_mainLayout, false, async () =>
             {
                 if (!_syncService.SyncInProgress || (await _cipherService.GetAllAsync()).Any())
@@ -130,18 +129,6 @@ namespace Bit.App.Pages
                     if (!_vm.Loaded)
                     {
                         await _vm.LoadAsync();
-                    }
-                }
-                // Forced sync if for some reason we have no data after a v1 migration
-                if (_vm.MainPage && !_syncService.SyncInProgress && migratedFromV1.GetValueOrDefault() &&
-                    !_vm.HasCiphers &&
-                    Xamarin.Essentials.Connectivity.NetworkAccess != Xamarin.Essentials.NetworkAccess.None)
-                {
-                    var triedV1ReSync = await _stateService.GetTriedV1ResyncAsync();
-                    if (!triedV1ReSync.GetValueOrDefault())
-                    {
-                        await _stateService.SetTriedV1ResyncAsync(true);
-                        await _syncService.FullSyncAsync(true);
                     }
                 }
                 await ShowPreviousPageAsync();
@@ -177,21 +164,6 @@ namespace Bit.App.Pages
                 {
                     await _pushNotificationService.RegisterAsync();
                 }
-                if (!_deviceActionService.AutofillAccessibilityServiceRunning()
-                    && !_deviceActionService.AutofillServiceEnabled())
-                {
-                    if (migratedFromV1.GetValueOrDefault())
-                    {
-                        var migratedFromV1AutofillPromptShown = 
-                            await _stateService.GetMigratedFromV1AutofillPromptShownAsync();
-                        if (!migratedFromV1AutofillPromptShown.GetValueOrDefault())
-                        {
-                            await DisplayAlert(AppResources.Autofill,
-                                AppResources.AutofillServiceNotEnabled, AppResources.Ok);
-                        }
-                    }
-                }
-                await _stateService.SetMigratedFromV1AutofillPromptShownAsync(true);
             }
         }
 

--- a/src/App/Services/MobileStorageService.cs
+++ b/src/App/Services/MobileStorageService.cs
@@ -13,7 +13,7 @@ namespace Bit.App.Services
 
         private readonly HashSet<string> _preferenceStorageKeys = new HashSet<string>
         {
-            Constants.AppIdKey,
+            Constants.StateVersionKey,
             Constants.PreAuthEnvironmentUrlsKey,
             Constants.AutofillTileAdded,
             Constants.AddSitePromptShownKey,
@@ -23,9 +23,6 @@ namespace Bit.App.Services
             Constants.PushRegisteredTokenKey,
             Constants.PushCurrentTokenKey,
             Constants.LastBuildKey,
-            Constants.MigratedFromV1,
-            Constants.MigratedFromV1AutofillPromptShown,
-            Constants.TriedV1Resync,
             Constants.ClearCiphersCacheKey,
             Constants.BiometricIntegrityKey,
             Constants.iOSAutoFillClearCiphersCacheKey,
@@ -40,12 +37,6 @@ namespace Bit.App.Services
             Constants.AppExtensionActivatedKey,
         };
 
-        private readonly HashSet<string> _migrateToPreferences = new HashSet<string>
-        {
-            "environmentUrls",
-        };
-        private readonly HashSet<string> _haveMigratedToPreferences = new HashSet<string>();
-
         public MobileStorageService(
             IStorageService preferenceStorageService,
             IStorageService liteDbStorageService)
@@ -58,24 +49,9 @@ namespace Bit.App.Services
         {
             if (_preferenceStorageKeys.Contains(key))
             {
-                var prefValue = await _preferencesStorageService.GetAsync<T>(key);
-                if (prefValue != null || !_migrateToPreferences.Contains(key) ||
-                    _haveMigratedToPreferences.Contains(key))
-                {
-                    return prefValue;
-                }
+                return await _preferencesStorageService.GetAsync<T>(key);
             }
-            var liteDbValue = await _liteDbStorageService.GetAsync<T>(key);
-            if (_migrateToPreferences.Contains(key))
-            {
-                if (liteDbValue != null)
-                {
-                    await _preferencesStorageService.SaveAsync(key, liteDbValue);
-                    await _liteDbStorageService.RemoveAsync(key);
-                }
-                _haveMigratedToPreferences.Add(key);
-            }
-            return liteDbValue;
+            return await _liteDbStorageService.GetAsync<T>(key);
         }
 
         public Task SaveAsync<T>(string key, T obj)

--- a/src/Core/Abstractions/IAppIdService.cs
+++ b/src/Core/Abstractions/IAppIdService.cs
@@ -5,5 +5,6 @@ namespace Bit.Core.Abstractions
     public interface IAppIdService
     {
         Task<string> GetAppIdAsync();
+        Task<string> GetAnonymousAppIdAsync();
     }
 }

--- a/src/Core/Abstractions/IStateMigrationService.cs
+++ b/src/Core/Abstractions/IStateMigrationService.cs
@@ -1,0 +1,10 @@
+﻿using System.Threading.Tasks;
+
+namespace Bit.Core.Abstractions
+{
+    public interface IStateMigrationService
+    {
+        Task<bool> NeedsMigration();
+        Task Migrate();
+    }
+}

--- a/src/Core/Abstractions/IStateService.cs
+++ b/src/Core/Abstractions/IStateService.cs
@@ -17,7 +17,6 @@ namespace Bit.Core.Abstractions
         Task<string> GetActiveUserIdAsync();
         Task SetActiveUserAsync(string userId);
         Task<bool> IsAuthenticatedAsync(string userId = null);
-        Task<bool> HasMultipleAccountsAsync();
         Task RefreshAccountViewsAsync(bool allowAddAccountRow);
         Task AddAccountAsync(Account account);
         Task ClearAsync(string userId);
@@ -115,12 +114,6 @@ namespace Bit.Core.Abstractions
         Task SetThemeAsync(string value, string userId = null);
         Task<bool?> GetAddSitePromptShownAsync(string userId = null);
         Task SetAddSitePromptShownAsync(bool? value, string userId = null);
-        Task<bool?> GetMigratedFromV1Async(string userId = null);
-        Task SetMigratedFromV1Async(bool? value, string userId = null);
-        Task<bool?> GetMigratedFromV1AutofillPromptShownAsync(string userId = null);
-        Task SetMigratedFromV1AutofillPromptShownAsync(bool? value, string userId = null);
-        Task<bool?> GetTriedV1ResyncAsync(string userId = null);
-        Task SetTriedV1ResyncAsync(bool? value, string userId = null);
         Task<bool?> GetPushInitialPromptShownAsync();
         Task SetPushInitialPromptShownAsync(bool? value);
         Task<DateTime?> GetPushLastRegistrationDateAsync();
@@ -141,8 +134,6 @@ namespace Bit.Core.Abstractions
         Task SetAppExtensionStartedAsync(bool? value, string userId = null);
         Task<bool?> GetAppExtensionActivatedAsync(string userId = null);
         Task SetAppExtensionActivatedAsync(bool? value, string userId = null);
-        Task<string> GetAppIdAsync(string userId = null);
-        Task SetAppIdAsync(string value, string userId = null);
         Task<bool> GetUsesKeyConnectorAsync(string userId = null);
         Task SetUsesKeyConnectorAsync(bool? value, string userId = null);
         Task<Dictionary<string, OrganizationData>> GetOrganizationsAsync(string userId = null);

--- a/src/Core/Constants.cs
+++ b/src/Core/Constants.cs
@@ -5,8 +5,8 @@
         public const int MaxAccounts = 5;
         public const string AndroidAppProtocol = "androidapp://";
         public const string iOSAppProtocol = "iosapp://";
+        public static string StateVersionKey = "stateVersion";
         public static string StateKey = "state";
-        public static string AppIdKey = "appId";
         public static string PreAuthEnvironmentUrlsKey = "preAuthEnvironmentUrls";
         public static string LastFileCacheClearKey = "lastFileCacheClear";
         public static string AutofillTileAdded = "autofillTileAdded";
@@ -23,9 +23,6 @@
         public static string iOSAutoFillBiometricIntegrityKey = "iOSAutoFillBiometricIntegrityState";
         public static string iOSExtensionClearCiphersCacheKey = "iOSExtensionClearCiphersCache";
         public static string iOSExtensionBiometricIntegrityKey = "iOSExtensionBiometricIntegrityState";
-        public static string MigratedFromV1 = "migratedFromV1";
-        public static string MigratedFromV1AutofillPromptShown = "migratedV1AutofillPromptShown";
-        public static string TriedV1Resync = "triedV1Resync";
         public static string EventCollectionKey = "eventCollection";
         public static string RememberEmailKey = "rememberEmail";
         public static string RememberedEmailKey = "rememberedEmail";

--- a/src/Core/Services/AppIdService.cs
+++ b/src/Core/Services/AppIdService.cs
@@ -6,28 +6,33 @@ namespace Bit.Core.Services
 {
     public class AppIdService : IAppIdService
     {
-        private readonly IStateService _stateService;
+        private readonly IStorageService _storageService;
 
-        public AppIdService(IStateService stateService)
+        public AppIdService(IStorageService storageService)
         {
-            _stateService = stateService;
+            _storageService = storageService;
         }
 
-        public async Task<string> GetAppIdAsync()
+        public Task<string> GetAppIdAsync()
         {
-            var appId = await _stateService.GetAppIdAsync();
-            if (appId != null)
+            return MakeAndGetAppIdAsync("appId");
+        }
+
+        public Task<string> GetAnonymousAppIdAsync()
+        {
+            return MakeAndGetAppIdAsync("anonymousAppId");
+        }
+
+        private async Task<string> MakeAndGetAppIdAsync(string key)
+        {
+            var existingId = await _storageService.GetAsync<string>(key);
+            if (existingId != null)
             {
-                return appId;
+                return existingId;
             }
-            appId = MakeAppId();
-            await _stateService.SetAppIdAsync(appId);
-            return appId;
-        }
-
-        private string MakeAppId()
-        {
-            return Guid.NewGuid().ToString();
+            var guid = Guid.NewGuid().ToString();
+            await _storageService.SaveAsync(key, guid);
+            return guid;
         }
     }
 }

--- a/src/Core/Services/StateMigrationService.cs
+++ b/src/Core/Services/StateMigrationService.cs
@@ -1,0 +1,419 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading.Tasks;
+using Bit.Core.Abstractions;
+using Bit.Core.Enums;
+using Bit.Core.Models.Data;
+using Bit.Core.Models.Domain;
+using Bit.Core.Utilities;
+using Newtonsoft.Json;
+
+namespace Bit.Core.Services
+{
+    public class StateMigrationService : IStateMigrationService
+    {
+        private const int StateVersion = 3;
+
+        private readonly IStorageService _preferencesStorageService;
+        private readonly IStorageService _liteDbStorageService;
+        private readonly IStorageService _secureStorageService;
+
+        private enum Storage
+        {
+            LiteDb,
+            Prefs,
+            Secure,
+        }
+
+        public StateMigrationService(IStorageService liteDbStorageService, IStorageService preferenceStorageService,
+            IStorageService secureStorageService)
+        {
+            _liteDbStorageService = liteDbStorageService;
+            _preferencesStorageService = preferenceStorageService;
+            _secureStorageService = secureStorageService;
+        }
+
+        public async Task<bool> NeedsMigration()
+        {
+            var lastVersion = await GetLastStateVersionAsync();
+            if (lastVersion == 0)
+            {
+                // fresh install, set current/latest version for availability going forward
+                lastVersion = StateVersion;
+                await SetLastStateVersionAsync(lastVersion);
+            }
+            return lastVersion < StateVersion;
+        }
+
+        public async Task Migrate()
+        {
+            var lastVersion = await GetLastStateVersionAsync();
+            switch (lastVersion)
+            {
+                case 1:
+                    await MigrateFrom1To2Async();
+                    goto case 2;
+                case 2:
+                    await MigrateFrom2To3Async();
+                    break;
+            }
+        }
+
+        // v1 to v2 Migration
+
+        private class V1Keys
+        {
+            internal const string EnvironmentUrlsKey = "environmentUrls";
+            
+        }
+
+        private async Task MigrateFrom1To2Async()
+        {
+            // move environmentUrls from LiteDB to prefs
+            var environmentUrls = await GetValueAsync<EnvironmentUrlData>(Storage.LiteDb, V1Keys.EnvironmentUrlsKey);
+            if (environmentUrls == null)
+            {
+                throw new Exception("'environmentUrls' must be in LiteDB during migration from 1 to 2");
+            }
+            await SetValueAsync(Storage.Prefs, V2Keys.EnvironmentUrlsKey, environmentUrls);
+
+            // Update stored version
+            await SetLastStateVersionAsync(2);
+
+            // Remove old data
+            await RemoveValueAsync(Storage.LiteDb, V1Keys.EnvironmentUrlsKey);
+        }
+
+        // v2 to v3 Migration
+
+        private class V2Keys
+        {
+            internal const string SyncOnRefreshKey = "syncOnRefresh";
+            internal const string VaultTimeoutKey = "lockOption";
+            internal const string VaultTimeoutActionKey = "vaultTimeoutAction";
+            internal const string LastActiveTimeKey = "lastActiveTime";
+            internal const string BiometricUnlockKey = "fingerprintUnlock";
+            internal const string ProtectedPin = "protectedPin";
+            internal const string PinProtectedKey = "pinProtectedKey";
+            internal const string DefaultUriMatch = "defaultUriMatch";
+            internal const string DisableAutoTotpCopyKey = "disableAutoTotpCopy";
+            internal const string EnvironmentUrlsKey = "environmentUrls";
+            internal const string AutofillDisableSavePromptKey = "autofillDisableSavePrompt";
+            internal const string AutofillBlacklistedUrisKey = "autofillBlacklistedUris";
+            internal const string DisableFaviconKey = "disableFavicon";
+            internal const string ThemeKey = "theme";
+            internal const string ClearClipboardKey = "clearClipboard";
+            internal const string PreviousPageKey = "previousPage";
+            internal const string InlineAutofillEnabledKey = "inlineAutofillEnabled";
+            internal const string InvalidUnlockAttempts = "invalidUnlockAttempts";
+            internal const string PasswordRepromptAutofillKey = "passwordRepromptAutofillKey";
+            internal const string PasswordVerifiedAutofillKey = "passwordVerifiedAutofillKey";
+            internal const string MigratedFromV1 = "migratedFromV1";
+            internal const string MigratedFromV1AutofillPromptShown = "migratedV1AutofillPromptShown";
+            internal const string TriedV1Resync = "triedV1Resync";
+            internal const string Keys_UserId = "userId";
+            internal const string Keys_UserEmail = "userEmail";
+            internal const string Keys_Stamp = "securityStamp";
+            internal const string Keys_Kdf = "kdf";
+            internal const string Keys_KdfIterations = "kdfIterations";
+            internal const string Keys_EmailVerified = "emailVerified";
+            internal const string Keys_ForcePasswordReset = "forcePasswordReset";
+            internal const string Keys_AccessToken = "accessToken";
+            internal const string Keys_RefreshToken = "refreshToken";
+            internal const string Keys_LocalData = "ciphersLocalData";
+            internal const string Keys_NeverDomains = "neverDomains";
+            internal const string Keys_Key = "key";
+            internal const string Keys_EncOrgKeys = "encOrgKeys";
+            internal const string Keys_EncPrivateKey = "encPrivateKey";
+            internal const string Keys_EncKey = "encKey";
+            internal const string Keys_KeyHash = "keyHash";
+            internal const string Keys_UsesKeyConnector = "usesKeyConnector";
+            internal const string Keys_PassGenOptions = "passwordGenerationOptions";
+            internal const string Keys_PassGenHistory = "generatedPasswordHistory";
+        }
+
+        private async Task MigrateFrom2To3Async()
+        {
+            // build account and state
+            var userId = await GetValueAsync<string>(Storage.LiteDb, V2Keys.Keys_UserId);
+            var email = await GetValueAsync<string>(Storage.LiteDb, V2Keys.Keys_UserEmail);
+            string name = null;
+            var hasPremiumPersonally = false;
+            var accessToken = await GetValueAsync<string>(Storage.LiteDb, V2Keys.Keys_AccessToken);
+            if (!string.IsNullOrWhiteSpace(accessToken))
+            {
+                var tokenService = ServiceContainer.Resolve<ITokenService>("tokenService");
+                await tokenService.SetAccessTokenAsync(accessToken, true);
+
+                if (string.IsNullOrWhiteSpace(userId))
+                {
+                    userId = tokenService.GetUserId();
+                }
+                if (string.IsNullOrWhiteSpace(email))
+                {
+                    email = tokenService.GetEmail();
+                }
+                name = tokenService.GetName();
+                hasPremiumPersonally = tokenService.GetPremium();
+            }
+            if (string.IsNullOrWhiteSpace(userId))
+            {
+                throw new Exception("'userId' must be in LiteDB during migration from 2 to 3");
+            }
+
+            var kdfType = await GetValueAsync<int?>(Storage.LiteDb, V2Keys.Keys_Kdf);
+            var kdfIterations = await GetValueAsync<int?>(Storage.LiteDb, V2Keys.Keys_KdfIterations);
+            var stamp = await GetValueAsync<string>(Storage.LiteDb, V2Keys.Keys_Stamp);
+            var emailVerified = await GetValueAsync<bool?>(Storage.LiteDb, V2Keys.Keys_EmailVerified);
+            var refreshToken = await GetValueAsync<string>(Storage.LiteDb, V2Keys.Keys_RefreshToken);
+            var account = new Account(
+                new Account.AccountProfile()
+                {
+                    UserId = userId,
+                    Email = email,
+                    Name = name,
+                    Stamp = stamp,
+                    KdfType = (KdfType?)kdfType,
+                    KdfIterations = kdfIterations,
+                    EmailVerified = emailVerified,
+                    HasPremiumPersonally = hasPremiumPersonally,
+                },
+                new Account.AccountTokens()
+                {
+                    AccessToken = accessToken,
+                    RefreshToken = refreshToken,
+                }
+            );
+            var environmentUrls = await GetValueAsync<EnvironmentUrlData>(Storage.Prefs, V2Keys.EnvironmentUrlsKey);
+            var pinProtected = await GetValueAsync<string>(Storage.LiteDb, V2Keys.PinProtectedKey);
+            var vaultTimeout = await GetValueAsync<int?>(Storage.Prefs, V2Keys.VaultTimeoutKey);
+            var vaultTimeoutAction = await GetValueAsync<string>(Storage.Prefs, V2Keys.VaultTimeoutActionKey);
+            account.Settings = new Account.AccountSettings()
+            {
+                EnvironmentUrls = environmentUrls,
+                VaultTimeout = vaultTimeout,
+                VaultTimeoutAction = vaultTimeoutAction,
+            };
+            if (!string.IsNullOrWhiteSpace(pinProtected))
+            {
+                account.Settings.PinProtected = new EncString(pinProtected);
+            }
+            var state = new State { Accounts = new Dictionary<string, Account> { [userId] = account } };
+            state.ActiveUserId = userId;
+            await SetValueAsync(Storage.LiteDb, Constants.StateKey, state);
+
+            // migrate user-specific non-state data
+            var syncOnRefresh = await GetValueAsync<bool?>(Storage.LiteDb, V2Keys.SyncOnRefreshKey);
+            await SetValueAsync(Storage.LiteDb, Constants.SyncOnRefreshKey(userId), syncOnRefresh);
+            var lastActiveTime = await GetValueAsync<long?>(Storage.Prefs, V2Keys.LastActiveTimeKey);
+            await SetValueAsync(Storage.LiteDb, Constants.LastActiveTimeKey(userId), lastActiveTime);
+            var biometricUnlock = await GetValueAsync<bool?>(Storage.LiteDb, V2Keys.BiometricUnlockKey);
+            await SetValueAsync(Storage.LiteDb, Constants.BiometricUnlockKey(userId), biometricUnlock);
+            var protectedPin = await GetValueAsync<string>(Storage.LiteDb, V2Keys.ProtectedPin);
+            await SetValueAsync(Storage.LiteDb, Constants.ProtectedPinKey(userId), protectedPin);
+            var defaultUriMatch = await GetValueAsync<int?>(Storage.Prefs, V2Keys.DefaultUriMatch);
+            await SetValueAsync(Storage.LiteDb, Constants.DefaultUriMatchKey(userId), defaultUriMatch);
+            var disableAutoTotpCopy = await GetValueAsync<bool?>(Storage.Prefs, V2Keys.DisableAutoTotpCopyKey);
+            await SetValueAsync(Storage.LiteDb, Constants.DisableAutoTotpCopyKey(userId), disableAutoTotpCopy);
+            var autofillDisableSavePrompt =
+                await GetValueAsync<bool?>(Storage.Prefs, V2Keys.AutofillDisableSavePromptKey);
+            await SetValueAsync(Storage.LiteDb, Constants.AutofillDisableSavePromptKey(userId),
+                autofillDisableSavePrompt);
+            var autofillBlacklistedUris =
+                await GetValueAsync<List<string>>(Storage.LiteDb, V2Keys.AutofillBlacklistedUrisKey);
+            await SetValueAsync(Storage.LiteDb, Constants.AutofillBlacklistedUrisKey(userId), autofillBlacklistedUris);
+            var disableFavicon = await GetValueAsync<bool?>(Storage.Prefs, V2Keys.DisableFaviconKey);
+            await SetValueAsync(Storage.LiteDb, Constants.DisableFaviconKey(userId), disableFavicon);
+            var theme = await GetValueAsync<string>(Storage.Prefs, V2Keys.ThemeKey);
+            await SetValueAsync(Storage.LiteDb, Constants.ThemeKey(userId), theme);
+            var clearClipboard = await GetValueAsync<int?>(Storage.Prefs, V2Keys.ClearClipboardKey);
+            await SetValueAsync(Storage.LiteDb, Constants.ClearClipboardKey(userId), clearClipboard);
+            var previousPage = await GetValueAsync<PreviousPageInfo>(Storage.LiteDb, V2Keys.PreviousPageKey);
+            await SetValueAsync(Storage.LiteDb, Constants.PreviousPageKey(userId), previousPage);
+            var inlineAutofillEnabled = await GetValueAsync<bool?>(Storage.Prefs, V2Keys.InlineAutofillEnabledKey);
+            await SetValueAsync(Storage.LiteDb, Constants.InlineAutofillEnabledKey(userId), inlineAutofillEnabled);
+            var invalidUnlockAttempts = await GetValueAsync<int?>(Storage.Prefs, V2Keys.InvalidUnlockAttempts);
+            await SetValueAsync(Storage.LiteDb, Constants.InvalidUnlockAttemptsKey(userId), invalidUnlockAttempts);
+            var passwordRepromptAutofill =
+                await GetValueAsync<bool?>(Storage.LiteDb, V2Keys.PasswordRepromptAutofillKey);
+            await SetValueAsync(Storage.LiteDb, Constants.PasswordRepromptAutofillKey(userId),
+                passwordRepromptAutofill);
+            var passwordVerifiedAutofill =
+                await GetValueAsync<bool?>(Storage.LiteDb, V2Keys.PasswordVerifiedAutofillKey);
+            await SetValueAsync(Storage.LiteDb, Constants.PasswordVerifiedAutofillKey(userId),
+                passwordVerifiedAutofill);
+            var forcePasswordReset = await GetValueAsync<bool?>(Storage.LiteDb, V2Keys.Keys_ForcePasswordReset);
+            await SetValueAsync(Storage.LiteDb, Constants.ForcePasswordResetKey(userId), forcePasswordReset);
+            var cipherLocalData = await GetValueAsync<Dictionary<string, Dictionary<string, object>>>(Storage.LiteDb,
+                V2Keys.Keys_LocalData);
+            await SetValueAsync(Storage.LiteDb, Constants.LocalDataKey(userId), cipherLocalData);
+            var neverDomains = await GetValueAsync<HashSet<string>>(Storage.LiteDb, V2Keys.Keys_NeverDomains);
+            await SetValueAsync(Storage.LiteDb, Constants.NeverDomainsKey(userId), neverDomains);
+            var key = await GetValueAsync<string>(Storage.Secure, V2Keys.Keys_Key);
+            await SetValueAsync(Storage.Secure, Constants.KeyKey(userId), key);
+            var encOrgKeys = await GetValueAsync<Dictionary<string, string>>(Storage.LiteDb, V2Keys.Keys_EncOrgKeys);
+            await SetValueAsync(Storage.LiteDb, Constants.EncOrgKeysKey(userId), encOrgKeys);
+            var encPrivateKey = await GetValueAsync<string>(Storage.LiteDb, V2Keys.Keys_EncPrivateKey);
+            await SetValueAsync(Storage.LiteDb, Constants.EncPrivateKeyKey(userId), encPrivateKey);
+            var encKey = await GetValueAsync<string>(Storage.LiteDb, V2Keys.Keys_EncKey);
+            await SetValueAsync(Storage.LiteDb, Constants.EncKeyKey(userId), encKey);
+            var keyHash = await GetValueAsync<string>(Storage.LiteDb, V2Keys.Keys_KeyHash);
+            await SetValueAsync(Storage.LiteDb, Constants.KeyHashKey(userId), keyHash);
+            var usesKeyConnector = await GetValueAsync<bool?>(Storage.LiteDb, V2Keys.Keys_UsesKeyConnector);
+            await SetValueAsync(Storage.LiteDb, Constants.UsesKeyConnectorKey(userId), usesKeyConnector);
+            var passGenOptions =
+                await GetValueAsync<PasswordGenerationOptions>(Storage.LiteDb, V2Keys.Keys_PassGenOptions);
+            await SetValueAsync(Storage.LiteDb, Constants.PassGenOptionsKey(userId), passGenOptions);
+            var passGenHistory =
+                await GetValueAsync<List<GeneratedPasswordHistory>>(Storage.LiteDb, V2Keys.Keys_PassGenHistory);
+            await SetValueAsync(Storage.LiteDb, Constants.PassGenHistoryKey(userId), passGenHistory);
+
+            // migrate global non-state data
+            await SetValueAsync(Storage.Prefs, Constants.PreAuthEnvironmentUrlsKey, environmentUrls);
+
+            // Update stored version
+            await SetLastStateVersionAsync(3);
+
+            // Remove old data
+            await RemoveValueAsync(Storage.LiteDb, V2Keys.Keys_UserId);
+            await RemoveValueAsync(Storage.LiteDb, V2Keys.Keys_UserEmail);
+            await RemoveValueAsync(Storage.LiteDb, V2Keys.Keys_AccessToken);
+            await RemoveValueAsync(Storage.LiteDb, V2Keys.Keys_RefreshToken);
+            await RemoveValueAsync(Storage.LiteDb, V2Keys.Keys_Kdf);
+            await RemoveValueAsync(Storage.LiteDb, V2Keys.Keys_KdfIterations);
+            await RemoveValueAsync(Storage.LiteDb, V2Keys.Keys_Stamp);
+            await RemoveValueAsync(Storage.LiteDb, V2Keys.Keys_EmailVerified);
+            await RemoveValueAsync(Storage.LiteDb, V2Keys.Keys_ForcePasswordReset);
+            await RemoveValueAsync(Storage.Prefs, V2Keys.EnvironmentUrlsKey);
+            await RemoveValueAsync(Storage.LiteDb, V2Keys.PinProtectedKey);
+            await RemoveValueAsync(Storage.Prefs, V2Keys.VaultTimeoutKey);
+            await RemoveValueAsync(Storage.Prefs, V2Keys.VaultTimeoutActionKey);
+            await RemoveValueAsync(Storage.LiteDb, V2Keys.SyncOnRefreshKey);
+            await RemoveValueAsync(Storage.Prefs, V2Keys.LastActiveTimeKey);
+            await RemoveValueAsync(Storage.LiteDb, V2Keys.BiometricUnlockKey);
+            await RemoveValueAsync(Storage.LiteDb, V2Keys.ProtectedPin);
+            await RemoveValueAsync(Storage.Prefs, V2Keys.DefaultUriMatch);
+            await RemoveValueAsync(Storage.Prefs, V2Keys.DisableAutoTotpCopyKey);
+            await RemoveValueAsync(Storage.Prefs, V2Keys.AutofillDisableSavePromptKey);
+            await RemoveValueAsync(Storage.LiteDb, V2Keys.AutofillBlacklistedUrisKey);
+            await RemoveValueAsync(Storage.Prefs, V2Keys.DisableFaviconKey);
+            await RemoveValueAsync(Storage.Prefs, V2Keys.ThemeKey);
+            await RemoveValueAsync(Storage.Prefs, V2Keys.ClearClipboardKey);
+            await RemoveValueAsync(Storage.LiteDb, V2Keys.PreviousPageKey);
+            await RemoveValueAsync(Storage.Prefs, V2Keys.InlineAutofillEnabledKey);
+            await RemoveValueAsync(Storage.Prefs, V2Keys.InvalidUnlockAttempts);
+            await RemoveValueAsync(Storage.LiteDb, V2Keys.PasswordRepromptAutofillKey);
+            await RemoveValueAsync(Storage.LiteDb, V2Keys.PasswordVerifiedAutofillKey);
+            await RemoveValueAsync(Storage.Prefs, V2Keys.MigratedFromV1);
+            await RemoveValueAsync(Storage.Prefs, V2Keys.MigratedFromV1AutofillPromptShown);
+            await RemoveValueAsync(Storage.Prefs, V2Keys.TriedV1Resync);
+            await RemoveValueAsync(Storage.LiteDb, V2Keys.Keys_LocalData);
+            await RemoveValueAsync(Storage.LiteDb, V2Keys.Keys_NeverDomains);
+            await RemoveValueAsync(Storage.Secure, V2Keys.Keys_Key);
+            await RemoveValueAsync(Storage.LiteDb, V2Keys.Keys_EncOrgKeys);
+            await RemoveValueAsync(Storage.LiteDb, V2Keys.Keys_EncPrivateKey);
+            await RemoveValueAsync(Storage.LiteDb, V2Keys.Keys_EncKey);
+            await RemoveValueAsync(Storage.LiteDb, V2Keys.Keys_KeyHash);
+            await RemoveValueAsync(Storage.LiteDb, V2Keys.Keys_UsesKeyConnector);
+            await RemoveValueAsync(Storage.LiteDb, V2Keys.Keys_PassGenOptions);
+            await RemoveValueAsync(Storage.LiteDb, V2Keys.Keys_PassGenHistory);
+        }
+
+        // Helpers
+
+        private async Task<int> GetLastStateVersionAsync()
+        {
+            var lastVersion = await GetValueAsync<int?>(Storage.Prefs, Constants.StateVersionKey);
+            if (lastVersion != null)
+            {
+                return lastVersion.Value;
+            }
+
+            // check for original v1 migration 
+            var envUrlsLiteDb = await GetValueAsync<EnvironmentUrlData>(Storage.LiteDb, V1Keys.EnvironmentUrlsKey);
+            if (envUrlsLiteDb != null)
+            {
+                // environmentUrls still in LiteDB (never migrated to prefs), this is v1
+                return 1;
+            }
+
+            // check for original v2 migration
+            var envUrlsPrefs = await GetValueAsync<EnvironmentUrlData>(Storage.Prefs, V2Keys.EnvironmentUrlsKey);
+            if (envUrlsPrefs != null)
+            {
+                // environmentUrls in Prefs (migrated from LiteDB), this is v2
+                return 2;
+            }
+
+            // this is a fresh install
+            return 0;
+        }
+
+        private async Task SetLastStateVersionAsync(int value)
+        {
+            await SetValueAsync(Storage.Prefs, Constants.StateVersionKey, value);
+        }
+
+        private async Task<T> GetValueAsync<T>(Storage storage, string key)
+        {
+            var value = await GetStorageService(storage).GetAsync<T>(key);
+            Log("GET", storage, key, JsonConvert.SerializeObject(value));
+            return value;
+        }
+
+        private async Task SetValueAsync<T>(Storage storage, string key, T value)
+        {
+            if (value == null)
+            {
+                await RemoveValueAsync(storage, key);
+                return;
+            }
+            Log("SET", storage, key, JsonConvert.SerializeObject(value));
+            await GetStorageService(storage).SaveAsync(key, value);
+        }
+
+        private async Task RemoveValueAsync(Storage storage, string key)
+        {
+            Log("REMOVE", storage, key, null);
+            await GetStorageService(storage).RemoveAsync(key);
+        }
+
+        private IStorageService GetStorageService(Storage storage)
+        {
+            switch (storage)
+            {
+                case Storage.Secure:
+                    return _secureStorageService;
+                case Storage.Prefs:
+                    return _preferencesStorageService;
+                default:
+                    return _liteDbStorageService;
+            }
+        }
+
+        private void Log(string tag, Storage storage, string key, string value)
+        {
+            // TODO Remove this once all bugs are squished
+            string text;
+            switch (storage)
+            {
+                case Storage.Secure:
+                    text = "SECURE / ";
+                    break;
+                case Storage.Prefs:
+                    text = "PREFS / ";
+                    break;
+                default:
+                    text = "LITEDB / ";
+                    break;
+            }
+            text += "Key: " + key + " / ";
+            if (value != null)
+            {
+                text += "Value: " + value;
+            }
+            Debug.WriteLine(text, ">>> " + tag);
+        }
+    }
+}

--- a/src/Core/Utilities/ServiceContainer.cs
+++ b/src/Core/Utilities/ServiceContainer.cs
@@ -35,7 +35,7 @@ namespace Bit.Core.Utilities
                 messagingService.Send("logout", extras);
                 return Task.FromResult(0);
             }, customUserAgent);
-            var appIdService = new AppIdService(stateService);
+            var appIdService = new AppIdService(storageService);
             var organizationService = new OrganizationService(stateService);
             var settingsService = new SettingsService(stateService);
             var fileUploadService = new FileUploadService(apiService);

--- a/src/iOS.Core/Utilities/iOSCoreHelpers.cs
+++ b/src/iOS.Core/Utilities/iOSCoreHelpers.cs
@@ -53,6 +53,8 @@ namespace Bit.iOS.Core.Utilities
             var cryptoPrimitiveService = new CryptoPrimitiveService();
             var mobileStorageService = new MobileStorageService(preferencesStorage, liteDbStorage);
             var stateService = new StateService(mobileStorageService, secureStorageService);
+            var stateMigrationService =
+                new StateMigrationService(liteDbStorage, preferencesStorage, secureStorageService);
             var deviceActionService = new DeviceActionService(stateService, messagingService);
             var clipboardService = new ClipboardService(stateService);
             var platformUtilsService = new MobilePlatformUtilsService(deviceActionService, messagingService,
@@ -70,6 +72,7 @@ namespace Bit.iOS.Core.Utilities
             ServiceContainer.Register<IStorageService>("storageService", mobileStorageService);
             ServiceContainer.Register<IStorageService>("secureStorageService", secureStorageService);
             ServiceContainer.Register<IStateService>("stateService", stateService);
+            ServiceContainer.Register<IStateMigrationService>("stateMigrationService", stateMigrationService);
             ServiceContainer.Register<IDeviceActionService>("deviceActionService", deviceActionService);
             ServiceContainer.Register<IClipboardService>("clipboardService", clipboardService);
             ServiceContainer.Register<IPlatformUtilsService>("platformUtilsService", platformUtilsService);


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Migrate existing user data to the new multi-account storage pattern upon app update.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **MainApplication.cs:** Init `StateMigrationService` with the required storage services
* **LockPage.xaml.cs:** Remove avatar appearance condition since it will always been shown here
* **GroupingsPage.xaml.xs:** Remove old v1-to-v2 migration code (some of which was moved to `StateMigrationService`)
* **BaseContentPage.cs:** Change avatar appearance condition to the presence of any active account, which should only ever be false before the very first login
* **MobileStorageService.cs:** Remove old migration keys & logic, add key for state version
* **AppIdService.cs:** Reverted to pre-multi-account state due to infinite loop during migration when it was using the state service (this particular value isn't user-specific so it's ok if it isn't managed by the state service)
* **StateMigrationService.cs:** Service that performs the migration.  As the mobile app had a previous migration, that was moved here as the "1 to 2" migration.  The multi-account migration was added as "2 to 3".
* **StateService.cs:** Removed unused methods, added migration check and trigger, changed ProtectedPin to default storage (was never in secure storage), changed account removal to clean house since it felt dirty to have settings restored when logging back in after previously removing an account (doesn't apply to logout as a vault timeout action), set new account theme to the current theme to avoid the jarring effect of possible theme change when adding a new account
* **ServiceContainer.cs:** Restore storageService to appIdService
* **Constants.cs:** Add/remove appropriate keys
* **iOSCoreHelpers.cs:** Init `StateMigrationService` with the required storage services

## Testing requirements
<!--What functionality requires testing by QA? This includes testing new behavior and regression testing-->
Create account with previous (non-account-switching build) then update to account switching build and confirm all data and settings is still intact


## Before you submit
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
