### PR TITLE
Account Switching Tap to dismiss

### DIFF
--- a/src/App/Pages/Accounts/HomePage.xaml
+++ b/src/App/Pages/Accounts/HomePage.xaml
@@ -80,7 +80,7 @@
 
             <StackLayout
                 x:Name="_accountListContainer"
-                VerticalOptions="StartAndExpand"
+                VerticalOptions="Fill"
                 HorizontalOptions="FillAndExpand"
                 BackgroundColor="{DynamicResource BackgroundColor}"
                 xct:ShadowEffect.Color="Black"
@@ -91,7 +91,7 @@
                     ItemsSource="{Binding AccountViews}"
                     ItemSelected="AccountRow_Selected"
                     BackgroundColor="Transparent"
-                    VerticalOptions="FillAndExpand"
+                    VerticalOptions="Start"
                     RowHeight="{OnPlatform 70, iOS=70, Android=74}">
                     <ListView.ItemTemplate>
                         <DataTemplate x:DataType="view:AccountView">
@@ -100,6 +100,14 @@
                         </DataTemplate>
                     </ListView.ItemTemplate>
                 </ListView>
+                <BoxView
+                    Background="Transparent"
+                    HorizontalOptions="Fill"
+                    VerticalOptions="FillAndExpand">
+                    <BoxView.GestureRecognizers>
+                        <TapGestureRecognizer Tapped="AccountSwitchingOverlay_Tapped" />
+                    </BoxView.GestureRecognizers>
+                </BoxView>
             </StackLayout>
         </ContentView>
     </AbsoluteLayout>

--- a/src/App/Pages/Accounts/HomePage.xaml
+++ b/src/App/Pages/Accounts/HomePage.xaml
@@ -82,26 +82,31 @@
                 x:Name="_accountListContainer"
                 VerticalOptions="Fill"
                 HorizontalOptions="FillAndExpand"
-                BackgroundColor="Transparent"
-                xct:ShadowEffect.Color="Black"
-                xct:ShadowEffect.Radius="10"
-                xct:ShadowEffect.OffsetY="3">
-                <ListView
-                    x:Name="_accountListView"
-                    ItemsSource="{Binding AccountViews}"
-                    ItemSelected="AccountRow_Selected"
-                    BackgroundColor="{DynamicResource BackgroundColor}"
+                BackgroundColor="Transparent">
+                <Frame
+                    Padding="0"
+                    HorizontalOptions="Fill"
                     VerticalOptions="Start"
-                    RowHeight="{OnPlatform 70, iOS=70, Android=74}">
-                    <ListView.ItemTemplate>
-                        <DataTemplate x:DataType="view:AccountView">
-                            <controls:AccountViewCell
-                                Account="{Binding .}" />
-                        </DataTemplate>
-                    </ListView.ItemTemplate>
-                </ListView>
+                    xct:ShadowEffect.Color="Black"
+                    xct:ShadowEffect.Radius="10"
+                    xct:ShadowEffect.OffsetY="3">
+                    <ListView
+                        x:Name="_accountListView"
+                        ItemsSource="{Binding AccountViews}"
+                        ItemSelected="AccountRow_Selected"
+                        BackgroundColor="{DynamicResource BackgroundColor}"
+                        VerticalOptions="Start"
+                        RowHeight="{OnPlatform 70, iOS=70, Android=74}">
+                        <ListView.ItemTemplate>
+                            <DataTemplate x:DataType="view:AccountView">
+                                <controls:AccountViewCell
+                                    Account="{Binding .}" />
+                            </DataTemplate>
+                        </ListView.ItemTemplate>
+                    </ListView>
+                </Frame>
                 <BoxView
-                    Background="Transparent"
+                    BackgroundColor="Transparent"
                     HorizontalOptions="Fill"
                     VerticalOptions="FillAndExpand">
                     <BoxView.GestureRecognizers>

--- a/src/App/Pages/Accounts/HomePage.xaml
+++ b/src/App/Pages/Accounts/HomePage.xaml
@@ -82,7 +82,7 @@
                 x:Name="_accountListContainer"
                 VerticalOptions="Fill"
                 HorizontalOptions="FillAndExpand"
-                BackgroundColor="{DynamicResource BackgroundColor}"
+                BackgroundColor="Transparent"
                 xct:ShadowEffect.Color="Black"
                 xct:ShadowEffect.Radius="10"
                 xct:ShadowEffect.OffsetY="3">
@@ -90,7 +90,7 @@
                     x:Name="_accountListView"
                     ItemsSource="{Binding AccountViews}"
                     ItemSelected="AccountRow_Selected"
-                    BackgroundColor="Transparent"
+                    BackgroundColor="{DynamicResource BackgroundColor}"
                     VerticalOptions="Start"
                     RowHeight="{OnPlatform 70, iOS=70, Android=74}">
                     <ListView.ItemTemplate>

--- a/src/App/Pages/Accounts/HomePage.xaml.cs
+++ b/src/App/Pages/Accounts/HomePage.xaml.cs
@@ -2,9 +2,13 @@
 using Bit.App.Utilities;
 using Bit.Core.Abstractions;
 using Bit.Core.Utilities;
+#if !FDROID
+using Microsoft.AppCenter.Crashes;
+#endif
 using System;
 using System.Threading.Tasks;
 using Xamarin.Forms;
+
 
 namespace Bit.App.Pages
 {
@@ -143,20 +147,44 @@ namespace Bit.App.Pages
 
         private async void AccountSwitch_Clicked(object sender, EventArgs e)
         {
-            if (_accountListOverlay.IsVisible)
+            try
             {
-                await ShowAccountListAsync(false, _accountListContainer, _accountListOverlay);
+                await ToggleAccountListAsync(_accountListContainer, _accountListOverlay, _accountListView, false);
             }
-            else
+            catch (Exception ex)
             {
-                await RefreshAccountViewsAsync(_accountListView, false);
-                await ShowAccountListAsync(true, _accountListContainer, _accountListOverlay);
+#if !FDROID
+                Crashes.TrackError(ex);
+#endif
             }
         }
 
         private async void AccountRow_Selected(object sender, SelectedItemChangedEventArgs e)
         {
-            await AccountRowSelectedAsync(sender, e, _accountListContainer, _accountListOverlay, null, true);
+            try
+            {
+                await AccountRowSelectedAsync(sender, e, _accountListContainer, _accountListOverlay, null, true);
+            }
+            catch (Exception ex)
+            {
+#if !FDROID
+                Crashes.TrackError(ex);
+#endif
+            }
+        }
+
+        private async void AccountSwitchingOverlay_Tapped(object sender, EventArgs e)
+        {
+            try
+            {
+                await HideAccountListAsync(_accountListContainer, _accountListOverlay);
+            }
+            catch (Exception ex)
+            {
+#if !FDROID
+                Crashes.TrackError(ex);
+#endif
+            }
         }
     }
 }

--- a/src/App/Pages/Accounts/LockPage.xaml
+++ b/src/App/Pages/Accounts/LockPage.xaml
@@ -173,9 +173,9 @@
             Padding="0">
             <StackLayout
                 x:Name="_accountListContainer"
+                Background="Transparent"
                 VerticalOptions="Fill"
                 HorizontalOptions="FillAndExpand"
-                BackgroundColor="{DynamicResource BackgroundColor}"
                 Orientation="Vertical"
                 xct:ShadowEffect.Color="Black"
                 xct:ShadowEffect.Radius="10"
@@ -184,7 +184,7 @@
                     x:Name="_accountListView"
                     ItemsSource="{Binding AccountViews}"
                     ItemSelected="AccountRow_Selected"
-                    BackgroundColor="Transparent"
+                    BackgroundColor="{DynamicResource BackgroundColor}"
                     VerticalOptions="Start"
                     RowHeight="{OnPlatform 70, iOS=70, Android=74}">
                     <ListView.ItemTemplate>

--- a/src/App/Pages/Accounts/LockPage.xaml
+++ b/src/App/Pages/Accounts/LockPage.xaml
@@ -171,12 +171,12 @@
             IsVisible="False"
             BackgroundColor="#22000000"
             Padding="0">
-
             <StackLayout
                 x:Name="_accountListContainer"
-                VerticalOptions="StartAndExpand"
+                VerticalOptions="Fill"
                 HorizontalOptions="FillAndExpand"
                 BackgroundColor="{DynamicResource BackgroundColor}"
+                Orientation="Vertical"
                 xct:ShadowEffect.Color="Black"
                 xct:ShadowEffect.Radius="10"
                 xct:ShadowEffect.OffsetY="3">
@@ -185,7 +185,7 @@
                     ItemsSource="{Binding AccountViews}"
                     ItemSelected="AccountRow_Selected"
                     BackgroundColor="Transparent"
-                    VerticalOptions="FillAndExpand"
+                    VerticalOptions="Start"
                     RowHeight="{OnPlatform 70, iOS=70, Android=74}">
                     <ListView.ItemTemplate>
                         <DataTemplate x:DataType="view:AccountView">
@@ -194,6 +194,14 @@
                         </DataTemplate>
                     </ListView.ItemTemplate>
                 </ListView>
+                <BoxView
+                    Background="Transparent"
+                    HorizontalOptions="Fill"
+                    VerticalOptions="FillAndExpand">
+                    <BoxView.GestureRecognizers>
+                        <TapGestureRecognizer Tapped="AccountSwitchingOverlay_Tapped" />
+                    </BoxView.GestureRecognizers>
+                </BoxView>
             </StackLayout>
         </ContentView>
     </AbsoluteLayout>

--- a/src/App/Pages/Accounts/LockPage.xaml
+++ b/src/App/Pages/Accounts/LockPage.xaml
@@ -173,29 +173,34 @@
             Padding="0">
             <StackLayout
                 x:Name="_accountListContainer"
-                Background="Transparent"
+                BackgroundColor="Transparent"
                 VerticalOptions="Fill"
                 HorizontalOptions="FillAndExpand"
-                Orientation="Vertical"
-                xct:ShadowEffect.Color="Black"
-                xct:ShadowEffect.Radius="10"
-                xct:ShadowEffect.OffsetY="3">
-                <ListView
-                    x:Name="_accountListView"
-                    ItemsSource="{Binding AccountViews}"
-                    ItemSelected="AccountRow_Selected"
-                    BackgroundColor="{DynamicResource BackgroundColor}"
+                Orientation="Vertical">
+                <Frame
+                    Padding="0"
+                    HorizontalOptions="Fill"
                     VerticalOptions="Start"
-                    RowHeight="{OnPlatform 70, iOS=70, Android=74}">
-                    <ListView.ItemTemplate>
-                        <DataTemplate x:DataType="view:AccountView">
-                            <controls:AccountViewCell
-                                Account="{Binding .}" />
-                        </DataTemplate>
-                    </ListView.ItemTemplate>
-                </ListView>
+                    xct:ShadowEffect.Color="Black"
+                    xct:ShadowEffect.Radius="10"
+                    xct:ShadowEffect.OffsetY="3">
+                    <ListView
+                        x:Name="_accountListView"
+                        ItemsSource="{Binding AccountViews}"
+                        ItemSelected="AccountRow_Selected"
+                        BackgroundColor="{DynamicResource BackgroundColor}"
+                        VerticalOptions="Start"
+                        RowHeight="{OnPlatform 70, iOS=70, Android=74}">
+                        <ListView.ItemTemplate>
+                            <DataTemplate x:DataType="view:AccountView">
+                                <controls:AccountViewCell
+                                    Account="{Binding .}" />
+                            </DataTemplate>
+                        </ListView.ItemTemplate>
+                    </ListView>
+                </Frame>
                 <BoxView
-                    Background="Transparent"
+                    BackgroundColor="Transparent"
                     HorizontalOptions="Fill"
                     VerticalOptions="FillAndExpand">
                     <BoxView.GestureRecognizers>

--- a/src/App/Pages/Accounts/LockPage.xaml.cs
+++ b/src/App/Pages/Accounts/LockPage.xaml.cs
@@ -3,6 +3,9 @@ using System.Threading.Tasks;
 using Bit.App.Models;
 using Bit.App.Resources;
 using Bit.App.Utilities;
+#if !FDROID
+using Microsoft.AppCenter.Crashes;
+#endif
 using Xamarin.Forms;
 
 namespace Bit.App.Pages
@@ -170,20 +173,44 @@ namespace Bit.App.Pages
 
         private async void AccountSwitch_Clicked(object sender, EventArgs e)
         {
-            if (_accountListOverlay.IsVisible)
+            try
             {
-                await ShowAccountListAsync(false, _accountListContainer, _accountListOverlay);
+                await ToggleAccountListAsync(_accountListContainer, _accountListOverlay, _accountListView, true);
             }
-            else
+            catch (Exception ex)
             {
-                await RefreshAccountViewsAsync(_accountListView, true);
-                await ShowAccountListAsync(true, _accountListContainer, _accountListOverlay);
+#if !FDROID
+                Crashes.TrackError(ex);
+#endif
             }
         }
 
         private async void AccountRow_Selected(object sender, SelectedItemChangedEventArgs e)
         {
-            await AccountRowSelectedAsync(sender, e, _accountListContainer, _accountListOverlay, null, true);
+            try
+            {
+                await AccountRowSelectedAsync(sender, e, _accountListContainer, _accountListOverlay, null, true);
+            }
+            catch (Exception ex)
+            {
+#if !FDROID
+                Crashes.TrackError(ex);
+#endif
+            }
+        }
+
+        private async void AccountSwitchingOverlay_Tapped(object sender, EventArgs e)
+        {
+            try
+            {
+                await HideAccountListAsync(_accountListContainer, _accountListOverlay);
+            }
+            catch (Exception ex)
+            {
+#if !FDROID
+                Crashes.TrackError(ex);
+#endif
+            }
         }
     }
 }

--- a/src/App/Pages/Accounts/LoginPage.xaml
+++ b/src/App/Pages/Accounts/LoginPage.xaml
@@ -125,7 +125,7 @@
                 x:Name="_accountListContainer"
                 VerticalOptions="Fill"
                 HorizontalOptions="FillAndExpand"
-                BackgroundColor="{DynamicResource BackgroundColor}"
+                BackgroundColor="Transparent"
                 xct:ShadowEffect.Color="Black"
                 xct:ShadowEffect.Radius="10"
                 xct:ShadowEffect.OffsetY="3">
@@ -133,7 +133,7 @@
                     x:Name="_accountListView"
                     ItemsSource="{Binding AccountViews}"
                     ItemSelected="AccountRow_Selected"
-                    BackgroundColor="Transparent"
+                    BackgroundColor="{DynamicResource BackgroundColor}"
                     VerticalOptions="Start"
                     RowHeight="{OnPlatform 70, iOS=70, Android=74}">
                     <ListView.ItemTemplate>

--- a/src/App/Pages/Accounts/LoginPage.xaml
+++ b/src/App/Pages/Accounts/LoginPage.xaml
@@ -123,7 +123,7 @@
 
             <StackLayout
                 x:Name="_accountListContainer"
-                VerticalOptions="StartAndExpand"
+                VerticalOptions="Fill"
                 HorizontalOptions="FillAndExpand"
                 BackgroundColor="{DynamicResource BackgroundColor}"
                 xct:ShadowEffect.Color="Black"
@@ -134,7 +134,7 @@
                     ItemsSource="{Binding AccountViews}"
                     ItemSelected="AccountRow_Selected"
                     BackgroundColor="Transparent"
-                    VerticalOptions="FillAndExpand"
+                    VerticalOptions="Start"
                     RowHeight="{OnPlatform 70, iOS=70, Android=74}">
                     <ListView.ItemTemplate>
                         <DataTemplate x:DataType="view:AccountView">
@@ -143,6 +143,14 @@
                         </DataTemplate>
                     </ListView.ItemTemplate>
                 </ListView>
+                <BoxView
+                    Background="Transparent"
+                    HorizontalOptions="Fill"
+                    VerticalOptions="FillAndExpand">
+                    <BoxView.GestureRecognizers>
+                        <TapGestureRecognizer Tapped="AccountSwitchingOverlay_Tapped" />
+                    </BoxView.GestureRecognizers>
+                </BoxView>
             </StackLayout>
         </ContentView>
     </AbsoluteLayout>

--- a/src/App/Pages/Accounts/LoginPage.xaml
+++ b/src/App/Pages/Accounts/LoginPage.xaml
@@ -125,26 +125,31 @@
                 x:Name="_accountListContainer"
                 VerticalOptions="Fill"
                 HorizontalOptions="FillAndExpand"
-                BackgroundColor="Transparent"
-                xct:ShadowEffect.Color="Black"
-                xct:ShadowEffect.Radius="10"
-                xct:ShadowEffect.OffsetY="3">
-                <ListView
-                    x:Name="_accountListView"
-                    ItemsSource="{Binding AccountViews}"
-                    ItemSelected="AccountRow_Selected"
-                    BackgroundColor="{DynamicResource BackgroundColor}"
+                BackgroundColor="Transparent">
+                <Frame
+                    Padding="0"
+                    HorizontalOptions="Fill"
                     VerticalOptions="Start"
-                    RowHeight="{OnPlatform 70, iOS=70, Android=74}">
-                    <ListView.ItemTemplate>
-                        <DataTemplate x:DataType="view:AccountView">
-                            <controls:AccountViewCell
-                                Account="{Binding .}" />
-                        </DataTemplate>
-                    </ListView.ItemTemplate>
-                </ListView>
+                    xct:ShadowEffect.Color="Black"
+                    xct:ShadowEffect.Radius="10"
+                    xct:ShadowEffect.OffsetY="3">
+                    <ListView
+                        x:Name="_accountListView"
+                        ItemsSource="{Binding AccountViews}"
+                        ItemSelected="AccountRow_Selected"
+                        BackgroundColor="{DynamicResource BackgroundColor}"
+                        VerticalOptions="Start"
+                        RowHeight="{OnPlatform 70, iOS=70, Android=74}">
+                        <ListView.ItemTemplate>
+                            <DataTemplate x:DataType="view:AccountView">
+                                <controls:AccountViewCell
+                                    Account="{Binding .}" />
+                            </DataTemplate>
+                        </ListView.ItemTemplate>
+                    </ListView>
+                </Frame>
                 <BoxView
-                    Background="Transparent"
+                    BackgroundColor="Transparent"
                     HorizontalOptions="Fill"
                     VerticalOptions="FillAndExpand">
                     <BoxView.GestureRecognizers>

--- a/src/App/Pages/Accounts/LoginPage.xaml.cs
+++ b/src/App/Pages/Accounts/LoginPage.xaml.cs
@@ -4,6 +4,9 @@ using System;
 using System.Threading.Tasks;
 using Bit.App.Utilities;
 using Xamarin.Forms;
+#if !FDROID
+using Microsoft.AppCenter.Crashes;
+#endif
 
 namespace Bit.App.Pages
 {
@@ -148,20 +151,44 @@ namespace Bit.App.Pages
 
         private async void AccountSwitch_Clicked(object sender, EventArgs e)
         {
-            if (_accountListOverlay.IsVisible)
+            try
             {
-                await ShowAccountListAsync(false, _accountListContainer, _accountListOverlay);
+                await ToggleAccountListAsync(_accountListContainer, _accountListOverlay, _accountListView, false);
             }
-            else
+            catch (Exception ex)
             {
-                await RefreshAccountViewsAsync(_accountListView, false);
-                await ShowAccountListAsync(true, _accountListContainer, _accountListOverlay);
+#if !FDROID
+                Crashes.TrackError(ex);
+#endif
             }
         }
 
         private async void AccountRow_Selected(object sender, SelectedItemChangedEventArgs e)
         {
-            await AccountRowSelectedAsync(sender, e, _accountListContainer, _accountListOverlay, null, true);
+            try
+            {
+                await AccountRowSelectedAsync(sender, e, _accountListContainer, _accountListOverlay, null, true);
+            }
+            catch (Exception ex)
+            {
+#if !FDROID
+                Crashes.TrackError(ex);
+#endif
+            }
+        }
+
+        private async void AccountSwitchingOverlay_Tapped(object sender, EventArgs e)
+        {
+            try
+            {
+                await HideAccountListAsync(_accountListContainer, _accountListOverlay);
+            }
+            catch (Exception ex)
+            {
+#if !FDROID
+                Crashes.TrackError(ex);
+#endif
+            }
         }
     }
 }

--- a/src/App/Pages/Vault/GroupingsPage/GroupingsPage.xaml
+++ b/src/App/Pages/Vault/GroupingsPage/GroupingsPage.xaml
@@ -175,7 +175,7 @@
                 x:Name="_accountListContainer"
                 VerticalOptions="Fill"
                 HorizontalOptions="FillAndExpand"
-                BackgroundColor="{DynamicResource BackgroundColor}"
+                Background="Transparent"
                 xct:ShadowEffect.Color="Black"
                 xct:ShadowEffect.Radius="10"
                 xct:ShadowEffect.OffsetY="3">
@@ -183,7 +183,7 @@
                     x:Name="_accountListView"
                     ItemsSource="{Binding AccountViews}"
                     ItemSelected="AccountRow_Selected"
-                    BackgroundColor="Transparent"
+                    BackgroundColor="{DynamicResource BackgroundColor}"
                     VerticalOptions="Start"
                     RowHeight="{OnPlatform 70, iOS=70, Android=74}">
                     <ListView.ItemTemplate>

--- a/src/App/Pages/Vault/GroupingsPage/GroupingsPage.xaml
+++ b/src/App/Pages/Vault/GroupingsPage/GroupingsPage.xaml
@@ -175,26 +175,31 @@
                 x:Name="_accountListContainer"
                 VerticalOptions="Fill"
                 HorizontalOptions="FillAndExpand"
-                Background="Transparent"
-                xct:ShadowEffect.Color="Black"
-                xct:ShadowEffect.Radius="10"
-                xct:ShadowEffect.OffsetY="3">
-                <ListView
-                    x:Name="_accountListView"
-                    ItemsSource="{Binding AccountViews}"
-                    ItemSelected="AccountRow_Selected"
-                    BackgroundColor="{DynamicResource BackgroundColor}"
+                BackgroundColor="Transparent">
+                <Frame
+                    Padding="0"
+                    HorizontalOptions="Fill"
                     VerticalOptions="Start"
-                    RowHeight="{OnPlatform 70, iOS=70, Android=74}">
-                    <ListView.ItemTemplate>
-                        <DataTemplate x:DataType="view:AccountView">
-                            <controls:AccountViewCell
-                                Account="{Binding .}" />
-                        </DataTemplate>
-                    </ListView.ItemTemplate>
-                </ListView>
+                    xct:ShadowEffect.Color="Black"
+                    xct:ShadowEffect.Radius="10"
+                    xct:ShadowEffect.OffsetY="3">
+                    <ListView
+                        x:Name="_accountListView"
+                        ItemsSource="{Binding AccountViews}"
+                        ItemSelected="AccountRow_Selected"
+                        BackgroundColor="{DynamicResource BackgroundColor}"
+                        VerticalOptions="Start"
+                        RowHeight="{OnPlatform 70, iOS=70, Android=74}">
+                        <ListView.ItemTemplate>
+                            <DataTemplate x:DataType="view:AccountView">
+                                <controls:AccountViewCell
+                                    Account="{Binding .}" />
+                            </DataTemplate>
+                        </ListView.ItemTemplate>
+                    </ListView>
+                </Frame>
                 <BoxView
-                    Background="Transparent"
+                    BackgroundColor="Transparent"
                     HorizontalOptions="Fill"
                     VerticalOptions="FillAndExpand">
                     <BoxView.GestureRecognizers>

--- a/src/App/Pages/Vault/GroupingsPage/GroupingsPage.xaml
+++ b/src/App/Pages/Vault/GroupingsPage/GroupingsPage.xaml
@@ -173,7 +173,7 @@
 
             <StackLayout
                 x:Name="_accountListContainer"
-                VerticalOptions="StartAndExpand"
+                VerticalOptions="Fill"
                 HorizontalOptions="FillAndExpand"
                 BackgroundColor="{DynamicResource BackgroundColor}"
                 xct:ShadowEffect.Color="Black"
@@ -184,7 +184,7 @@
                     ItemsSource="{Binding AccountViews}"
                     ItemSelected="AccountRow_Selected"
                     BackgroundColor="Transparent"
-                    VerticalOptions="FillAndExpand"
+                    VerticalOptions="Start"
                     RowHeight="{OnPlatform 70, iOS=70, Android=74}">
                     <ListView.ItemTemplate>
                         <DataTemplate x:DataType="view:AccountView">
@@ -193,6 +193,14 @@
                         </DataTemplate>
                     </ListView.ItemTemplate>
                 </ListView>
+                <BoxView
+                    Background="Transparent"
+                    HorizontalOptions="Fill"
+                    VerticalOptions="FillAndExpand">
+                    <BoxView.GestureRecognizers>
+                        <TapGestureRecognizer Tapped="AccountSwitchingOverlay_Tapped" />
+                    </BoxView.GestureRecognizers>
+                </BoxView>
             </StackLayout>
         </ContentView>
     </AbsoluteLayout>

--- a/src/App/Pages/Vault/GroupingsPage/GroupingsPage.xaml.cs
+++ b/src/App/Pages/Vault/GroupingsPage/GroupingsPage.xaml.cs
@@ -1,13 +1,16 @@
-﻿using Bit.App.Abstractions;
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Bit.App.Abstractions;
+using Bit.App.Controls;
 using Bit.App.Resources;
 using Bit.Core.Abstractions;
 using Bit.Core.Enums;
-using Bit.Core.Utilities;
-using System;
-using System.Linq;
-using System.Threading.Tasks;
-using Bit.App.Controls;
 using Bit.Core.Models.Data;
+using Bit.Core.Utilities;
+#if !FDROID
+using Microsoft.AppCenter.Crashes;
+#endif
 using Xamarin.Forms;
 
 namespace Bit.App.Pages
@@ -297,21 +300,44 @@ namespace Bit.App.Pages
 
         private async void AccountSwitch_Clicked(object sender, EventArgs e)
         {
-            
-            if (_accountListOverlay.IsVisible)
+            try
             {
-                await ShowAccountListAsync(false, _accountListContainer, _accountListOverlay, _fab);
+                await ToggleAccountListAsync(_accountListContainer, _accountListOverlay, _accountListView, true);
             }
-            else
+            catch (Exception ex)
             {
-                await RefreshAccountViewsAsync(_accountListView, true);
-                await ShowAccountListAsync(true, _accountListContainer, _accountListOverlay, _fab);
+#if !FDROID
+                Crashes.TrackError(ex);
+#endif
             }
         }
 
         private async void AccountRow_Selected(object sender, SelectedItemChangedEventArgs e)
         {
-            await AccountRowSelectedAsync(sender, e, _accountListContainer, _accountListOverlay, _fab);
+            try
+            {
+                await AccountRowSelectedAsync(sender, e, _accountListContainer, _accountListOverlay, _fab);
+            }
+            catch (Exception ex)
+            {
+#if !FDROID
+                Crashes.TrackError(ex);
+#endif
+            }
+        }
+
+        private async void AccountSwitchingOverlay_Tapped(object sender, EventArgs e)
+        {
+            try
+            {
+                await HideAccountListAsync(_accountListContainer, _accountListOverlay);
+            }
+            catch (Exception ex)
+            {
+#if !FDROID
+                Crashes.TrackError(ex);
+#endif
+            }
         }
     }
 }


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Add tap to dismiss on the Account Switching list when tapping outside the list on the overlay.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **BaseContentPage.cs:** Renamed `ShowAccountListAsync` to `ToggleAccountListAsync` handling the `IsVisible` inside from the overlay reference thus reducing the boilerplate from the callers. Added two new methods `ShowAccountListAsync` and `HideAccountListAsync` to be used directly where they are needed.
* **...Page.xaml:** Added `BoxView` to add the tap gesture and dismiss the overlay
* **...Page.xaml.cs:** Added behavior to dismiss the overlay on tapping and improved the code to reduce boilerplate


## Testing requirements
<!--What functionality requires testing by QA? This includes testing new behavior and regression testing-->
When the Account Switching overlay list is opened, tapping on the bottom part should close it.


## Before you submit
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
