### PR TITLE
Fix iOS top space on Account switching list overlay after modal

### DIFF
--- a/src/App/Effects/ScrollViewContentInsetAdjustmentBehaviorEffect.cs
+++ b/src/App/Effects/ScrollViewContentInsetAdjustmentBehaviorEffect.cs
@@ -1,0 +1,33 @@
+﻿using Xamarin.Forms;
+
+namespace Bit.App.Effects
+{
+    public enum ScrollContentInsetAdjustmentBehavior
+    {
+        Automatic,
+        ScrollableAxes,
+        Never,
+        Always
+    }
+
+    public class ScrollViewContentInsetAdjustmentBehaviorEffect : RoutingEffect
+    {
+        public static readonly BindableProperty ContentInsetAdjustmentBehaviorProperty =
+          BindableProperty.CreateAttached("ContentInsetAdjustmentBehavior", typeof(ScrollContentInsetAdjustmentBehavior), typeof(ScrollViewContentInsetAdjustmentBehaviorEffect), ScrollContentInsetAdjustmentBehavior.Automatic);
+
+        public static ScrollContentInsetAdjustmentBehavior GetContentInsetAdjustmentBehavior(BindableObject view)
+        {
+            return (ScrollContentInsetAdjustmentBehavior)view.GetValue(ContentInsetAdjustmentBehaviorProperty);
+        }
+
+        public static void SetContentInsetAdjustmentBehavior(BindableObject view, ScrollContentInsetAdjustmentBehavior value)
+        {
+            view.SetValue(ContentInsetAdjustmentBehaviorProperty, value);
+        }
+
+        public ScrollViewContentInsetAdjustmentBehaviorEffect()
+            : base($"Bitwarden.{nameof(ScrollViewContentInsetAdjustmentBehaviorEffect)}")
+        {
+        }
+    }
+}

--- a/src/App/Pages/Accounts/HomePage.xaml
+++ b/src/App/Pages/Accounts/HomePage.xaml
@@ -6,6 +6,7 @@
     x:Class="Bit.App.Pages.HomePage"
     xmlns:pages="clr-namespace:Bit.App.Pages"
     xmlns:controls="clr-namespace:Bit.App.Controls"
+    xmlns:effects="clr-namespace:Bit.App.Effects"
     xmlns:view="clr-namespace:Bit.Core.Models.View;assembly=BitwardenCore"
     xmlns:u="clr-namespace:Bit.App.Utilities"
     x:DataType="pages:HomeViewModel"
@@ -96,13 +97,18 @@
                         ItemSelected="AccountRow_Selected"
                         BackgroundColor="{DynamicResource BackgroundColor}"
                         VerticalOptions="Start"
-                        RowHeight="{OnPlatform 70, iOS=70, Android=74}">
+                        RowHeight="{OnPlatform 70, iOS=70, Android=74}"
+                        effects:ScrollViewContentInsetAdjustmentBehaviorEffect.ContentInsetAdjustmentBehavior="Never">
                         <ListView.ItemTemplate>
                             <DataTemplate x:DataType="view:AccountView">
                                 <controls:AccountViewCell
                                     Account="{Binding .}" />
                             </DataTemplate>
                         </ListView.ItemTemplate>
+                        <ListView.Effects>
+                            <effects:ScrollViewContentInsetAdjustmentBehaviorEffect />
+                        </ListView.Effects>
+
                     </ListView>
                 </Frame>
                 <BoxView

--- a/src/App/Pages/Accounts/LockPage.xaml
+++ b/src/App/Pages/Accounts/LockPage.xaml
@@ -6,6 +6,7 @@
     x:Class="Bit.App.Pages.LockPage"
     xmlns:pages="clr-namespace:Bit.App.Pages"
     xmlns:controls="clr-namespace:Bit.App.Controls"
+    xmlns:effects="clr-namespace:Bit.App.Effects"
     xmlns:view="clr-namespace:Bit.Core.Models.View;assembly=BitwardenCore"
     xmlns:u="clr-namespace:Bit.App.Utilities"
     x:DataType="pages:LockPageViewModel"
@@ -190,13 +191,18 @@
                         ItemSelected="AccountRow_Selected"
                         BackgroundColor="{DynamicResource BackgroundColor}"
                         VerticalOptions="Start"
-                        RowHeight="{OnPlatform 70, iOS=70, Android=74}">
+                        RowHeight="{OnPlatform 70, iOS=70, Android=74}"
+                        effects:ScrollViewContentInsetAdjustmentBehaviorEffect.ContentInsetAdjustmentBehavior="Never">
                         <ListView.ItemTemplate>
                             <DataTemplate x:DataType="view:AccountView">
                                 <controls:AccountViewCell
                                     Account="{Binding .}" />
                             </DataTemplate>
                         </ListView.ItemTemplate>
+                        <ListView.Effects>
+                            <effects:ScrollViewContentInsetAdjustmentBehaviorEffect />
+                        </ListView.Effects>
+
                     </ListView>
                 </Frame>
                 <BoxView

--- a/src/App/Pages/Accounts/LoginPage.xaml
+++ b/src/App/Pages/Accounts/LoginPage.xaml
@@ -6,6 +6,7 @@
     x:Class="Bit.App.Pages.LoginPage"
     xmlns:pages="clr-namespace:Bit.App.Pages"
     xmlns:controls="clr-namespace:Bit.App.Controls"
+    xmlns:effects="clr-namespace:Bit.App.Effects"
     xmlns:view="clr-namespace:Bit.Core.Models.View;assembly=BitwardenCore"
     xmlns:u="clr-namespace:Bit.App.Utilities"
     x:DataType="pages:LoginPageViewModel"
@@ -139,13 +140,18 @@
                         ItemSelected="AccountRow_Selected"
                         BackgroundColor="{DynamicResource BackgroundColor}"
                         VerticalOptions="Start"
-                        RowHeight="{OnPlatform 70, iOS=70, Android=74}">
+                        RowHeight="{OnPlatform 70, iOS=70, Android=74}"
+                        effects:ScrollViewContentInsetAdjustmentBehaviorEffect.ContentInsetAdjustmentBehavior="Never">
                         <ListView.ItemTemplate>
                             <DataTemplate x:DataType="view:AccountView">
                                 <controls:AccountViewCell
                                     Account="{Binding .}" />
                             </DataTemplate>
                         </ListView.ItemTemplate>
+                        <ListView.Effects>
+                            <effects:ScrollViewContentInsetAdjustmentBehaviorEffect />
+                        </ListView.Effects>
+
                     </ListView>
                 </Frame>
                 <BoxView

--- a/src/App/Pages/Vault/GroupingsPage/GroupingsPage.xaml
+++ b/src/App/Pages/Vault/GroupingsPage/GroupingsPage.xaml
@@ -189,13 +189,17 @@
                         ItemSelected="AccountRow_Selected"
                         BackgroundColor="{DynamicResource BackgroundColor}"
                         VerticalOptions="Start"
-                        RowHeight="{OnPlatform 70, iOS=70, Android=74}">
+                        RowHeight="{OnPlatform 70, iOS=70, Android=74}"
+                        effects:ScrollViewContentInsetAdjustmentBehaviorEffect.ContentInsetAdjustmentBehavior="Never">
                         <ListView.ItemTemplate>
                             <DataTemplate x:DataType="view:AccountView">
                                 <controls:AccountViewCell
                                     Account="{Binding .}" />
                             </DataTemplate>
                         </ListView.ItemTemplate>
+                        <ListView.Effects>
+                            <effects:ScrollViewContentInsetAdjustmentBehaviorEffect />
+                        </ListView.Effects>
                     </ListView>
                 </Frame>
                 <BoxView

--- a/src/iOS.Core/Effects/ScrollViewContentInsetAdjustmentBehaviorEffect.cs
+++ b/src/iOS.Core/Effects/ScrollViewContentInsetAdjustmentBehaviorEffect.cs
@@ -1,0 +1,37 @@
+﻿using Bit.iOS.Core.Effects;
+using UIKit;
+using Xamarin.Forms;
+using Xamarin.Forms.Platform.iOS;
+
+[assembly: ExportEffect(typeof(ScrollViewContentInsetAdjustmentBehaviorEffect), nameof(ScrollViewContentInsetAdjustmentBehaviorEffect))]
+namespace Bit.iOS.Core.Effects
+{
+    public class ScrollViewContentInsetAdjustmentBehaviorEffect : PlatformEffect
+    {
+        protected override void OnAttached()
+        {
+            if (Element != null && Control is UIScrollView scrollView)
+            {
+                switch (App.Effects.ScrollViewContentInsetAdjustmentBehaviorEffect.GetContentInsetAdjustmentBehavior(Element))
+                {
+                    case App.Effects.ScrollContentInsetAdjustmentBehavior.Automatic:
+                        scrollView.ContentInsetAdjustmentBehavior = UIScrollViewContentInsetAdjustmentBehavior.Automatic;
+                        break;
+                    case App.Effects.ScrollContentInsetAdjustmentBehavior.ScrollableAxes:
+                        scrollView.ContentInsetAdjustmentBehavior = UIScrollViewContentInsetAdjustmentBehavior.ScrollableAxes;
+                        break;
+                    case App.Effects.ScrollContentInsetAdjustmentBehavior.Never:
+                        scrollView.ContentInsetAdjustmentBehavior = UIScrollViewContentInsetAdjustmentBehavior.Never;
+                        break;
+                    case App.Effects.ScrollContentInsetAdjustmentBehavior.Always:
+                        scrollView.ContentInsetAdjustmentBehavior = UIScrollViewContentInsetAdjustmentBehavior.Always;
+                        break;
+                }
+            }
+        }
+
+        protected override void OnDetached()
+        {
+        }
+    }
+}

--- a/src/iOS.Core/iOS.Core.csproj
+++ b/src/iOS.Core/iOS.Core.csproj
@@ -193,6 +193,7 @@
     <Compile Include="Renderers\SelectableLabelRenderer.cs" />
     <Compile Include="Effects\ScrollEnabledEffect.cs" />
     <Compile Include="Services\ClipboardService.cs" />
+    <Compile Include="Effects\ScrollViewContentInsetAdjustmentBehaviorEffect.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\App\App.csproj">


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Fix top space shown on iOS on the Account Switching overlay after opening and closing a modal on the Vault and then opening the Account Switching list.

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **GroupingsPage.xaml:** Added effect to change the behavior of content inset adjustment on the list view of account switching overlay so that it never takes into account the Safe Area which was causing the issue.


## Testing requirements
<!--What functionality requires testing by QA? This includes testing new behavior and regression testing-->
In the Vault, after opening and closing a modal like adding a cypher, and opening the account switching overlay shouldn't present any weird spaces at the top.


## Before you submit
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
