### PR TITLE
Usability: dismiss account list on certain events

### DIFF
--- a/src/App/Pages/Accounts/HomePage.xaml.cs
+++ b/src/App/Pages/Accounts/HomePage.xaml.cs
@@ -73,10 +73,7 @@ namespace Bit.App.Pages
         {
             if (_accountListOverlay.IsVisible)
             {
-                Task.Run(async () =>
-                {
-                    await HideAccountListAsync(_accountListContainer, _accountListOverlay);
-                });
+                HideAccountListAsync(_accountListContainer, _accountListOverlay).FireAndForget();
                 return true;
             }
             return false;

--- a/src/App/Pages/Accounts/HomePage.xaml.cs
+++ b/src/App/Pages/Accounts/HomePage.xaml.cs
@@ -69,6 +69,19 @@ namespace Bit.App.Pages
             });
         }
 
+        protected override bool OnBackButtonPressed()
+        {
+            if (_accountListOverlay.IsVisible)
+            {
+                Task.Run(async () =>
+                {
+                    await HideAccountListAsync(_accountListContainer, _accountListOverlay);
+                });
+                return true;
+            }
+            return false;
+        }
+
         protected override void OnDisappearing()
         {
             base.OnDisappearing();
@@ -141,6 +154,7 @@ namespace Bit.App.Pages
         
         private async Task StartEnvironmentAsync()
         {
+            await HideAccountListAsync(_accountListContainer, _accountListOverlay);
             var page = new EnvironmentPage();
             await Navigation.PushModalAsync(new NavigationPage(page));
         }

--- a/src/App/Pages/Accounts/LockPage.xaml
+++ b/src/App/Pages/Accounts/LockPage.xaml
@@ -171,12 +171,12 @@
             IsVisible="False"
             BackgroundColor="#22000000"
             Padding="0">
+
             <StackLayout
                 x:Name="_accountListContainer"
-                BackgroundColor="Transparent"
                 VerticalOptions="Fill"
                 HorizontalOptions="FillAndExpand"
-                Orientation="Vertical">
+                BackgroundColor="Transparent">
                 <Frame
                     Padding="0"
                     HorizontalOptions="Fill"

--- a/src/App/Pages/Accounts/LockPage.xaml.cs
+++ b/src/App/Pages/Accounts/LockPage.xaml.cs
@@ -101,6 +101,19 @@ namespace Bit.App.Pages
             }
         }
 
+        protected override bool OnBackButtonPressed()
+        {
+            if (_accountListOverlay.IsVisible)
+            {
+                Task.Run(async () =>
+                {
+                    await HideAccountListAsync(_accountListContainer, _accountListOverlay);
+                });
+                return true;
+            }
+            return false;
+        }
+
         protected override void OnDisappearing()
         {
             base.OnDisappearing();
@@ -122,6 +135,7 @@ namespace Bit.App.Pages
 
         private async void LogOut_Clicked(object sender, EventArgs e)
         {
+            await HideAccountListAsync(_accountListContainer, _accountListOverlay);
             if (DoOnce())
             {
                 await _vm.LogOutAsync();
@@ -138,6 +152,7 @@ namespace Bit.App.Pages
 
         private async void More_Clicked(object sender, System.EventArgs e)
         {
+            await HideAccountListAsync(_accountListContainer, _accountListOverlay);
             if (!DoOnce())
             {
                 return;

--- a/src/App/Pages/Accounts/LockPage.xaml.cs
+++ b/src/App/Pages/Accounts/LockPage.xaml.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using Bit.App.Models;
 using Bit.App.Resources;
 using Bit.App.Utilities;
+using Bit.Core.Utilities;
 #if !FDROID
 using Microsoft.AppCenter.Crashes;
 #endif
@@ -105,10 +106,7 @@ namespace Bit.App.Pages
         {
             if (_accountListOverlay.IsVisible)
             {
-                Task.Run(async () =>
-                {
-                    await HideAccountListAsync(_accountListContainer, _accountListOverlay);
-                });
+                HideAccountListAsync(_accountListContainer, _accountListOverlay).FireAndForget();
                 return true;
             }
             return false;

--- a/src/App/Pages/Accounts/LoginPage.xaml.cs
+++ b/src/App/Pages/Accounts/LoginPage.xaml.cs
@@ -3,6 +3,7 @@ using Bit.App.Resources;
 using System;
 using System.Threading.Tasks;
 using Bit.App.Utilities;
+using Bit.Core.Utilities;
 using Xamarin.Forms;
 #if !FDROID
 using Microsoft.AppCenter.Crashes;
@@ -85,10 +86,7 @@ namespace Bit.App.Pages
         {
             if (_accountListOverlay.IsVisible)
             {
-                Task.Run(async () =>
-                {
-                    await HideAccountListAsync(_accountListContainer, _accountListOverlay);
-                });
+                HideAccountListAsync(_accountListContainer, _accountListOverlay).FireAndForget();
                 return true;
             }
             return false;

--- a/src/App/Pages/Accounts/LoginPage.xaml.cs
+++ b/src/App/Pages/Accounts/LoginPage.xaml.cs
@@ -29,6 +29,7 @@ namespace Bit.App.Pages
                 () => Device.BeginInvokeOnMainThread(async () => await UpdateTempPasswordAsync());
             _vm.CloseAction = async () =>
             {
+                await HideAccountListAsync(_accountListContainer, _accountListOverlay);
                 await Navigation.PopModalAsync();
             };
             _vm.Email = email;
@@ -80,6 +81,19 @@ namespace Bit.App.Pages
             }
         }
 
+        protected override bool OnBackButtonPressed()
+        {
+            if (_accountListOverlay.IsVisible)
+            {
+                Task.Run(async () =>
+                {
+                    await HideAccountListAsync(_accountListContainer, _accountListOverlay);
+                });
+                return true;
+            }
+            return false;
+        }
+
         protected override void OnDisappearing()
         {
             base.OnDisappearing();
@@ -113,6 +127,7 @@ namespace Bit.App.Pages
 
         private async void More_Clicked(object sender, System.EventArgs e)
         {
+            await HideAccountListAsync(_accountListContainer, _accountListOverlay);
             if (!DoOnce())
             {
                 return;

--- a/src/App/Pages/BaseContentPage.cs
+++ b/src/App/Pages/BaseContentPage.cs
@@ -183,6 +183,11 @@ namespace Bit.App.Pages
 
         protected async Task HideAccountListAsync(View listContainer, View overlay, View fab = null)
         {
+            if (!overlay.IsVisible)
+            {
+                // already hidden, don't animate again
+                return;
+            }
             // Not all animations are awaited. This is intentional to allow multiple simultaneous animations.
             await Device.InvokeOnMainThreadAsync(async () =>
             {

--- a/src/App/Pages/Vault/GroupingsPage/GroupingsPage.xaml.cs
+++ b/src/App/Pages/Vault/GroupingsPage/GroupingsPage.xaml.cs
@@ -170,6 +170,19 @@ namespace Bit.App.Pages
             }
         }
 
+        protected override bool OnBackButtonPressed()
+        {
+            if (_accountListOverlay.IsVisible)
+            {
+                Task.Run(async () =>
+                {
+                    await HideAccountListAsync(_accountListContainer, _accountListOverlay, _fab);
+                });
+                return true;
+            }
+            return false;
+        }
+
         protected override void OnDisappearing()
         {
             base.OnDisappearing();
@@ -215,6 +228,7 @@ namespace Bit.App.Pages
 
         private async void Search_Clicked(object sender, EventArgs e)
         {
+            await HideAccountListAsync(_accountListContainer, _accountListOverlay, _fab);
             if (DoOnce())
             {
                 var page = new CiphersPage(_vm.Filter, _vm.FolderId != null, _vm.CollectionId != null,
@@ -225,21 +239,31 @@ namespace Bit.App.Pages
 
         private async void Sync_Clicked(object sender, EventArgs e)
         {
+            await HideAccountListAsync(_accountListContainer, _accountListOverlay, _fab);
             await _vm.SyncAsync();
         }
 
         private async void Lock_Clicked(object sender, EventArgs e)
         {
+            await HideAccountListAsync(_accountListContainer, _accountListOverlay, _fab);
             await _vaultTimeoutService.LockAsync(true, true);
         }
 
         private async void Exit_Clicked(object sender, EventArgs e)
         {
+            await HideAccountListAsync(_accountListContainer, _accountListOverlay, _fab);
             await _vm.ExitAsync();
         }
 
         private async void AddButton_Clicked(object sender, EventArgs e)
         {
+            var skipAction = _accountListOverlay.IsVisible && Device.RuntimePlatform == Device.Android;
+            await HideAccountListAsync(_accountListContainer, _accountListOverlay, _fab);
+            if (skipAction)
+            {
+                // Account list in the process of closing via tapping on invisible FAB, skip this attempt
+                return;
+            }
             if (!_vm.Deleted && DoOnce())
             {
                 var page = new AddEditPage(null, _vm.Type, _vm.FolderId, _vm.CollectionId);
@@ -253,6 +277,7 @@ namespace Bit.App.Pages
             {
                 return;
             }
+            await HideAccountListAsync(_accountListContainer, _accountListOverlay, _fab);
             if (_previousPage.Page == "view" && !string.IsNullOrWhiteSpace(_previousPage.CipherId))
             {
                 await Navigation.PushModalAsync(new NavigationPage(new ViewPage(_previousPage.CipherId)));
@@ -274,7 +299,7 @@ namespace Bit.App.Pages
         {
             try
             {
-                await ToggleAccountListAsync(_accountListContainer, _accountListOverlay, _accountListView, true);
+                await ToggleAccountListAsync(_accountListContainer, _accountListOverlay, _accountListView, true, _fab);
             }
             catch (Exception ex)
             {
@@ -302,7 +327,7 @@ namespace Bit.App.Pages
         {
             try
             {
-                await HideAccountListAsync(_accountListContainer, _accountListOverlay);
+                await HideAccountListAsync(_accountListContainer, _accountListOverlay, _fab);
             }
             catch (Exception ex)
             {

--- a/src/App/Pages/Vault/GroupingsPage/GroupingsPage.xaml.cs
+++ b/src/App/Pages/Vault/GroupingsPage/GroupingsPage.xaml.cs
@@ -174,10 +174,7 @@ namespace Bit.App.Pages
         {
             if (_accountListOverlay.IsVisible)
             {
-                Task.Run(async () =>
-                {
-                    await HideAccountListAsync(_accountListContainer, _accountListOverlay, _fab);
-                });
+                HideAccountListAsync(_accountListContainer, _accountListOverlay, _fab).FireAndForget();
                 return true;
             }
             return false;


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Dismiss the account list on certain events, like selecting toolbar options that are still accessible when the menu is showing, the Android back button, etc.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **HomePage.xaml.cs:** Hide account list when opening environment controls, and Android back button support
* **LockPage.xaml:** Cleanup formatting to be identical to other pages with account switching overlay
* **LockPage.xaml.cs:** Hide account list when selecting Log Out (Android) or when More is clicked (iOS), and Android back button support
* **LoginPage.xaml.cs:** Hide account list in CloseAction, when More is clicked, and Android back button support
* **GroupingsPage.xaml.cs:** Hide account list on Search, Sync, Lock, Exit, Add, and ShowPreviousPage.  Added missing _fab arg in `AccountSwitch_Clicked` and `AccountSwitchingOverlay_Tapped`.  Support for Android back button.
* **BaseContentPage.xaml.cs:** Prevent animation flow from executing again if account list is already hidden


## Testing requirements
<!--What functionality requires testing by QA? This includes testing new behavior and regression testing-->
Observe open account list behavior when tapping other elements on screen that are still accessible. 


## Before you submit
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
