### PR TITLE
Fix Account Deletion SSO with CME OTP parameter 

### DIFF
--- a/src/Android/MainApplication.cs
+++ b/src/Android/MainApplication.cs
@@ -52,14 +52,14 @@ namespace Bit.Droid
                 var deleteAccountActionFlowExecutioner = new DeleteAccountActionFlowExecutioner(
                     ServiceContainer.Resolve<IApiService>("apiService"),
                     ServiceContainer.Resolve<IMessagingService>("messagingService"),
-                    ServiceContainer.Resolve<ICryptoService>("cryptoService"),
                     ServiceContainer.Resolve<IPlatformUtilsService>("platformUtilsService"),
                     ServiceContainer.Resolve<IDeviceActionService>("deviceActionService"));
                 ServiceContainer.Register<IDeleteAccountActionFlowExecutioner>("deleteAccountActionFlowExecutioner", deleteAccountActionFlowExecutioner);
 
                 var verificationActionsFlowHelper = new VerificationActionsFlowHelper(
                     ServiceContainer.Resolve<IKeyConnectorService>("keyConnectorService"),
-                    ServiceContainer.Resolve<IPasswordRepromptService>("passwordRepromptService"));
+                    ServiceContainer.Resolve<IPasswordRepromptService>("passwordRepromptService"),
+                    ServiceContainer.Resolve<ICryptoService>("cryptoService"));
                 ServiceContainer.Register<IVerificationActionsFlowHelper>("verificationActionsFlowHelper", verificationActionsFlowHelper);
             }
 #if !FDROID

--- a/src/App/Pages/Accounts/DeleteAccountViewModel.cs
+++ b/src/App/Pages/Accounts/DeleteAccountViewModel.cs
@@ -58,19 +58,16 @@ namespace Bit.App.Pages
     {
         readonly IApiService _apiService;
         readonly IMessagingService _messagingService;
-        readonly ICryptoService _cryptoService;
         readonly IPlatformUtilsService _platformUtilsService;
         readonly IDeviceActionService _deviceActionService;
 
         public DeleteAccountActionFlowExecutioner(IApiService apiService,
             IMessagingService messagingService,
-            ICryptoService cryptoService,
             IPlatformUtilsService platformUtilsService,
             IDeviceActionService deviceActionService)
         {
             _apiService = apiService;
             _messagingService = messagingService;
-            _cryptoService = cryptoService;
             _platformUtilsService = platformUtilsService;
             _deviceActionService = deviceActionService;
         }
@@ -81,10 +78,10 @@ namespace Bit.App.Pages
             {
                 await _deviceActionService.ShowLoadingAsync(AppResources.DeletingYourAccount);
 
-                var masterPasswordHashKey = await _cryptoService.HashPasswordAsync(parameters.Secret, null);
                 await _apiService.DeleteAccountAsync(new Core.Models.Request.DeleteAccountRequest
                 {
-                    MasterPasswordHash = masterPasswordHashKey
+                    MasterPasswordHash = parameters.VerificationType == Core.Enums.VerificationType.MasterPassword ? parameters.Secret : (string)null,
+                    OTP = parameters.VerificationType == Core.Enums.VerificationType.OTP ? parameters.Secret : (string)null
                 });
 
                 await _deviceActionService.HideLoadingAsync();

--- a/src/App/Pages/Accounts/VerificationCodeViewModel.cs
+++ b/src/App/Pages/Accounts/VerificationCodeViewModel.cs
@@ -10,6 +10,7 @@ using Xamarin.CommunityToolkit.ObjectModel;
 using System.Windows.Input;
 using Bit.App.Utilities;
 using Bit.Core;
+using Bit.Core.Enums;
 #if !FDROID
 using Microsoft.AppCenter.Crashes;
 #endif
@@ -144,7 +145,7 @@ namespace Bit.App.Pages
 
                 await _deviceActionService.ShowLoadingAsync(AppResources.Verifying);
 
-                if (!await _userVerificationService.VerifyUser(Secret, Core.Enums.VerificationType.OTP))
+                if (!await _userVerificationService.VerifyUser(Secret, VerificationType.OTP))
                 {
                     await _deviceActionService.HideLoadingAsync();
                     return;
@@ -154,6 +155,7 @@ namespace Bit.App.Pages
 
                 var parameters = _verificationActionsFlowHelper.GetParameters();
                 parameters.Secret = Secret;
+                parameters.VerificationType = VerificationType.OTP;
                 await _verificationActionsFlowHelper.ExecuteAsync(parameters);
 
                 Secret = string.Empty;

--- a/src/Core/Models/Request/DeleteAccountRequest.cs
+++ b/src/Core/Models/Request/DeleteAccountRequest.cs
@@ -3,5 +3,7 @@
     public class DeleteAccountRequest
     {
         public string MasterPasswordHash { get; set; }
+
+        public string OTP { get; set; }
     }
 }

--- a/src/Core/Services/UserVerificationService.cs
+++ b/src/Core/Services/UserVerificationService.cs
@@ -1,9 +1,7 @@
-﻿using System;
+﻿using System.Threading.Tasks;
+using Bit.Core.Abstractions;
 using Bit.Core.Enums;
 using Bit.Core.Models.Request;
-using Bit.Core.Services;
-using Bit.Core.Abstractions;
-using System.Threading.Tasks;
 
 namespace Bit.Core.Services
 {

--- a/src/iOS.Core/Utilities/iOSCoreHelpers.cs
+++ b/src/iOS.Core/Utilities/iOSCoreHelpers.cs
@@ -154,14 +154,14 @@ namespace Bit.iOS.Core.Utilities
             var deleteAccountActionFlowExecutioner = new DeleteAccountActionFlowExecutioner(
                 ServiceContainer.Resolve<IApiService>("apiService"),
                 ServiceContainer.Resolve<IMessagingService>("messagingService"),
-                ServiceContainer.Resolve<ICryptoService>("cryptoService"),
                 ServiceContainer.Resolve<IPlatformUtilsService>("platformUtilsService"),
                 ServiceContainer.Resolve<IDeviceActionService>("deviceActionService"));
             ServiceContainer.Register<IDeleteAccountActionFlowExecutioner>("deleteAccountActionFlowExecutioner", deleteAccountActionFlowExecutioner);
 
             var verificationActionsFlowHelper = new VerificationActionsFlowHelper(
-            ServiceContainer.Resolve<IKeyConnectorService>("keyConnectorService"),
-            ServiceContainer.Resolve<IPasswordRepromptService>("passwordRepromptService"));
+                ServiceContainer.Resolve<IKeyConnectorService>("keyConnectorService"),
+                ServiceContainer.Resolve<IPasswordRepromptService>("passwordRepromptService"),
+                ServiceContainer.Resolve<ICryptoService>("cryptoService"));
             ServiceContainer.Register<IVerificationActionsFlowHelper>("verificationActionsFlowHelper", verificationActionsFlowHelper);
 
             if (postBootstrapFunc != null)


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Fix OTP parameter sent on account deletion of SSO with CME.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **DeleteAccountRequest.cs:** Added OTP parameter
* **VerificationActionsFlowHelper:** Added more logic to set the verification type on the parameters and also hash the password directly here
* **VerificationCodeViewModel:** Set the verification type on the parameters
* **DeleteAccountViewModel.cs -> DeleteAccountActionFlowExecutioner:** Updated it to consider passing the master password hash or the OTP parameter to the request.

## Testing requirements
<!--What functionality requires testing by QA? This includes testing new behavior and regression testing-->
A user should be able to delete an account with master password and also with OTP (SSO with CME)


## Before you submit
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
