### PR TITLE
Create and use Account Switching overlay control

### DIFF
--- a/src/App/App.csproj
+++ b/src/App/App.csproj
@@ -128,6 +128,7 @@
   <ItemGroup>
     <Folder Include="Resources\" />
     <Folder Include="Behaviors\" />
+    <Folder Include="Controls\AccountSwitchingOverlay\" />
   </ItemGroup>
 
   <ItemGroup>
@@ -419,5 +420,6 @@
   <ItemGroup>
     <None Remove="Behaviors\" />
     <None Remove="Xamarin.CommunityToolkit" />
+    <None Remove="Controls\AccountSwitchingOverlay\" />
   </ItemGroup>
 </Project>

--- a/src/App/Controls/AccountSwitchingOverlay/AccountSwitchingOverlayView.xaml
+++ b/src/App/Controls/AccountSwitchingOverlay/AccountSwitchingOverlayView.xaml
@@ -1,0 +1,56 @@
+﻿<?xml version="1.0" encoding="UTF-8" ?>
+<ContentView
+    xmlns="http://xamarin.com/schemas/2014/forms"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:xct="http://xamarin.com/schemas/2020/toolkit"
+    xmlns:controls="clr-namespace:Bit.App.Controls"
+    xmlns:effects="clr-namespace:Bit.App.Effects"
+    xmlns:view="clr-namespace:Bit.Core.Models.View;assembly=BitwardenCore"
+    x:Name="_mainOverlay"
+    x:DataType="controls:AccountSwitchingOverlayViewModel"
+    x:Class="Bit.App.Controls.AccountSwitchingOverlayView"
+    BackgroundColor="#22000000"
+    Padding="0"
+    IsVisible="False">
+    <StackLayout
+        x:Name="_accountListContainer"
+        VerticalOptions="Fill"
+        HorizontalOptions="FillAndExpand"
+        BackgroundColor="Transparent">
+        <Frame
+            Padding="0"
+            HorizontalOptions="Fill"
+            VerticalOptions="Start"
+            xct:ShadowEffect.Color="Black"
+            xct:ShadowEffect.Radius="10"
+            xct:ShadowEffect.OffsetY="3">
+            <ListView
+                x:Name="_accountListView"
+                ItemsSource="{Binding BindingContext.AccountViews, Source={x:Reference _mainOverlay}}"
+                ItemSelected="AccountRow_Selected"
+                BackgroundColor="{DynamicResource BackgroundColor}"
+                VerticalOptions="Start"
+                RowHeight="{OnPlatform 70, iOS=70, Android=74}"
+                effects:ScrollViewContentInsetAdjustmentBehaviorEffect.ContentInsetAdjustmentBehavior="Never">
+                <ListView.ItemTemplate>
+                    <DataTemplate x:DataType="view:AccountView">
+                        <controls:AccountViewCell
+                            Account="{Binding .}" />
+                    </DataTemplate>
+                </ListView.ItemTemplate>
+                <ListView.Effects>
+                    <effects:ScrollViewContentInsetAdjustmentBehaviorEffect />
+                </ListView.Effects>
+
+            </ListView>
+        </Frame>
+        <BoxView
+            BackgroundColor="Transparent"
+            HorizontalOptions="Fill"
+            VerticalOptions="FillAndExpand">
+            <BoxView.GestureRecognizers>
+                <TapGestureRecognizer Tapped="FreeSpaceOverlay_Tapped" />
+            </BoxView.GestureRecognizers>
+        </BoxView>
+    </StackLayout>
+</ContentView>

--- a/src/App/Controls/AccountSwitchingOverlay/AccountSwitchingOverlayView.xaml
+++ b/src/App/Controls/AccountSwitchingOverlay/AccountSwitchingOverlayView.xaml
@@ -41,7 +41,6 @@
                 <ListView.Effects>
                     <effects:ScrollViewContentInsetAdjustmentBehaviorEffect />
                 </ListView.Effects>
-
             </ListView>
         </Frame>
         <BoxView

--- a/src/App/Controls/AccountSwitchingOverlay/AccountSwitchingOverlayView.xaml.cs
+++ b/src/App/Controls/AccountSwitchingOverlay/AccountSwitchingOverlayView.xaml.cs
@@ -1,0 +1,142 @@
+﻿using System;
+using System.Threading.Tasks;
+using System.Windows.Input;
+#if !FDROID
+using Microsoft.AppCenter.Crashes;
+#endif
+using Xamarin.CommunityToolkit.ObjectModel;
+using Xamarin.Forms;
+
+namespace Bit.App.Controls
+{
+    public partial class AccountSwitchingOverlayView : ContentView
+    {
+        public static readonly BindableProperty MainFabProperty = BindableProperty.Create(
+            nameof(MainFab),
+            typeof(View),
+            typeof(AccountSwitchingOverlayView),
+            defaultBindingMode: BindingMode.OneWay);
+
+        public View MainFab
+        {
+            get => (View)GetValue(MainFabProperty);
+            set => SetValue(MainFabProperty, value);
+        }
+
+        public AccountSwitchingOverlayView()
+        {
+            InitializeComponent();
+
+            ToggleVisibililtyCommand = new AsyncCommand(ToggleVisibilityAsync,
+#if !FDROID
+                onException: ex => Crashes.TrackError(ex),
+#endif
+                allowsMultipleExecutions: false);
+        }
+
+        public AccountSwitchingOverlayViewModel ViewModel => BindingContext as AccountSwitchingOverlayViewModel;
+
+        public ICommand ToggleVisibililtyCommand { get; }
+
+        public async Task ToggleVisibilityAsync()
+        {
+            if (IsVisible)
+            {
+                await HideAsync();
+            }
+            else
+            {
+                await ShowAsync();
+            }
+        }
+
+        public async Task ShowAsync()
+        {
+            await ViewModel?.RefreshAccountViewsAsync();
+
+            await Device.InvokeOnMainThreadAsync(async () =>
+            {
+                // start listView in default (off-screen) position
+                await _accountListContainer.TranslateTo(0, _accountListContainer.Height * -1, 0);
+
+                // set overlay opacity to zero before making visible and start fade-in
+                Opacity = 0;
+                IsVisible = true;
+                this.FadeTo(1, 100);
+                
+                if (Device.RuntimePlatform == Device.Android && MainFab != null)
+                {
+                    // start fab fade-out
+                    MainFab.FadeTo(0, 200);
+                }
+
+                // slide account list into view
+                await _accountListContainer.TranslateTo(0, 0, 200, Easing.SinOut);
+            });
+        }
+
+        public async Task HideAsync()
+        {
+            if (!IsVisible)
+            {
+                // already hidden, don't animate again
+                return;
+            }
+            // Not all animations are awaited. This is intentional to allow multiple simultaneous animations.
+            await Device.InvokeOnMainThreadAsync(async () =>
+            {
+                // start overlay fade-out
+                this.FadeTo(0, 200);
+
+                if (Device.RuntimePlatform == Device.Android && MainFab != null)
+                {
+                    // start fab fade-in
+                    MainFab.FadeTo(1, 200);
+                }
+
+                // slide account list out of view
+                await _accountListContainer.TranslateTo(0, _accountListContainer.Height * -1, 200, Easing.SinIn);
+
+                // remove overlay
+                IsVisible = false;
+            });
+        }
+
+        private async void FreeSpaceOverlay_Tapped(object sender, EventArgs e)
+        {
+            try
+            {
+                await HideAsync();
+            }
+            catch (Exception ex)
+            {
+#if !FDROID
+                Crashes.TrackError(ex);
+#endif
+            }
+        }
+
+        async void AccountRow_Selected(object sender, SelectedItemChangedEventArgs e)
+        {
+            try
+            {
+                if (!(e.SelectedItem is AccountViewCellViewModel item))
+                {
+                    return;
+                }
+
+                ((ListView)sender).SelectedItem = null;
+                await Task.Delay(100);
+                await HideAsync();
+
+                ViewModel?.SelectAccountCommand?.Execute(item);
+            }
+            catch (Exception ex)
+            {
+#if !FDROID
+                Crashes.TrackError(ex);
+#endif
+            }
+        }
+    }
+}

--- a/src/App/Controls/AccountSwitchingOverlay/AccountSwitchingOverlayViewModel.cs
+++ b/src/App/Controls/AccountSwitchingOverlay/AccountSwitchingOverlayViewModel.cs
@@ -28,7 +28,10 @@ namespace Bit.App.Controls
                 allowsMultipleExecutions: false);
         }
 
-        public List<AccountView> AccountViews => _stateService.AccountViews;
+        // this needs to be a new list every time for the binding to get updated,
+        // XF doesn't currentlyl provide a direct way to update on same instance
+        // https://github.com/xamarin/Xamarin.Forms/issues/1950
+        public List<AccountView> AccountViews => _stateService?.AccountViews is null ? null : new List<AccountView>(_stateService.AccountViews);
 
         public bool AllowActiveAccountSelection { get; set; }
 

--- a/src/App/Controls/AccountSwitchingOverlay/AccountSwitchingOverlayViewModel.cs
+++ b/src/App/Controls/AccountSwitchingOverlay/AccountSwitchingOverlayViewModel.cs
@@ -1,0 +1,66 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using System.Windows.Input;
+using Bit.Core.Abstractions;
+using Bit.Core.Models.View;
+using Bit.Core.Utilities;
+using Microsoft.AppCenter.Crashes;
+using Xamarin.CommunityToolkit.ObjectModel;
+using Xamarin.Forms;
+
+namespace Bit.App.Controls
+{
+    public class AccountSwitchingOverlayViewModel : ExtendedViewModel
+    {
+        private readonly IStateService _stateService;
+        private readonly IMessagingService _messagingService;
+
+        public AccountSwitchingOverlayViewModel(IStateService stateService,
+            IMessagingService messagingService)
+        {
+            _stateService = stateService;
+            _messagingService = messagingService;
+            
+            SelectAccountCommand = new AsyncCommand<AccountViewCellViewModel>(SelectAccountAsync,
+#if !FDROID
+                onException: ex => Crashes.TrackError(ex),
+#endif
+                allowsMultipleExecutions: false);
+        }
+
+        public List<AccountView> AccountViews => _stateService.AccountViews;
+
+        public bool AllowActiveAccountSelection { get; set; }
+
+        public bool AllowAddAccountRow { get; set; }
+
+        public ICommand SelectAccountCommand { get; }
+
+        private async Task SelectAccountAsync(AccountViewCellViewModel item)
+        {
+            if (item.AccountView.IsAccount)
+            {
+                if (!item.AccountView.IsActive)
+                {
+                    await _stateService.SetActiveUserAsync(item.AccountView.UserId);
+                    _messagingService.Send("switchedAccount");
+                }
+                else if (AllowActiveAccountSelection)
+                {
+                    _messagingService.Send("switchedAccount");
+                }
+            }
+            else
+            {
+                _messagingService.Send("addAccount");
+            }
+        }
+
+        public async Task RefreshAccountViewsAsync()
+        {
+            await _stateService.RefreshAccountViewsAsync(AllowAddAccountRow);
+
+            Device.BeginInvokeOnMainThread(() => TriggerPropertyChanged(nameof(AccountViews)));
+        }
+    }
+}

--- a/src/App/Pages/Accounts/HomePage.xaml
+++ b/src/App/Pages/Accounts/HomePage.xaml
@@ -1,13 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <pages:BaseContentPage 
     xmlns="http://xamarin.com/schemas/2014/forms"
-    xmlns:xct="http://xamarin.com/schemas/2020/toolkit"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     x:Class="Bit.App.Pages.HomePage"
     xmlns:pages="clr-namespace:Bit.App.Pages"
     xmlns:controls="clr-namespace:Bit.App.Controls"
-    xmlns:effects="clr-namespace:Bit.App.Effects"
-    xmlns:view="clr-namespace:Bit.Core.Models.View;assembly=BitwardenCore"
     xmlns:u="clr-namespace:Bit.App.Utilities"
     x:DataType="pages:HomeViewModel"
     Title="{Binding PageTitle}">
@@ -20,7 +17,7 @@
             x:Name="_accountAvatar"
             x:Key="accountAvatar"
             IconImageSource="{Binding AvatarImageSource}"
-            Clicked="AccountSwitch_Clicked"
+            Command="{Binding Source={x:Reference _accountListOverlay}, Path=ToggleVisibililtyCommand}"
             Order="Primary"
             Priority="-1"
             UseOriginalImage="True"
@@ -70,57 +67,11 @@
             AbsoluteLayout.LayoutBounds="0, 0, 1, 1">
         </ContentView>
 
-        <!-- Account Switching Overlay -->
-        <ContentView
+        <controls:AccountSwitchingOverlayView
             x:Name="_accountListOverlay"
             AbsoluteLayout.LayoutBounds="0, 0, 1, 1"
             AbsoluteLayout.LayoutFlags="All"
-            IsVisible="False"
-            BackgroundColor="#22000000"
-            Padding="0">
-
-            <StackLayout
-                x:Name="_accountListContainer"
-                VerticalOptions="Fill"
-                HorizontalOptions="FillAndExpand"
-                BackgroundColor="Transparent">
-                <Frame
-                    Padding="0"
-                    HorizontalOptions="Fill"
-                    VerticalOptions="Start"
-                    xct:ShadowEffect.Color="Black"
-                    xct:ShadowEffect.Radius="10"
-                    xct:ShadowEffect.OffsetY="3">
-                    <ListView
-                        x:Name="_accountListView"
-                        ItemsSource="{Binding AccountViews}"
-                        ItemSelected="AccountRow_Selected"
-                        BackgroundColor="{DynamicResource BackgroundColor}"
-                        VerticalOptions="Start"
-                        RowHeight="{OnPlatform 70, iOS=70, Android=74}"
-                        effects:ScrollViewContentInsetAdjustmentBehaviorEffect.ContentInsetAdjustmentBehavior="Never">
-                        <ListView.ItemTemplate>
-                            <DataTemplate x:DataType="view:AccountView">
-                                <controls:AccountViewCell
-                                    Account="{Binding .}" />
-                            </DataTemplate>
-                        </ListView.ItemTemplate>
-                        <ListView.Effects>
-                            <effects:ScrollViewContentInsetAdjustmentBehaviorEffect />
-                        </ListView.Effects>
-
-                    </ListView>
-                </Frame>
-                <BoxView
-                    BackgroundColor="Transparent"
-                    HorizontalOptions="Fill"
-                    VerticalOptions="FillAndExpand">
-                    <BoxView.GestureRecognizers>
-                        <TapGestureRecognizer Tapped="AccountSwitchingOverlay_Tapped" />
-                    </BoxView.GestureRecognizers>
-                </BoxView>
-            </StackLayout>
-        </ContentView>
+            BindingContext="{Binding AccountSwitchingOverlayViewModel}"/>
     </AbsoluteLayout>
 
 </pages:BaseContentPage>

--- a/src/App/Pages/Accounts/HomePage.xaml.cs
+++ b/src/App/Pages/Accounts/HomePage.xaml.cs
@@ -1,14 +1,10 @@
-﻿using Bit.App.Models;
+﻿using System;
+using System.Threading.Tasks;
+using Bit.App.Models;
 using Bit.App.Utilities;
 using Bit.Core.Abstractions;
 using Bit.Core.Utilities;
-#if !FDROID
-using Microsoft.AppCenter.Crashes;
-#endif
-using System;
-using System.Threading.Tasks;
 using Xamarin.Forms;
-
 
 namespace Bit.App.Pages
 {
@@ -73,7 +69,7 @@ namespace Bit.App.Pages
         {
             if (_accountListOverlay.IsVisible)
             {
-                HideAccountListAsync(_accountListContainer, _accountListOverlay).FireAndForget();
+                _accountListOverlay.HideAsync().FireAndForget();
                 return true;
             }
             return false;
@@ -151,51 +147,9 @@ namespace Bit.App.Pages
         
         private async Task StartEnvironmentAsync()
         {
-            await HideAccountListAsync(_accountListContainer, _accountListOverlay);
+            await _accountListOverlay.HideAsync();
             var page = new EnvironmentPage();
             await Navigation.PushModalAsync(new NavigationPage(page));
-        }
-
-        private async void AccountSwitch_Clicked(object sender, EventArgs e)
-        {
-            try
-            {
-                await ToggleAccountListAsync(_accountListContainer, _accountListOverlay, _accountListView, false);
-            }
-            catch (Exception ex)
-            {
-#if !FDROID
-                Crashes.TrackError(ex);
-#endif
-            }
-        }
-
-        private async void AccountRow_Selected(object sender, SelectedItemChangedEventArgs e)
-        {
-            try
-            {
-                await AccountRowSelectedAsync(sender, e, _accountListContainer, _accountListOverlay, null, true);
-            }
-            catch (Exception ex)
-            {
-#if !FDROID
-                Crashes.TrackError(ex);
-#endif
-            }
-        }
-
-        private async void AccountSwitchingOverlay_Tapped(object sender, EventArgs e)
-        {
-            try
-            {
-                await HideAccountListAsync(_accountListContainer, _accountListOverlay);
-            }
-            catch (Exception ex)
-            {
-#if !FDROID
-                Crashes.TrackError(ex);
-#endif
-            }
         }
     }
 }

--- a/src/App/Pages/Accounts/HomePageViewModel.cs
+++ b/src/App/Pages/Accounts/HomePageViewModel.cs
@@ -1,7 +1,7 @@
 ﻿using System;
+using Bit.App.Controls;
 using Bit.App.Resources;
 using Bit.Core.Abstractions;
-using Bit.Core.Models.View;
 using Bit.Core.Utilities;
 
 namespace Bit.App.Pages
@@ -9,18 +9,22 @@ namespace Bit.App.Pages
     public class HomeViewModel : BaseViewModel
     {
         private readonly IStateService _stateService;
+        private readonly IMessagingService _messagingService;
 
         public HomeViewModel()
         {
             _stateService = ServiceContainer.Resolve<IStateService>("stateService");
+            _messagingService = ServiceContainer.Resolve<IMessagingService>("messagingService");
 
             PageTitle = AppResources.Bitwarden;
+
+            AccountSwitchingOverlayViewModel = new AccountSwitchingOverlayViewModel(_stateService, _messagingService)
+            {
+                AllowActiveAccountSelection = true
+            };
         }
 
-        public ExtendedObservableCollection<AccountView> AccountViews
-        {
-            get => _stateService.AccountViews;
-        }
+        public AccountSwitchingOverlayViewModel AccountSwitchingOverlayViewModel { get; }
 
         public Action StartLoginAction { get; set; }
         public Action StartRegisterAction { get; set; }

--- a/src/App/Pages/Accounts/LockPage.xaml
+++ b/src/App/Pages/Accounts/LockPage.xaml
@@ -1,13 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <pages:BaseContentPage 
     xmlns="http://xamarin.com/schemas/2014/forms"
-    xmlns:xct="http://xamarin.com/schemas/2020/toolkit"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     x:Class="Bit.App.Pages.LockPage"
     xmlns:pages="clr-namespace:Bit.App.Pages"
     xmlns:controls="clr-namespace:Bit.App.Controls"
-    xmlns:effects="clr-namespace:Bit.App.Effects"
-    xmlns:view="clr-namespace:Bit.Core.Models.View;assembly=BitwardenCore"
     xmlns:u="clr-namespace:Bit.App.Utilities"
     x:DataType="pages:LockPageViewModel"
     Title="{Binding PageTitle}">
@@ -21,14 +18,14 @@
                 x:Name="_accountAvatar"
                 x:Key="accountAvatar"
                 IconImageSource="{Binding AvatarImageSource}"
-                Clicked="AccountSwitch_Clicked"
+                Command="{Binding Source={x:Reference _accountListOverlay}, Path=ToggleVisibililtyCommand}"
                 Order="Primary"
                 Priority="-1"
                 UseOriginalImage="True"
                 AutomationProperties.IsInAccessibleTree="True"
                 AutomationProperties.Name="{u:I18n Account}" />
     </ContentPage.ToolbarItems>
-
+    
     <ContentPage.Resources>
         <ResourceDictionary>
             <u:InverseBoolConverter x:Key="inverseBool" />
@@ -164,57 +161,12 @@
             AbsoluteLayout.LayoutBounds="0, 0, 1, 1">
         </ContentView>
 
-        <!-- Account Switching Overlay -->
-        <ContentView
+        <controls:AccountSwitchingOverlayView
             x:Name="_accountListOverlay"
             AbsoluteLayout.LayoutBounds="0, 0, 1, 1"
             AbsoluteLayout.LayoutFlags="All"
-            IsVisible="False"
-            BackgroundColor="#22000000"
-            Padding="0">
-
-            <StackLayout
-                x:Name="_accountListContainer"
-                VerticalOptions="Fill"
-                HorizontalOptions="FillAndExpand"
-                BackgroundColor="Transparent">
-                <Frame
-                    Padding="0"
-                    HorizontalOptions="Fill"
-                    VerticalOptions="Start"
-                    xct:ShadowEffect.Color="Black"
-                    xct:ShadowEffect.Radius="10"
-                    xct:ShadowEffect.OffsetY="3">
-                    <ListView
-                        x:Name="_accountListView"
-                        ItemsSource="{Binding AccountViews}"
-                        ItemSelected="AccountRow_Selected"
-                        BackgroundColor="{DynamicResource BackgroundColor}"
-                        VerticalOptions="Start"
-                        RowHeight="{OnPlatform 70, iOS=70, Android=74}"
-                        effects:ScrollViewContentInsetAdjustmentBehaviorEffect.ContentInsetAdjustmentBehavior="Never">
-                        <ListView.ItemTemplate>
-                            <DataTemplate x:DataType="view:AccountView">
-                                <controls:AccountViewCell
-                                    Account="{Binding .}" />
-                            </DataTemplate>
-                        </ListView.ItemTemplate>
-                        <ListView.Effects>
-                            <effects:ScrollViewContentInsetAdjustmentBehaviorEffect />
-                        </ListView.Effects>
-
-                    </ListView>
-                </Frame>
-                <BoxView
-                    BackgroundColor="Transparent"
-                    HorizontalOptions="Fill"
-                    VerticalOptions="FillAndExpand">
-                    <BoxView.GestureRecognizers>
-                        <TapGestureRecognizer Tapped="AccountSwitchingOverlay_Tapped" />
-                    </BoxView.GestureRecognizers>
-                </BoxView>
-            </StackLayout>
-        </ContentView>
+            BindingContext="{Binding AccountSwitchingOverlayViewModel}"/>
+        
     </AbsoluteLayout>
 
 </pages:BaseContentPage>

--- a/src/App/Pages/Accounts/LockPage.xaml.cs
+++ b/src/App/Pages/Accounts/LockPage.xaml.cs
@@ -4,9 +4,6 @@ using Bit.App.Models;
 using Bit.App.Resources;
 using Bit.App.Utilities;
 using Bit.Core.Utilities;
-#if !FDROID
-using Microsoft.AppCenter.Crashes;
-#endif
 using Xamarin.Forms;
 
 namespace Bit.App.Pages
@@ -106,7 +103,7 @@ namespace Bit.App.Pages
         {
             if (_accountListOverlay.IsVisible)
             {
-                HideAccountListAsync(_accountListContainer, _accountListOverlay).FireAndForget();
+                _accountListOverlay.HideAsync().FireAndForget();
                 return true;
             }
             return false;
@@ -133,7 +130,7 @@ namespace Bit.App.Pages
 
         private async void LogOut_Clicked(object sender, EventArgs e)
         {
-            await HideAccountListAsync(_accountListContainer, _accountListOverlay);
+            await _accountListOverlay.HideAsync();
             if (DoOnce())
             {
                 await _vm.LogOutAsync();
@@ -150,7 +147,8 @@ namespace Bit.App.Pages
 
         private async void More_Clicked(object sender, System.EventArgs e)
         {
-            await HideAccountListAsync(_accountListContainer, _accountListOverlay);
+            await _accountListOverlay.HideAsync();
+
             if (!DoOnce())
             {
                 return;
@@ -174,48 +172,6 @@ namespace Bit.App.Pages
             var previousPage = await AppHelpers.ClearPreviousPage();
 
             Application.Current.MainPage = new TabsPage(_appOptions, previousPage);
-        }
-
-        private async void AccountSwitch_Clicked(object sender, EventArgs e)
-        {
-            try
-            {
-                await ToggleAccountListAsync(_accountListContainer, _accountListOverlay, _accountListView, true);
-            }
-            catch (Exception ex)
-            {
-#if !FDROID
-                Crashes.TrackError(ex);
-#endif
-            }
-        }
-
-        private async void AccountRow_Selected(object sender, SelectedItemChangedEventArgs e)
-        {
-            try
-            {
-                await AccountRowSelectedAsync(sender, e, _accountListContainer, _accountListOverlay, null, true);
-            }
-            catch (Exception ex)
-            {
-#if !FDROID
-                Crashes.TrackError(ex);
-#endif
-            }
-        }
-
-        private async void AccountSwitchingOverlay_Tapped(object sender, EventArgs e)
-        {
-            try
-            {
-                await HideAccountListAsync(_accountListContainer, _accountListOverlay);
-            }
-            catch (Exception ex)
-            {
-#if !FDROID
-                Crashes.TrackError(ex);
-#endif
-            }
         }
     }
 }

--- a/src/App/Pages/Accounts/LockPageViewModel.cs
+++ b/src/App/Pages/Accounts/LockPageViewModel.cs
@@ -1,15 +1,15 @@
-﻿using Bit.App.Abstractions;
+﻿using System;
+using System.Threading.Tasks;
+using Bit.App.Abstractions;
+using Bit.App.Controls;
 using Bit.App.Resources;
+using Bit.App.Utilities;
+using Bit.Core;
 using Bit.Core.Abstractions;
 using Bit.Core.Enums;
 using Bit.Core.Models.Domain;
-using Bit.Core.Utilities;
-using System;
-using System.Threading.Tasks;
-using Bit.App.Utilities;
-using Bit.Core;
 using Bit.Core.Models.Request;
-using Bit.Core.Models.View;
+using Bit.Core.Utilities;
 using Xamarin.Forms;
 
 namespace Bit.App.Pages
@@ -55,6 +55,12 @@ namespace Bit.App.Pages
             PageTitle = AppResources.VerifyMasterPassword;
             TogglePasswordCommand = new Command(TogglePassword);
             SubmitCommand = new Command(async () => await SubmitAsync());
+
+            AccountSwitchingOverlayViewModel = new AccountSwitchingOverlayViewModel(_stateService, _messagingService)
+            {
+                AllowAddAccountRow = true,
+                AllowActiveAccountSelection = true
+            };
         }
 
         public bool ShowPassword
@@ -114,10 +120,7 @@ namespace Bit.App.Pages
             set => SetProperty(ref _lockedVerifyText, value);
         }
 
-        public ExtendedObservableCollection<AccountView> AccountViews
-        {
-            get => _stateService.AccountViews;
-        }
+        public AccountSwitchingOverlayViewModel AccountSwitchingOverlayViewModel { get; }
 
         public Command SubmitCommand { get; }
         public Command TogglePasswordCommand { get; }

--- a/src/App/Pages/Accounts/LoginPage.xaml
+++ b/src/App/Pages/Accounts/LoginPage.xaml
@@ -1,13 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <pages:BaseContentPage 
     xmlns="http://xamarin.com/schemas/2014/forms"
-    xmlns:xct="http://xamarin.com/schemas/2020/toolkit"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     x:Class="Bit.App.Pages.LoginPage"
     xmlns:pages="clr-namespace:Bit.App.Pages"
     xmlns:controls="clr-namespace:Bit.App.Controls"
-    xmlns:effects="clr-namespace:Bit.App.Effects"
-    xmlns:view="clr-namespace:Bit.Core.Models.View;assembly=BitwardenCore"
     xmlns:u="clr-namespace:Bit.App.Utilities"
     x:DataType="pages:LoginPageViewModel"
     Title="{Binding PageTitle}">
@@ -21,7 +18,7 @@
                 x:Name="_accountAvatar"
                 x:Key="accountAvatar"
                 IconImageSource="{Binding AvatarImageSource}"
-                Clicked="AccountSwitch_Clicked"
+                Command="{Binding Source={x:Reference _accountListOverlay}, Path=ToggleVisibililtyCommand}"
                 Order="Primary"
                 Priority="-1"
                 UseOriginalImage="True"
@@ -113,57 +110,11 @@
             AbsoluteLayout.LayoutBounds="0, 0, 1, 1">
         </ContentView>
 
-        <!-- Account Switching Overlay -->
-        <ContentView
+        <controls:AccountSwitchingOverlayView
             x:Name="_accountListOverlay"
             AbsoluteLayout.LayoutBounds="0, 0, 1, 1"
             AbsoluteLayout.LayoutFlags="All"
-            IsVisible="False"
-            BackgroundColor="#22000000"
-            Padding="0">
-
-            <StackLayout
-                x:Name="_accountListContainer"
-                VerticalOptions="Fill"
-                HorizontalOptions="FillAndExpand"
-                BackgroundColor="Transparent">
-                <Frame
-                    Padding="0"
-                    HorizontalOptions="Fill"
-                    VerticalOptions="Start"
-                    xct:ShadowEffect.Color="Black"
-                    xct:ShadowEffect.Radius="10"
-                    xct:ShadowEffect.OffsetY="3">
-                    <ListView
-                        x:Name="_accountListView"
-                        ItemsSource="{Binding AccountViews}"
-                        ItemSelected="AccountRow_Selected"
-                        BackgroundColor="{DynamicResource BackgroundColor}"
-                        VerticalOptions="Start"
-                        RowHeight="{OnPlatform 70, iOS=70, Android=74}"
-                        effects:ScrollViewContentInsetAdjustmentBehaviorEffect.ContentInsetAdjustmentBehavior="Never">
-                        <ListView.ItemTemplate>
-                            <DataTemplate x:DataType="view:AccountView">
-                                <controls:AccountViewCell
-                                    Account="{Binding .}" />
-                            </DataTemplate>
-                        </ListView.ItemTemplate>
-                        <ListView.Effects>
-                            <effects:ScrollViewContentInsetAdjustmentBehaviorEffect />
-                        </ListView.Effects>
-
-                    </ListView>
-                </Frame>
-                <BoxView
-                    BackgroundColor="Transparent"
-                    HorizontalOptions="Fill"
-                    VerticalOptions="FillAndExpand">
-                    <BoxView.GestureRecognizers>
-                        <TapGestureRecognizer Tapped="AccountSwitchingOverlay_Tapped" />
-                    </BoxView.GestureRecognizers>
-                </BoxView>
-            </StackLayout>
-        </ContentView>
+            BindingContext="{Binding AccountSwitchingOverlayViewModel}"/>
     </AbsoluteLayout>
 
 </pages:BaseContentPage>

--- a/src/App/Pages/Accounts/LoginPage.xaml.cs
+++ b/src/App/Pages/Accounts/LoginPage.xaml.cs
@@ -1,13 +1,10 @@
-﻿using Bit.App.Models;
-using Bit.App.Resources;
-using System;
+﻿using System;
 using System.Threading.Tasks;
+using Bit.App.Models;
+using Bit.App.Resources;
 using Bit.App.Utilities;
 using Bit.Core.Utilities;
 using Xamarin.Forms;
-#if !FDROID
-using Microsoft.AppCenter.Crashes;
-#endif
 
 namespace Bit.App.Pages
 {
@@ -30,7 +27,7 @@ namespace Bit.App.Pages
                 () => Device.BeginInvokeOnMainThread(async () => await UpdateTempPasswordAsync());
             _vm.CloseAction = async () =>
             {
-                await HideAccountListAsync(_accountListContainer, _accountListOverlay);
+                await _accountListOverlay.HideAsync();
                 await Navigation.PopModalAsync();
             };
             _vm.Email = email;
@@ -86,7 +83,7 @@ namespace Bit.App.Pages
         {
             if (_accountListOverlay.IsVisible)
             {
-                HideAccountListAsync(_accountListContainer, _accountListOverlay).FireAndForget();
+                _accountListOverlay.HideAsync().FireAndForget();
                 return true;
             }
             return false;
@@ -125,7 +122,7 @@ namespace Bit.App.Pages
 
         private async void More_Clicked(object sender, System.EventArgs e)
         {
-            await HideAccountListAsync(_accountListContainer, _accountListOverlay);
+            await _accountListOverlay.HideAsync();
             if (!DoOnce())
             {
                 return;
@@ -160,48 +157,6 @@ namespace Bit.App.Pages
         {
             var page = new UpdateTempPasswordPage();
             await Navigation.PushModalAsync(new NavigationPage(page));
-        }
-
-        private async void AccountSwitch_Clicked(object sender, EventArgs e)
-        {
-            try
-            {
-                await ToggleAccountListAsync(_accountListContainer, _accountListOverlay, _accountListView, false);
-            }
-            catch (Exception ex)
-            {
-#if !FDROID
-                Crashes.TrackError(ex);
-#endif
-            }
-        }
-
-        private async void AccountRow_Selected(object sender, SelectedItemChangedEventArgs e)
-        {
-            try
-            {
-                await AccountRowSelectedAsync(sender, e, _accountListContainer, _accountListOverlay, null, true);
-            }
-            catch (Exception ex)
-            {
-#if !FDROID
-                Crashes.TrackError(ex);
-#endif
-            }
-        }
-
-        private async void AccountSwitchingOverlay_Tapped(object sender, EventArgs e)
-        {
-            try
-            {
-                await HideAccountListAsync(_accountListContainer, _accountListOverlay);
-            }
-            catch (Exception ex)
-            {
-#if !FDROID
-                Crashes.TrackError(ex);
-#endif
-            }
         }
     }
 }

--- a/src/App/Pages/Accounts/LoginPageViewModel.cs
+++ b/src/App/Pages/Accounts/LoginPageViewModel.cs
@@ -1,13 +1,13 @@
-﻿using Bit.App.Abstractions;
+﻿using System;
+using System.Threading.Tasks;
+using Bit.App.Abstractions;
+using Bit.App.Controls;
 using Bit.App.Resources;
+using Bit.App.Utilities;
+using Bit.Core;
 using Bit.Core.Abstractions;
 using Bit.Core.Exceptions;
 using Bit.Core.Utilities;
-using System;
-using System.Threading.Tasks;
-using Bit.App.Utilities;
-using Bit.Core;
-using Bit.Core.Models.View;
 using Xamarin.Forms;
 
 namespace Bit.App.Pages
@@ -21,6 +21,7 @@ namespace Bit.App.Pages
         private readonly IStateService _stateService;
         private readonly IEnvironmentService _environmentService;
         private readonly II18nService _i18nService;
+        private readonly IMessagingService _messagingService;
 
         private bool _showPassword;
         private string _email;
@@ -35,10 +36,16 @@ namespace Bit.App.Pages
             _stateService = ServiceContainer.Resolve<IStateService>("stateService");
             _environmentService = ServiceContainer.Resolve<IEnvironmentService>("environmentService");
             _i18nService = ServiceContainer.Resolve<II18nService>("i18nService");
+            _messagingService = ServiceContainer.Resolve<IMessagingService>("messagingService");
 
             PageTitle = AppResources.Bitwarden;
             TogglePasswordCommand = new Command(TogglePassword);
             LogInCommand = new Command(async () => await LogInAsync());
+
+            AccountSwitchingOverlayViewModel = new AccountSwitchingOverlayViewModel(_stateService, _messagingService)
+            {
+                AllowActiveAccountSelection = true
+            };
         }
 
         public bool ShowPassword
@@ -63,10 +70,7 @@ namespace Bit.App.Pages
             set => SetProperty(ref _masterPassword, value);
         }
 
-        public ExtendedObservableCollection<AccountView> AccountViews
-        {
-            get => _stateService.AccountViews;
-        }
+        public AccountSwitchingOverlayViewModel AccountSwitchingOverlayViewModel { get; }
 
         public Command LogInCommand { get; }
         public Command TogglePasswordCommand { get; }

--- a/src/App/Pages/Vault/GroupingsPage/GroupingsPage.xaml
+++ b/src/App/Pages/Vault/GroupingsPage/GroupingsPage.xaml
@@ -1,13 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <pages:BaseContentPage xmlns="http://xamarin.com/schemas/2014/forms"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-    xmlns:xct="http://xamarin.com/schemas/2020/toolkit"
     x:Class="Bit.App.Pages.GroupingsPage"
     xmlns:pages="clr-namespace:Bit.App.Pages"
     xmlns:u="clr-namespace:Bit.App.Utilities"
     xmlns:effects="clr-namespace:Bit.App.Effects"
     xmlns:controls="clr-namespace:Bit.App.Controls"
-    xmlns:view="clr-namespace:Bit.Core.Models.View;assembly=BitwardenCore"
     x:DataType="pages:GroupingsPageViewModel"
     Title="{Binding PageTitle}"
     x:Name="_page">
@@ -20,7 +18,7 @@
         <controls:ExtendedToolbarItem
             x:Name="_accountAvatar"
             IconImageSource="{Binding AvatarImageSource}"
-            Clicked="AccountSwitch_Clicked"
+            Command="{Binding Source={x:Reference _accountListOverlay}, Path=ToggleVisibililtyCommand}"
             Order="Primary"
             Priority="-1"
             UseOriginalImage="True"
@@ -162,56 +160,12 @@
             </Button.Effects>
         </Button>
 
-        <!-- Account Switching Overlay -->
-        <ContentView
+        <controls:AccountSwitchingOverlayView
             x:Name="_accountListOverlay"
             AbsoluteLayout.LayoutBounds="0, 0, 1, 1"
             AbsoluteLayout.LayoutFlags="All"
-            IsVisible="False"
-            BackgroundColor="#22000000"
-            Padding="0">
-
-            <StackLayout
-                x:Name="_accountListContainer"
-                VerticalOptions="Fill"
-                HorizontalOptions="FillAndExpand"
-                BackgroundColor="Transparent">
-                <Frame
-                    Padding="0"
-                    HorizontalOptions="Fill"
-                    VerticalOptions="Start"
-                    xct:ShadowEffect.Color="Black"
-                    xct:ShadowEffect.Radius="10"
-                    xct:ShadowEffect.OffsetY="3">
-                    <ListView
-                        x:Name="_accountListView"
-                        ItemsSource="{Binding AccountViews}"
-                        ItemSelected="AccountRow_Selected"
-                        BackgroundColor="{DynamicResource BackgroundColor}"
-                        VerticalOptions="Start"
-                        RowHeight="{OnPlatform 70, iOS=70, Android=74}"
-                        effects:ScrollViewContentInsetAdjustmentBehaviorEffect.ContentInsetAdjustmentBehavior="Never">
-                        <ListView.ItemTemplate>
-                            <DataTemplate x:DataType="view:AccountView">
-                                <controls:AccountViewCell
-                                    Account="{Binding .}" />
-                            </DataTemplate>
-                        </ListView.ItemTemplate>
-                        <ListView.Effects>
-                            <effects:ScrollViewContentInsetAdjustmentBehaviorEffect />
-                        </ListView.Effects>
-                    </ListView>
-                </Frame>
-                <BoxView
-                    BackgroundColor="Transparent"
-                    HorizontalOptions="Fill"
-                    VerticalOptions="FillAndExpand">
-                    <BoxView.GestureRecognizers>
-                        <TapGestureRecognizer Tapped="AccountSwitchingOverlay_Tapped" />
-                    </BoxView.GestureRecognizers>
-                </BoxView>
-            </StackLayout>
-        </ContentView>
+            MainFab="{Binding Source={x:Reference _fab}, Path=.}"
+            BindingContext="{Binding AccountSwitchingOverlayViewModel}"/>
     </AbsoluteLayout>
 
 </pages:BaseContentPage>

--- a/src/App/Pages/Vault/GroupingsPage/GroupingsPage.xaml.cs
+++ b/src/App/Pages/Vault/GroupingsPage/GroupingsPage.xaml.cs
@@ -8,9 +8,6 @@ using Bit.Core.Abstractions;
 using Bit.Core.Enums;
 using Bit.Core.Models.Data;
 using Bit.Core.Utilities;
-#if !FDROID
-using Microsoft.AppCenter.Crashes;
-#endif
 using Xamarin.Forms;
 
 namespace Bit.App.Pages
@@ -174,7 +171,7 @@ namespace Bit.App.Pages
         {
             if (_accountListOverlay.IsVisible)
             {
-                HideAccountListAsync(_accountListContainer, _accountListOverlay, _fab).FireAndForget();
+                _accountListOverlay.HideAsync().FireAndForget();
                 return true;
             }
             return false;
@@ -225,7 +222,7 @@ namespace Bit.App.Pages
 
         private async void Search_Clicked(object sender, EventArgs e)
         {
-            await HideAccountListAsync(_accountListContainer, _accountListOverlay, _fab);
+            await _accountListOverlay.HideAsync();
             if (DoOnce())
             {
                 var page = new CiphersPage(_vm.Filter, _vm.FolderId != null, _vm.CollectionId != null,
@@ -236,26 +233,26 @@ namespace Bit.App.Pages
 
         private async void Sync_Clicked(object sender, EventArgs e)
         {
-            await HideAccountListAsync(_accountListContainer, _accountListOverlay, _fab);
+            await _accountListOverlay.HideAsync();
             await _vm.SyncAsync();
         }
 
         private async void Lock_Clicked(object sender, EventArgs e)
         {
-            await HideAccountListAsync(_accountListContainer, _accountListOverlay, _fab);
+            await _accountListOverlay.HideAsync();
             await _vaultTimeoutService.LockAsync(true, true);
         }
 
         private async void Exit_Clicked(object sender, EventArgs e)
         {
-            await HideAccountListAsync(_accountListContainer, _accountListOverlay, _fab);
+            await _accountListOverlay.HideAsync();
             await _vm.ExitAsync();
         }
 
         private async void AddButton_Clicked(object sender, EventArgs e)
         {
             var skipAction = _accountListOverlay.IsVisible && Device.RuntimePlatform == Device.Android;
-            await HideAccountListAsync(_accountListContainer, _accountListOverlay, _fab);
+            await _accountListOverlay.HideAsync();
             if (skipAction)
             {
                 // Account list in the process of closing via tapping on invisible FAB, skip this attempt
@@ -274,7 +271,7 @@ namespace Bit.App.Pages
             {
                 return;
             }
-            await HideAccountListAsync(_accountListContainer, _accountListOverlay, _fab);
+            await _accountListOverlay.HideAsync();
             if (_previousPage.Page == "view" && !string.IsNullOrWhiteSpace(_previousPage.CipherId))
             {
                 await Navigation.PushModalAsync(new NavigationPage(new ViewPage(_previousPage.CipherId)));
@@ -290,48 +287,6 @@ namespace Bit.App.Pages
         {
             _addItem.IsEnabled = !_vm.Deleted;
             _addItem.IconImageSource = _vm.Deleted ? null : "plus.png";
-        }
-
-        private async void AccountSwitch_Clicked(object sender, EventArgs e)
-        {
-            try
-            {
-                await ToggleAccountListAsync(_accountListContainer, _accountListOverlay, _accountListView, true, _fab);
-            }
-            catch (Exception ex)
-            {
-#if !FDROID
-                Crashes.TrackError(ex);
-#endif
-            }
-        }
-
-        private async void AccountRow_Selected(object sender, SelectedItemChangedEventArgs e)
-        {
-            try
-            {
-                await AccountRowSelectedAsync(sender, e, _accountListContainer, _accountListOverlay, _fab);
-            }
-            catch (Exception ex)
-            {
-#if !FDROID
-                Crashes.TrackError(ex);
-#endif
-            }
-        }
-
-        private async void AccountSwitchingOverlay_Tapped(object sender, EventArgs e)
-        {
-            try
-            {
-                await HideAccountListAsync(_accountListContainer, _accountListOverlay, _fab);
-            }
-            catch (Exception ex)
-            {
-#if !FDROID
-                Crashes.TrackError(ex);
-#endif
-            }
         }
     }
 }

--- a/src/App/Pages/Vault/GroupingsPage/GroupingsPageViewModel.cs
+++ b/src/App/Pages/Vault/GroupingsPage/GroupingsPageViewModel.cs
@@ -1,4 +1,9 @@
-﻿using Bit.App.Abstractions;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Bit.App.Abstractions;
+using Bit.App.Controls;
 using Bit.App.Resources;
 using Bit.App.Utilities;
 using Bit.Core.Abstractions;
@@ -6,11 +11,6 @@ using Bit.Core.Enums;
 using Bit.Core.Models.Domain;
 using Bit.Core.Models.View;
 using Bit.Core.Utilities;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-using Bit.Core;
 using Xamarin.Forms;
 
 namespace Bit.App.Pages
@@ -68,6 +68,11 @@ namespace Bit.App.Pages
                 await LoadAsync();
             });
             CipherOptionsCommand = new Command<CipherView>(CipherOptionsAsync);
+
+            AccountSwitchingOverlayViewModel = new AccountSwitchingOverlayViewModel(_stateService, _messagingService)
+            {
+                AllowAddAccountRow = true
+            };
         }
 
         public bool MainPage { get; set; }
@@ -134,10 +139,8 @@ namespace Bit.App.Pages
             get => _websiteIconsEnabled;
             set => SetProperty(ref _websiteIconsEnabled, value);
         }
-        public ExtendedObservableCollection<AccountView> AccountViews
-        {
-            get => _stateService.AccountViews;
-        }
+
+        public AccountSwitchingOverlayViewModel AccountSwitchingOverlayViewModel { get; }
 
         public ExtendedObservableCollection<GroupingsPageListGroup> GroupedItems { get; set; }
         public Command RefreshCommand { get; set; }

--- a/src/Core/Abstractions/IStateService.cs
+++ b/src/Core/Abstractions/IStateService.cs
@@ -5,14 +5,13 @@ using Bit.Core.Enums;
 using Bit.Core.Models.Data;
 using Bit.Core.Models.Domain;
 using Bit.Core.Models.View;
-using Bit.Core.Utilities;
 
 namespace Bit.Core.Abstractions
 {
     public interface IStateService
     {
         bool BiometricLocked { get; set; }
-        ExtendedObservableCollection<AccountView> AccountViews { get; set; }
+        List<AccountView> AccountViews { get; }
         Task<List<string>> GetUserIdsAsync();
         Task<string> GetActiveUserIdAsync();
         Task SetActiveUserAsync(string userId);

--- a/src/Core/Services/StateService.cs
+++ b/src/Core/Services/StateService.cs
@@ -23,7 +23,7 @@ namespace Bit.Core.Services
 
         public bool BiometricLocked { get; set; }
 
-        public ExtendedObservableCollection<AccountView> AccountViews { get; set; }
+        public List<AccountView> AccountViews { get; set; }
 
         public StateService(IStorageService storageService, IStorageService secureStorageService)
         {
@@ -82,9 +82,13 @@ namespace Bit.Core.Services
 
             if (AccountViews == null)
             {
-                AccountViews = new ExtendedObservableCollection<AccountView>();
+                AccountViews = new List<AccountView>();
             }
-            AccountViews.Clear();
+            else
+            {
+                AccountViews.Clear();
+            }
+
             var accountList = _state?.Accounts?.Values.ToList();
             if (accountList == null)
             {


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [X] New feature development
- [X] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Add an account switching overlay control to be reused on all the views. Also add its own ViewModel to handle the logic and configuration.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **AccountSwitchingOverlayView:** This is the new control for the overlay
* **AccountSwitchingOverlayViewModel:** This is the overlay's viewmodel to handle logic and configuration
* **...Page.xaml:** Changed to use the new overlay control
* **...Page.xaml.cs:** Changed to use the new overlay control and removed old code
* **...PageViewModel.cs:** Added and created new `AccountSwitchingOverlayViewModel` on each to offer the binding context for the new overlay control and configuration 
* **BaseContentPage.cs:** Moved Account switching overlay logic to the new control
* **StateService:** Change the `AccountViews` to be a `List` instead of an `ExtendedObservableCollection` given that we don't change items while the view is open; it only changes when adding/removing accounts and that happens on pages transition so it doesn't make sense to use all the notifying events of the `ExtendedObservableCollection`. And also the List is replaced completely when refreshing the accounts so a simple `List` makes more sense for this case given that there are just a few items.

## Testing requirements
<!--What functionality requires testing by QA? This includes testing new behavior and regression testing-->
Everything should work as before.


## Before you submit
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
