### PR TITLE
Dismiss Account Switching overlay when tapping on the tabs

### DIFF
--- a/src/Android/Renderers/CustomTabbedRenderer.cs
+++ b/src/Android/Renderers/CustomTabbedRenderer.cs
@@ -1,7 +1,9 @@
 ﻿using Android.Content;
 using Android.Views;
+using Bit.App.Pages;
 using Bit.Droid.Renderers;
 using Google.Android.Material.BottomNavigation;
+using Google.Android.Material.Navigation;
 using Xamarin.Forms;
 using Xamarin.Forms.Platform.Android;
 using Xamarin.Forms.Platform.Android.AppCompat;
@@ -9,7 +11,7 @@ using Xamarin.Forms.Platform.Android.AppCompat;
 [assembly: ExportRenderer(typeof(TabbedPage), typeof(CustomTabbedRenderer))]
 namespace Bit.Droid.Renderers
 {
-    public class CustomTabbedRenderer : TabbedPageRenderer, BottomNavigationView.IOnNavigationItemReselectedListener
+    public class CustomTabbedRenderer : TabbedPageRenderer, NavigationBarView.IOnItemReselectedListener
     {
         private TabbedPage _page;
 
@@ -21,7 +23,7 @@ namespace Bit.Droid.Renderers
             if (e.NewElement != null)
             {
                 _page = e.NewElement;
-                GetBottomNavigationView()?.SetOnNavigationItemReselectedListener(this);
+                GetBottomNavigationView()?.SetOnItemReselectedListener(this);
             }
             else
             {
@@ -53,6 +55,10 @@ namespace Bit.Droid.Renderers
         {
             if (_page?.CurrentPage?.Navigation != null && _page.CurrentPage.Navigation.NavigationStack.Count > 0)
             {
+                if (_page is TabsPage tabsPage)
+                {
+                    tabsPage.OnPageReselected();
+                }
                 Device.BeginInvokeOnMainThread(async () => await _page.CurrentPage.Navigation.PopToRootAsync());
             }
         }

--- a/src/App/Pages/TabsPage.cs
+++ b/src/App/Pages/TabsPage.cs
@@ -103,8 +103,13 @@ namespace Bit.App.Pages
         {
             if (CurrentPage is NavigationPage navPage)
             {
+                if (_groupingsPage?.RootPage is GroupingsPage groupingsPage)
+                {
+                    await groupingsPage.HideAccountSwitchingOverlayAsync();
+                }
+
                 _messagingService.Send("updatedTheme");
-                if (navPage.RootPage is GroupingsPage groupingsPage)
+                if (navPage.RootPage is GroupingsPage)
                 {
                     // Load something?
                 }
@@ -116,6 +121,14 @@ namespace Bit.App.Pages
                 {
                     await settingsPage.InitAsync();
                 }
+            }
+        }
+
+        public void OnPageReselected()
+        {
+            if (_groupingsPage?.RootPage is GroupingsPage groupingsPage)
+            {
+                groupingsPage.HideAccountSwitchingOverlayAsync().FireAndForget();
             }
         }
     }

--- a/src/App/Pages/Vault/GroupingsPage/GroupingsPage.xaml.cs
+++ b/src/App/Pages/Vault/GroupingsPage/GroupingsPage.xaml.cs
@@ -333,5 +333,10 @@ namespace Bit.App.Pages
 #endif
             }
         }
+
+        public async Task HideAccountSwitchingOverlayAsync()
+        {
+            await HideAccountListAsync(_accountListContainer, _accountListOverlay, _fab);
+        }
     }
 }

--- a/src/iOS.Core/Renderers/CustomTabbedRenderer.cs
+++ b/src/iOS.Core/Renderers/CustomTabbedRenderer.cs
@@ -1,4 +1,6 @@
-﻿using Bit.App.Abstractions;
+﻿using System;
+using Bit.App.Abstractions;
+using Bit.App.Pages;
 using Bit.Core.Abstractions;
 using Bit.Core.Utilities;
 using Bit.iOS.Core.Renderers;
@@ -14,6 +16,7 @@ namespace Bit.iOS.Core.Renderers
     public class CustomTabbedRenderer : TabbedRenderer
     {
         private IBroadcasterService _broadcasterService;
+        private UITabBarItem _previousSelectedItem;
 
         public CustomTabbedRenderer()
         {
@@ -37,6 +40,25 @@ namespace Bit.iOS.Core.Renderers
             TabBar.Translucent = false;
             TabBar.Opaque = true;
             UpdateTabBarAppearance();
+        }
+
+        public override void ViewDidAppear(bool animated)
+        {
+            base.ViewDidAppear(animated);
+
+            if (SelectedIndex < TabBar.Items.Length)
+            {
+                _previousSelectedItem = TabBar.Items[SelectedIndex];
+            }
+        }
+
+        public override void ItemSelected(UITabBar tabbar, UITabBarItem item)
+        {
+            if (_previousSelectedItem == item && Element is TabsPage tabsPage)
+            {
+                tabsPage.OnPageReselected();
+            }
+            _previousSelectedItem = item;
         }
 
         protected override void Dispose(bool disposing)


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Dismiss the Account Switching Overlay when tapping on the tabs. 

**Merge #1753 before merging this so the call to hide the overlay gets updated in the new way the other PR has.**


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **TabsPage:** Implemented call to hide the overlay on the `GroupingsPage` on tab re-selection and when changing tabs
* **Android/Renderers/CustomTabbedRenderer.cs:** Called hide the overlay on tab re-selection and updated the deprecated listener.
* **/iOS.Core/Renderers/CustomTabbedRenderer.cs:** Called hide the overlay on tab re-selection
* **GroupigsPage.xaml.cs:** Made pubic method to hide the overlay (this needs to change when #1753 gets merged)

## Testing requirements
<!--What functionality requires testing by QA? This includes testing new behavior and regression testing-->
When the overlay is open and you tap on a tab, the overlay should hide.


## Before you submit
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
