### PR TITLE
remove datepicker style workaround

### DIFF
--- a/src/iOS.Core/Renderers/ExtendedDatePickerRenderer.cs
+++ b/src/iOS.Core/Renderers/ExtendedDatePickerRenderer.cs
@@ -23,19 +23,6 @@ namespace Bit.iOS.Core.Renderers
                 {
                     Control.Text = element.PlaceHolder;
                 }
-
-                // force use of wheel picker on iOS 14+
-                // TODO remove this when we upgrade to X.F 5 SR-1
-                // https://github.com/xamarin/Xamarin.Forms/issues/12258#issuecomment-700168665
-                try
-                {
-                    if (UIDevice.CurrentDevice.CheckSystemVersion(13, 2))
-                    {
-                        var picker = (UIDatePicker)Control.InputView;
-                        picker.PreferredDatePickerStyle = UIDatePickerStyle.Wheels;
-                    }
-                }
-                catch { }
             }
         }
 


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
We had a workaround for `DatePicker` styling that targeted iOS 13.2 and above. This workaround was actually supposed to be targeting 14.0 and above, so was throwing an error on anything between 13.2 and 14.0.  

Since we have upgraded to Xamarin 5.0.0.2125, we can remove this as Xamarin has [fixed the issue](https://github.com/xamarin/Xamarin.Forms/pull/13344)


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **src/iOS.Core/Renderers/ExtendedDatePickerRenderer.cs:** Remove styling workaround


## Testing requirements
<!--What functionality requires testing by QA? This includes testing new behavior and regression testing-->
`DatePicker` should continue working correctly. There are examples on the Settings and EditSend screens.


## Before you submit
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
