### PR TITLE
[Icons] - BUG - Update groupings icon for collections

### DIFF
--- a/src/App/Pages/Vault/GroupingsPage/GroupingsPageListItem.cs
+++ b/src/App/Pages/Vault/GroupingsPage/GroupingsPageListItem.cs
@@ -80,7 +80,7 @@ namespace Bit.App.Pages
                 }
                 else if (Collection != null)
                 {
-                    _icon = BitwardenIcons.Globe;
+                    _icon = BitwardenIcons.Collection;
                 }
                 else if (Type != null)
                 {


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
> Fix the groupings icon for collections: `bwi-globe` --> `bwi-collection`

## Code changes
- **GroupingsPageListItem**: Changed icon for collections to `BitwardenIcons.Collection`

## Screenshots
- Reference for correct icon
<img width="365" alt="Screen Shot 2022-02-11 at 11 09 57 PM" src="https://user-images.githubusercontent.com/26154748/153697705-94dd54ed-4308-471a-8e92-06f22c6c516f.png">


## Testing requirements
- Make sure that the icon for collections within the groupings page is using the correct icon

## Before you submit
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
