### PR TITLE
Fix for vault timeout not firing on resume

### DIFF
--- a/src/App/App.xaml.cs
+++ b/src/App/App.xaml.cs
@@ -97,7 +97,7 @@ namespace Bit.App
                 {
                     if (Device.RuntimePlatform == Device.iOS)
                     {
-                        ResumedAsync();
+                        ResumedAsync().FireAndForget();
                     }
                 }
                 else if (message.Command == "slept")
@@ -205,7 +205,7 @@ namespace Bit.App
             _isResumed = true;
             if (Device.RuntimePlatform == Device.Android)
             {
-                ResumedAsync();
+                ResumedAsync().FireAndForget();
             }
         }
 
@@ -215,7 +215,7 @@ namespace Bit.App
             _messagingService.Send("stopEventTimer");
         }
 
-        private async void ResumedAsync()
+        private async Task ResumedAsync()
         {
             await _vaultTimeoutService.CheckVaultTimeoutAsync();
             _messagingService.Send("startEventTimer");

--- a/src/App/App.xaml.cs
+++ b/src/App/App.xaml.cs
@@ -217,10 +217,9 @@ namespace Bit.App
 
         private async void ResumedAsync()
         {
-            await UpdateThemeAsync();
-
             await _vaultTimeoutService.CheckVaultTimeoutAsync();
             _messagingService.Send("startEventTimer");
+            await UpdateThemeAsync();
             await ClearCacheIfNeededAsync();
             Prime();
             SyncIfNeeded();


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Fix for vault timeout not firing on app resume in most recent release.  Closes #1772


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **App.xaml.cs:** The [recent change](https://github.com/bitwarden/mobile/pull/1707) to make `UpdateTheme` async resulted in a race condition which allowed `BaseContentPage.SaveActivity()` to execute prior to `VaultTimeoutService.CheckVaultTimeoutAsync()`.  This resulted in the `LastActiveTime` value being reset before it could be compared to the current time, making the app think only a few milliseconds had passed regardless of how long it was in the background.  By checking vault timeout before executing the improved theme update process, we're able to establish the correct elapsed time again.  @fedemkr Let me know if you see any issues with this interfering with the theme updater.

## Testing requirements
<!--What functionality requires testing by QA? This includes testing new behavior and regression testing-->
Vault timeout should function as expected again.


## Before you submit
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
