### PR TITLE
Usability improvements to handling logout on vault timeout

### DIFF
--- a/src/App/Pages/Accounts/LoginPageViewModel.cs
+++ b/src/App/Pages/Accounts/LoginPageViewModel.cs
@@ -75,7 +75,6 @@ namespace Bit.App.Pages
         public Command LogInCommand { get; }
         public Command TogglePasswordCommand { get; }
         public string ShowPasswordIcon => ShowPassword ? BitwardenIcons.EyeSlash : BitwardenIcons.Eye;
-        public bool RememberEmail { get; set; }
         public Action StartTwoFactorAction { get; set; }
         public Action LogInSuccessAction { get; set; }
         public Action UpdateTempPasswordAction { get; set; }
@@ -92,8 +91,6 @@ namespace Bit.App.Pages
             {
                 Email = await _stateService.GetRememberedEmailAsync();
             }
-            var rememberEmail = await _stateService.GetRememberEmailAsync();
-            RememberEmail = rememberEmail.GetValueOrDefault(true);
         }
 
         public async Task LogInAsync(bool showLoading = true)
@@ -134,14 +131,7 @@ namespace Bit.App.Pages
                 }
 
                 var response = await _authService.LogInAsync(Email, MasterPassword, _captchaToken);
-                if (RememberEmail)
-                {
-                    await _stateService.SetRememberedEmailAsync(Email);
-                }
-                else
-                {
-                    await _stateService.SetRememberedEmailAsync(null);
-                }
+                await _stateService.SetRememberedEmailAsync(Email);
                 await AppHelpers.ResetInvalidUnlockAttemptsAsync();
 
                 if (response.CaptchaNeeded)

--- a/src/App/Pages/Accounts/LoginSsoPageViewModel.cs
+++ b/src/App/Pages/Accounts/LoginSsoPageViewModel.cs
@@ -49,7 +49,6 @@ namespace Bit.App.Pages
         }
 
         public Command LogInCommand { get; }
-        public bool RememberOrgIdentifier { get; set; }
         public Action StartTwoFactorAction { get; set; }
         public Action StartSetPasswordAction { get; set; }
         public Action SsoAuthSuccessAction { get; set; }
@@ -62,8 +61,6 @@ namespace Bit.App.Pages
             {
                 OrgIdentifier = await _stateService.GetRememberedOrgIdentifierAsync();
             }
-            var rememberOrgIdentifier = await _stateService.GetRememberOrgIdentifierAsync();
-            RememberOrgIdentifier = rememberOrgIdentifier.GetValueOrDefault(true);
         }
 
         public async Task LogInAsync()
@@ -164,14 +161,7 @@ namespace Bit.App.Pages
             {
                 var response = await _authService.LogInSsoAsync(code, codeVerifier, redirectUri, orgId);
                 await AppHelpers.ResetInvalidUnlockAttemptsAsync();
-                if (RememberOrgIdentifier)
-                {
-                    await _stateService.SetRememberedOrgIdentifierAsync(OrgIdentifier);
-                }
-                else
-                {
-                    await _stateService.SetRememberedOrgIdentifierAsync(null);
-                }
+                await _stateService.SetRememberedOrgIdentifierAsync(OrgIdentifier);
                 await _deviceActionService.HideLoadingAsync();
                 if (response.TwoFactor)
                 {

--- a/src/App/Pages/Settings/ExtensionPageViewModel.cs
+++ b/src/App/Pages/Settings/ExtensionPageViewModel.cs
@@ -8,7 +8,6 @@ namespace Bit.App.Pages
     public class ExtensionPageViewModel : BaseViewModel
     {
         private readonly IMessagingService _messagingService;
-        private readonly IStateService _stateService;
 
         private bool _started;
         private bool _activated;
@@ -16,7 +15,6 @@ namespace Bit.App.Pages
         public ExtensionPageViewModel()
         {
             _messagingService = ServiceContainer.Resolve<IMessagingService>("messagingService");
-            _stateService = ServiceContainer.Resolve<IStateService>("stateService");
             PageTitle = AppResources.AppExtension;
         }
 
@@ -47,10 +45,8 @@ namespace Bit.App.Pages
 
         public async Task InitAsync()
         {
-            var started = await _stateService.GetAppExtensionStartedAsync();
-            var activated = await _stateService.GetAppExtensionActivatedAsync();
-            Started = started.GetValueOrDefault();
-            Activated = activated.GetValueOrDefault();
+            Started = false;
+            Activated = false;
         }
 
         public void ShowExtension()

--- a/src/App/Resources/AppResources.Designer.cs
+++ b/src/App/Resources/AppResources.Designer.cs
@@ -3743,6 +3743,12 @@ namespace Bit.App.Resources {
             }
         }
         
+        public static string AccountSwitchedAutomatically {
+            get {
+                return ResourceManager.GetString("AccountSwitchedAutomatically", resourceCulture);
+            }
+        }
+        
         public static string DeleteAccount {
             get {
                 return ResourceManager.GetString("DeleteAccount", resourceCulture);

--- a/src/App/Resources/AppResources.resx
+++ b/src/App/Resources/AppResources.resx
@@ -2105,6 +2105,9 @@
   <data name="AccountLoggedOut" xml:space="preserve">
     <value>Logged Out</value>
   </data>
+  <data name="AccountSwitchedAutomatically" xml:space="preserve">
+    <value>Switched to next available account</value>
+  </data>
   <data name="DeleteAccount" xml:space="preserve">
     <value>Delete Account</value>
   </data>

--- a/src/App/Services/MobileStorageService.cs
+++ b/src/App/Services/MobileStorageService.cs
@@ -29,12 +29,8 @@ namespace Bit.App.Services
             Constants.iOSAutoFillBiometricIntegrityKey,
             Constants.iOSExtensionClearCiphersCacheKey,
             Constants.iOSExtensionBiometricIntegrityKey,
-            Constants.RememberEmailKey,
             Constants.RememberedEmailKey,
-            Constants.RememberOrgIdentifierKey,
             Constants.RememberedOrgIdentifierKey,
-            Constants.AppExtensionStartedKey,
-            Constants.AppExtensionActivatedKey,
         };
 
         public MobileStorageService(

--- a/src/Core/Abstractions/IStateService.cs
+++ b/src/Core/Abstractions/IStateService.cs
@@ -12,13 +12,12 @@ namespace Bit.Core.Abstractions
     {
         bool BiometricLocked { get; set; }
         List<AccountView> AccountViews { get; }
-        Task<List<string>> GetUserIdsAsync();
         Task<string> GetActiveUserIdAsync();
         Task SetActiveUserAsync(string userId);
         Task<bool> IsAuthenticatedAsync(string userId = null);
         Task RefreshAccountViewsAsync(bool allowAddAccountRow);
         Task AddAccountAsync(Account account);
-        Task ClearAsync(string userId);
+        Task LogoutAccountAsync(string userId, bool userInitiated);
         Task<EnvironmentUrlData> GetPreAuthEnvironmentUrlsAsync();
         Task SetPreAuthEnvironmentUrlsAsync(EnvironmentUrlData value);
         Task<EnvironmentUrlData> GetEnvironmentUrlsAsync(string userId = null);
@@ -49,8 +48,8 @@ namespace Bit.Core.Abstractions
         Task SetPrivateKeyEncryptedAsync(string value, string userId = null);
         Task<List<string>> GetAutofillBlacklistedUrisAsync(string userId = null);
         Task SetAutofillBlacklistedUrisAsync(List<string> value, string userId = null);
-        Task<bool?> GetAutofillTileAddedAsync(string userId = null);
-        Task SetAutofillTileAddedAsync(bool? value, string userId = null);
+        Task<bool?> GetAutofillTileAddedAsync();
+        Task SetAutofillTileAddedAsync(bool? value);
         Task<string> GetEmailAsync(string userId = null);
         Task<string> GetNameAsync(string userId = null);
         Task<long?> GetLastActiveTimeAsync(string userId = null);
@@ -65,8 +64,8 @@ namespace Bit.Core.Abstractions
         Task SetPreviousPageInfoAsync(PreviousPageInfo value, string userId = null);
         Task<int> GetInvalidUnlockAttemptsAsync(string userId = null);
         Task SetInvalidUnlockAttemptsAsync(int? value, string userId = null);
-        Task<string> GetLastBuildAsync(string userId = null);
-        Task SetLastBuildAsync(string value, string userId = null);
+        Task<string> GetLastBuildAsync();
+        Task SetLastBuildAsync(string value);
         Task<bool?> GetDisableFaviconAsync(string userId = null);
         Task SetDisableFaviconAsync(bool? value, string userId = null);
         Task<bool?> GetDisableAutoTotpCopyAsync(string userId = null);
@@ -97,18 +96,12 @@ namespace Bit.Core.Abstractions
         Task SetSecurityStampAsync(string value, string userId = null);
         Task<bool> GetEmailVerifiedAsync(string userId = null);
         Task SetEmailVerifiedAsync(bool? value, string userId = null);
-        Task<bool> GetForcePasswordReset(string userId = null);
-        Task SetForcePasswordResetAsync(bool? value, string userId = null);
         Task<bool> GetSyncOnRefreshAsync(string userId = null);
         Task SetSyncOnRefreshAsync(bool? value, string userId = null);
-        Task<string> GetRememberedEmailAsync(string userId = null);
-        Task SetRememberedEmailAsync(string value, string userId = null);
-        Task<bool?> GetRememberEmailAsync(string userId = null);
-        Task SetRememberEmailAsync(bool? value, string userId = null);
-        Task<string> GetRememberedOrgIdentifierAsync(string userId = null);
-        Task SetRememberedOrgIdentifierAsync(string value, string userId = null);
-        Task<bool?> GetRememberOrgIdentifierAsync(string userId = null);
-        Task SetRememberOrgIdentifierAsync(bool? value, string userId = null);
+        Task<string> GetRememberedEmailAsync();
+        Task SetRememberedEmailAsync(string value);
+        Task<string> GetRememberedOrgIdentifierAsync();
+        Task SetRememberedOrgIdentifierAsync(string value);
         Task<string> GetThemeAsync(string userId = null);
         Task SetThemeAsync(string value, string userId = null);
         Task<bool?> GetAddSitePromptShownAsync(string userId = null);
@@ -119,20 +112,16 @@ namespace Bit.Core.Abstractions
         Task SetPushLastRegistrationDateAsync(DateTime? value);
         Task<string> GetPushInstallationRegistrationErrorAsync();
         Task SetPushInstallationRegistrationErrorAsync(string value);
-        Task<string> GetPushCurrentTokenAsync(string userId = null);
-        Task SetPushCurrentTokenAsync(string value, string userId = null);
-        Task<List<EventData>> GetEventCollectionAsync(string userId = null);
-        Task SetEventCollectionAsync(List<EventData> value, string userId = null);
+        Task<string> GetPushCurrentTokenAsync();
+        Task SetPushCurrentTokenAsync(string value);
+        Task<List<EventData>> GetEventCollectionAsync();
+        Task SetEventCollectionAsync(List<EventData> value);
         Task<Dictionary<string, FolderData>> GetEncryptedFoldersAsync(string userId = null);
         Task SetEncryptedFoldersAsync(Dictionary<string, FolderData> value, string userId = null);
         Task<Dictionary<string, PolicyData>> GetEncryptedPoliciesAsync(string userId = null);
         Task SetEncryptedPoliciesAsync(Dictionary<string, PolicyData> value, string userId = null);
         Task<string> GetPushRegisteredTokenAsync();
         Task SetPushRegisteredTokenAsync(string value);
-        Task<bool?> GetAppExtensionStartedAsync(string userId = null);
-        Task SetAppExtensionStartedAsync(bool? value, string userId = null);
-        Task<bool?> GetAppExtensionActivatedAsync(string userId = null);
-        Task SetAppExtensionActivatedAsync(bool? value, string userId = null);
         Task<bool> GetUsesKeyConnectorAsync(string userId = null);
         Task SetUsesKeyConnectorAsync(bool? value, string userId = null);
         Task<Dictionary<string, OrganizationData>> GetOrganizationsAsync(string userId = null);

--- a/src/Core/Constants.cs
+++ b/src/Core/Constants.cs
@@ -24,12 +24,8 @@
         public static string iOSExtensionClearCiphersCacheKey = "iOSExtensionClearCiphersCache";
         public static string iOSExtensionBiometricIntegrityKey = "iOSExtensionBiometricIntegrityState";
         public static string EventCollectionKey = "eventCollection";
-        public static string RememberEmailKey = "rememberEmail";
         public static string RememberedEmailKey = "rememberedEmail";
-        public static string RememberOrgIdentifierKey = "rememberOrgIdentifier";
         public static string RememberedOrgIdentifierKey = "rememberedOrgIdentifier";
-        public static string AppExtensionStartedKey = "appExtensionStarted";
-        public static string AppExtensionActivatedKey = "appExtensionActivated";
         public const int SelectFileRequestCode = 42;
         public const int SelectFilePermissionRequestCode = 43;
         public const int SaveFileRequestCode = 44;
@@ -80,7 +76,6 @@
         public static string SettingsKey(string userId) => $"settings_{userId}";
         public static string UsesKeyConnectorKey(string userId) => $"usesKeyConnector_{userId}";
         public static string ProtectedPinKey(string userId) => $"protectedPin_{userId}";
-        public static string ForcePasswordResetKey(string userId) => $"forcePasswordReset_{userId}";
         public static string LastSyncKey(string userId) => $"lastSync_{userId}";
         public static string BiometricUnlockKey(string userId) => $"biometricUnlock_{userId}";
     }

--- a/src/Core/Services/StateMigrationService.cs
+++ b/src/Core/Services/StateMigrationService.cs
@@ -243,8 +243,6 @@ namespace Bit.Core.Services
                 await GetValueAsync<bool?>(Storage.LiteDb, V2Keys.PasswordVerifiedAutofillKey);
             await SetValueAsync(Storage.LiteDb, Constants.PasswordVerifiedAutofillKey(userId),
                 passwordVerifiedAutofill);
-            var forcePasswordReset = await GetValueAsync<bool?>(Storage.LiteDb, V2Keys.Keys_ForcePasswordReset);
-            await SetValueAsync(Storage.LiteDb, Constants.ForcePasswordResetKey(userId), forcePasswordReset);
             var cipherLocalData = await GetValueAsync<Dictionary<string, Dictionary<string, object>>>(Storage.LiteDb,
                 V2Keys.Keys_LocalData);
             await SetValueAsync(Storage.LiteDb, Constants.LocalDataKey(userId), cipherLocalData);

--- a/src/Core/Services/SyncService.cs
+++ b/src/Core/Services/SyncService.cs
@@ -327,7 +327,6 @@ namespace Bit.Core.Services
             var organizations = response.Organizations.ToDictionary(o => o.Id, o => new OrganizationData(o));
             await _organizationService.ReplaceAsync(organizations);
             await _stateService.SetEmailVerifiedAsync(response.EmailVerified);
-            await _stateService.SetForcePasswordResetAsync(response.ForcePasswordReset);
             await _keyConnectorService.SetUsesKeyConnector(response.UsesKeyConnector);
         }
 

--- a/src/Core/Services/VaultTimeoutService.cs
+++ b/src/Core/Services/VaultTimeoutService.cs
@@ -88,7 +88,8 @@ namespace Bit.Core.Services
             {
                 return false;
             }
-            if (await IsLockedAsync(userId))
+            var vaultTimeoutAction = await _stateService.GetVaultTimeoutActionAsync(userId);
+            if (vaultTimeoutAction == "lock" && await IsLockedAsync(userId))
             {
                 return false;
             }


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Improvements to the handling and presentation of logging out on vault timeout.  Some high-level details:
- Being "logged out" on timeout is presented to the user the same way as being "locked" (i.e. the account is still displayed in the account switcher and can be selected as the active account)
- User settings are maintained so when the user logs back in the app behaves like they're picking up where they left off.  Vault data however (pretty much everything encrypted for that matter) is removed, otherwise it would defeat the purpose of logging out on timeout.  Logging back in will sync and reconstruct that data.
- When the user logs out via the settings menu (known internally as "user initiated"), then we clean house of all settings and data, making subsequent logins by the same user a from-scratch affair.
- This flow feels the most natural in the mobile app since we don't run timers to manage account auth states

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **AppHelpers.cs:** Flow updates and added automatic account switch toast on user initiated logout
* **StateService.cs:** Added support for `userInitiated` bool to logout and account removal flow to keep or remove data accordingly, removed userId support for non user-specific data, removed unused methods
* **StateMigrationService.cs/SyncService.cs:** Removed support for ForcePasswordReset value since that was moved to the auth flow awhile back
* **VaultTimeoutService.cs:** Check for "lock" action set before establishing `isLocked` to prevent result from having multiple meanings
* **Constants.cs/MobileStorageService.cs:** Removed unused storage/pref keys
* **AppResources.resx:** Added string for automatic account switch toast
* **LoginPageViewModel.cs:** Removed `RememberEmail` property since it was never set and is always true
* **LoginSsoPageViewModel.cs:** Removed `RememberOrgIdentifier` property since it was never set and is always true
* **ExtensionPageViewModel.cs:** Removed use of `StateService` since the values were never set and defaulted to false


## Testing requirements
<!--What functionality requires testing by QA? This includes testing new behavior and regression testing-->
Use "Logout" and "Lock" vault timeout actions with multiple accounts simultaneously


## Before you submit
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
