### PR TITLE
Account switching fixes

### DIFF
--- a/src/App/Models/AppOptions.cs
+++ b/src/App/Models/AppOptions.cs
@@ -22,6 +22,7 @@ namespace Bit.App.Models
         public bool IosExtension { get; set; }
         public Tuple<SendType, string, byte[], string> CreateSend { get; set; }
         public bool CopyInsteadOfShareAfterSaving { get; set; }
+        public bool HideAccountSwitcher { get; set; }
 
         public void SetAllFrom(AppOptions o)
         {
@@ -46,6 +47,7 @@ namespace Bit.App.Models
             IosExtension = o.IosExtension;
             CreateSend = o.CreateSend;
             CopyInsteadOfShareAfterSaving = o.CopyInsteadOfShareAfterSaving;
+            HideAccountSwitcher = o.HideAccountSwitcher;
         }
     }
 }

--- a/src/App/Pages/Accounts/HomePage.xaml
+++ b/src/App/Pages/Accounts/HomePage.xaml
@@ -23,8 +23,6 @@
             UseOriginalImage="True"
             AutomationProperties.IsInAccessibleTree="True"
             AutomationProperties.Name="{u:I18n Account}" />
-        <ToolbarItem x:Name="_closeItem" x:Key="closeItem" Text="{u:I18n Close}"
-                     Clicked="Close_Clicked" Order="Primary" Priority="-1" />
         <ToolbarItem
             Icon="cog_environment.png" Clicked="Environment_Clicked" Order="Primary"
             AutomationProperties.IsInAccessibleTree="True"
@@ -51,6 +49,10 @@
                                 Clicked="Register_Clicked" />
                         <Button Text="{u:I18n LogInSso}"
                                 Clicked="LogInSso_Clicked" />
+                        <Button Text="{u:I18n Cancel}"
+                                IsVisible="{Binding ShowCancelButton}"
+                                Margin="0,10,0,0"
+                                Clicked="Cancel_Clicked" />
                     </StackLayout>
                 </StackLayout>
             </StackLayout>

--- a/src/App/Pages/Accounts/HomePage.xaml.cs
+++ b/src/App/Pages/Accounts/HomePage.xaml.cs
@@ -27,9 +27,14 @@ namespace Bit.App.Pages
             _vm.StartEnvironmentAction = () => Device.BeginInvokeOnMainThread(async () => await StartEnvironmentAsync());
             UpdateLogo();
 
-            if (!_appOptions?.IosExtension ?? false)
+            if (_appOptions?.IosExtension ?? false)
             {
-                ToolbarItems.Remove(_closeItem);
+                _vm.ShowCancelButton = true;
+            }
+
+            if (_appOptions?.HideAccountSwitcher ?? false)
+            {
+                ToolbarItems.Remove(_accountAvatar);
             }
         }
 
@@ -45,13 +50,9 @@ namespace Bit.App.Pages
             _mainContent.Content = _mainLayout;
             _accountAvatar?.OnAppearing();
 
-            if (await ShowAccountSwitcherAsync())
+            if (!_appOptions?.HideAccountSwitcher ?? false)
             {
                 _vm.AvatarImageSource = await GetAvatarImageSourceAsync();
-            }
-            else
-            {
-                ToolbarItems.Remove(_accountAvatar);
             }
             _broadcasterService.Subscribe(nameof(HomePage), async (message) =>
             {
@@ -87,7 +88,7 @@ namespace Bit.App.Pages
             _logo.Source = !ThemeManager.UsingLightTheme ? "logo_white.png" : "logo.png";
         }
         
-        private void Close_Clicked(object sender, EventArgs e)
+        private void Cancel_Clicked(object sender, EventArgs e)
         {
             if (DoOnce())
             {

--- a/src/App/Pages/Accounts/HomePageViewModel.cs
+++ b/src/App/Pages/Accounts/HomePageViewModel.cs
@@ -11,6 +11,8 @@ namespace Bit.App.Pages
         private readonly IStateService _stateService;
         private readonly IMessagingService _messagingService;
 
+        private bool _showCancelButton;
+
         public HomeViewModel()
         {
             _stateService = ServiceContainer.Resolve<IStateService>("stateService");
@@ -24,8 +26,13 @@ namespace Bit.App.Pages
             };
         }
 
-        public AccountSwitchingOverlayViewModel AccountSwitchingOverlayViewModel { get; }
+        public bool ShowCancelButton
+        {
+            get => _showCancelButton;
+            set => SetProperty(ref _showCancelButton, value);
+        }
 
+        public AccountSwitchingOverlayViewModel AccountSwitchingOverlayViewModel { get; }
         public Action StartLoginAction { get; set; }
         public Action StartRegisterAction { get; set; }
         public Action StartSsoLoginAction { get; set; }

--- a/src/App/Pages/Accounts/LoginPage.xaml
+++ b/src/App/Pages/Accounts/LoginPage.xaml
@@ -24,8 +24,6 @@
                 UseOriginalImage="True"
                 AutomationProperties.IsInAccessibleTree="True"
                 AutomationProperties.Name="{u:I18n Account}" />
-        <ToolbarItem x:Name="_closeItem" x:Key="closeItem" Text="{u:I18n Close}"
-                     Clicked="Close_Clicked" Order="Primary" Priority="-1" />
     </ContentPage.ToolbarItems>
 
     <ContentPage.Resources>
@@ -52,7 +50,17 @@
                                 x:Name="_email"
                                 Text="{Binding Email}"
                                 Keyboard="Email"
-                                StyleClass="box-value" />
+                                StyleClass="box-value">
+                                <VisualStateManager.VisualStateGroups>
+                                    <VisualStateGroup x:Name="CommonStates">
+                                        <VisualState x:Name="Disabled">
+                                            <VisualState.Setters>
+                                                <Setter Property="TextColor" Value="{DynamicResource MutedColor}" />
+                                            </VisualState.Setters>
+                                        </VisualState>
+                                    </VisualStateGroup>
+                                </VisualStateManager.VisualStateGroups>
+                                </Entry>
                         </StackLayout>
                         <Grid StyleClass="box-row">
                             <Grid.RowDefinitions>
@@ -94,6 +102,9 @@
                         <Button Text="{u:I18n LogIn}" 
                                 StyleClass="btn-primary"
                                 Clicked="LogIn_Clicked" />
+                        <Button Text="{u:I18n Cancel}"
+                                IsVisible="{Binding ShowCancelButton}"
+                                Clicked="Cancel_Clicked" />
                     </StackLayout>
                 </StackLayout>
             </ScrollView>

--- a/src/App/Pages/Accounts/LoginPage.xaml.cs
+++ b/src/App/Pages/Accounts/LoginPage.xaml.cs
@@ -30,12 +30,16 @@ namespace Bit.App.Pages
                 await _accountListOverlay.HideAsync();
                 await Navigation.PopModalAsync();
             };
+            if (!string.IsNullOrWhiteSpace(email))
+            {
+                _email.IsEnabled = false;
+            }
+            else
+            {
+                _vm.ShowCancelButton = true;
+            }
             _vm.Email = email;
             MasterPasswordEntry = _masterPassword;
-            if (Device.RuntimePlatform == Device.Android)
-            {
-                ToolbarItems.RemoveAt(0);
-            }
 
             _email.ReturnType = ReturnType.Next;
             _email.ReturnCommand = new Command(() => _masterPassword.Focus());
@@ -49,9 +53,14 @@ namespace Bit.App.Pages
                 ToolbarItems.Add(_getPasswordHint);
             }
 
-            if (!_appOptions?.IosExtension ?? false)
+            if (_appOptions?.IosExtension ?? false)
             {
-                ToolbarItems.Remove(_closeItem);
+                _vm.ShowCancelButton = true;
+            }
+
+            if (_appOptions?.HideAccountSwitcher ?? false)
+            {
+                ToolbarItems.Remove(_accountAvatar);
             }
         }
 
@@ -63,13 +72,9 @@ namespace Bit.App.Pages
             _mainContent.Content = _mainLayout;
             _accountAvatar?.OnAppearing();
 
-            if (await ShowAccountSwitcherAsync())
+            if (!_appOptions?.HideAccountSwitcher ?? false)
             {
                 _vm.AvatarImageSource = await GetAvatarImageSourceAsync();
-            }
-            else
-            {
-                ToolbarItems.Remove(_accountAvatar);
             }
             await _vm.InitAsync();
             if (!_inputFocused)
@@ -112,7 +117,7 @@ namespace Bit.App.Pages
             }
         }
 
-        private void Close_Clicked(object sender, EventArgs e)
+        private void Cancel_Clicked(object sender, EventArgs e)
         {
             if (DoOnce())
             {

--- a/src/App/Pages/Accounts/LoginPageViewModel.cs
+++ b/src/App/Pages/Accounts/LoginPageViewModel.cs
@@ -24,6 +24,7 @@ namespace Bit.App.Pages
         private readonly IMessagingService _messagingService;
 
         private bool _showPassword;
+        private bool _showCancelButton;
         private string _email;
         private string _masterPassword;
 
@@ -44,6 +45,7 @@ namespace Bit.App.Pages
 
             AccountSwitchingOverlayViewModel = new AccountSwitchingOverlayViewModel(_stateService, _messagingService)
             {
+                AllowAddAccountRow = true,
                 AllowActiveAccountSelection = true
             };
         }
@@ -58,6 +60,12 @@ namespace Bit.App.Pages
                 });
         }
 
+        public bool ShowCancelButton
+        {
+            get => _showCancelButton;
+            set => SetProperty(ref _showCancelButton, value);
+        }
+        
         public string Email
         {
             get => _email;

--- a/src/App/Pages/Settings/SettingsPage/SettingsPageViewModel.cs
+++ b/src/App/Pages/Settings/SettingsPage/SettingsPageViewModel.cs
@@ -53,11 +53,11 @@ namespace Bit.App.Pages
                 new KeyValuePair<string, int?>(AppResources.Never, null),
                 new KeyValuePair<string, int?>(AppResources.Custom, CustomVaultTimeoutValue),
             };
-        private List<KeyValuePair<string, string>> _vaultTimeoutActions =
-            new List<KeyValuePair<string, string>>
+        private List<KeyValuePair<string, VaultTimeoutAction>> _vaultTimeoutActions =
+            new List<KeyValuePair<string, VaultTimeoutAction>>
             {
-                new KeyValuePair<string, string>(AppResources.Lock, "lock"),
-                new KeyValuePair<string, string>(AppResources.LogOut, "logOut"),
+                new KeyValuePair<string, VaultTimeoutAction>(AppResources.Lock, VaultTimeoutAction.Lock),
+                new KeyValuePair<string, VaultTimeoutAction>(AppResources.LogOut, VaultTimeoutAction.Logout),
             };
 
         private Policy _vaultTimeoutPolicy;
@@ -109,7 +109,7 @@ namespace Bit.App.Pages
 
             _vaultTimeout = await _vaultTimeoutService.GetVaultTimeout();
             _vaultTimeoutDisplayValue = _vaultTimeouts.FirstOrDefault(o => o.Value == _vaultTimeout).Key;
-            var action = await _stateService.GetVaultTimeoutActionAsync() ?? "lock";
+            var action = await _stateService.GetVaultTimeoutActionAsync() ?? VaultTimeoutAction.Lock;
             _vaultTimeoutActionDisplayValue = _vaultTimeoutActions.FirstOrDefault(o => o.Value == action).Key;
             var pinSet = await _vaultTimeoutService.IsPinLockSetAsync();
             _pin = pinSet.Item1 || pinSet.Item2;
@@ -526,7 +526,7 @@ namespace Bit.App.Pages
             return true;
         }
 
-        private string GetVaultTimeoutActionFromKey(string key)
+        private VaultTimeoutAction GetVaultTimeoutActionFromKey(string key)
         {
             return _vaultTimeoutActions.FirstOrDefault(o => o.Key == key).Value;
         }

--- a/src/App/Utilities/AppHelpers.cs
+++ b/src/App/Utilities/AppHelpers.cs
@@ -460,6 +460,7 @@ namespace Bit.App.Utilities
             var vaultTimeoutService = ServiceContainer.Resolve<IVaultTimeoutService>("vaultTimeoutService");
             var stateService = ServiceContainer.Resolve<IStateService>("stateService");
             var deviceActionService = ServiceContainer.Resolve<IDeviceActionService>("deviceActionService");
+            var policyService = ServiceContainer.Resolve<IPolicyService>("policyService");
             var searchService = ServiceContainer.Resolve<ISearchService>("searchService");
 
             if (userId == null)
@@ -477,7 +478,11 @@ namespace Bit.App.Utilities
                 cryptoService.ClearKeysAsync(userId),
                 settingsService.ClearAsync(userId),
                 vaultTimeoutService.ClearAsync(userId),
+                policyService.ClearAsync(userId),
                 stateService.LogoutAccountAsync(userId, userInitiated));
+
+            stateService.BiometricLocked = true;
+            searchService.ClearIndex();
 
             // check if we switched accounts automatically
             if (userInitiated && await stateService.GetActiveUserIdAsync() != null)
@@ -488,8 +493,6 @@ namespace Bit.App.Utilities
                 var platformUtilsService = ServiceContainer.Resolve<IPlatformUtilsService>("platformUtilsService");
                 platformUtilsService.ShowToast("info", null, AppResources.AccountSwitchedAutomatically);
             }
-            stateService.BiometricLocked = true;
-            searchService.ClearIndex();
         }
 
         public static async Task OnAccountSwitchAsync()
@@ -504,6 +507,7 @@ namespace Bit.App.Utilities
             var passwordGenerationService = ServiceContainer.Resolve<IPasswordGenerationService>(
                 "passwordGenerationService");
             var deviceActionService = ServiceContainer.Resolve<IDeviceActionService>("deviceActionService");
+            var policyService = ServiceContainer.Resolve<IPolicyService>("policyService");
             var searchService = ServiceContainer.Resolve<ISearchService>("searchService");
 
             await environmentService.SetUrlsFromStorageAsync();
@@ -517,6 +521,7 @@ namespace Bit.App.Utilities
             folderService.ClearCache();
             collectionService.ClearCache();
             passwordGenerationService.ClearCache();
+            policyService.ClearCache();
             searchService.ClearIndex();
         }
     }

--- a/src/Core/Abstractions/IPolicyService.cs
+++ b/src/Core/Abstractions/IPolicyService.cs
@@ -10,15 +10,15 @@ namespace Bit.Core.Abstractions
     public interface IPolicyService
     {
         void ClearCache();
-        Task<IEnumerable<Policy>> GetAll(PolicyType? type);
-        Task Replace(Dictionary<string, PolicyData> policies);
-        Task Clear(string userId);
-        Task<MasterPasswordPolicyOptions> GetMasterPasswordPolicyOptions(IEnumerable<Policy> policies = null);
+        Task<IEnumerable<Policy>> GetAll(PolicyType? type, string userId = null);
+        Task Replace(Dictionary<string, PolicyData> policies, string userId = null);
+        Task ClearAsync(string userId);
+        Task<MasterPasswordPolicyOptions> GetMasterPasswordPolicyOptions(IEnumerable<Policy> policies = null, string userId = null);
         Task<bool> EvaluateMasterPassword(int passwordStrength, string newPassword,
             MasterPasswordPolicyOptions enforcedPolicyOptions);
         Tuple<ResetPasswordPolicyOptions, bool> GetResetPasswordPolicyOptions(IEnumerable<Policy> policies,
             string orgId);
-        Task<bool> PolicyAppliesToUser(PolicyType policyType, Func<Policy, bool> policyFilter = null);
+        Task<bool> PolicyAppliesToUser(PolicyType policyType, Func<Policy, bool> policyFilter = null, string userId = null);
         int? GetPolicyInt(Policy policy, string key);
     }
 }

--- a/src/Core/Abstractions/IStateService.cs
+++ b/src/Core/Abstractions/IStateService.cs
@@ -52,12 +52,13 @@ namespace Bit.Core.Abstractions
         Task SetAutofillTileAddedAsync(bool? value);
         Task<string> GetEmailAsync(string userId = null);
         Task<string> GetNameAsync(string userId = null);
+        Task<string> GetOrgIdentifierAsync(string userId = null);
         Task<long?> GetLastActiveTimeAsync(string userId = null);
         Task SetLastActiveTimeAsync(long? value, string userId = null);
         Task<int?> GetVaultTimeoutAsync(string userId = null);
         Task SetVaultTimeoutAsync(int? value, string userId = null);
-        Task<string> GetVaultTimeoutActionAsync(string userId = null);
-        Task SetVaultTimeoutActionAsync(string value, string userId = null);
+        Task<VaultTimeoutAction?> GetVaultTimeoutActionAsync(string userId = null);
+        Task SetVaultTimeoutActionAsync(VaultTimeoutAction? value, string userId = null);
         Task<DateTime?> GetLastFileCacheClearAsync(string userId = null);
         Task SetLastFileCacheClearAsync(DateTime? value, string userId = null);
         Task<PreviousPageInfo> GetPreviousPageInfoAsync(string userId = null);

--- a/src/Core/Abstractions/IVaultTimeoutService.cs
+++ b/src/Core/Abstractions/IVaultTimeoutService.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Threading.Tasks;
+using Bit.Core.Enums;
 
 namespace Bit.Core.Abstractions
 {
@@ -12,11 +13,12 @@ namespace Bit.Core.Abstractions
         Task ExecuteTimeoutActionAsync(string userId = null);
         Task ClearAsync(string userId = null);
         Task<bool> IsLockedAsync(string userId = null);
+        Task<bool> IsLoggedOutByTimeoutAsync(string userId = null);
         Task<Tuple<bool, bool>> IsPinLockSetAsync(string userId = null);
         Task<bool> IsBiometricLockSetAsync(string userId = null);
         Task LockAsync(bool allowSoftLock = false, bool userInitiated = false, string userId = null);
         Task LogOutAsync(bool userInitiated = true, string userId = null);
-        Task SetVaultTimeoutOptionsAsync(int? timeout, string action);
+        Task SetVaultTimeoutOptionsAsync(int? timeout, VaultTimeoutAction? action);
         Task<int?> GetVaultTimeout(string userId = null);
     }
 }

--- a/src/Core/Enums/VaultTimeoutAction.cs
+++ b/src/Core/Enums/VaultTimeoutAction.cs
@@ -1,0 +1,8 @@
+﻿namespace Bit.Core.Enums
+{
+    public enum VaultTimeoutAction
+    {
+        Lock = 0,
+        Logout = 1,
+    }
+}

--- a/src/Core/Models/Domain/Account.cs
+++ b/src/Core/Models/Domain/Account.cs
@@ -43,6 +43,7 @@ namespace Bit.Core.Models.Domain
                 Email = copy.Email;
                 Name = copy.Name;
                 Stamp = copy.Stamp;
+                OrgIdentifier = copy.OrgIdentifier;
                 KdfType = copy.KdfType;
                 KdfIterations = copy.KdfIterations;
                 EmailVerified = copy.EmailVerified;
@@ -53,6 +54,7 @@ namespace Bit.Core.Models.Domain
             public string Email;
             public string Name;
             public string Stamp;
+            public string OrgIdentifier;
             public KdfType? KdfType;
             public int? KdfIterations;
             public bool? EmailVerified;
@@ -98,7 +100,7 @@ namespace Bit.Core.Models.Domain
             public EnvironmentUrlData EnvironmentUrls;
             public EncString PinProtected;
             public int? VaultTimeout;
-            public string VaultTimeoutAction;
+            public VaultTimeoutAction? VaultTimeoutAction;
         }
 
         public class AccountKeys

--- a/src/Core/Services/PolicyService.cs
+++ b/src/Core/Services/PolicyService.cs
@@ -30,11 +30,11 @@ namespace Bit.Core.Services
             _policyCache = null;
         }
 
-        public async Task<IEnumerable<Policy>> GetAll(PolicyType? type)
+        public async Task<IEnumerable<Policy>> GetAll(PolicyType? type, string userId = null)
         {
             if (_policyCache == null)
             {
-                var policies = await _stateService.GetEncryptedPoliciesAsync();
+                var policies = await _stateService.GetEncryptedPoliciesAsync(userId);
                 if (policies == null)
                 {
                     return null;
@@ -52,26 +52,26 @@ namespace Bit.Core.Services
             }
         }
 
-        public async Task Replace(Dictionary<string, PolicyData> policies)
+        public async Task Replace(Dictionary<string, PolicyData> policies, string userId = null)
         {
-            await _stateService.SetEncryptedPoliciesAsync(policies);
+            await _stateService.SetEncryptedPoliciesAsync(policies, userId);
             _policyCache = null;
         }
 
-        public async Task Clear(string userId)
+        public async Task ClearAsync(string userId)
         {
             await _stateService.SetEncryptedPoliciesAsync(null, userId);
             _policyCache = null;
         }
 
         public async Task<MasterPasswordPolicyOptions> GetMasterPasswordPolicyOptions(
-            IEnumerable<Policy> policies = null)
+            IEnumerable<Policy> policies = null, string userId = null)
         {
             MasterPasswordPolicyOptions enforcedOptions = null;
 
             if (policies == null)
             {
-                policies = await GetAll(PolicyType.MasterPassword);
+                policies = await GetAll(PolicyType.MasterPassword, userId);
             }
             else
             {
@@ -193,14 +193,14 @@ namespace Bit.Core.Services
             return new Tuple<ResetPasswordPolicyOptions, bool>(resetPasswordPolicyOptions, policy != null);
         }
 
-        public async Task<bool> PolicyAppliesToUser(PolicyType policyType, Func<Policy, bool> policyFilter)
+        public async Task<bool> PolicyAppliesToUser(PolicyType policyType, Func<Policy, bool> policyFilter, string userId = null)
         {
-            var policies = await GetAll(policyType);
+            var policies = await GetAll(policyType, userId);
             if (policies == null)
             {
                 return false;
             }
-            var organizations = await _organizationService.GetAllAsync();
+            var organizations = await _organizationService.GetAllAsync(userId);
 
             IEnumerable<Policy> filteredPolicies;
 

--- a/src/Core/Services/StateMigrationService.cs
+++ b/src/Core/Services/StateMigrationService.cs
@@ -193,7 +193,8 @@ namespace Bit.Core.Services
             {
                 EnvironmentUrls = environmentUrls,
                 VaultTimeout = vaultTimeout,
-                VaultTimeoutAction = vaultTimeoutAction,
+                VaultTimeoutAction =
+                    vaultTimeoutAction == "logout" ? VaultTimeoutAction.Logout : VaultTimeoutAction.Lock,
             };
             if (!string.IsNullOrWhiteSpace(pinProtected))
             {

--- a/src/Core/Services/TokenService.cs
+++ b/src/Core/Services/TokenService.cs
@@ -5,6 +5,7 @@ using System;
 using System.Text;
 using System.Threading.Tasks;
 using System.Linq;
+using Bit.Core.Enums;
 
 namespace Bit.Core.Services
 {
@@ -220,7 +221,7 @@ namespace Bit.Core.Services
         {
             var timeout = await _stateService.GetVaultTimeoutAsync();
             var action = await _stateService.GetVaultTimeoutActionAsync();
-            return timeout.HasValue && action == "logOut";
+            return timeout.HasValue && action == VaultTimeoutAction.Logout;
         }
     }
 }

--- a/src/iOS.Core/Utilities/ASHelpers.cs
+++ b/src/iOS.Core/Utilities/ASHelpers.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using AuthenticationServices;
 using Bit.Core.Abstractions;
+using Bit.Core.Enums;
 using Bit.Core.Models.View;
 using Bit.Core.Utilities;
 
@@ -17,7 +18,7 @@ namespace Bit.iOS.Core.Utilities
                 var storageService = ServiceContainer.Resolve<IStorageService>("storageService");
                 var stateService = ServiceContainer.Resolve<IStateService>("stateService");
                 var timeoutAction = await stateService.GetVaultTimeoutActionAsync();
-                if (timeoutAction == "logOut")
+                if (timeoutAction == VaultTimeoutAction.Logout)
                 {
                     return;
                 }
@@ -50,7 +51,7 @@ namespace Bit.iOS.Core.Utilities
         {
             var stateService = ServiceContainer.Resolve<IStateService>("stateService");
             var timeoutAction = await stateService.GetVaultTimeoutActionAsync();
-            if (timeoutAction == "logOut")
+            if (timeoutAction == VaultTimeoutAction.Logout)
             {
                 return false;
             }

--- a/src/iOS/AppDelegate.cs
+++ b/src/iOS/AppDelegate.cs
@@ -8,6 +8,7 @@ using Bit.App.Services;
 using Bit.App.Utilities;
 using Bit.Core;
 using Bit.Core.Abstractions;
+using Bit.Core.Enums;
 using Bit.Core.Services;
 using Bit.Core.Utilities;
 using Bit.iOS.Core.Utilities;
@@ -161,7 +162,7 @@ namespace Bit.iOS
                 else if (message.Command == "vaultTimeoutActionChanged")
                 {
                     var timeoutAction = await _stateService.GetVaultTimeoutActionAsync();
-                    if (timeoutAction == "logOut")
+                    if (timeoutAction == VaultTimeoutAction.Logout)
                     {
                         var userId = await _stateService.GetActiveUserIdAsync();
                         // TODO make specific to userId


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
A multitude of fixes, things I missed, etc.  See code changes for details.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **AppOptions.cs:** Added `HideAccountSwitcher` bool to control this asynchronously when constructing a page
* **HomePage.*:** Replaced "Close" ToolbarItem with a "Cancel" button since there doesn't appear to be a way to alternate with the avatar (only shown when running as iOS extension), hide account switcher based on AppOptions in constructor (so it works in iOS now)
* **LoginPage.*:** Replaced "Close" ToolbarItem with a "Cancel" button since there doesn't appear to be a way to alternate with the avatar (only shown during normal (not vault-timeout) login flow), added disabled Entry visual state for text color when disabling email field (when logging back in after logout via vault timeout), hide account switcher based on AppOptions in constructor (so it works in iOS now)
* **App.xaml.cs:** Added support for going directly to appropriate login page (login or SSO login instead of Home) when logging back in after vault timeout (left TODO for SSO flow handling which is not complete)
* **PolicyService.cs (and all references to it):** Added proper support for userId (missed this in the OG pass)
* **VaultTimeoutAction (and all references to it):** Converted from string to enum (was going to save this for later until I realized migration would be much easier before account switching is released)
* **Account.cs:** Added `OrgIdentifier` to `AccountProfile` for use with the SSO login flow after logout via vault timeout
* **StateService.cs:** Removed text status for active account since it was becoming messy (and expensive) to discern "what I am" vs. "what I will be" upon selection.  2 points in favor: 1) current screen of active user acts as "where I am", so no need to tell them twice, and 2) the modified appearance in the menu acts as another visual enforcement of the active account at a glance
* **VaultTimeoutService.cs:** Added handy `IsLoggedOutByTimeoutAsync` bool to reduce noise


## Screenshots
<!--Required for any UI changes. Delete if not applicable-->
<img width="765" alt="Screen Shot 2022-02-17 at 11 55 14 AM" src="https://user-images.githubusercontent.com/59324545/154531708-b7f4df44-737a-4841-bcc6-71614d6ad10d.png">



## Testing requirements
<!--What functionality requires testing by QA? This includes testing new behavior and regression testing-->
Continued testing of account switching as a whole


## Before you submit
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
