### PR TITLE
Fix Large Font Accessibility issues on icons on Vault and Send

### DIFF
--- a/src/Android/Services/DeviceActionService.cs
+++ b/src/Android/Services/DeviceActionService.cs
@@ -938,5 +938,11 @@ namespace Bit.Droid.Services
                 Context.ClipboardService) as Android.Content.ClipboardManager;
             clipboardManager.PrimaryClip = ClipData.NewPlainText("bitwarden", text);
         }
+
+        public float GetSystemFontSizeScale()
+        {
+            var activity = CrossCurrentActivity.Current?.Activity as MainActivity;
+            return activity?.Resources?.Configuration?.FontScale ?? 1;
+        }
     }
 }

--- a/src/App/Abstractions/IDeviceActionService.cs
+++ b/src/App/Abstractions/IDeviceActionService.cs
@@ -45,5 +45,6 @@ namespace Bit.App.Abstractions
         long GetActiveTime();
         void CloseMainApp();
         bool SupportsFido2();
+        float GetSystemFontSizeScale();
     }
 }

--- a/src/App/Controls/CipherViewCell/CipherViewCell.xaml
+++ b/src/App/Controls/CipherViewCell/CipherViewCell.xaml
@@ -12,10 +12,10 @@
     x:DataType="controls:CipherViewCellViewModel">
 
     <Grid.Resources>
-          <u:IconGlyphConverter x:Key="iconGlyphConverter"/>
-          <u:IconImageConverter x:Key="iconImageConverter"/>
-          <u:InverseBoolConverter x:Key="inverseBool" />
-          <u:StringHasValueConverter x:Key="stringHasValueConverter" />
+        <u:IconGlyphConverter x:Key="iconGlyphConverter"/>
+        <u:IconImageConverter x:Key="iconImageConverter"/>
+        <u:InverseBoolConverter x:Key="inverseBool" />
+        <u:StringHasValueConverter x:Key="stringHasValueConverter" />
     </Grid.Resources>
 
     <Grid.RowDefinitions>
@@ -23,7 +23,7 @@
     </Grid.RowDefinitions>
 
     <Grid.ColumnDefinitions>
-        <ColumnDefinition Width="40" />
+        <ColumnDefinition Width="40" x:Name="_iconColumn" />
         <ColumnDefinition Width="*" />
         <ColumnDefinition Width="60" />
     </Grid.ColumnDefinitions>
@@ -35,6 +35,7 @@
         StyleClass="list-icon, list-icon-platform"
         IsVisible="{Binding ShowIconImage, Converter={StaticResource inverseBool}}"
         Text="{Binding Cipher, Converter={StaticResource iconGlyphConverter}}"
+        ShouldUpdateFontSizeDynamicallyForAccesibility="True"
         AutomationProperties.IsInAccessibleTree="False" />
 
     <ff:CachedImage
@@ -42,10 +43,12 @@
         BitmapOptimizations="True"
         ErrorPlaceholder="login.png"
         LoadingPlaceholder="login.png"
-        HorizontalOptions="Center"
-        VerticalOptions="Center"
-        WidthRequest="22"
-        HeightRequest="22"
+        HorizontalOptions="Fill"
+        VerticalOptions="Fill"
+        Margin="9"
+        MinimumWidthRequest="22"
+        MinimumHeightRequest="22"
+        Aspect="AspectFit"
         IsVisible="{Binding ShowIconImage}"
         Source="{Binding IconImageSource, Mode=OneTime}"
         AutomationProperties.IsInAccessibleTree="False" />

--- a/src/App/Controls/CipherViewCell/CipherViewCell.xaml.cs
+++ b/src/App/Controls/CipherViewCell/CipherViewCell.xaml.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using Bit.App.Abstractions;
 using Bit.Core.Models.View;
+using Bit.Core.Utilities;
 using Xamarin.Forms;
 
 namespace Bit.App.Controls
@@ -18,6 +20,9 @@ namespace Bit.App.Controls
         public CipherViewCell()
         {
             InitializeComponent();
+
+            var deviceActionService = ServiceContainer.Resolve<IDeviceActionService>("deviceActionService");
+            _iconColumn.Width = new GridLength(40 * deviceActionService.GetSystemFontSizeScale(), GridUnitType.Absolute);
         }
 
         public bool? WebsiteIconsEnabled

--- a/src/App/Controls/IconLabel.cs
+++ b/src/App/Controls/IconLabel.cs
@@ -4,6 +4,8 @@ namespace Bit.App.Controls
 {
     public class IconLabel : Label
     {
+        public bool ShouldUpdateFontSizeDynamicallyForAccesibility { get; set; }
+
         public IconLabel()
         {
             switch (Device.RuntimePlatform)

--- a/src/App/Controls/SendViewCell/SendViewCell.xaml
+++ b/src/App/Controls/SendViewCell/SendViewCell.xaml
@@ -19,7 +19,7 @@
     </Grid.RowDefinitions>
 
     <Grid.ColumnDefinitions>
-        <ColumnDefinition Width="40" />
+        <ColumnDefinition Width="40" x:Name="_iconColumn" />
         <ColumnDefinition Width="*" />
         <ColumnDefinition Width="60" />
     </Grid.ColumnDefinitions>
@@ -31,6 +31,7 @@
         VerticalOptions="Center"
         StyleClass="list-icon, list-icon-platform"
         Text="{Binding Send, Converter={StaticResource sendIconGlyphConverter}}"
+        ShouldUpdateFontSizeDynamicallyForAccesibility="True"
         AutomationProperties.IsInAccessibleTree="False" />
 
     <Grid RowSpacing="0" ColumnSpacing="0" Grid.Row="0" Grid.Column="1" VerticalOptions="Center" Padding="0, 7">

--- a/src/App/Controls/SendViewCell/SendViewCell.xaml.cs
+++ b/src/App/Controls/SendViewCell/SendViewCell.xaml.cs
@@ -1,5 +1,7 @@
 using System;
+using Bit.App.Abstractions;
 using Bit.Core.Models.View;
+using Bit.Core.Utilities;
 using Xamarin.Forms;
 
 namespace Bit.App.Controls
@@ -18,6 +20,9 @@ namespace Bit.App.Controls
         public SendViewCell()
         {
             InitializeComponent();
+
+            var deviceActionService = ServiceContainer.Resolve<IDeviceActionService>("deviceActionService");
+            _iconColumn.Width = new GridLength(40 * deviceActionService.GetSystemFontSizeScale(), GridUnitType.Absolute);
         }
 
         public SendView Send

--- a/src/App/Pages/Send/SendGroupingsPage/SendGroupingsPage.xaml
+++ b/src/App/Pages/Send/SendGroupingsPage/SendGroupingsPage.xaml
@@ -54,7 +54,8 @@
                     <controls:IconLabel Text="{Binding Icon, Mode=OneWay}"
                                       HorizontalOptions="Start"
                                       VerticalOptions="Center"
-                                      StyleClass="list-icon, list-icon-platform">
+                                      StyleClass="list-icon, list-icon-platform"
+                                      ShouldUpdateFontSizeDynamicallyForAccesibility="True">
                         <controls:IconLabel.Effects>
                             <effects:FixedSizeEffect />
                         </controls:IconLabel.Effects>

--- a/src/App/Pages/Vault/GroupingsPage/GroupingsPage.xaml
+++ b/src/App/Pages/Vault/GroupingsPage/GroupingsPage.xaml
@@ -50,7 +50,8 @@
                     <controls:IconLabel Text="{Binding Icon, Mode=OneWay}"
                                       HorizontalOptions="Start"
                                       VerticalOptions="Center"
-                                      StyleClass="list-icon, list-icon-platform">
+                                      StyleClass="list-icon, list-icon-platform"
+                                      ShouldUpdateFontSizeDynamicallyForAccesibility="True">
                         <controls:IconLabel.Effects>
                             <effects:FixedSizeEffect />
                         </controls:IconLabel.Effects>

--- a/src/App/Styles/Base.xaml
+++ b/src/App/Styles/Base.xaml
@@ -239,9 +239,9 @@
     <Style TargetType="Label"
            Class="list-icon"
            ApplyToDerivedTypes="True">
-        <Setter Property="WidthRequest"
+        <Setter Property="MinimumWidthRequest"
                 Value="26" />
-        <Setter Property="HeightRequest"
+        <Setter Property="MinimumHeightRequest"
                 Value="26" />
         <Setter Property="HorizontalTextAlignment"
                 Value="Center" />

--- a/src/iOS.Core/Renderers/CustomLabelRenderer.cs
+++ b/src/iOS.Core/Renderers/CustomLabelRenderer.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.ComponentModel;
+using Bit.App.Controls;
 using Bit.iOS.Core.Renderers;
 using Bit.iOS.Core.Utilities;
 using UIKit;
@@ -48,10 +49,19 @@ namespace Bit.iOS.Core.Renderers
 			if (Element is null || Control is null)
 				return;
 
-			var pointSize = iOSHelpers.GetAccessibleFont<Label>(Element.FontSize);
+            var pointSize = iOSHelpers.GetAccessibleFont<Label>(Element.FontSize);
 			if (pointSize != null)
 			{
-				Control.Font = UIFont.FromDescriptor(Element.Font.ToUIFont().FontDescriptor, pointSize.Value);
+				Control.Font = UIFont.FromDescriptor(Element.ToUIFont().FontDescriptor, pointSize.Value);
+			}
+			// TODO: For now, I'm only doing this for IconLabel with setup just in case I break the whole app labels.
+			// We need to revisit this when we address Accessibility Large Font issues across the app
+            // to check if we can left it more generic like
+			// else if (Element.FontFamily != null)
+			else if (Element is IconLabel iconLabel && iconLabel.ShouldUpdateFontSizeDynamicallyForAccesibility)
+			{
+				var customFont = Element.ToUIFont();
+				Control.Font = new UIFontMetrics(UIFontTextStyle.Body.GetConstant()).GetScaledFont(customFont);
 			}
 		}
 	}

--- a/src/iOS.Core/Services/DeviceActionService.cs
+++ b/src/iOS.Core/Services/DeviceActionService.cs
@@ -587,6 +587,13 @@ namespace Bit.iOS.Core.Services
             throw new NotImplementedException();
         }
 
+        public float GetSystemFontSizeScale()
+        {
+            var tempHeight = 20f;
+            var scaledHeight = (float)new UIFontMetrics(UIFontTextStyle.Body.GetConstant()).GetScaledValue(tempHeight);
+            return scaledHeight / tempHeight;
+        }
+
         public class PickerDelegate : UIDocumentPickerDelegate
         {
             private readonly DeviceActionService _deviceActionService;

--- a/src/iOS.Core/Utilities/FontElementExtensions.cs
+++ b/src/iOS.Core/Utilities/FontElementExtensions.cs
@@ -1,0 +1,21 @@
+﻿using UIKit;
+using Xamarin.Forms;
+using Xamarin.Forms.Internals;
+using Xamarin.Forms.Platform.iOS;
+
+namespace Bit.iOS.Core.Utilities
+{
+    public static class FontElementExtensions
+    {
+        public static UIFont ToUIFont(this IFontElement fontElement)
+        {
+            var fontSize = fontElement.FontSize;
+            var fontAttributes = fontElement.FontAttributes;
+            var fontFamily = fontElement.FontFamily;
+
+            return fontFamily is null
+                ? Font.SystemFontOfSize(fontSize, fontAttributes).ToUIFont()
+                : Font.OfSize(fontFamily, fontSize).WithAttributes(fontAttributes).ToUIFont();
+        }
+    }
+}

--- a/src/iOS.Core/iOS.Core.csproj
+++ b/src/iOS.Core/iOS.Core.csproj
@@ -192,6 +192,7 @@
     <Compile Include="Renderers\SelectableLabelRenderer.cs" />
     <Compile Include="Effects\ScrollEnabledEffect.cs" />
     <Compile Include="Services\ClipboardService.cs" />
+    <Compile Include="Utilities\FontElementExtensions.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\App\App.csproj">


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
This PR fixes the Large Font Accessibility issues on the Vault and Send views, that were displaying the icons partially when the system font was too big.

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **DeviceActionService.cs:** Added `GetSystemFontSizeScale()` to calculate sizes that are not directly related to fonts like grid columns.
* **CypherViewCell / SendViewCell:** Changed so that icons are columns are adapted to Accessibility Large Fonts
* **IconLabel:** Added `ShouldUpdateFontSizeDynamicallyForAccesibility` to be specific on when we want to update the font size for accesibility. This was added just in case to not affect the whole app thus introducing this change little by little. Then when we address the Accessibillity Large Font issues across the whole app we can make the logic more generic and remove this property.
* **(iOS) CustomLabelRenderer:** Added logic to adapt non-NamedSizes font sizes to dynamic font sizes for accessibility but only for `IconLabel` with `ShouldUpdateFontSizeDynamicallyForAccesibility` set to `true`
* **FontElementExtetnsions.cs:** Added helper method to get `UIFont` from a `IFontElement`

## Screenshots
<!--Required for any UI changes. Delete if not applicable-->

![Simulator Screen Shot - iPhone 11 Pro Max - 2022-02-17 at 17 42 30](https://user-images.githubusercontent.com/15682323/154569955-3a9abc46-f865-46fe-b7b2-386e0fec6868.png)
![Simulator Screen Shot - iPhone 11 Pro Max - 2022-02-17 at 17 42 15](https://user-images.githubusercontent.com/15682323/154569966-57026520-39f1-4478-b043-5e7b9d0d321e.png)


## Testing requirements
<!--What functionality requires testing by QA? This includes testing new behavior and regression testing-->
On the Vault and Send tabs, the rows should be shown correctly without clipping the icons when changing the Accessibility Large Fonts from the system settings.

Known issue: On iOS, for web icons you may not see the update on size if you don't close the app and open it again after changing the Large Font settings. This will be addressed in a different PR


## Before you submit
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
