### PR TITLE
Fix for invalid PIN lock state when switching accounts

### DIFF
--- a/src/App/Pages/Accounts/LockPageViewModel.cs
+++ b/src/App/Pages/Accounts/LockPageViewModel.cs
@@ -135,7 +135,7 @@ namespace Bit.App.Pages
         public async Task InitAsync()
         {
             _pinSet = await _vaultTimeoutService.IsPinLockSetAsync();
-            PinLock = (_pinSet.Item1 && _stateService.GetPinProtectedAsync() != null) || _pinSet.Item2;
+            PinLock = (_pinSet.Item1 && await _stateService.GetPinProtectedKeyAsync() != null) || _pinSet.Item2;
             BiometricLock = await _vaultTimeoutService.IsBiometricLockSetAsync() && await _cryptoService.HasKeyAsync();
 
             // Users with key connector and without biometric or pin has no MP to unlock with
@@ -230,7 +230,7 @@ namespace Bit.App.Pages
                     {
                         var key = await _cryptoService.MakeKeyFromPinAsync(Pin, _email,
                             kdf.GetValueOrDefault(KdfType.PBKDF2_SHA256), kdfIterations.GetValueOrDefault(5000),
-                            await _stateService.GetPinProtectedCachedAsync());
+                            await _stateService.GetPinProtectedKeyAsync());
                         var encKey = await _cryptoService.GetEncKeyAsync(key);
                         var protectedPin = await _stateService.GetProtectedPinAsync();
                         var decPin = await _cryptoService.DecryptToUtf8Async(new EncString(protectedPin), encKey);
@@ -306,7 +306,7 @@ namespace Bit.App.Pages
                         var decPin = await _cryptoService.DecryptToUtf8Async(new EncString(protectedPin), encKey);
                         var pinKey = await _cryptoService.MakePinKeyAysnc(decPin, _email,
                             kdf.GetValueOrDefault(KdfType.PBKDF2_SHA256), kdfIterations.GetValueOrDefault(5000));
-                        await _stateService.SetPinProtectedCachedAsync(await _cryptoService.EncryptAsync(key.Key, pinKey));
+                        await _stateService.SetPinProtectedKeyAsync(await _cryptoService.EncryptAsync(key.Key, pinKey));
                     }
                     MasterPassword = string.Empty;
                     await AppHelpers.ResetInvalidUnlockAttemptsAsync();

--- a/src/App/Pages/Settings/SettingsPage/SettingsPageViewModel.cs
+++ b/src/App/Pages/Settings/SettingsPage/SettingsPageViewModel.cs
@@ -353,7 +353,7 @@ namespace Bit.App.Pages
                     {
                         var encPin = await _cryptoService.EncryptAsync(pin);
                         await _stateService.SetProtectedPinAsync(encPin.EncryptedString);
-                        await _stateService.SetPinProtectedCachedAsync(pinProtectedKey);
+                        await _stateService.SetPinProtectedKeyAsync(pinProtectedKey);
                     }
                     else
                     {

--- a/src/Core/Abstractions/IStateService.cs
+++ b/src/Core/Abstractions/IStateService.cs
@@ -28,8 +28,8 @@ namespace Bit.Core.Abstractions
         Task SetProtectedPinAsync(string value, string userId = null);
         Task<string> GetPinProtectedAsync(string userId = null);
         Task SetPinProtectedAsync(string value, string userId = null);
-        Task<EncString> GetPinProtectedCachedAsync(string userId = null);
-        Task SetPinProtectedCachedAsync(EncString value, string userId = null);
+        Task<EncString> GetPinProtectedKeyAsync(string userId = null);
+        Task SetPinProtectedKeyAsync(EncString value, string userId = null);
         Task<KdfType?> GetKdfTypeAsync(string userId = null);
         Task SetKdfTypeAsync(KdfType? value, string userId = null);
         Task<int?> GetKdfIterationsAsync(string userId = null);

--- a/src/Core/Models/Domain/Account.cs
+++ b/src/Core/Models/Domain/Account.cs
@@ -92,13 +92,11 @@ namespace Bit.Core.Models.Domain
                 }
 
                 EnvironmentUrls = copy.EnvironmentUrls;
-                PinProtected = copy.PinProtected;
                 VaultTimeout = copy.VaultTimeout;
                 VaultTimeoutAction = copy.VaultTimeoutAction;
             }
 
             public EnvironmentUrlData EnvironmentUrls;
-            public EncString PinProtected;
             public int? VaultTimeout;
             public VaultTimeoutAction? VaultTimeoutAction;
         }
@@ -106,6 +104,7 @@ namespace Bit.Core.Models.Domain
         public class AccountKeys
         {
             public SymmetricCryptoKey Key;
+            public EncString PinProtectedKey;
         }
     }
 }

--- a/src/Core/Services/StateMigrationService.cs
+++ b/src/Core/Services/StateMigrationService.cs
@@ -186,7 +186,6 @@ namespace Bit.Core.Services
                 }
             );
             var environmentUrls = await GetValueAsync<EnvironmentUrlData>(Storage.Prefs, V2Keys.EnvironmentUrlsKey);
-            var pinProtected = await GetValueAsync<string>(Storage.LiteDb, V2Keys.PinProtectedKey);
             var vaultTimeout = await GetValueAsync<int?>(Storage.Prefs, V2Keys.VaultTimeoutKey);
             var vaultTimeoutAction = await GetValueAsync<string>(Storage.Prefs, V2Keys.VaultTimeoutActionKey);
             account.Settings = new Account.AccountSettings()
@@ -196,10 +195,6 @@ namespace Bit.Core.Services
                 VaultTimeoutAction =
                     vaultTimeoutAction == "logout" ? VaultTimeoutAction.Logout : VaultTimeoutAction.Lock,
             };
-            if (!string.IsNullOrWhiteSpace(pinProtected))
-            {
-                account.Settings.PinProtected = new EncString(pinProtected);
-            }
             var state = new State { Accounts = new Dictionary<string, Account> { [userId] = account } };
             state.ActiveUserId = userId;
             await SetValueAsync(Storage.LiteDb, Constants.StateKey, state);
@@ -213,6 +208,8 @@ namespace Bit.Core.Services
             await SetValueAsync(Storage.LiteDb, Constants.BiometricUnlockKey(userId), biometricUnlock);
             var protectedPin = await GetValueAsync<string>(Storage.LiteDb, V2Keys.ProtectedPin);
             await SetValueAsync(Storage.LiteDb, Constants.ProtectedPinKey(userId), protectedPin);
+            var pinProtectedKey = await GetValueAsync<string>(Storage.LiteDb, V2Keys.PinProtectedKey);
+            await SetValueAsync(Storage.LiteDb, Constants.PinProtectedKey(userId), pinProtectedKey);
             var defaultUriMatch = await GetValueAsync<int?>(Storage.Prefs, V2Keys.DefaultUriMatch);
             await SetValueAsync(Storage.LiteDb, Constants.DefaultUriMatchKey(userId), defaultUriMatch);
             var disableAutoTotpCopy = await GetValueAsync<bool?>(Storage.Prefs, V2Keys.DisableAutoTotpCopyKey);

--- a/src/Core/Services/StateService.cs
+++ b/src/Core/Services/StateService.cs
@@ -238,19 +238,19 @@ namespace Bit.Core.Services
             await SetValueAsync(key, value, reconciledOptions);
         }
 
-        public async Task<EncString> GetPinProtectedCachedAsync(string userId = null)
+        public async Task<EncString> GetPinProtectedKeyAsync(string userId = null)
         {
             return (await GetAccountAsync(
-                ReconcileOptions(new StorageOptions { UserId = userId }, await GetDefaultStorageOptionsAsync())
-            ))?.Settings?.PinProtected;
+                ReconcileOptions(new StorageOptions { UserId = userId }, await GetDefaultInMemoryOptionsAsync())
+            ))?.Keys?.PinProtectedKey;
         }
 
-        public async Task SetPinProtectedCachedAsync(EncString value, string userId = null)
+        public async Task SetPinProtectedKeyAsync(EncString value, string userId = null)
         {
             var reconciledOptions = ReconcileOptions(new StorageOptions { UserId = userId },
-                await GetDefaultStorageOptionsAsync());
+                await GetDefaultInMemoryOptionsAsync());
             var account = await GetAccountAsync(reconciledOptions);
-            account.Settings.PinProtected = value;
+            account.Keys.PinProtectedKey = value;
             await SaveAccountAsync(account, reconciledOptions);
         }
 
@@ -1243,7 +1243,6 @@ namespace Bit.Core.Services
                 {
                     _state.Accounts[userId].Tokens.AccessToken = null;
                     _state.Accounts[userId].Tokens.RefreshToken = null;
-                    _state.Accounts[userId].Settings.PinProtected = null;
                     _state.Accounts[userId].Keys.Key = null;
                 }
             }
@@ -1265,7 +1264,6 @@ namespace Bit.Core.Services
                 {
                     state.Accounts[userId].Tokens.AccessToken = null;
                     state.Accounts[userId].Tokens.RefreshToken = null;
-                    state.Accounts[userId].Settings.PinProtected = null;
                 }
                 stateModified = true;
             }

--- a/src/Core/Services/VaultTimeoutService.cs
+++ b/src/Core/Services/VaultTimeoutService.cs
@@ -145,8 +145,9 @@ namespace Bit.Core.Services
             }
 
             if (await _keyConnectorService.GetUsesKeyConnector()) {
-                var pinSet = await IsPinLockSetAsync(userId);
-                var pinLock = (pinSet.Item1 && await _stateService.GetPinProtectedKeyAsync(userId) != null) || pinSet.Item2;
+                var (isPinProtected, isPinProtectedWithKey) = await IsPinLockSetAsync(userId);
+                var pinLock = (isPinProtected && await _stateService.GetPinProtectedKeyAsync(userId) != null) ||
+                              isPinProtectedWithKey;
 
                 if (!pinLock && !await IsBiometricLockSetAsync())
                 {

--- a/src/Core/Services/VaultTimeoutService.cs
+++ b/src/Core/Services/VaultTimeoutService.cs
@@ -146,7 +146,7 @@ namespace Bit.Core.Services
 
             if (await _keyConnectorService.GetUsesKeyConnector()) {
                 var pinSet = await IsPinLockSetAsync(userId);
-                var pinLock = (pinSet.Item1 && _stateService.GetPinProtectedAsync(userId) != null) || pinSet.Item2;
+                var pinLock = (pinSet.Item1 && await _stateService.GetPinProtectedKeyAsync(userId) != null) || pinSet.Item2;
 
                 if (!pinLock && !await IsBiometricLockSetAsync())
                 {
@@ -210,7 +210,7 @@ namespace Bit.Core.Services
 
         public async Task ClearAsync(string userId = null)
         {
-            await _stateService.SetPinProtectedAsync(null, userId);
+            await _stateService.SetPinProtectedKeyAsync(null, userId);
             await _stateService.SetProtectedPinAsync(null, userId);
         }
 

--- a/src/iOS.Core/Controllers/LockPasswordViewController.cs
+++ b/src/iOS.Core/Controllers/LockPasswordViewController.cs
@@ -101,7 +101,7 @@ namespace Bit.iOS.Core.Controllers
             else
             {
                 _pinSet = _vaultTimeoutService.IsPinLockSetAsync().GetAwaiter().GetResult();
-                _pinLock = (_pinSet.Item1 && _stateService.GetPinProtectedAsync() != null) || _pinSet.Item2;
+                _pinLock = (_pinSet.Item1 && await _stateService.GetPinProtectedKeyAsync() != null) || _pinSet.Item2;
                 _biometricLock = _vaultTimeoutService.IsBiometricLockSetAsync().GetAwaiter().GetResult() &&
                     _cryptoService.HasKeyAsync().GetAwaiter().GetResult();
                 _biometricIntegrityValid = _biometricService.ValidateIntegrityAsync(BiometricIntegrityKey).GetAwaiter()
@@ -225,7 +225,7 @@ namespace Bit.iOS.Core.Controllers
                     {
                         var key = await _cryptoService.MakeKeyFromPinAsync(inputtedValue, email,
                             kdf.GetValueOrDefault(KdfType.PBKDF2_SHA256), kdfIterations.GetValueOrDefault(5000),
-                            await _stateService.GetPinProtectedCachedAsync());
+                            await _stateService.GetPinProtectedKeyAsync());
                         var encKey = await _cryptoService.GetEncKeyAsync(key);
                         var protectedPin = await _stateService.GetProtectedPinAsync();
                         var decPin = await _cryptoService.DecryptToUtf8Async(new EncString(protectedPin), encKey);
@@ -285,7 +285,7 @@ namespace Bit.iOS.Core.Controllers
                         var decPin = await _cryptoService.DecryptToUtf8Async(new EncString(protectedPin), encKey);
                         var pinKey = await _cryptoService.MakePinKeyAysnc(decPin, email,
                             kdf.GetValueOrDefault(KdfType.PBKDF2_SHA256), kdfIterations.GetValueOrDefault(5000));
-                        await _stateService.SetPinProtectedCachedAsync(await _cryptoService.EncryptAsync(key2.Key, pinKey));
+                        await _stateService.SetPinProtectedKeyAsync(await _cryptoService.EncryptAsync(key2.Key, pinKey));
                     }
                     await AppHelpers.ResetInvalidUnlockAttemptsAsync();
                     await SetKeyAndContinueAsync(key2, true);


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Fixes to data handling for PIN lock flow caused by my misinterpretation of a specific "key" used for crypto purposes vs a "key" used for storage purposes.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **Account.cs:** Moved `PinProtected` from `AccountSettings` to `PinProtectedKey` in `AccountKeys` as it represents a value held in memory only (`AccountKeys` is never written to state storage)
* **Everything else:** Updated references to changes made in `Account.cs`, and added `await` to a calls to `_stateService.GetPinProtectedKeyAsync(..)` so null check actually works as expected


## Testing requirements
<!--What functionality requires testing by QA? This includes testing new behavior and regression testing-->

https://app.asana.com/0/1166330464508357/1201846609152550

## Before you submit
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
