### PR TITLE
Fix vault item icon image size to be adaptive on Large Font Size Accessibility

### DIFF
--- a/src/App/Controls/CipherViewCell/CipherViewCell.xaml
+++ b/src/App/Controls/CipherViewCell/CipherViewCell.xaml
@@ -39,15 +39,16 @@
         AutomationProperties.IsInAccessibleTree="False" />
 
     <ff:CachedImage
+        x:Name="_iconImage"
         Grid.Column="0"
         BitmapOptimizations="True"
         ErrorPlaceholder="login.png"
         LoadingPlaceholder="login.png"
-        HorizontalOptions="Fill"
-        VerticalOptions="Fill"
+        HorizontalOptions="CenterAndExpand"
+        VerticalOptions="CenterAndExpand"
         Margin="9"
-        MinimumWidthRequest="22"
-        MinimumHeightRequest="22"
+        WidthRequest="22"
+        HeightRequest="22"
         Aspect="AspectFit"
         IsVisible="{Binding ShowIconImage}"
         Source="{Binding IconImageSource, Mode=OneTime}"

--- a/src/App/Controls/CipherViewCell/CipherViewCell.xaml.cs
+++ b/src/App/Controls/CipherViewCell/CipherViewCell.xaml.cs
@@ -21,8 +21,10 @@ namespace Bit.App.Controls
         {
             InitializeComponent();
 
-            var deviceActionService = ServiceContainer.Resolve<IDeviceActionService>("deviceActionService");
-            _iconColumn.Width = new GridLength(40 * deviceActionService.GetSystemFontSizeScale(), GridUnitType.Absolute);
+            var fontScale = ServiceContainer.Resolve<IDeviceActionService>("deviceActionService").GetSystemFontSizeScale();
+            _iconColumn.Width = new GridLength(40 * fontScale, GridUnitType.Absolute);
+            _iconImage.WidthRequest = 22 * fontScale;
+            _iconImage.HeightRequest = 22 * fontScale;
         }
 
         public bool? WebsiteIconsEnabled

--- a/src/App/Controls/CipherViewCell/CipherViewCell.xaml.cs
+++ b/src/App/Controls/CipherViewCell/CipherViewCell.xaml.cs
@@ -8,6 +8,9 @@ namespace Bit.App.Controls
 {
     public partial class CipherViewCell : ExtendedGrid
     {
+        private const int ICON_COLUMN_DEFAULT_WIDTH = 40;
+        private const int ICON_IMAGE_DEFAULT_WIDTH = 22;
+
         public static readonly BindableProperty CipherProperty = BindableProperty.Create(
             nameof(Cipher), typeof(CipherView), typeof(CipherViewCell), default(CipherView), BindingMode.OneWay);
 
@@ -22,9 +25,9 @@ namespace Bit.App.Controls
             InitializeComponent();
 
             var fontScale = ServiceContainer.Resolve<IDeviceActionService>("deviceActionService").GetSystemFontSizeScale();
-            _iconColumn.Width = new GridLength(40 * fontScale, GridUnitType.Absolute);
-            _iconImage.WidthRequest = 22 * fontScale;
-            _iconImage.HeightRequest = 22 * fontScale;
+            _iconColumn.Width = new GridLength(ICON_COLUMN_DEFAULT_WIDTH * fontScale, GridUnitType.Absolute);
+            _iconImage.WidthRequest = ICON_IMAGE_DEFAULT_WIDTH * fontScale;
+            _iconImage.HeightRequest = ICON_IMAGE_DEFAULT_WIDTH * fontScale;
         }
 
         public bool? WebsiteIconsEnabled


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Fix icon image size to be adaptive on Large Font Size Accessibility which also fixes the row height being really high on large vault items.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **CipherViewCell:** Change the Width/HeightrRequest of the CachedImage icon to be calculated with the font scale.

## Screenshots
### Before:
<!--Required for any UI changes. Delete if not applicable-->
![image](https://user-images.githubusercontent.com/15682323/154976733-4198aac6-02a5-4435-a821-a2ba9bab61f0.png)
### After:
<img width="374" alt="image" src="https://user-images.githubusercontent.com/15682323/154977322-f1439ab3-09d5-44de-9175-418c3b671c5d.png">
<img width="377" alt="image" src="https://user-images.githubusercontent.com/15682323/154977383-cd2723d0-5c90-4bca-88e7-46eab6c6a548.png">



## Testing requirements
<!--What functionality requires testing by QA? This includes testing new behavior and regression testing-->
Test that the icons have the correct size and check this on large vault as well.


## Before you submit
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
