### PR TITLE
Fix Options being seen in two lines on Add/edit Send

### DIFF
--- a/src/App/Pages/Send/SendAddEditPage.xaml.cs
+++ b/src/App/Pages/Send/SendAddEditPage.xaml.cs
@@ -55,9 +55,10 @@ namespace Bit.App.Pages
                 _vm.SegmentedButtonFontSize = 13;
                 _vm.SegmentedButtonMargins = new Thickness(0, 10, 0, 0);
                 _vm.EditorMargins = new Thickness(0, 5, 0, 0);
-                _btnOptions.WidthRequest = 70;
-                _btnOptionsDown.WidthRequest = 30;
-                _btnOptionsUp.WidthRequest = 30;
+                // Review this when https://github.com/bitwarden/mobile/pull/1454 workaround can be reverted
+                //_btnOptions.WidthRequest = 70;
+                //_btnOptionsDown.WidthRequest = 30;
+                //_btnOptionsUp.WidthRequest = 30;
             }
             else if (Device.RuntimePlatform == Device.iOS)
             {


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Fix Options to be displayed in one line on add edit Send. The issue was in German (Optionen)


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **SendAddEditPage.xaml.cs:** Removed `WidthRequest` on button options given that now only the first one is being displayed due to #1454 

## Screenshots
<!--Required for any UI changes. Delete if not applicable-->
![Screenshot_20220222-140127](https://user-images.githubusercontent.com/15682323/155182630-f61aa0f9-e4a8-486f-812b-3d259e74c8ea.png)



## Testing requirements
<!--What functionality requires testing by QA? This includes testing new behavior and regression testing-->
The `Options` should be displayed correctly in one line, particularly test in German.


## Before you submit
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
