### PR TITLE
Improved keyboard UX on Identity fields

### DIFF
--- a/src/App/Pages/Vault/AddEditPage.xaml
+++ b/src/App/Pages/Vault/AddEditPage.xaml
@@ -338,7 +338,7 @@
                         <Entry
                             x:Name="_identityFirstNameEntry"
                             Text="{Binding Cipher.Identity.FirstName}"
-                            StyleClass="box-value" />
+                            StyleClass="box-value,capitalize-word-input"/>
                     </StackLayout>
                     <StackLayout StyleClass="box-row, box-row-input">
                         <Label
@@ -347,7 +347,7 @@
                         <Entry
                             x:Name="_identityMiddleNameEntry"
                             Text="{Binding Cipher.Identity.MiddleName}"
-                            StyleClass="box-value" />
+                            StyleClass="box-value,capitalize-word-input" />
                     </StackLayout>
                     <StackLayout StyleClass="box-row, box-row-input">
                         <Label
@@ -356,7 +356,7 @@
                         <Entry
                             x:Name="_identityLastNameEntry"
                             Text="{Binding Cipher.Identity.LastName}"
-                            StyleClass="box-value" />
+                            StyleClass="box-value,capitalize-word-input" />
                     </StackLayout>
                     <StackLayout StyleClass="box-row, box-row-input">
                         <Label
@@ -420,6 +420,7 @@
                         <Entry
                             x:Name="_identityPhoneEntry"
                             Text="{Binding Cipher.Identity.Phone}"
+                            Keyboard="Telephone"
                             StyleClass="box-value" />
                     </StackLayout>
                     <StackLayout StyleClass="box-row, box-row-input">
@@ -456,7 +457,7 @@
                         <Entry
                             x:Name="_identityCityEntry"
                             Text="{Binding Cipher.Identity.City}"
-                            StyleClass="box-value" />
+                            StyleClass="box-value,capitalize-sentence-input" />
                     </StackLayout>
                     <StackLayout StyleClass="box-row, box-row-input">
                         <Label
@@ -465,7 +466,7 @@
                         <Entry
                             x:Name="_identityStateEntry"
                             Text="{Binding Cipher.Identity.State}"
-                            StyleClass="box-value" />
+                            StyleClass="box-value,capitalize-sentence-input" />
                     </StackLayout>
                     <StackLayout StyleClass="box-row, box-row-input">
                         <Label
@@ -483,7 +484,7 @@
                         <Entry
                             x:Name="_identityCountryEntry"
                             Text="{Binding Cipher.Identity.Country}"
-                            StyleClass="box-value" />
+                            StyleClass="box-value,capitalize-sentence-input" />
                     </StackLayout>
                 </StackLayout>
             </StackLayout>

--- a/src/App/Styles/Base.xaml
+++ b/src/App/Styles/Base.xaml
@@ -463,4 +463,28 @@
         <Setter Property="TextColor"
                 Value="{DynamicResource TextColor}" />
     </Style>
+
+    <!--Entry-->
+    <Style TargetType="InputView"
+           Class="capitalize-word-input"
+           ApplyToDerivedTypes="True">
+        <Setter Property="Keyboard">
+            <Keyboard x:FactoryMethod="Create">
+                <x:Arguments>
+                    <KeyboardFlags>CapitalizeWord</KeyboardFlags>
+                </x:Arguments>
+            </Keyboard>
+        </Setter>
+    </Style>
+    <Style TargetType="InputView"
+           Class="capitalize-sentence-input"
+           ApplyToDerivedTypes="True">
+        <Setter Property="Keyboard">
+            <Keyboard x:FactoryMethod="Create">
+                <x:Arguments>
+                    <KeyboardFlags>CapitalizeSentence</KeyboardFlags>
+                </x:Arguments>
+            </Keyboard>
+        </Setter>
+    </Style>
 </ResourceDictionary>


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Improve UX on Identity fields, to have phone keyboard and capitalize names and city/state/country. Based on [https://github.com/bitwarden/web/pull/1384](https://github.com/bitwarden/web/pull/1384)


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **Base.xaml:** Added styles for capitalize word/sentence
* **AddEditPage.xaml:** Changed styles for better keyboard UX

## Screenshots
<!--Required for any UI changes. Delete if not applicable-->
![Screenshot_20220223-104916](https://user-images.githubusercontent.com/15682323/155332581-1b21d963-932f-4059-8c39-315bb6454b2c.png)
![Screenshot_20220223-104944](https://user-images.githubusercontent.com/15682323/155332588-b1d08f7b-e15c-4ae7-9258-0ed65a731d0a.png)
![Screenshot_20220223-104953](https://user-images.githubusercontent.com/15682323/155332595-be7b3a20-152d-4d7d-94e0-16e50959dc9c.png)


## Testing requirements
<!--What functionality requires testing by QA? This includes testing new behavior and regression testing-->
On First name, Middle Name and Last Name the keyboard should appear capitalizing each word.
On Phone should open the telephone keyboard
On City, State and Country the keyboard should appear capitalizing the sentence.


## Before you submit
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
