### PR TITLE
Changed links on Settings "Change Master Password" and "Two Step Login"

### DIFF
--- a/src/App/Pages/Accounts/LockPageViewModel.cs
+++ b/src/App/Pages/Accounts/LockPageViewModel.cs
@@ -156,7 +156,7 @@ namespace Bit.App.Pages
 #endif
                 return;
             }
-            var webVault = _environmentService.GetWebVaultUrl();
+            var webVault = _environmentService.GetWebVaultUrl(true);
             if (string.IsNullOrWhiteSpace(webVault))
             {
                 webVault = "https://bitwarden.com";

--- a/src/App/Pages/CaptchaProtectedViewModel.cs
+++ b/src/App/Pages/CaptchaProtectedViewModel.cs
@@ -27,13 +27,11 @@ namespace Bit.App.Pages
                 captchaRequiredText = AppResources.CaptchaRequired,
             });
 
-            var url = environmentService.GetWebVaultUrl();
-            if (url == null)
-            {
-                url = "https://vault.bitwarden.com";
-            }
-            url += "/captcha-mobile-connector.html?" + "data=" + data +
-                "&parent=" + Uri.EscapeDataString(callbackUri) + "&v=1";
+            var url = environmentService.GetWebVaultUrl() +
+                      "/captcha-mobile-connector.html?" +
+                      "data=" + data +
+                      "&parent=" + Uri.EscapeDataString(callbackUri) +
+                      "&v=1";
 
             WebAuthenticatorResult authResult = null;
             bool cancelled = false;

--- a/src/App/Pages/Settings/SettingsPage/SettingsPageViewModel.cs
+++ b/src/App/Pages/Settings/SettingsPage/SettingsPageViewModel.cs
@@ -190,12 +190,7 @@ namespace Bit.App.Pages
 
         public void WebVault()
         {
-            var url = _environmentService.GetWebVaultUrl();
-            if (url == null)
-            {
-                url = "https://vault.bitwarden.com";
-            }
-            _platformUtilsService.LaunchUri(url);
+            _platformUtilsService.LaunchUri(_environmentService.GetWebVaultUrl());
         }
 
         public async Task ShareAsync()
@@ -214,7 +209,7 @@ namespace Bit.App.Pages
                 AppResources.TwoStepLogin, AppResources.Yes, AppResources.Cancel);
             if (confirmed)
             {
-                _platformUtilsService.LaunchUri("https://bitwarden.com/help/setup-two-step-login/");
+                _platformUtilsService.LaunchUri($"{_environmentService.GetWebVaultUrl()}/#/settings");
             }
         }
 
@@ -224,7 +219,7 @@ namespace Bit.App.Pages
                 AppResources.ChangeMasterPassword, AppResources.Yes, AppResources.Cancel);
             if (confirmed)
             {
-                _platformUtilsService.LaunchUri("https://bitwarden.com/help/master-password/#change-your-master-password");
+                _platformUtilsService.LaunchUri($"{_environmentService.GetWebVaultUrl()}/#/settings");
             }
         }
 

--- a/src/App/Utilities/AppHelpers.cs
+++ b/src/App/Utilities/AppHelpers.cs
@@ -225,12 +225,7 @@ namespace Bit.App.Utilities
         private static string GetSendUrl(SendView send)
         {
             var environmentService = ServiceContainer.Resolve<IEnvironmentService>("environmentService");
-            var webVaultUrl = environmentService.GetWebVaultUrl();
-            if (webVaultUrl != null)
-            {
-                return webVaultUrl + "/#/send/" + send.AccessId + "/" + send.UrlB64Key;
-            }
-            return "https://send.bitwarden.com/#" + send.AccessId + "/" + send.UrlB64Key;
+            return environmentService.GetWebSendUrl() + send.AccessId + "/" + send.UrlB64Key;
         }
 
         public static async Task<bool> RemoveSendPasswordAsync(string sendId)

--- a/src/Core/Abstractions/IEnvironmentService.cs
+++ b/src/Core/Abstractions/IEnvironmentService.cs
@@ -13,7 +13,8 @@ namespace Bit.Core.Abstractions
         string WebVaultUrl { get; set; }
         string EventsUrl { get; set; }
 
-        string GetWebVaultUrl();
+        string GetWebVaultUrl(bool returnNullIfDefault = false);
+        string GetWebSendUrl();
         Task<EnvironmentUrlData> SetUrlsAsync(EnvironmentUrlData urls);
         Task SetUrlsFromStorageAsync();
     }

--- a/src/Core/Services/EnvironmentService.cs
+++ b/src/Core/Services/EnvironmentService.cs
@@ -1,13 +1,16 @@
-﻿using Bit.Core.Abstractions;
+﻿using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using Bit.Core.Abstractions;
 using Bit.Core.Models.Data;
 using Bit.Core.Models.Domain;
-using System.Text.RegularExpressions;
-using System.Threading.Tasks;
 
 namespace Bit.Core.Services
 {
     public class EnvironmentService : IEnvironmentService
     {
+        private const string DEFAULT_WEB_VAULT_URL = "https://vault.bitwarden.com";
+        private const string DEFAULT_WEB_SEND_URL = "https://send.bitwarden.com/#";
+
         private readonly IApiService _apiService;
         private readonly IStateService _stateService;
 
@@ -27,17 +30,24 @@ namespace Bit.Core.Services
         public string NotificationsUrl { get; set; }
         public string EventsUrl { get; set; }
 
-        public string GetWebVaultUrl()
+        public string GetWebVaultUrl(bool returnNullIfDefault = false)
         {
             if (!string.IsNullOrWhiteSpace(WebVaultUrl))
             {
                 return WebVaultUrl;
             }
-            else if (!string.IsNullOrWhiteSpace(BaseUrl))
+
+            if (!string.IsNullOrWhiteSpace(BaseUrl))
             {
                 return BaseUrl;
             }
-            return null;
+
+            return returnNullIfDefault ? (string)null : DEFAULT_WEB_VAULT_URL;
+        }
+
+        public string GetWebSendUrl()
+        {
+            return GetWebVaultUrl(true) is string webVaultUrl ? $"{webVaultUrl}/#/send/" : DEFAULT_WEB_SEND_URL;
         }
 
         public async Task SetUrlsFromStorageAsync()


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Change link on Settings "Change Master Password" and "Two-Step Login" to go to Web Vault Settings.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **EnvironmentService.cs:** Added constants for default Web Vault and Snd url and refactored a bit the code to use them and also added a new method to get the web url for Send.
* **SettingsPageViewModel.cs:** Changed the url on "Change Master Password" and "Two-Step Login" to go to the Web Vault Settings
* **Others:** Adapted to the new `EnvironmentService`


## Testing requirements
<!--What functionality requires testing by QA? This includes testing new behavior and regression testing-->
For any of the testing, take into consideration that the web url is different depending on what is configured, the precedence is as follows: 

- Web Vault Server URL
- Self-hosted Environment -> Server URL
- Default (https://vault.bitwarden.com)

### Mainly
Test that when clicking on **Settings > Change Master Password** and **Settings > Two-Step Login** the user is redirected to the web vault login (in fact, it should go to the web vault settings after login but deep linking is not implemented on the web yet, so it will just land the user on the login)
### Secondary
I changed some things on the `EnvironmentService` that were being used, so just in case we should check that they are still working:

- On Lock screen, the text should indicate on which host the user is logged in
- The Captcha should load correctly when logging in
- On Settings, the Web Vault should still redirect to the webpage of the web vault
- Share link should keep working when Copying/Sharing it

## Before you submit
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
