### PR TITLE
Fix for missing bio unlock on app restart

### DIFF
--- a/src/Core/Services/StateService.cs
+++ b/src/Core/Services/StateService.cs
@@ -21,7 +21,7 @@ namespace Bit.Core.Services
         private State _state;
         private bool _migrationChecked;
 
-        public bool BiometricLocked { get; set; }
+        public bool BiometricLocked { get; set; } = true;
 
         public List<AccountView> AccountViews { get; set; }
 


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
App went directly to unlocked vault, skipping bio unlock prompt on cold start when bio unlock was enabled.  Turned out the in-memory bio lock state bool should default to true for the flow to work correctly (overlooked as part of account switching transition)


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **StateService.cs:** Make `BiometricLocked` true by default for cold-start bio unlock flow to function correctly

## Testing requirements
<!--What functionality requires testing by QA? This includes testing new behavior and regression testing-->

1. Set vault timeout to something long-ish (15 minute default is fine)
2. Set vault timeout action to Lock
3. Enable biometric unlock support (face, finger, DNA sample, etc.)
4. Swipe away (kill) app
5. Launch app.  With fix: Biometric unlock prompt will be shown.  Without fix: Waltz right into unlocked vault (unless vault timeout period elapsed)

## Before you submit
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
