### PR TITLE
Apply Disable Favicon setting globally to match desktop

### DIFF
--- a/src/App/Pages/Settings/OptionsPageViewModel.cs
+++ b/src/App/Pages/Settings/OptionsPageViewModel.cs
@@ -187,7 +187,6 @@ namespace Bit.App.Pages
             if (_inited)
             {
                 await _stateService.SetDisableFaviconAsync(DisableFavicon);
-                _stateService.ApplyDisableFaviconGloballyAsync(DisableFavicon).FireAndForget();
             }
         }
 
@@ -207,7 +206,6 @@ namespace Bit.App.Pages
                 await _stateService.SetThemeAsync(theme);
                 ThemeManager.SetTheme(Application.Current.Resources);
                 _messagingService.Send("updatedTheme");
-                _stateService.ApplyThemeGloballyAsync(theme).FireAndForget();
             }
         }
 

--- a/src/Core/Abstractions/IStateService.cs
+++ b/src/Core/Abstractions/IStateService.cs
@@ -70,7 +70,6 @@ namespace Bit.Core.Abstractions
         Task SetLastBuildAsync(string value);
         Task<bool?> GetDisableFaviconAsync(string userId = null);
         Task SetDisableFaviconAsync(bool? value, string userId = null);
-        Task ApplyDisableFaviconGloballyAsync(bool? value);
         Task<bool?> GetDisableAutoTotpCopyAsync(string userId = null);
         Task SetDisableAutoTotpCopyAsync(bool? value, string userId = null);
         Task<bool?> GetInlineAutofillEnabledAsync(string userId = null);
@@ -107,7 +106,6 @@ namespace Bit.Core.Abstractions
         Task SetRememberedOrgIdentifierAsync(string value);
         Task<string> GetThemeAsync(string userId = null);
         Task SetThemeAsync(string value, string userId = null);
-        Task ApplyThemeGloballyAsync(string value);
         Task<bool?> GetAddSitePromptShownAsync(string userId = null);
         Task SetAddSitePromptShownAsync(bool? value, string userId = null);
         Task<bool?> GetPushInitialPromptShownAsync();


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Make the "Disable Website Icons" option global to match desktop.  I'm continuing to follow the `Apply*Globally` pattern established with the Theme change so a single block of code can be removed to restore per-account functionality in the future.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **StateService.cs:** Created `SetValueGloballyAsync` method to support key/value based settings (values not in the `Account` object)
* **OptionsPageViewModel.cs:** Removed previous `Apply*Global` calls since everything is contained within `StateService` now

## Testing requirements
<!--What functionality requires testing by QA? This includes testing new behavior and regression testing-->

https://app.asana.com/0/1201803072708593/1201880420113232

## Before you submit
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
