### PR TITLE
BEEEP: Colorize hidden custom field when value visible

### DIFF
--- a/src/App/Pages/Vault/ViewPage.xaml
+++ b/src/App/Pages/Vault/ViewPage.xaml
@@ -579,8 +579,8 @@
                                                          Grid.Row="1"
                                                          Grid.Column="0">
                                                 <controls:MonoLabel
-                                                    Text="{Binding ValueText, Mode=OneWay}"
-                                                    StyleClass="box-value"
+                                                    Text="{Binding ColoredHiddenValue, Mode=OneWay}"
+                                                    StyleClass="box-value, text-html"
                                                     IsVisible="{Binding ShowHiddenValue}" />
                                                 <controls:MonoLabel
                                                     Text="{Binding Field.MaskedValue, Mode=OneWay}"

--- a/src/App/Pages/Vault/ViewPageViewModel.cs
+++ b/src/App/Pages/Vault/ViewPageViewModel.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -767,6 +767,8 @@ namespace Bit.App.Pages
                 }
             }
         }
+
+        public FormattedString ColoredHiddenValue => PasswordFormatter.FormatPassword(_field.Value);
 
         public Command ToggleHiddenValueCommand { get; set; }
 


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
The standard password field displays number and special characters in a different color for better readability. A hidden custom-field currently does not colorize it's value when shown.

Asana task: https://app.asana.com/0/1200804338582616/1201884248598927/f

## Code changes
* **src/App/Pages/Vault/ViewPageViewModel.cs:** Add new public property ColoredHiddenValue which formats the hidden custom field value
* **src/App/Pages/Vault/ViewPage.xaml:** Adjust hidden fieldvalue binding to new property and add text-html to StyleClass

## Screenshots
**BEFORE:**
![image](https://user-images.githubusercontent.com/2670567/155734787-46730156-ae72-432a-9f4c-b386f8d3747c.png)

**AFTER:**
![image](https://user-images.githubusercontent.com/2670567/155734738-2fe1f7ac-394f-4093-a559-a78fc36f386b.png)

## Testing requirements
When the value of a hidden custom field is shown, it should be colorized as the standard password field

## Before you submit
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
