### PR TITLE
Bump target framework to netcoreapp3.1

### DIFF
--- a/store/google/Publisher/Publisher.csproj
+++ b/store/google/Publisher/Publisher.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <RootNamespace>Bit.Publisher</RootNamespace>
     <Configurations>Debug;Release;FDroid</Configurations>
   </PropertyGroup>


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
The latest master builds are failing as it can't publish to the Play Store. This is due to a dependency on Net Core 2.0 which is not present in the Github Actions.

This PR bumps the target framework of the Google Play Store Publisher from `netcoreapp2.1` to `netcoreapp3.1`.
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

## Code changes

* **store/google/Publisher/Publisher.csproj:** Use netcoreapp3.1 instead of netcoreapp2.0

## Before you submit
- [X] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
