### PR TITLE
Fixed migration and account removal issues

### DIFF
--- a/src/App/Pages/Accounts/LoginPage.xaml.cs
+++ b/src/App/Pages/Accounts/LoginPage.xaml.cs
@@ -147,8 +147,10 @@ namespace Bit.App.Pages
                 return;
             }
 
-            var selection = await DisplayActionSheet(AppResources.Options, 
-                AppResources.Cancel, null, AppResources.GetPasswordHint, AppResources.RemoveAccount);
+            var buttons = _email.IsEnabled ? new[] { AppResources.GetPasswordHint }
+                : new[] { AppResources.GetPasswordHint, AppResources.RemoveAccount };
+            var selection = await DisplayActionSheet(AppResources.Options,
+                AppResources.Cancel, null, buttons);
 
             if (selection == AppResources.GetPasswordHint)
             {

--- a/src/Core/Services/StateMigrationService.cs
+++ b/src/Core/Services/StateMigrationService.cs
@@ -326,19 +326,19 @@ namespace Bit.Core.Services
                 return lastVersion.Value;
             }
 
-            // check for original v1 migration 
-            var envUrlsLiteDb = await GetValueAsync<EnvironmentUrlData>(Storage.LiteDb, V1Keys.EnvironmentUrlsKey);
-            if (envUrlsLiteDb != null)
+            // check for v1 state 
+            var v1EnvUrls = await GetValueAsync<EnvironmentUrlData>(Storage.LiteDb, V1Keys.EnvironmentUrlsKey);
+            if (v1EnvUrls != null)
             {
                 // environmentUrls still in LiteDB (never migrated to prefs), this is v1
                 return 1;
             }
 
-            // check for original v2 migration
-            var envUrlsPrefs = await GetValueAsync<EnvironmentUrlData>(Storage.Prefs, V2Keys.EnvironmentUrlsKey);
-            if (envUrlsPrefs != null)
+            // check for v2 state
+            var v2UserId = await GetValueAsync<string>(Storage.LiteDb, V2Keys.Keys_UserId);
+            if (v2UserId != null)
             {
-                // environmentUrls in Prefs (migrated from LiteDB), this is v2
+                // standalone userId still exists (never moved to Account object), this is v2
                 return 2;
             }
 

--- a/src/Core/Services/StateService.cs
+++ b/src/Core/Services/StateService.cs
@@ -1377,6 +1377,7 @@ namespace Bit.Core.Services
         {
             await CheckStateAsync();
             var currentTheme = await GetThemeAsync();
+            var currentDisableFavicons = await GetDisableFaviconAsync();
 
             account.Settings.EnvironmentUrls = await GetPreAuthEnvironmentUrlsAsync();
 
@@ -1405,6 +1406,7 @@ namespace Bit.Core.Services
                 account.Settings.VaultTimeoutAction = VaultTimeoutAction.Lock;
             }
             await SetThemeAsync(currentTheme, account.Profile.UserId);
+            await SetDisableFaviconAsync(currentDisableFavicons, account.Profile.UserId);
             
             state.Accounts[account.Profile.UserId] = account;
             await SaveStateToStorageAsync(state);


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Fixed issue where migration was skipped when using default environment, "Remove Account" was shown on iOS when it shouldn't be, and creating a new account was not carrying forward the current `DisableFavicon` setting


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **LoginPage.xaml.cs:** Only show "Remove Account" in the iOS action sheet when `_email` is disabled (same condition as Android)
* **StateMigrationService.cs:** Check for existence of standalone `userId` to signify v2 and trigger migration to v3 (was previously checking if `envUrls` were stored in Prefs (instead of LiteDb) but those particular prefs are only saved when a custom env is set on the Environment page (which I always did throughout the dev process, classic) so the migrator assumed it was a fresh install and never ran
* **StateService.cs:** Copy the current `DisableFavicon` setting when creating a new account (same approach as theme)

## Testing requirements
<!--What functionality requires testing by QA? This includes testing new behavior and regression testing-->

- Remove existing installation to clear data
- Install v2.16.2 (1434) via TestFlight and login + configure any settings
- Install latest TestFlight build over top and observe migration

## Before you submit
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
