### PR TITLE
Add url encoding to data parameter

### DIFF
--- a/src/App/Utilities/AppHelpers.cs
+++ b/src/App/Utilities/AppHelpers.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Net;
 using Bit.App.Abstractions;
 using Bit.App.Pages;
 using Bit.App.Resources;
@@ -439,7 +440,7 @@ namespace Bit.App.Utilities
 
             var escaped = Uri.EscapeDataString(JsonConvert.SerializeObject(obj));
             var multiByteEscaped = Regex.Replace(escaped, "%([0-9A-F]{2})", EncodeMultibyte);
-            return Convert.ToBase64String(Encoding.UTF8.GetBytes(multiByteEscaped));
+            return WebUtility.UrlEncode(Convert.ToBase64String(Encoding.UTF8.GetBytes(multiByteEscaped)));
         }
 
         public static async Task LogOutAsync(string userId, bool userInitiated = false)


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
URL encode base64 in url parameters. B64 include the `+` character, which is converted to a ` `, which is _not_ a valid base 64 character.

This was causing errors while loading our captcha connectors, and likely our 2fa connectors, for certain languages.


## Testing requirements
Test captcha functionality with czech locale.



## Before you submit
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
