### PR TITLE
[Captcha] Implement for 2fa

### DIFF
--- a/src/Core/Abstractions/IAuthService.cs
+++ b/src/Core/Abstractions/IAuthService.cs
@@ -24,7 +24,7 @@ namespace Bit.Core.Abstractions
         Task<AuthResult> LogInAsync(string email, string masterPassword, string captchaToken);
         Task<AuthResult> LogInSsoAsync(string code, string codeVerifier, string redirectUrl, string orgId);
         Task<AuthResult> LogInCompleteAsync(string email, string masterPassword, TwoFactorProviderType twoFactorProvider, string twoFactorToken, bool? remember = null);
-        Task<AuthResult> LogInTwoFactorAsync(TwoFactorProviderType twoFactorProvider, string twoFactorToken, bool? remember = null);
+        Task<AuthResult> LogInTwoFactorAsync(TwoFactorProviderType twoFactorProvider, string twoFactorToken, string captchaToken, bool? remember = null);
         void LogOut(Action callback);
         void Init();
     }

--- a/src/Core/Services/AuthService.cs
+++ b/src/Core/Services/AuthService.cs
@@ -141,8 +141,12 @@ namespace Bit.Core.Services
         }
 
         public Task<AuthResult> LogInTwoFactorAsync(TwoFactorProviderType twoFactorProvider, string twoFactorToken,
-            bool? remember = null)
+            string captchaToken, bool? remember = null)
         {
+            if (captchaToken != null)
+            {
+                CaptchaToken = captchaToken;
+            }
             return LogInHelperAsync(Email, MasterPasswordHash, LocalMasterPasswordHash, Code, CodeVerifier, SsoRedirectUrl, _key,
                 twoFactorProvider, twoFactorToken, remember, CaptchaToken);
         }


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
> Implement `captcha` functionality for the `2fa` page

## Code changes
- **TwoFactorPageViewModel.cs:** Added captcha functionality by using the existing `CaptchaProtectedViewModel`
- **AuthService**: Expanded `LogInTwoFactorAsync` method to take in potentially passed in `captchaToken`. Will only overwrite the existing property if the passed in value is not null.

## Testing requirements
- Make sure captcha can be triggered/collected from the 2fa component and complete a successful login

## Before you submit
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [X] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
