### PR TITLE
fix for logging out active account from switcher and cleanup

### DIFF
--- a/src/App/Utilities/AppHelpers.cs
+++ b/src/App/Utilities/AppHelpers.cs
@@ -240,6 +240,13 @@ namespace Bit.App.Utilities
                     await platformUtilsService.ShowDialogAsync(text, title, AppResources.Yes, AppResources.Cancel);
                 if (confirmed)
                 {
+                    var stateService = ServiceContainer.Resolve<IStateService>("stateService");
+                    if (await stateService.IsActiveAccountAsync(userId))
+                    {
+                        var messagingService = ServiceContainer.Resolve<IMessagingService>("messagingService");
+                        messagingService.Send("logout");
+                        return selection;
+                    }
                     await LogOutAsync(userId, true);
                 }
             }
@@ -509,7 +516,7 @@ namespace Bit.App.Utilities
             var policyService = ServiceContainer.Resolve<IPolicyService>("policyService");
             var searchService = ServiceContainer.Resolve<ISearchService>("searchService");
 
-            var isActiveAccount = await stateService.IsActiveAccount(userId);
+            var isActiveAccount = await stateService.IsActiveAccountAsync(userId);
 
             if (userId == null)
             {

--- a/src/Core/Abstractions/IStateService.cs
+++ b/src/Core/Abstractions/IStateService.cs
@@ -12,7 +12,7 @@ namespace Bit.Core.Abstractions
     {
         List<AccountView> AccountViews { get; }
         Task<string> GetActiveUserIdAsync();
-        Task<bool> IsActiveAccount(string userId = null);
+        Task<bool> IsActiveAccountAsync(string userId = null);
         Task SetActiveUserAsync(string userId);
         Task<bool> IsAuthenticatedAsync(string userId = null);
         Task<string> GetUserIdAsync(string email);

--- a/src/Core/Services/StateService.cs
+++ b/src/Core/Services/StateService.cs
@@ -42,7 +42,7 @@ namespace Bit.Core.Services
             return activeUserId;
         }
 
-        public async Task<bool> IsActiveAccount(string userId = null)
+        public async Task<bool> IsActiveAccountAsync(string userId = null)
         {
             if (userId == null)
             {

--- a/src/Core/Utilities/ServiceContainer.cs
+++ b/src/Core/Utilities/ServiceContainer.cs
@@ -33,7 +33,7 @@ namespace Bit.Core.Utilities
             var apiService = new ApiService(tokenService, platformUtilsService, (extras) =>
             {
                 messagingService.Send("logout", extras);
-                return Task.FromResult(0);
+                return Task.CompletedTask;
             }, customUserAgent);
             var appIdService = new AppIdService(storageService);
             var organizationService = new OrganizationService(stateService);
@@ -56,19 +56,19 @@ namespace Bit.Core.Utilities
                 (extras) =>
                 {
                     messagingService.Send("locked", extras);
-                    return Task.FromResult(0);
+                    return Task.CompletedTask;
                 }, 
                 (extras) =>
                 {
                     messagingService.Send("logout", extras);
-                    return Task.FromResult(0);
+                    return Task.CompletedTask;
                 });
             var syncService = new SyncService(stateService, apiService, settingsService, folderService, cipherService, 
                 cryptoService, collectionService, organizationService, messagingService, policyService, sendService,
                 keyConnectorService, (extras) =>
                 {
                     messagingService.Send("logout", extras);
-                    return Task.FromResult(0);
+                    return Task.CompletedTask;
                 });
             var passwordGenerationService = new PasswordGenerationService(cryptoService, stateService,
                 cryptoFunctionService, policyService);


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
- Fixed an issue where logging out the active account from the switcher menu removed the data but left the current screen in place (instead of switching to another user or showing the home screen if there was only one user)
- Also made some changes requested in #1826 (will add comments inline on that PR shortly)


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **AppHelpers.cs:** Added logout message for handling logging out of active account
* **StateService.cs:** Added `Async` suffix to `IsActiveAccount` method name
* **App.xaml.cs/VaultTimeoutService.cs/ServiceContainer.cs:** cleanup (see other PR linked above)

## Testing requirements
<!--What functionality requires testing by QA? This includes testing new behavior and regression testing-->
Perform a logout on the active (current) account via long-press in the account switching menu and observe behavior


## Before you submit
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
