### PR TITLE
[Build] Remove Microsoft.AppCenter.Crashes from Core on F-Droid

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -241,6 +241,7 @@ jobs:
         run: |
           $androidPath = $($env:GITHUB_WORKSPACE + "/src/Android/Android.csproj");
           $appPath = $($env:GITHUB_WORKSPACE + "/src/App/App.csproj");
+          $corePath = $($env:GITHUB_WORKSPACE + "/src/Core/Core.csproj");
 
           $androidManifest = $($env:GITHUB_WORKSPACE + "/src/Android/Properties/AndroidManifest.xml");
 
@@ -306,6 +307,18 @@ jobs:
           $appCenterNode.ParentNode.RemoveChild($appCenterNode);
 
           $xml.Save($appPath);
+
+          Write-Output "########################################"
+          Write-Output "##### Uninstall from Core.csproj"
+          Write-Output "########################################"
+
+          $xml=New-Object XML;
+          $xml.Load($corePath);
+
+          $appCenterNode=$xml.SelectSingleNode("/Project/ItemGroup/PackageReference[@Include='Microsoft.AppCenter.Crashes']");
+          $appCenterNode.ParentNode.RemoveChild($appCenterNode);
+
+          $xml.Save($corePath);
         shell: pwsh
 
       - name: Restore packages


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Remove the dependency on Microsoft.AppCenter.Crashes from Core on F-Droid build


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **build.yml:** Remove the package node oof Microsoft.AppCenter.Crashes from Core.csproj on F-Droid build

## Testing requirements
<!--What functionality requires testing by QA? This includes testing new behavior and regression testing-->
Use some static analysis tool to check that no tracker is found on F-Droid apk. On the linked issue they used "Aurora Warden"


## Before you submit
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [X] This change has particular **deployment requirements** (notify the DevOps team)
