### PR TITLE
Fix for lock & logout message parsing issue

### DIFF
--- a/src/App/App.xaml.cs
+++ b/src/App/App.xaml.cs
@@ -73,8 +73,9 @@ namespace Bit.App
                 }
                 else if (message.Command == "locked")
                 {
-                    var (userId, userInitiated) =
-                        message.Data as Tuple<string, bool> ?? new Tuple<string, bool>(null, false);
+                    var extras = message.Data as Tuple<string, bool>;
+                    var userId = extras?.Item1;
+                    var userInitiated = extras?.Item2 ?? false;
                     Device.BeginInvokeOnMainThread(async () => await LockedAsync(userId, userInitiated));
                 }
                 else if (message.Command == "lockVault")
@@ -83,8 +84,10 @@ namespace Bit.App
                 }
                 else if (message.Command == "logout")
                 {
-                    var (userId, userInitiated, expired) =
-                        message.Data as Tuple<string, bool, bool> ?? new Tuple<string, bool, bool>(null, true, false);
+                    var extras = message.Data as Tuple<string, bool, bool>;
+                    var userId = extras?.Item1;
+                    var userInitiated = extras?.Item2 ?? true;
+                    var expired = extras?.Item3 ?? false;
                     Device.BeginInvokeOnMainThread(async () => await LogOutAsync(userId, userInitiated, expired));
                 }
                 else if (message.Command == "loggedOut")

--- a/src/Core/Services/VaultTimeoutService.cs
+++ b/src/Core/Services/VaultTimeoutService.cs
@@ -19,8 +19,8 @@ namespace Bit.Core.Services
         private readonly ITokenService _tokenService;
         private readonly IPolicyService _policyService;
         private readonly IKeyConnectorService _keyConnectorService;
-        private readonly Func<(string userId, bool userInitiated), Task> _lockedCallback;
-        private readonly Func<(string userId, bool userInitiated, bool expired), Task> _loggedOutCallback;
+        private readonly Func<Tuple<string, bool>, Task> _lockedCallback;
+        private readonly Func<Tuple<string, bool, bool>, Task> _loggedOutCallback;
 
         public VaultTimeoutService(
             ICryptoService cryptoService,
@@ -34,8 +34,8 @@ namespace Bit.Core.Services
             ITokenService tokenService,
             IPolicyService policyService,
             IKeyConnectorService keyConnectorService,
-            Func<(string userId, bool userInitiated), Task> lockedCallback,
-            Func<(string userId, bool userInitiated, bool expired), Task> loggedOutCallback)
+            Func<Tuple<string, bool>, Task> lockedCallback,
+            Func<Tuple<string, bool, bool>, Task> loggedOutCallback)
         {
             _cryptoService = cryptoService;
             _stateService = stateService;
@@ -183,7 +183,7 @@ namespace Bit.Core.Services
                 await _stateService.SetBiometricLockedAsync(isBiometricLockSet, userId);
                 if (isBiometricLockSet)
                 {
-                    _lockedCallback?.Invoke((userId, userInitiated));
+                    _lockedCallback?.Invoke(new Tuple<string, bool>(userId, userInitiated));
                     return;
                 }
             }
@@ -200,14 +200,14 @@ namespace Bit.Core.Services
                 _collectionService.ClearCache();
                 _searchService.ClearIndex();
             }
-            _lockedCallback?.Invoke((userId, userInitiated));
+            _lockedCallback?.Invoke(new Tuple<string, bool>(userId, userInitiated));
         }
         
         public async Task LogOutAsync(bool userInitiated = true, string userId = null)
         {
             if(_loggedOutCallback != null)
             {
-                await _loggedOutCallback.Invoke((userId, userInitiated, false));
+                await _loggedOutCallback.Invoke(new Tuple<string, bool, bool>(userId, userInitiated, false));
             }
         }
 


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
An attempt to streamline the implementation of passing values with "lock" and "logout" messages resulted in missing data, resulting in both messages acting on the active account regardless of context.  This reverts that change so we can rethink later.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **App.xaml.cs & VaultTimeoutService.cs:** Revert to previous use of Tuple

## Testing requirements
<!--What functionality requires testing by QA? This includes testing new behavior and regression testing-->

https://app.asana.com/0/1201803072708593/1201936151872719/f
https://app.asana.com/0/1201803072708593/1201929380000890/f

## Before you submit
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
