### PR TITLE
Fix for short profile Name value crashing app

### DIFF
--- a/src/App/Controls/AvatarImageSource.cs
+++ b/src/App/Controls/AvatarImageSource.cs
@@ -62,6 +62,10 @@ namespace Bit.App.Controls
                 upperData = _data.ToUpper();
                 chars = GetFirstLetters(upperData, 2);
             }
+            else
+            {
+                chars = upperData = _data.ToUpper();
+            }
 
             var bgColor = StringToColor(upperData);
             var textColor = Color.White;
@@ -122,7 +126,7 @@ namespace Bit.App.Controls
             {
                 return data.Substring(0, 2);
             }
-            return null;
+            return data;
         }
 
         private Color StringToColor(string str)

--- a/src/Core/Abstractions/IStateService.cs
+++ b/src/Core/Abstractions/IStateService.cs
@@ -55,6 +55,7 @@ namespace Bit.Core.Abstractions
         Task SetAutofillTileAddedAsync(bool? value);
         Task<string> GetEmailAsync(string userId = null);
         Task<string> GetNameAsync(string userId = null);
+        Task SetNameAsync(string value, string userId = null);
         Task<string> GetOrgIdentifierAsync(string userId = null);
         Task<long?> GetLastActiveTimeAsync(string userId = null);
         Task SetLastActiveTimeAsync(long? value, string userId = null);

--- a/src/Core/Services/StateService.cs
+++ b/src/Core/Services/StateService.cs
@@ -470,6 +470,15 @@ namespace Bit.Core.Services
             ))?.Profile?.Name;
         }
 
+        public async Task SetNameAsync(string value, string userId = null)
+        {
+            var reconciledOptions = ReconcileOptions(new StorageOptions { UserId = userId },
+                await GetDefaultStorageOptionsAsync());
+            var account = await GetAccountAsync(reconciledOptions);
+            account.Profile.Name = value;
+            await SaveAccountAsync(account, reconciledOptions);
+        }
+
         public async Task<string> GetOrgIdentifierAsync(string userId = null)
         {
             return (await GetAccountAsync(

--- a/src/Core/Services/SyncService.cs
+++ b/src/Core/Services/SyncService.cs
@@ -327,6 +327,7 @@ namespace Bit.Core.Services
             var organizations = response.Organizations.ToDictionary(o => o.Id, o => new OrganizationData(o));
             await _organizationService.ReplaceAsync(organizations);
             await _stateService.SetEmailVerifiedAsync(response.EmailVerified);
+            await _stateService.SetNameAsync(response.Name);
             await _keyConnectorService.SetUsesKeyConnector(response.UsesKeyConnector);
         }
 

--- a/src/iOS.Core/Renderers/CustomNavigationRenderer.cs
+++ b/src/iOS.Core/Renderers/CustomNavigationRenderer.cs
@@ -71,7 +71,7 @@ namespace Bit.iOS.Core.Renderers
                         {
                             try
                             {
-                                uiBarButtonItem.Image = uiBarButtonItem.Image.ImageWithRenderingMode(UIImageRenderingMode.AlwaysOriginal);
+                                uiBarButtonItem.Image = uiBarButtonItem.Image?.ImageWithRenderingMode(UIImageRenderingMode.AlwaysOriginal);
                             }
                             catch (ObjectDisposedException)
                             {


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
- Using a one or two character "Name" in your account profile would result in an invisible avatar, which then caused iOS to crash when our `CustomNavigationRenderer` tried to apply a rendering mode to the non-existent avatar.  The latter issue is now protected from crashing, and the former issue has been fixed so both platforms create the avatar properly if "Name" is 1 or 2 chars.  Special thanks to "AJ" for the help tracking this down. :)
- Discovered "Name" was never updated after account was initially added, so now it's updated on sync


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **AvatarImageSource.cs:** Make sure `chars` and `upperData` are both populated if the first two conditions fail in `Draw()`, and return the original value if both conditions fail in `GetFirstLetters(..)`
* **CustomNavigationRenderer.cs:** Null check `uiBarButtonItem.Image` before applying rendering mode
* **SyncService.cs & StateService.cs:** Added support for updating "Name" on sync (previously was only set when adding account)


## Testing requirements
<!--What functionality requires testing by QA? This includes testing new behavior and regression testing-->



## Before you submit
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
