### PR TITLE
Prevent tapping on app area if its obscured by another window

### DIFF
--- a/src/Android/MainActivity.cs
+++ b/src/Android/MainActivity.cs
@@ -74,6 +74,12 @@ namespace Bit.Droid
             var appCenterTask = appCenterHelper.InitAsync();
 #endif
 
+            var toplayout = Window?.DecorView?.RootView;
+            if (toplayout != null)
+            {
+                toplayout.FilterTouchesWhenObscured = true;
+            }
+
             Xamarin.Essentials.Platform.Init(this, savedInstanceState);
             Xamarin.Forms.Forms.Init(this, savedInstanceState);
             _appOptions = GetOptions();


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Prevent tap actions from being redirected/missed when another view is obscuring the Bitwarden app.
Right now I've enabled it app wide but I do have stashed code to apply it for specific controls if we need to apply in a more granular way.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **MainActivity.cs:** Enabled `FilterTouchesWhenObscured` on the root view so nothing on the app is tappable if it's obscured by another toast, dialog, or window (other app)

## Testing requirements
<!--What functionality requires testing by QA? This includes testing new behavior and regression testing-->
Use an app that has a transparent or semi-transparent background to interact with Bitwarden app and check whether the controls are tapped like buttons, fields, etc.
If you don't have an app to test this let me know and I'll build a apk with the one I crerated and been using.
Also test to interact with the app when popups/dialogs and toasts are shown to see that I haven't broken anything.


## Before you submit
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
