### PR TITLE
Fixed issues with logging out inactive accounts

### DIFF
--- a/src/Core/Abstractions/IStateService.cs
+++ b/src/Core/Abstractions/IStateService.cs
@@ -63,8 +63,8 @@ namespace Bit.Core.Abstractions
         Task SetVaultTimeoutAsync(int? value, string userId = null);
         Task<VaultTimeoutAction?> GetVaultTimeoutActionAsync(string userId = null);
         Task SetVaultTimeoutActionAsync(VaultTimeoutAction? value, string userId = null);
-        Task<DateTime?> GetLastFileCacheClearAsync(string userId = null);
-        Task SetLastFileCacheClearAsync(DateTime? value, string userId = null);
+        Task<DateTime?> GetLastFileCacheClearAsync();
+        Task SetLastFileCacheClearAsync(DateTime? value);
         Task<PreviousPageInfo> GetPreviousPageInfoAsync(string userId = null);
         Task SetPreviousPageInfoAsync(PreviousPageInfo value, string userId = null);
         Task<int> GetInvalidUnlockAttemptsAsync(string userId = null);


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

Fixed two issues with logging out inactive accounts:
- Active account could be changed even though it wasn't the account being logged out
- In-memory decryption keys were being removed for other accounts, resetting them to a locked state

Other things fixed along the way:
- Fixed issue where account removal would reset "Theme" and "Show Website Icons" settings for all users
- Removed redundant account deletion operations
- Removed unused `userId` args for `LastFileCacheClear` getter/setter

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **AppHelpers.cs:** 
   - Removed calls to `xService.ClearAsync` as 1) that's already handled by `stateService.LogoutAccountAsync` and 2) it was also clearing cache regardless of which user was being logged out (should only happen for the active user since we anticipate automatically switching to another user)
   - Established "logged out" vs "removed" toast text earlier in the logout process since automatic account switching could result in incorrect state detection
   - Moved service cache clearing to a dedicated method
* **StateService.cs:** 
   - Removed redundant call to `CheckState` when checking for active account
   - Only perform automatic account switching after account removal if the ActiveUserId is null (which only results if the account being removed is the active account)
   - Removed unused `userId` args for `LastFileCacheClear` getter/setter (this isn't a user-specific value)
   - Don't perform `SetValueGloballyAsync` if the value is null (to prevent global removal of Theme and Favicon settings when account is removed)
   - Don't overwrite `_state` from storage in `GetAccountAsync` if the account doesn't exist in memory (this was the main culprit behind all accounts being locked, since existing VolatileData in `_state.Accounts` was being wiped out (they aren't stored in storage), resetting all other accounts to a locked state. Somehow I was tricking myself into not running into this problem until now)

## Testing requirements
<!--What functionality requires testing by QA? This includes testing new behavior and regression testing-->

https://app.asana.com/0/1201803072708593/1201929380000890/f

## Before you submit
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
