### PR TITLE
Fix Crash on Scroll on iOS 15.4 beta

### DIFF
--- a/src/App/Pages/Send/SendGroupingsPage/SendGroupingsPage.xaml
+++ b/src/App/Pages/Send/SendGroupingsPage/SendGroupingsPage.xaml
@@ -125,8 +125,7 @@
                                     Spacing="0" Padding="0" VerticalOptions="FillAndExpand"
                                     StyleClass="list-row-header-container, list-row-header-container-platform">
                                     <BoxView
-                                        StyleClass="list-section-separator-top, list-section-separator-top-platform"
-                                        IsVisible="{Binding First, Converter={StaticResource inverseBool}}" />
+                                        StyleClass="list-section-separator-top, list-section-separator-top-platform" />
                                     <StackLayout StyleClass="list-row-header, list-row-header-platform">
                                         <Label
                                             Text="{Binding Name}"

--- a/src/App/Pages/Settings/SettingsPage/SettingsPage.xaml
+++ b/src/App/Pages/Settings/SettingsPage/SettingsPage.xaml
@@ -104,8 +104,7 @@
                     Padding="0" Spacing="0" VerticalOptions="FillAndExpand"
                     StyleClass="list-row-header-container, list-row-header-container-platform">
                     <BoxView
-                        StyleClass="list-section-separator-top, list-section-separator-top-platform"
-                        IsVisible="{Binding First, Converter={StaticResource inverseBool}}" />
+                        StyleClass="list-section-separator-top, list-section-separator-top-platform" />
                     <StackLayout StyleClass="list-row-header, list-row-header-platform">
                         <Label
                             Text="{Binding Name}"

--- a/src/App/Pages/Settings/SettingsPage/SettingsPageViewModel.cs
+++ b/src/App/Pages/Settings/SettingsPage/SettingsPageViewModel.cs
@@ -10,6 +10,7 @@ using Bit.Core.Enums;
 using Bit.Core.Models.Domain;
 using Xamarin.Forms;
 using ZXing.Client.Result;
+using Xamarin.CommunityToolkit.ObjectModel;
 
 namespace Bit.App.Pages
 {
@@ -79,11 +80,11 @@ namespace Bit.App.Pages
             _keyConnectorService = ServiceContainer.Resolve<IKeyConnectorService>("keyConnectorService");
             _clipboardService = ServiceContainer.Resolve<IClipboardService>("clipboardService");
 
-            GroupedItems = new ExtendedObservableCollection<SettingsPageListGroup>();
+            GroupedItems = new ObservableRangeCollection<SettingsPageListGroup>();
             PageTitle = AppResources.Settings;
         }
 
-        public ExtendedObservableCollection<SettingsPageListGroup> GroupedItems { get; set; }
+        public ObservableRangeCollection<SettingsPageListGroup> GroupedItems { get; set; }
 
         public async Task InitAsync()
         {
@@ -400,6 +401,8 @@ namespace Bit.App.Pages
 
         public void BuildList()
         {
+            GroupedItems.Clear();
+
             var doUpper = Device.RuntimePlatform != Device.Android;
             var autofillItems = new List<SettingsPageListItem>();
             if (Device.RuntimePlatform == Device.Android)
@@ -501,7 +504,7 @@ namespace Bit.App.Pages
                 new SettingsPageListItem { Name = AppResources.RateTheApp },
                 new SettingsPageListItem { Name = AppResources.DeleteAccount }
             };
-            GroupedItems.ResetWithRange(new List<SettingsPageListGroup>
+            GroupedItems.AddRange(new List<SettingsPageListGroup>
             {
                 new SettingsPageListGroup(autofillItems, AppResources.Autofill, doUpper, true),
                 new SettingsPageListGroup(manageItems, AppResources.Manage, doUpper),

--- a/src/App/Pages/Vault/GroupingsPage/GroupingsPage.xaml
+++ b/src/App/Pages/Vault/GroupingsPage/GroupingsPage.xaml
@@ -116,8 +116,7 @@
                                     Spacing="0" Padding="0" VerticalOptions="FillAndExpand"
                                     StyleClass="list-row-header-container, list-row-header-container-platform">
                                     <BoxView
-                                        StyleClass="list-section-separator-top, list-section-separator-top-platform"
-                                        IsVisible="{Binding First, Converter={StaticResource inverseBool}}" />
+                                        StyleClass="list-section-separator-top, list-section-separator-top-platform" />
                                     <StackLayout StyleClass="list-row-header, list-row-header-platform">
                                         <Label
                                             Text="{Binding Name}"


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Fixes crash produced on iOS 15.4 beta when:
- Scrolling on vault
- Accessing Send list
- Accessing Settings

There seems to be a different calculation algorithm on iOS 15.4 beta for auto cell sizes. And if the header has something that changes visibility therefore the height of the cell, it's invalidating the context of layout measurement and it seems to be triggering the recursion calculation process again indefinitely. I'm not sure why the recursion process doesn't stop when it should after some recursion cycles but that visibility seems to be the root of the problem.
On a side note, also I've found out that if the header `HeightRequest` is given a value that is not an `int` (i.e. has decimals) the recursion is infinite as well so the app crashes. So IMHO, there seems to be something on Xamarin.Forms and/or Apple internal calculations that is comparing with some tolerance that is not expected when using non `int` fixed values.

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **....xaml:** Removed the visibility binding on the top `BoxView` of the `GroupHeaderTemplate` so that the auto cell size calculations don't get messed up
* **SettingsPageViewModel.cs:** Changed the `ExtendedObservableCollection` to use `ObservableRangeCollection` from the Community toolkit so that the collection property change notifications are done propertly

## Testing requirements
<!--What functionality requires testing by QA? This includes testing new behavior and regression testing-->
Update to iOS 15.4 RC and check that the app doesn't crash on vault, settings, send lists and when using autofill.
Make some general testing as well just in case I've missed some other form of crash.
Make some tests on the same views on Android just in case something got broken which I don't think.


## Before you submit
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
