### PR TITLE
Fix Settings crash by removing grouped items

### DIFF
--- a/src/App/Pages/Settings/SettingsPage/ISettingsPageListItem.cs
+++ b/src/App/Pages/Settings/SettingsPage/ISettingsPageListItem.cs
@@ -1,0 +1,6 @@
+﻿namespace Bit.App.Pages
+{
+    public interface ISettingsPageListItem
+    {
+    }
+}

--- a/src/App/Pages/Settings/SettingsPage/SettingsPage.xaml
+++ b/src/App/Pages/Settings/SettingsPage/SettingsPage.xaml
@@ -82,8 +82,26 @@
                 </controls:ExtendedStackLayout>
 	        </DataTemplate>
 
+            <DataTemplate
+                x:Key="headerTemplate"
+                x:DataType="pages:SettingsPageHeaderListItem">
+                <StackLayout
+                    Padding="0" Spacing="0" VerticalOptions="FillAndExpand"
+                    StyleClass="list-row-header-container, list-row-header-container-platform">
+                    <BoxView
+                        StyleClass="list-section-separator-top, list-section-separator-top-platform" />
+                    <StackLayout StyleClass="list-row-header, list-row-header-platform">
+                        <Label
+                            Text="{Binding Title}"
+                            StyleClass="list-header, list-header-platform" />
+                    </StackLayout>
+                    <BoxView StyleClass="list-section-separator-bottom, list-section-separator-bottom-platform" />
+                </StackLayout>
+	        </DataTemplate>
+
             <pages:SettingsPageListItemSelector
                 x:Key="listItemDataTemplateSelector"
+                HeaderTemplate="{StaticResource headerTemplate}"
                 RegularTemplate="{StaticResource regularTemplate}"
                 TimePickerTemplate="{StaticResource timePickerTemplate}" />
         </ResourceDictionary>
@@ -93,27 +111,8 @@
         ItemsSource="{Binding GroupedItems}"
         VerticalOptions="FillAndExpand"
         ItemTemplate="{StaticResource listItemDataTemplateSelector}"
-        IsGrouped="True"
         SelectionMode="Single"
         SelectionChanged="RowSelected"
-        StyleClass="list, list-platform">
-
-        <CollectionView.GroupHeaderTemplate>
-            <DataTemplate x:DataType="pages:SettingsPageListGroup">
-                <StackLayout
-                    Padding="0" Spacing="0" VerticalOptions="FillAndExpand"
-                    StyleClass="list-row-header-container, list-row-header-container-platform">
-                    <BoxView
-                        StyleClass="list-section-separator-top, list-section-separator-top-platform" />
-                    <StackLayout StyleClass="list-row-header, list-row-header-platform">
-                        <Label
-                            Text="{Binding Name}"
-                            StyleClass="list-header, list-header-platform" />
-                    </StackLayout>
-                    <BoxView StyleClass="list-section-separator-bottom, list-section-separator-bottom-platform" />
-                </StackLayout>
-            </DataTemplate>
-        </CollectionView.GroupHeaderTemplate>
-    </controls:ExtendedCollectionView>
+        StyleClass="list, list-platform" />
 
 </pages:BaseContentPage>

--- a/src/App/Pages/Settings/SettingsPage/SettingsPageHeaderListItem.cs
+++ b/src/App/Pages/Settings/SettingsPage/SettingsPageHeaderListItem.cs
@@ -1,0 +1,12 @@
+﻿namespace Bit.App.Pages
+{
+    public class SettingsPageHeaderListItem : ISettingsPageListItem
+    {
+        public SettingsPageHeaderListItem(string title)
+        {
+            Title = title;
+        }
+
+        public string Title { get; }
+    }
+}

--- a/src/App/Pages/Settings/SettingsPage/SettingsPageListItem.cs
+++ b/src/App/Pages/Settings/SettingsPage/SettingsPageListItem.cs
@@ -1,12 +1,11 @@
 ﻿using System;
 using Bit.App.Resources;
 using Bit.App.Utilities;
-using System.Collections.Generic;
 using Xamarin.Forms;
 
 namespace Bit.App.Pages
 {
-    public class SettingsPageListItem
+    public class SettingsPageListItem : ISettingsPageListItem
     {
         public string Icon { get; set; }
         public string Name { get; set; }

--- a/src/App/Pages/Settings/SettingsPage/SettingsPageListItemSelector.cs
+++ b/src/App/Pages/Settings/SettingsPage/SettingsPageListItemSelector.cs
@@ -4,21 +4,19 @@ namespace Bit.App.Pages
 {
     public class SettingsPageListItemSelector : DataTemplateSelector
     {
+        public DataTemplate HeaderTemplate { get; set; }
         public DataTemplate RegularTemplate { get; set; }
         public DataTemplate TimePickerTemplate { get; set; }
 
         protected override DataTemplate OnSelectTemplate(object item, BindableObject container)
         {
+            if (item is SettingsPageHeaderListItem)
+            {
+                return HeaderTemplate;
+            }
             if (item is SettingsPageListItem listItem)
             {
-                if (listItem.ShowTimeInput)
-                {
-                    return TimePickerTemplate;
-                }
-                else
-                {
-                    return RegularTemplate;
-                }
+                return listItem.ShowTimeInput ? TimePickerTemplate : RegularTemplate;
             }
             return null;
         }

--- a/src/App/Pages/Settings/SettingsPage/SettingsPageViewModel.cs
+++ b/src/App/Pages/Settings/SettingsPage/SettingsPageViewModel.cs
@@ -80,11 +80,11 @@ namespace Bit.App.Pages
             _keyConnectorService = ServiceContainer.Resolve<IKeyConnectorService>("keyConnectorService");
             _clipboardService = ServiceContainer.Resolve<IClipboardService>("clipboardService");
 
-            GroupedItems = new ObservableRangeCollection<SettingsPageListGroup>();
+            GroupedItems = new ObservableRangeCollection<ISettingsPageListItem>();
             PageTitle = AppResources.Settings;
         }
 
-        public ObservableRangeCollection<SettingsPageListGroup> GroupedItems { get; set; }
+        public ObservableRangeCollection<ISettingsPageListItem> GroupedItems { get; set; }
 
         public async Task InitAsync()
         {
@@ -401,8 +401,6 @@ namespace Bit.App.Pages
 
         public void BuildList()
         {
-            GroupedItems.Clear();
-
             var doUpper = Device.RuntimePlatform != Device.Android;
             var autofillItems = new List<SettingsPageListItem>();
             if (Device.RuntimePlatform == Device.Android)
@@ -504,7 +502,9 @@ namespace Bit.App.Pages
                 new SettingsPageListItem { Name = AppResources.RateTheApp },
                 new SettingsPageListItem { Name = AppResources.DeleteAccount }
             };
-            GroupedItems.AddRange(new List<SettingsPageListGroup>
+
+            // TODO: improve this. Leaving this as is to reduce error possibility on the hotfix.
+            var settingsListGroupItems = new List<SettingsPageListGroup>()
             {
                 new SettingsPageListGroup(autofillItems, AppResources.Autofill, doUpper, true),
                 new SettingsPageListGroup(manageItems, AppResources.Manage, doUpper),
@@ -512,7 +512,14 @@ namespace Bit.App.Pages
                 new SettingsPageListGroup(accountItems, AppResources.Account, doUpper),
                 new SettingsPageListGroup(toolsItems, AppResources.Tools, doUpper),
                 new SettingsPageListGroup(otherItems, AppResources.Other, doUpper)
-            });
+            };
+            var settingsItems = new List<ISettingsPageListItem>();
+            foreach (var itemGroup in settingsListGroupItems)
+            {
+                settingsItems.Add(new SettingsPageHeaderListItem(itemGroup.Name));
+                settingsItems.AddRange(itemGroup);
+            }
+            GroupedItems.ReplaceRange(settingsItems);
         }
 
         private bool IncludeLinksWithSubscriptionInfo()


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Fix Settings crash on iOS 15.4


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **ISettingsPageListItem:** Interface that all items share
* **ISettingsPageHeaderListItem:** Item for the header
* **SettingsPageViewModel** Changed the approach so that group is not used and there is a plain list of items
* **SettingsPageView** Removed the `GroupHeaderTemplate` and added a new template for the header list item
* **SettingsPageListItemSelector** Added the `HeaderTemplate`


## Testing requirements
<!--What functionality requires testing by QA? This includes testing new behavior and regression testing-->
Settings page should behave as expected without crashing even if you change tabs rapidly


## Before you submit
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
