### PR TITLE
Misc fixes for account switching

### DIFF
--- a/src/Android/Services/DeviceActionService.cs
+++ b/src/Android/Services/DeviceActionService.cs
@@ -943,5 +943,10 @@ namespace Bit.Droid.Services
             var activity = CrossCurrentActivity.Current?.Activity as MainActivity;
             return activity?.Resources?.Configuration?.FontScale ?? 1;
         }
+        
+        public async Task OnAccountSwitchCompleteAsync()
+        {
+            // for any Android-specific cleanup required after switching accounts
+        }
     }
 }

--- a/src/App/Abstractions/IDeviceActionService.cs
+++ b/src/App/Abstractions/IDeviceActionService.cs
@@ -46,5 +46,6 @@ namespace Bit.App.Abstractions
         void CloseMainApp();
         bool SupportsFido2();
         float GetSystemFontSizeScale();
+        Task OnAccountSwitchCompleteAsync();
     }
 }

--- a/src/App/App.xaml.cs
+++ b/src/App/App.xaml.cs
@@ -428,7 +428,7 @@ namespace Bit.App
             });
         }
 
-        private async Task LockedAsync(string userId, bool autoPromptBiometric)
+        private async Task LockedAsync(string userId, bool userInitiated)
         {
             if (!await _stateService.IsActiveAccountAsync(userId))
             {
@@ -436,6 +436,7 @@ namespace Bit.App
                 return;
             }
 
+            var autoPromptBiometric = !userInitiated;
             if (autoPromptBiometric && Device.RuntimePlatform == Device.iOS)
             {
                 var vaultTimeout = await _stateService.GetVaultTimeoutAsync();

--- a/src/App/Services/MobileStorageService.cs
+++ b/src/App/Services/MobileStorageService.cs
@@ -29,6 +29,8 @@ namespace Bit.App.Services
             Constants.iOSAutoFillBiometricIntegrityKey,
             Constants.iOSExtensionClearCiphersCacheKey,
             Constants.iOSExtensionBiometricIntegrityKey,
+            Constants.iOSShareExtensionClearCiphersCacheKey,
+            Constants.iOSShareExtensionBiometricIntegrityKey,
             Constants.RememberedEmailKey,
             Constants.RememberedOrgIdentifierKey,
         };

--- a/src/App/Utilities/AppHelpers.cs
+++ b/src/App/Utilities/AppHelpers.cs
@@ -556,6 +556,8 @@ namespace Bit.App.Utilities
             var environmentService = ServiceContainer.Resolve<IEnvironmentService>("environmentService");
             await environmentService.SetUrlsFromStorageAsync();
             await ClearServiceCacheAsync();
+            var deviceActionService = ServiceContainer.Resolve<IDeviceActionService>("deviceActionService");
+            await deviceActionService.OnAccountSwitchCompleteAsync();
         }
 
         public static async Task ClearServiceCacheAsync()

--- a/src/Core/Constants.cs
+++ b/src/Core/Constants.cs
@@ -23,6 +23,8 @@
         public static string iOSAutoFillBiometricIntegrityKey = "iOSAutoFillBiometricIntegrityState";
         public static string iOSExtensionClearCiphersCacheKey = "iOSExtensionClearCiphersCache";
         public static string iOSExtensionBiometricIntegrityKey = "iOSExtensionBiometricIntegrityState";
+        public static string iOSShareExtensionClearCiphersCacheKey = "iOSShareExtensionClearCiphersCache";
+        public static string iOSShareExtensionBiometricIntegrityKey = "iOSShareExtensionBiometricIntegrityState";
         public static string EventCollectionKey = "eventCollection";
         public static string RememberedEmailKey = "rememberedEmail";
         public static string RememberedOrgIdentifierKey = "rememberedOrgIdentifier";
@@ -39,7 +41,8 @@
         {
             ClearCiphersCacheKey,
             iOSAutoFillClearCiphersCacheKey,
-            iOSExtensionClearCiphersCacheKey
+            iOSExtensionClearCiphersCacheKey,
+            iOSShareExtensionClearCiphersCacheKey
         };
         
         public static string CiphersKey(string userId) => $"ciphers_{userId}";

--- a/src/iOS.Core/Services/DeviceActionService.cs
+++ b/src/iOS.Core/Services/DeviceActionService.cs
@@ -594,6 +594,11 @@ namespace Bit.iOS.Core.Services
             return scaledHeight / tempHeight;
         }
 
+        public async Task OnAccountSwitchCompleteAsync()
+        {
+            await ASHelpers.ReplaceAllIdentities();
+        }
+
         public class PickerDelegate : UIDocumentPickerDelegate
         {
             private readonly DeviceActionService _deviceActionService;

--- a/src/iOS.Core/Utilities/ASHelpers.cs
+++ b/src/iOS.Core/Utilities/ASHelpers.cs
@@ -20,11 +20,13 @@ namespace Bit.iOS.Core.Utilities
                 var timeoutAction = await stateService.GetVaultTimeoutActionAsync();
                 if (timeoutAction == VaultTimeoutAction.Logout)
                 {
+                    await ASCredentialIdentityStore.SharedStore?.RemoveAllCredentialIdentitiesAsync();
                     return;
                 }
                 var vaultTimeoutService = ServiceContainer.Resolve<IVaultTimeoutService>("vaultTimeoutService");
                 if (await vaultTimeoutService.IsLockedAsync())
                 {
+                    await ASCredentialIdentityStore.SharedStore?.RemoveAllCredentialIdentitiesAsync();
                     await storageService.SaveAsync(Constants.AutofillNeedsIdentityReplacementKey, true);
                     return;
                 }
@@ -43,7 +45,9 @@ namespace Bit.iOS.Core.Utilities
                 {
                     await ASCredentialIdentityStore.SharedStore?.ReplaceCredentialIdentitiesAsync(identities.ToArray());
                     await storageService.SaveAsync(Constants.AutofillNeedsIdentityReplacementKey, false);
+                    return;
                 }
+                await ASCredentialIdentityStore.SharedStore?.RemoveAllCredentialIdentitiesAsync();
             }
         }
 

--- a/src/iOS.ShareExtension/LoadingViewController.cs
+++ b/src/iOS.ShareExtension/LoadingViewController.cs
@@ -31,7 +31,7 @@ namespace Bit.iOS.ShareExtension
         private NFCNdefReaderSession _nfcSession = null;
         private Core.NFCReaderDelegate _nfcDelegate = null;
 
-        readonly LazyResolve<IStateService> _stateService = new LazyResolve<IStateService>("stateervice");
+        readonly LazyResolve<IStateService> _stateService = new LazyResolve<IStateService>("stateService");
         readonly LazyResolve<IVaultTimeoutService> _vaultTimeoutService = new LazyResolve<IVaultTimeoutService>("vaultTimeoutService");
         readonly LazyResolve<IDeviceActionService> _deviceActionService = new LazyResolve<IDeviceActionService>("deviceActionService");
         readonly LazyResolve<IEventService> _eventService = new LazyResolve<IEventService>("eventService");
@@ -215,7 +215,7 @@ namespace Bit.iOS.ShareExtension
             iOSCoreHelpers.RegisterLocalServices();
             var messagingService = ServiceContainer.Resolve<IMessagingService>("messagingService");
             ServiceContainer.Init(_deviceActionService.Value.DeviceUserAgent,
-                Bit.Core.Constants.iOSExtensionClearCiphersCacheKey, Bit.Core.Constants.iOSAllClearCipherCacheKeys);
+                Bit.Core.Constants.iOSShareExtensionClearCiphersCacheKey, Bit.Core.Constants.iOSAllClearCipherCacheKeys);
             if (!_initedAppCenter)
             {
                 iOSCoreHelpers.RegisterAppCenter();

--- a/src/iOS.ShareExtension/LockPasswordViewController.cs
+++ b/src/iOS.ShareExtension/LockPasswordViewController.cs
@@ -9,7 +9,7 @@ namespace Bit.iOS.ShareExtension
         public LockPasswordViewController(IntPtr handle)
             : base(handle)
         {
-            BiometricIntegrityKey = Bit.Core.Constants.iOSExtensionBiometricIntegrityKey;
+            BiometricIntegrityKey = Bit.Core.Constants.iOSShareExtensionBiometricIntegrityKey;
             DismissModalAction = Cancel;
         }
 

--- a/src/iOS/AppDelegate.cs
+++ b/src/iOS/AppDelegate.cs
@@ -146,12 +146,7 @@ namespace Bit.iOS
                 {
                     if (_deviceActionService.SystemMajorVersion() >= 12)
                     {
-                        var extras = message.Data as Tuple<string, bool, bool>;
-                        var userId = extras?.Item1;
-                        var userInitiated = extras?.Item2;
-                        var expired = extras?.Item3;
-                        // TODO make specific to userId
-                        // await ASCredentialIdentityStore.SharedStore?.RemoveAllCredentialIdentitiesAsync();
+                        await ASCredentialIdentityStore.SharedStore?.RemoveAllCredentialIdentitiesAsync();
                     }
                 }
                 else if ((message.Command == "softDeletedCipher" || message.Command == "restoredCipher")
@@ -164,9 +159,7 @@ namespace Bit.iOS
                     var timeoutAction = await _stateService.GetVaultTimeoutActionAsync();
                     if (timeoutAction == VaultTimeoutAction.Logout)
                     {
-                        var userId = await _stateService.GetActiveUserIdAsync();
-                        // TODO make specific to userId
-                        // await ASCredentialIdentityStore.SharedStore?.RemoveAllCredentialIdentitiesAsync();
+                        await ASCredentialIdentityStore.SharedStore?.RemoveAllCredentialIdentitiesAsync();
                     }
                     else
                     {


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

Fixes account switching issues:
- Update iOS QuickType Bar credentials list when switching accounts without re-syncing
- Don't auto-prompt biometrics when user initiates lock
- Add unique cache and bio integrity keys to ShareExtension to make sure it's working from the most recent data

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **DeviceActionService.cs:** Added `OnAccountSwitchCompleteAsync` for any platform-specific cleanup required after switching accounts (used to refresh or remove iOS QuickType bar credentials)
* **AppHelpers.cs:** Added call to `deviceActionService.OnAccountSwitchCompleteAsync()` upon account switch completion
* **ASHelpers.cs:** Added calls to `RemoveAllCredentialIdentitiesAsync()` to remove stale credentials from the iOS QuickType bar if the active account isn't authed or unlocked, or contains no matches
* **AppDelegate.cs:** Restore calls to `RemoveAllCredentialIdentitiesAsync` (now that I have a better understanding of the usage) to remove stale credentials from the iOS QuickType bar
* **App.xaml.cs:** Added `autoPromptBiometric` bool as the inverse of `userInitiated` to fix newly-introduced bio prompt bug
* **Constants/MobileStorageService.cs:** Added ShareExtension cache and bio integrity keys 
* **LockPasswordViewController.cs:** Use unique bio integrity key for ShareExtension
* **LoadingViewController.cs:** Fixed typo in `stateService` resolver and use unique cache key for ShareExtension

## Testing requirements
<!--What functionality requires testing by QA? This includes testing new behavior and regression testing-->

https://app.asana.com/0/1201965132275037/1201978140678545
https://app.asana.com/0/1201803072708593/1201967780107162

## Before you submit
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
