### PR TITLE
Fix for missing token when checking for key connector migration

### DIFF
--- a/src/Core/Services/TokenService.cs
+++ b/src/Core/Services/TokenService.cs
@@ -209,6 +209,10 @@ namespace Bit.Core.Services
             {
                 await GetTokenAsync();
             }
+            if (_accessTokenForDecoding == null)
+            {
+                return false;
+            }
             var decoded = DecodeToken();
             if (decoded?["amr"] == null)
             {


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Crash data from both platforms show a common thread where `TokenService.DecodeToken` is throwing `Access token not found` when called from `KeyConnectorService.UserNeedsMigration` > `TokenService.GetIsExternal`.  Based on the 1:1 ratio of users to crashes, this seems like a race condition that occurs once before an active account token is written to storage.  An additional null check of `_accessTokenForDecoding` before calling `DecodeToken` from `GetIsExternal` (following the same logic of the `decoded?["amr"]` null check immediately below it) should prevent this.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **TokenService.cs:** Return `false` if `_accessTokenForDecoding` if still null after `GetTokenAsync` and before `DecodeToken`


## Testing requirements
<!--What functionality requires testing by QA? This includes testing new behavior and regression testing-->



## Before you submit
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
