### PR TITLE
EC-149 Fix crash when trying to Focus on Lock page

### DIFF
--- a/src/App/Pages/Accounts/LockPageViewModel.cs
+++ b/src/App/Pages/Accounts/LockPageViewModel.cs
@@ -10,6 +10,7 @@ using Bit.Core.Enums;
 using Bit.Core.Models.Domain;
 using Bit.Core.Models.Request;
 using Bit.Core.Utilities;
+using Xamarin.CommunityToolkit.Helpers;
 using Xamarin.Forms;
 
 namespace Bit.App.Pages
@@ -27,6 +28,7 @@ namespace Bit.App.Pages
         private readonly IBiometricService _biometricService;
         private readonly IKeyConnectorService _keyConnectorService;
         private readonly ILogger _logger;
+        private readonly WeakEventManager<int?> _secretEntryFocusWeakEventManager = new WeakEventManager<int?>();
 
         private string _email;
         private bool _showPassword;
@@ -131,6 +133,11 @@ namespace Bit.App.Pages
         public string MasterPassword { get; set; }
         public string Pin { get; set; }
         public Action UnlockedAction { get; set; }
+        public event Action<int?> FocusSecretEntry
+        {
+            add => _secretEntryFocusWeakEventManager.AddEventHandler(value);
+            remove => _secretEntryFocusWeakEventManager.RemoveEventHandler(value);
+        }
 
         public async Task InitAsync()
         {
@@ -340,15 +347,12 @@ namespace Bit.App.Pages
                 _messagingService.Send("logout");
             }
         }
-
+        
         public void TogglePassword()
         {
             ShowPassword = !ShowPassword;
-            var page = (Page as LockPage);
-            var entry = PinLock ? page.PinEntry : page.MasterPasswordEntry;
-            var str = PinLock ? Pin : MasterPassword;
-            entry.Focus();
-            entry.CursorPosition = String.IsNullOrEmpty(str) ? 0 : str.Length;
+            var secret = PinLock ? Pin : MasterPassword;
+            _secretEntryFocusWeakEventManager.RaiseEvent(string.IsNullOrEmpty(secret) ? 0 : secret.Length, nameof(FocusSecretEntry));
         }
 
         public async Task PromptBiometricAsync()
@@ -359,18 +363,8 @@ namespace Bit.App.Pages
                 return;
             }
             var success = await _platformUtilsService.AuthenticateBiometricAsync(null,
-            PinLock ? AppResources.PIN : AppResources.MasterPassword, () =>
-            {
-                var page = Page as LockPage;
-                if (PinLock)
-                {
-                    page.PinEntry.Focus();
-                }
-                else
-                {
-                    page.MasterPasswordEntry.Focus();
-                }
-            });
+                PinLock ? AppResources.PIN : AppResources.MasterPassword,
+                () => _secretEntryFocusWeakEventManager.RaiseEvent((int?)null, nameof(FocusSecretEntry)));
             await _stateService.SetBiometricLockedAsync(!success);
             if (success)
             {


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Fix crash produced when focussing the pin/master password entry on the lock page after choosing the fallback method on a failed biometric scan.
I couldn't reproduced this but there are a lot of crashes reported on AppCenter so just fixed it where it's appearing to crash.
Also improved the code so that the ViewModel have fewer direct accesses to the View/Page.

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **LockPage.xaml.cs:** Improved the code making the `SecretEntry` centralizing the logic with the `PinLock` to get the correct entry. Also perform the logic of Focusing on the `Page` invoking it on the main thread to avoid the crash.
* **LockPageViewModel.cs:** Moved the focus action to the page, given that the VM should not do this directly on MVVM. Also added `WeakEventManager` so we don't have to worry about memory leaks.

## Testing requirements
<!--What functionality requires testing by QA? This includes testing new behavior and regression testing-->
I couldn't reproduce the issue but given the crash report it would be like:

1. Enter you account
2. Configure biometrics
3. Configure pin
4. Lock the account
5. Try to unlock with fail biometric (i.e. don't use the correct one)
6. Try again until the fallback appears (Master Password / Pin)
7. Choose the fallback
8. Then it should crash

Also it could be like that but with the automatic prompting of biometrics when minimizing the app and starting it again.

Btw, if no biometrics is setup the pin/master password entry should be automatically focused (i.e. should work as before) and if biometrics are configured and the fallback is selected the same should happen, i.e. it should automatically focus the pin/master password.


## Before you submit
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
