### PR TITLE
[EC-326] Add support for iodé Browser

### DIFF
--- a/src/Android/Accessibility/AccessibilityHelpers.cs
+++ b/src/Android/Accessibility/AccessibilityHelpers.cs
@@ -54,6 +54,7 @@ namespace Bit.Droid.Accessibility
             new Browser("com.google.android.apps.chrome", "url_bar"),
             new Browser("com.google.android.apps.chrome_dev", "url_bar"),
             // Rem. for "com.google.android.captiveportallogin": URL displayed in ActionBar subtitle without viewId.
+            new Browser("com.iode.firefox", "mozac_browser_toolbar_url_view"),
             new Browser("com.jamal2367.styx", "search"),
             new Browser("com.kiwibrowser.browser", "url_bar"),
             new Browser("com.kiwibrowser.browser.dev", "url_bar"),

--- a/src/Android/Autofill/AutofillHelpers.cs
+++ b/src/Android/Autofill/AutofillHelpers.cs
@@ -73,6 +73,7 @@ namespace Bit.Droid.Autofill
             "com.google.android.apps.chrome",
             "com.google.android.apps.chrome_dev",
             "com.google.android.captiveportallogin",
+            "com.iode.firefox",
             "com.jamal2367.styx",
             "com.kiwibrowser.browser",
             "com.kiwibrowser.browser.dev",

--- a/src/Android/Resources/xml/autofillservice.xml
+++ b/src/Android/Resources/xml/autofillservice.xml
@@ -78,6 +78,9 @@
     android:name="com.google.android.captiveportallogin"
     android:maxLongVersionCode="10000000000"/>
   <compatibility-package
+    android:name="com.iode.firefox"
+    android:maxLongVersionCode="10000000000"/>
+  <compatibility-package
     android:name="com.jamal2367.styx"
     android:maxLongVersionCode="10000000000"/>
   <compatibility-package


### PR DESCRIPTION
This adds support for iodé Browser (https://gitlab.com/iode/os/apps/iodebrowser), a Firefox fork developed for the iodéOS privacy-oriented rom (but can be used independently of the rom).