### PR TITLE
PS-330 Fix a11y issue with hCaptcha on iOS

### DIFF
--- a/src/App/Pages/CaptchaProtectedViewModel.cs
+++ b/src/App/Pages/CaptchaProtectedViewModel.cs
@@ -37,11 +37,14 @@ namespace Bit.App.Pages
             bool cancelled = false;
             try
             {
+                // PrefersEphemeralWebBrowserSession should be false to allow access to the hCaptcha accessibility
+                // cookie set in the default browser
+                // https://www.hcaptcha.com/accessibility
                 var options = new WebAuthenticatorOptions
                 {
                     Url = new Uri(url),
                     CallbackUrl = new Uri(callbackUri),
-                    PrefersEphemeralWebBrowserSession = true,
+                    PrefersEphemeralWebBrowserSession = false,
                 };
                 authResult = await WebAuthenticator.AuthenticateAsync(options);
             }


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

hCaptcha has an option to bypass captcha requests for accessibility purposes, but the flow requires access to existing cookies when using `WebAuthenticator`, which we previously disabled to prevent any unforeseen issues.  This PR enables cookie access within the captcha flow to allow the accessibility bypass to function.  (Note this was only an issue on iOS since `PrefersEphemeralWebBrowserSession` has no effect on Android)

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **CaptchaProtectedViewModel.cs:** Set `PrefersEphemeralWebBrowserSession` to false to allow access to existing cookies during captcha flow

## Testing requirements
<!--What functionality requires testing by QA? This includes testing new behavior and regression testing-->

See PS-330 for details

## Before you submit
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
