### PR TITLE
PS-591 Fix avoid ambiguous characters #1664

### DIFF
--- a/src/App/Pages/Generator/GeneratorPage.xaml
+++ b/src/App/Pages/Generator/GeneratorPage.xaml
@@ -277,7 +277,7 @@
                                 StyleClass="box-label-regular"
                                 HorizontalOptions="StartAndExpand" />
                             <Switch
-                                IsToggled="{Binding AvoidAmbiguous}"
+                                IsToggled="{Binding AvoidAmbiguousChars}"
                                 StyleClass="box-value"
                                 HorizontalOptions="End" />
                         </StackLayout>

--- a/src/App/Pages/Generator/GeneratorPageViewModel.cs
+++ b/src/App/Pages/Generator/GeneratorPageViewModel.cs
@@ -23,7 +23,7 @@ namespace Bit.App.Pages
         private bool _lowercase;
         private bool _number;
         private bool _special;
-        private bool _avoidAmbiguous;
+        private bool _allowAmbiguousChars;
         private int _minNumber;
         private int _minSpecial;
         private int _length = 5;
@@ -130,17 +130,27 @@ namespace Bit.App.Pages
             }
         }
 
-        public bool AvoidAmbiguous
+        public bool AllowAmbiguousChars
         {
-            get => _avoidAmbiguous;
+            get => _allowAmbiguousChars;
             set
             {
-                if (SetProperty(ref _avoidAmbiguous, value))
+                if (SetProperty(ref _allowAmbiguousChars, value,
+                    additionalPropertyNames: new string[]
+                    {
+                        nameof(AvoidAmbiguousChars)
+                    }))
                 {
-                    _options.AvoidAmbiguous = value;
+                    _options.AllowAmbiguousChar = value;
                     var task = SaveOptionsAsync();
                 }
             }
+        }
+
+        public bool AvoidAmbiguousChars
+        {
+            get => !AllowAmbiguousChars;
+            set => AllowAmbiguousChars = !value;
         }
 
         public int MinNumber
@@ -315,7 +325,7 @@ namespace Bit.App.Pages
 
         private void LoadFromOptions()
         {
-            AvoidAmbiguous = _options.AvoidAmbiguous.GetValueOrDefault();
+            AllowAmbiguousChars = _options.AllowAmbiguousChar.GetValueOrDefault();
             TypeSelectedIndex = _options.Type == "passphrase" ? 1 : 0;
             IsPassword = TypeSelectedIndex == 0;
             MinNumber = _options.MinNumber.GetValueOrDefault();
@@ -333,7 +343,7 @@ namespace Bit.App.Pages
 
         private void SetOptions()
         {
-            _options.AvoidAmbiguous = AvoidAmbiguous;
+            _options.AllowAmbiguousChar = AllowAmbiguousChars;
             _options.Type = TypeSelectedIndex == 1 ? "passphrase" : "password";
             _options.MinNumber = MinNumber;
             _options.MinSpecial = MinSpecial;

--- a/src/Core/Models/Domain/PasswordGenerationOptions.cs
+++ b/src/Core/Models/Domain/PasswordGenerationOptions.cs
@@ -9,7 +9,7 @@
             if (defaultOptions)
             {
                 Length = 14;
-                AvoidAmbiguous = false;
+                AllowAmbiguousChar = true;
                 Number = true;
                 MinNumber = 1;
                 Uppercase = true;
@@ -27,7 +27,7 @@
         }
 
         public int? Length { get; set; }
-        public bool? AvoidAmbiguous { get; set; }
+        public bool? AllowAmbiguousChar { get; set; }
         public bool? Number { get; set; }
         public int? MinNumber { get; set; }
         public bool? Uppercase { get; set; }
@@ -45,7 +45,7 @@
         public void Merge(PasswordGenerationOptions defaults)
         {
             Length = Length ?? defaults.Length;
-            AvoidAmbiguous = AvoidAmbiguous ?? defaults.AvoidAmbiguous;
+            AllowAmbiguousChar = AllowAmbiguousChar ?? defaults.AllowAmbiguousChar;
             Number = Number ?? defaults.Number;
             MinNumber = MinNumber ?? defaults.MinNumber;
             Uppercase = Uppercase ?? defaults.Uppercase;

--- a/src/Core/Services/PasswordGenerationService.cs
+++ b/src/Core/Services/PasswordGenerationService.cs
@@ -93,7 +93,7 @@ namespace Bit.Core.Services
             // Build out other character sets
             var allCharSet = string.Empty;
             var lowercaseCharSet = LowercaseCharSet;
-            if (!options.AvoidAmbiguous.GetValueOrDefault())
+            if (options.AllowAmbiguousChar.GetValueOrDefault())
             {
                 lowercaseCharSet = string.Concat(lowercaseCharSet, "l");
             }
@@ -103,7 +103,7 @@ namespace Bit.Core.Services
             }
 
             var uppercaseCharSet = UppercaseCharSet;
-            if (!options.AvoidAmbiguous.GetValueOrDefault())
+            if (options.AllowAmbiguousChar.GetValueOrDefault())
             {
                 uppercaseCharSet = string.Concat(uppercaseCharSet, "IO");
             }
@@ -113,7 +113,7 @@ namespace Bit.Core.Services
             }
 
             var numberCharSet = NumberCharSet;
-            if (!options.AvoidAmbiguous.GetValueOrDefault())
+            if (options.AllowAmbiguousChar.GetValueOrDefault())
             {
                 numberCharSet = string.Concat(numberCharSet, "01");
             }

--- a/src/iOS.Core/Controllers/PasswordGeneratorViewController.cs
+++ b/src/iOS.Core/Controllers/PasswordGeneratorViewController.cs
@@ -101,7 +101,7 @@ namespace Bit.iOS.Core.Controllers
             MinNumbersCell.Value = options.MinNumber.GetValueOrDefault(1);
             MinSpecialCell.Value = options.MinSpecial.GetValueOrDefault(1);
             LengthCell.Value = options.Length.GetValueOrDefault(14);
-            AmbiguousCell.Switch.On = options.AvoidAmbiguous.GetValueOrDefault();
+            AmbiguousCell.Switch.On = !options.AllowAmbiguousChar.GetValueOrDefault();
 
             NumWordsCell.Value = options.NumWords.GetValueOrDefault(3);
             WordSeparatorCell.TextField.Text = options.WordSeparator ?? "";
@@ -219,7 +219,7 @@ namespace Bit.iOS.Core.Controllers
                     Special = SpecialCell.Switch.On,
                     MinSpecial = MinSpecialCell.Value,
                     MinNumber = MinNumbersCell.Value,
-                    AvoidAmbiguous = AmbiguousCell.Switch.On,
+                    AllowAmbiguousChar = !AmbiguousCell.Switch.On,
                     NumWords = NumWordsCell.Value,
                     WordSeparator = WordSeparatorCell.TextField.Text,
                     Capitalize = CapitalizeCell.Switch.On,


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
Fix **avoid ambiguous characters** option. On mobile the value was being stored locally inverted of what the user had selected. Wasn't noticed during the session due to caching.

## Code changes
Refactor the name of the property `Ambiguous` to `AvoidAmbiguous`, this naming was misleading.
Fixed bug where the boolean value for the `AvoidAmbiguous` property was being stored inverted.

* **GeneratorPageViewModel.cs:140:** value was being stored inverted of what UI was showing

## Before you submit
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
