### PR TITLE
PS-592 Name field is not prioritised in search results #1687

### DIFF
--- a/src/Core/Services/SearchService.cs
+++ b/src/Core/Services/SearchService.cs
@@ -74,28 +74,34 @@ namespace Bit.Core.Services
             CancellationToken ct = default, bool deleted = false)
         {
             ct.ThrowIfCancellationRequested();
+            var matchedCiphers = new List<CipherView>();
+            var lowPriorityMatchedCiphers = new List<CipherView>();
             query = query.Trim().ToLower();
-            return ciphers.Where(c =>
+
+            foreach (var c in ciphers)
             {
                 ct.ThrowIfCancellationRequested();
                 if (c.Name?.ToLower().Contains(query) ?? false)
                 {
-                    return true;
+                    matchedCiphers.Add(c);
                 }
-                if (query.Length >= 8 && c.Id.StartsWith(query))
+                else if (query.Length >= 8 && c.Id.StartsWith(query))
                 {
-                    return true;
+                    lowPriorityMatchedCiphers.Add(c);
                 }
-                if (c.SubTitle?.ToLower().Contains(query) ?? false)
+                else if (c.SubTitle?.ToLower().Contains(query) ?? false)
                 {
-                    return true;
+                    lowPriorityMatchedCiphers.Add(c);
                 }
-                if (c.Login?.Uri?.ToLower()?.Contains(query) ?? false)
+                else if (c.Login?.Uri?.ToLower()?.Contains(query) ?? false)
                 {
-                    return true;
+                    lowPriorityMatchedCiphers.Add(c);
                 }
-                return false;
-            }).ToList();
+            }
+
+            ct.ThrowIfCancellationRequested();
+            matchedCiphers.AddRange(lowPriorityMatchedCiphers);
+            return matchedCiphers;
         }
 
         public async Task<List<SendView>> SearchSendsAsync(string query, Func<SendView, bool> filter = null,
@@ -133,25 +139,31 @@ namespace Bit.Core.Services
         public List<SendView> SearchSendsBasic(List<SendView> sends, string query, CancellationToken ct = default,
             bool deleted = false)
         {
+            var matchedSends = new List<SendView>();
+            var lowPriorityMatchSends = new List<SendView>();
             ct.ThrowIfCancellationRequested();
             query = query.Trim().ToLower();
-            return sends.Where(s =>
+
+            foreach (var s in sends)
             {
                 ct.ThrowIfCancellationRequested();
                 if (s.Name?.ToLower().Contains(query) ?? false)
                 {
-                    return true;
+                    matchedSends.Add(s);
                 }
-                if (s.Text?.Text?.ToLower().Contains(query) ?? false)
+                else if (s.Text?.Text?.ToLower().Contains(query) ?? false)
                 {
-                    return true;
+                    lowPriorityMatchSends.Add(s);
                 }
-                if (s.File?.FileName?.ToLower()?.Contains(query) ?? false)
+                else if (s.File?.FileName?.ToLower()?.Contains(query) ?? false)
                 {
-                    return true;
+                    lowPriorityMatchSends.Add(s);
                 }
-                return false;
-            }).ToList();
+            }
+
+            ct.ThrowIfCancellationRequested();
+            matchedSends.AddRange(lowPriorityMatchSends);
+            return matchedSends;
         }
     }
 }


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
When search for ciphers or sends give priority to matches with the `Name` property, show them first in the results list.

## Code changes
* **SearchService.cs:** While running the search methods, created two list, one for matches and another for matches with lower priority. After the search, merged the two lists and retuned the results. This ensures that we only iterate through the list once and give it the order we desire.   

## Screenshots
<img width="396" alt="image" src="https://user-images.githubusercontent.com/4648522/168114020-9c12a554-e1cd-4b40-8240-8380cd0c9a60.png">



## Before you submit
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
