### PR TITLE
settings option to allow screen capture on Android

### DIFF
--- a/src/Android/MainActivity.cs
+++ b/src/Android/MainActivity.cs
@@ -41,7 +41,7 @@ namespace Bit.Droid
         private Java.Util.Regex.Pattern _otpPattern =
             Java.Util.Regex.Pattern.Compile("^.*?([cbdefghijklnrtuv]{32,64})$");
 
-        protected override void OnCreate(Bundle savedInstanceState)
+        protected override async void OnCreate(Bundle savedInstanceState)
         {
             var eventUploadIntent = new Intent(this, typeof(EventUploadReceiver));
             _eventUploadPendingIntent = PendingIntent.GetBroadcast(this, 0, eventUploadIntent,
@@ -64,10 +64,8 @@ namespace Bit.Droid
             Intent?.Validate();
 
             base.OnCreate(savedInstanceState);
-            if (!CoreHelpers.InDebugMode())
-            {
-                Window.AddFlags(Android.Views.WindowManagerFlags.Secure);
-            }
+
+            await _deviceActionService.SetScreenCaptureAllowedAsync();
 
             ServiceContainer.Resolve<ILogger>("logger").InitAsync();
 

--- a/src/Android/Services/DeviceActionService.cs
+++ b/src/Android/Services/DeviceActionService.cs
@@ -953,5 +953,18 @@ namespace Bit.Droid.Services
         {
             // for any Android-specific cleanup required after switching accounts
         }
+
+        public async Task SetScreenCaptureAllowedAsync()
+        {
+            if (CoreHelpers.InDebugMode()) return;
+
+            var activity = CrossCurrentActivity.Current?.Activity;
+            if (await _stateService.GetScreenCaptureAllowedAsync())
+            {
+                activity.Window.ClearFlags(WindowManagerFlags.Secure);
+                return;
+            }
+            activity.Window.AddFlags(WindowManagerFlags.Secure);
+        }
     }
 }

--- a/src/App/Abstractions/IDeviceActionService.cs
+++ b/src/App/Abstractions/IDeviceActionService.cs
@@ -48,5 +48,6 @@ namespace Bit.App.Abstractions
         bool SupportsFido2();
         float GetSystemFontSizeScale();
         Task OnAccountSwitchCompleteAsync();
+        Task SetScreenCaptureAllowedAsync();
     }
 }

--- a/src/App/Pages/Settings/SettingsPage/SettingsPage.xaml.cs
+++ b/src/App/Pages/Settings/SettingsPage/SettingsPage.xaml.cs
@@ -170,6 +170,10 @@ namespace Bit.App.Pages
             else if (item.Name == AppResources.ReportCrashLogs)
             {
                 await _vm.LoggerReportingAsync();
+			}
+            else if (item.Name == AppResources.AllowScreenCapture)
+            {
+                await _vm.SetScreenCaptureAllowedAsync();
             }
             else
             {

--- a/src/App/Pages/Vault/GroupingsPage/GroupingsPageViewModel.cs
+++ b/src/App/Pages/Vault/GroupingsPage/GroupingsPageViewModel.cs
@@ -282,6 +282,8 @@ namespace Bit.App.Pages
                     }, AppResources.Trash, _deletedCount, uppercaseGroupNames, false));
                 }
 
+                await _deviceActionService.SetScreenCaptureAllowedAsync();
+                
                 // TODO: refactor this
                 if (Device.RuntimePlatform == Device.Android
                     ||

--- a/src/App/Resources/AppResources.Designer.cs
+++ b/src/App/Resources/AppResources.Designer.cs
@@ -1102,10 +1102,19 @@ namespace Bit.App.Resources {
                 return ResourceManager.GetString("TouchID", resourceCulture);
             }
         }
-        
-        public static string TwoStepLogin {
+
+        public static string TwoStepLogin
+        {
             get {
                 return ResourceManager.GetString("TwoStepLogin", resourceCulture);
+            }
+        }
+
+        public static string AllowScreenCapture
+        {
+            get {
+                //TODO: insert string "Allow Screen Capture" in resources and remove condition from the next line of code
+                return ResourceManager.GetString("AllowScreenCapture", resourceCulture)?? "Allow Screen Capture";
             }
         }
         

--- a/src/Core/Abstractions/IStateService.cs
+++ b/src/Core/Abstractions/IStateService.cs
@@ -145,5 +145,7 @@ namespace Bit.Core.Abstractions
         Task SetRefreshTokenAsync(string value, bool skipTokenStorage, string userId = null);
         Task<string> GetTwoFactorTokenAsync(string email = null);
         Task SetTwoFactorTokenAsync(string value, string email = null);
+        Task<bool> GetScreenCaptureAllowedAsync(string userId = null);
+        Task SetScreenCaptureAllowedAsync(bool value, string userId = null);
     }
 }

--- a/src/Core/Models/Domain/Account.cs
+++ b/src/Core/Models/Domain/Account.cs
@@ -94,11 +94,13 @@ namespace Bit.Core.Models.Domain
                 EnvironmentUrls = copy.EnvironmentUrls;
                 VaultTimeout = copy.VaultTimeout;
                 VaultTimeoutAction = copy.VaultTimeoutAction;
+                ScreenCaptureAllowed = copy.ScreenCaptureAllowed;
             }
 
             public EnvironmentUrlData EnvironmentUrls;
             public int? VaultTimeout;
             public VaultTimeoutAction? VaultTimeoutAction;
+            public bool? ScreenCaptureAllowed;
         }
 
         public class AccountVolatileData

--- a/src/Core/Services/StateMigrationService.cs
+++ b/src/Core/Services/StateMigrationService.cs
@@ -90,6 +90,7 @@ namespace Bit.Core.Services
             internal const string SyncOnRefreshKey = "syncOnRefresh";
             internal const string VaultTimeoutKey = "lockOption";
             internal const string VaultTimeoutActionKey = "vaultTimeoutAction";
+            internal const string ScreenCaptureAllowedKey = "screenCaptureAllowed";
             internal const string LastActiveTimeKey = "lastActiveTime";
             internal const string BiometricUnlockKey = "fingerprintUnlock";
             internal const string ProtectedPin = "protectedPin";
@@ -186,12 +187,14 @@ namespace Bit.Core.Services
             var environmentUrls = await GetValueAsync<EnvironmentUrlData>(Storage.Prefs, V2Keys.EnvironmentUrlsKey);
             var vaultTimeout = await GetValueAsync<int?>(Storage.Prefs, V2Keys.VaultTimeoutKey);
             var vaultTimeoutAction = await GetValueAsync<string>(Storage.Prefs, V2Keys.VaultTimeoutActionKey);
+            var screenCaptureAllowed = await GetValueAsync<bool>(Storage.Prefs, V2Keys.ScreenCaptureAllowedKey);
             account.Settings = new Account.AccountSettings()
             {
                 EnvironmentUrls = environmentUrls,
                 VaultTimeout = vaultTimeout,
                 VaultTimeoutAction =
                     vaultTimeoutAction == "logout" ? VaultTimeoutAction.Logout : VaultTimeoutAction.Lock,
+                ScreenCaptureAllowed = screenCaptureAllowed
             };
             var state = new State { Accounts = new Dictionary<string, Account> { [userId] = account } };
             state.ActiveUserId = userId;

--- a/src/Core/Services/StateService.cs
+++ b/src/Core/Services/StateService.cs
@@ -532,6 +532,22 @@ namespace Bit.Core.Services
             await SaveAccountAsync(account, reconciledOptions);
         }
 
+        public async Task<bool> GetScreenCaptureAllowedAsync(string userId = null)
+        {
+            return (await GetAccountAsync(
+                ReconcileOptions(new StorageOptions { UserId = userId }, await GetDefaultStorageOptionsAsync())
+            ))?.Settings?.ScreenCaptureAllowed ?? false;
+        }
+
+        public async Task SetScreenCaptureAllowedAsync(bool value, string userId = null)
+        {
+            var reconciledOptions = ReconcileOptions(new StorageOptions { UserId = userId },
+                await GetDefaultStorageOptionsAsync());
+            var account = await GetAccountAsync(reconciledOptions);
+            account.Settings.ScreenCaptureAllowed = value;
+            await SaveAccountAsync(account, reconciledOptions);
+        }
+
         public async Task<DateTime?> GetLastFileCacheClearAsync()
         {
             var options = await GetDefaultStorageOptionsAsync();
@@ -1418,6 +1434,7 @@ namespace Bit.Core.Services
                 var existingAccount = state.Accounts[account.Profile.UserId];
                 account.Settings.VaultTimeout = existingAccount.Settings.VaultTimeout;
                 account.Settings.VaultTimeoutAction = existingAccount.Settings.VaultTimeoutAction;
+                account.Settings.ScreenCaptureAllowed = existingAccount.Settings.ScreenCaptureAllowed;
             }
 
             // New account defaults
@@ -1428,6 +1445,10 @@ namespace Bit.Core.Services
             if (account.Settings.VaultTimeoutAction == null)
             {
                 account.Settings.VaultTimeoutAction = VaultTimeoutAction.Lock;
+            }
+            if (account.Settings.ScreenCaptureAllowed == null)
+            {
+                account.Settings.ScreenCaptureAllowed = false;
             }
             await SetThemeAsync(currentTheme, account.Profile.UserId);
             await SetDisableFaviconAsync(currentDisableFavicons, account.Profile.UserId);

--- a/src/iOS.Core/Services/DeviceActionService.cs
+++ b/src/iOS.Core/Services/DeviceActionService.cs
@@ -604,6 +604,12 @@ namespace Bit.iOS.Core.Services
             await ASHelpers.ReplaceAllIdentities();
         }
 
+        public Task SetScreenCaptureAllowedAsync()
+        {
+            // only used by Android. Not possible in iOS
+            return Task.CompletedTask;
+        }
+
         public class PickerDelegate : UIDocumentPickerDelegate
         {
             private readonly DeviceActionService _deviceActionService;


### PR DESCRIPTION
Feature name:
Screen Capture

Feature Description:
- This feature was requested by the community: https://community.bitwarden.com/t/option-to-allow-screenshots/317
- It only concerns the Android platform.
- Added a toggle on the settings page that enables/disables the possibility to capture the screen, either by screen sharing, screenshots or screen recording.

Clients / Repos Affected:
Mobile

Timeline to completion (estimate):
One week




## Type of change
- [ ] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
- Added a toggle on the setting page that enables/disables the possibility to capture the screen, either by screen sharing, screenshots or screen recording.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- Created an async `Task` on `IDeviceActionService`, called `SetScreenCaptureAllowedAsync`. On Android, it adds/removes the secure flag in order to allow/prevent screen capturing. On iOS, it does nothing.
- On Android, `SetScreenCaptureAllowedAsync` is called on `MainActivity` in `OnCreate`. Since this is an `async Task`, I had to make `OnCreate` `async`.
- On `SettingsPageViewModel`, I'm checking if the app is running on Android and, if so, add a new item to `securityItems` that toggles the allow screen capture feature. In order to prevent thread concurrency issues accessing `SetScreenCaptureAllowedAsync`, the state is affected by the item state itself, guaranteeing that the state that the user is seeing on the device screen is the one that's being saved.
- Since the app supports multiple accounts, added the flag `ScreenCaptureAllowed` to the `Account` model to save the state for each account. The state is saved and loaded on `StateService` and `StateMigrationService`.
- I'm calling `_deviceActionService.SetScreenCaptureAllowedAsync()` on `GroupingsPageViewModel` `LoadAsync` to keep consistency.
- Added a static method on `AppResources.Designer` that returns the string "Allow Screen Capture", that will be used to display the item on the respective page. I left a `TODO` there to add this string to the resources. Please help me with this task.
- Disabled in Debug.
- Also, tested iOS to make sure it didn't suffer any changes from the code updates.



## Screenshots
<!--Required for any UI changes. Delete if not applicable-->
![Screenshot1](https://user-images.githubusercontent.com/3696035/169279194-46f58f7d-8976-4913-95d4-d15c543a3cbc.png)



## Before you submit
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
