### PR TITLE
[PS-90] App keeps asking for 2FA even though I've checked the "remember me" checkbox.

### DIFF
--- a/src/Core/Services/AuthService.cs
+++ b/src/Core/Services/AuthService.cs
@@ -346,6 +346,7 @@ namespace Bit.Core.Services
                 TwoFactorProvidersData = response.TwoFactorResponse.TwoFactorProviders2;
                 result.TwoFactorProviders = response.TwoFactorResponse.TwoFactorProviders2;
                 CaptchaToken = response.TwoFactorResponse.CaptchaToken;
+                await _tokenService.ClearTwoFactorTokenAsync(email);
                 return result;
             }
 

--- a/src/Core/Services/StateService.cs
+++ b/src/Core/Services/StateService.cs
@@ -1372,10 +1372,6 @@ namespace Bit.Core.Services
             await SetEncryptedPasswordGenerationHistoryAsync(null, userId);
             await SetEncryptedSendsAsync(null, userId);
             await SetSettingsAsync(null, userId);
-            if (!string.IsNullOrWhiteSpace(email))
-            {
-                await SetTwoFactorTokenAsync(null, email);
-            }
 
             if (userInitiated)
             {


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
App keeps asking for 2FA, even if "remember me" was previously selected.  

## Code changes
* **AuthService.cs:** Previous 2FA code gets cleared if there is an auth error regarding 2FA.
* **StateService.cs:** Removed code that was deleting user 2FA token. Not having this token was causing 2FA login after user logout. 

## Before you submit
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
