### PR TITLE
[PS-673] Add check for master password reprompt to share sheet extension

### DIFF
--- a/src/iOS.Extension/LoginListViewController.cs
+++ b/src/iOS.Extension/LoginListViewController.cs
@@ -9,6 +9,8 @@ using MobileCoreServices;
 using Bit.iOS.Core.Controllers;
 using Bit.App.Resources;
 using Bit.iOS.Core.Views;
+using Bit.App.Abstractions;
+using Bit.Core.Utilities;
 
 namespace Bit.iOS.Extension
 {
@@ -18,10 +20,12 @@ namespace Bit.iOS.Extension
             : base(handle)
         {
             DismissModalAction = Cancel;
+            PasswordRepromptService = ServiceContainer.Resolve<IPasswordRepromptService>("passwordRepromptService");
         }
 
         public Context Context { get; set; }
         public LoadingViewController LoadingController { get; set; }
+        public IPasswordRepromptService PasswordRepromptService { get; private set; }
 
         public async override void ViewDidLoad()
         {
@@ -104,7 +108,7 @@ namespace Bit.iOS.Extension
                 _controller = controller;
             }
 
-            public override void RowSelected(UITableView tableView, NSIndexPath indexPath)
+            public async override void RowSelected(UITableView tableView, NSIndexPath indexPath)
             {
                 tableView.DeselectRow(indexPath, true);
                 tableView.EndEditing(true);
@@ -119,6 +123,11 @@ namespace Bit.iOS.Extension
                 if (item == null)
                 {
                     _controller.LoadingController.CompleteRequest(null, null);
+                    return;
+                }
+
+                if (item.Reprompt != Bit.Core.Enums.CipherRepromptType.None && !await _controller.PasswordRepromptService.ShowPasswordPromptAsync())
+                {
                     return;
                 }
 


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Master password reprompts were not being checked on the share sheet extension for iOS. This adds that functionality.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **src/iOS.Extension/LoginListViewController.cs:** add passwordRepromptService and use on `RowSelected`



## Before you submit
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
