### PR TITLE
[PS-672] Accessibility - File/Text controls unintuitive, "Text" accessible name incorrect

### DIFF
--- a/src/App/Pages/Send/SendAddEditPage.xaml
+++ b/src/App/Pages/Send/SendAddEditPage.xaml
@@ -113,6 +113,7 @@
                                     <ColumnDefinition Width="*" />
                                 </Grid.ColumnDefinitions>
                                 <Button
+                                    x:Name="_typeFileButton"
                                     Text="{u:I18n TypeFile}"
                                     StyleClass="segmented-button"
                                     IsEnabled="{Binding IsText}"
@@ -124,6 +125,7 @@
                                     Grid.Column="0">
                                 </Button>
                                 <Button
+                                    x:Name="_typeTextButton"
                                     Text="{u:I18n TypeText}"
                                     StyleClass="segmented-button"
                                     IsEnabled="{Binding IsFile}"

--- a/src/App/Pages/Send/SendAddEditPage.xaml.cs
+++ b/src/App/Pages/Send/SendAddEditPage.xaml.cs
@@ -126,6 +126,7 @@ namespace Bit.App.Pages
                     }
                     AdjustToolbar();
                 });
+                SetAccessibilityLabels();
             }
             catch (Exception ex)
             {
@@ -173,6 +174,7 @@ namespace Bit.App.Pages
             {
                 RequestFocus(_nameEntry);
             }
+            SetAccessibilityLabels();
         }
 
         private async void FileType_Clicked(object sender, EventArgs eventArgs)
@@ -184,6 +186,7 @@ namespace Bit.App.Pages
             {
                 RequestFocus(_nameEntry);
             }
+            SetAccessibilityLabels();
         }
 
         private void OnMaxAccessCountTextChanged(object sender, TextChangedEventArgs e)
@@ -355,6 +358,12 @@ namespace Bit.App.Pages
                 TextType_Clicked(null, null);
             }
             _appOptions.CreateSend = null;
+        }
+
+        private void SetAccessibilityLabels()
+        {
+            AutomationProperties.SetHelpText(_typeFileButton, _vm.FileTypeAccessibilityLabel);
+            AutomationProperties.SetHelpText(_typeTextButton, _vm.TextTypeAccessibilityLabel);
         }
     }
 }

--- a/src/App/Pages/Send/SendAddEditPageViewModel.cs
+++ b/src/App/Pages/Send/SendAddEditPageViewModel.cs
@@ -23,6 +23,7 @@ namespace Bit.App.Pages
         private readonly IStateService _stateService;
         private readonly ISendService _sendService;
         private readonly ILogger _logger;
+        private readonly II18nService _i18nService;
         private bool _sendEnabled;
         private bool _canAccessPremium;
         private bool _emailVerified;
@@ -57,6 +58,7 @@ namespace Bit.App.Pages
             _stateService = ServiceContainer.Resolve<IStateService>("stateService");
             _sendService = ServiceContainer.Resolve<ISendService>("sendService");
             _logger = ServiceContainer.Resolve<ILogger>("logger");
+            _i18nService = ServiceContainer.Resolve<II18nService>("i18nService");
 
             TogglePasswordCommand = new Command(TogglePassword);
 
@@ -231,6 +233,8 @@ namespace Bit.App.Pages
         public bool ShowDeletionCustomPickers => EditMode || DeletionDateTypeSelectedIndex == 6;
         public bool ShowExpirationCustomPickers => EditMode || ExpirationDateTypeSelectedIndex == 7;
         public string ShowPasswordIcon => ShowPassword ? BitwardenIcons.EyeSlash : BitwardenIcons.Eye;
+        public string FileTypeAccessibilityLabel => $"{_i18nService.T("File")} {_i18nService.T(IsFile ? "TypeIsSelected" : "TypeIsNotSelected")}";
+        public string TextTypeAccessibilityLabel => $"{_i18nService.T("Text")} {_i18nService.T(IsText ? "TypeIsSelected" : "TypeIsNotSelected")}";
 
         public async Task InitAsync()
         {

--- a/src/App/Resources/AppResources.Designer.cs
+++ b/src/App/Resources/AppResources.Designer.cs
@@ -3299,6 +3299,12 @@ namespace Bit.App.Resources {
             }
         }
         
+        public static string Text {
+            get {
+                return ResourceManager.GetString("Text", resourceCulture);
+            }
+        }
+        
         public static string TypeText {
             get {
                 return ResourceManager.GetString("TypeText", resourceCulture);
@@ -3326,6 +3332,18 @@ namespace Bit.App.Resources {
         public static string TypeFileInfo {
             get {
                 return ResourceManager.GetString("TypeFileInfo", resourceCulture);
+            }
+        }
+        
+        public static string TypeIsSelected {
+            get {
+                return ResourceManager.GetString("TypeIsSelected", resourceCulture);
+            }
+        }
+        
+        public static string TypeIsNotSelected {
+            get {
+                return ResourceManager.GetString("TypeIsNotSelected", resourceCulture);
             }
         }
         

--- a/src/App/Resources/AppResources.resx
+++ b/src/App/Resources/AppResources.resx
@@ -1861,6 +1861,9 @@
     <value>A friendly name to describe this Send.</value>
     <comment>'Send' is a noun and the name of a feature called 'Bitwarden Send'. It should not be translated.</comment>
   </data>
+  <data name="Text" xml:space="preserve">
+    <value>Text</value>
+  </data>
   <data name="TypeText" xml:space="preserve">
     <value>Text</value>
   </data>
@@ -1876,6 +1879,12 @@
   </data>
   <data name="TypeFileInfo" xml:space="preserve">
     <value>The file you want to send.</value>
+  </data>
+  <data name="TypeIsSelected" xml:space="preserve">
+    <value>type is, selected.</value>
+  </data>
+  <data name="TypeIsNotSelected" xml:space="preserve">
+    <value>type is, not selected, click to select.</value>
   </data>
   <data name="DeletionDate" xml:space="preserve">
     <value>Deletion Date</value>


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
Change the segmented button (File/Text) in Sends tab, to have a better voice feedback to the user using TalkBack or VoiceOver. Added a missing "Text" resource and dynamic voice over based on button state.

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **src/App/Pages/Send/SendAddEditPageViewModel.cs:** Label properties for button states
* **src/App/Pages/Send/SendAddEditPage.xaml.cs:** Accessibility help text change on button click and screen init.

## Before you submit
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
