### PR TITLE
[PS-674] Mobile: Accessibility - expand label/name for password generator toggles

### DIFF
--- a/src/App/Pages/Generator/GeneratorPage.xaml
+++ b/src/App/Pages/Generator/GeneratorPage.xaml
@@ -183,52 +183,68 @@
                             <Label
                                 Text="A-Z"
                                 StyleClass="box-label-regular"
-                                HorizontalOptions="StartAndExpand" />
+                                HorizontalOptions="StartAndExpand" 
+                                AutomationProperties.IsInAccessibleTree="True"
+                                AutomationProperties.Name="{u:I18n UppercaseAtoZ}"/>
                             <Switch
                                 IsToggled="{Binding Uppercase}"
                                 IsEnabled="{Binding EnforcedPolicyOptions.UseUppercase,
                                     Converter={StaticResource inverseBool}}"
                                 StyleClass="box-value"
-                                HorizontalOptions="End" />
+                                HorizontalOptions="End" 
+                                AutomationProperties.IsInAccessibleTree="True"
+                                AutomationProperties.Name="{u:I18n UppercaseAtoZ}"/>
                         </StackLayout>
                         <BoxView StyleClass="box-row-separator" />
                         <StackLayout StyleClass="box-row, box-row-switch">
                             <Label
                                 Text="a-z"
                                 StyleClass="box-label-regular"
-                                HorizontalOptions="StartAndExpand" />
+                                HorizontalOptions="StartAndExpand" 
+                                AutomationProperties.IsInAccessibleTree="True"
+                                AutomationProperties.Name="{u:I18n LowercaseAtoZ}"/>
                             <Switch
                                 IsToggled="{Binding Lowercase}"
                                 IsEnabled="{Binding EnforcedPolicyOptions.UseLowercase,
                                     Converter={StaticResource inverseBool}}"
                                 StyleClass="box-value"
-                                HorizontalOptions="End" />
+                                HorizontalOptions="End"
+                                AutomationProperties.IsInAccessibleTree="True"
+                                AutomationProperties.Name="{u:I18n LowercaseAtoZ}" />
                         </StackLayout>
                         <BoxView StyleClass="box-row-separator" />
                         <StackLayout StyleClass="box-row, box-row-switch">
                             <Label
                                 Text="0-9"
                                 StyleClass="box-label-regular"
-                                HorizontalOptions="StartAndExpand" />
+                                HorizontalOptions="StartAndExpand" 
+                                AutomationProperties.IsInAccessibleTree="True"
+                                AutomationProperties.Name="{u:I18n NumbersZeroToNine}"/>
                             <Switch
                                 IsToggled="{Binding Number}"
                                 IsEnabled="{Binding EnforcedPolicyOptions.UseNumbers,
                                     Converter={StaticResource inverseBool}}"
                                 StyleClass="box-value"
-                                HorizontalOptions="End" />
+                                HorizontalOptions="End" 
+                                AutomationProperties.IsInAccessibleTree="True"
+                                AutomationProperties.Name="{u:I18n NumbersZeroToNine}"/>
                         </StackLayout>
                         <BoxView StyleClass="box-row-separator" />
                         <StackLayout StyleClass="box-row, box-row-switch">
                             <Label
                                 Text="!@#$%^&amp;*"
                                 StyleClass="box-label-regular"
-                                HorizontalOptions="StartAndExpand" />
+                                HorizontalOptions="StartAndExpand" 
+                                AutomationProperties.IsInAccessibleTree="True"
+                                AutomationProperties.Name="{u:I18n SpecialCharacters}"/>
                             <Switch
                                 IsToggled="{Binding Special}"
                                 IsEnabled="{Binding EnforcedPolicyOptions.UseSpecial,
                                     Converter={StaticResource inverseBool}}"
                                 StyleClass="box-value"
-                                HorizontalOptions="End" />
+                                HorizontalOptions="End"
+                                AutomationProperties.IsInAccessibleTree="True"
+                                AutomationProperties.Name="{u:I18n SpecialCharacters}"/>
                         </StackLayout>
                         <BoxView StyleClass="box-row-separator" />
                         <StackLayout StyleClass="box-row, box-row-stepper">

--- a/src/App/Resources/AppResources.Designer.cs
+++ b/src/App/Resources/AppResources.Designer.cs
@@ -3904,5 +3904,29 @@ namespace Bit.App.Resources {
                 return ResourceManager.GetString("ReportCrashLogsDescription", resourceCulture);
             }
         }
+        
+        public static string UppercaseAtoZ {
+            get {
+                return ResourceManager.GetString("UppercaseAtoZ", resourceCulture);
+            }
+        }
+        
+        public static string LowercaseAtoZ {
+            get {
+                return ResourceManager.GetString("LowercaseAtoZ", resourceCulture);
+            }
+        }
+        
+        public static string NumbersZeroToNine {
+            get {
+                return ResourceManager.GetString("NumbersZeroToNine", resourceCulture);
+            }
+        }
+        
+        public static string SpecialCharacters {
+            get {
+                return ResourceManager.GetString("SpecialCharacters", resourceCulture);
+            }
+        }
     }
 }

--- a/src/App/Resources/AppResources.resx
+++ b/src/App/Resources/AppResources.resx
@@ -2187,4 +2187,16 @@
   <data name="ReportCrashLogsDescription" xml:space="preserve">
     <value>Help Bitwarden improve app stability by allowing crash reports.</value>
   </data>
+  <data name="UppercaseAtoZ" xml:space="preserve">
+    <value>Uppercase (A to Z)</value>
+  </data>
+  <data name="LowercaseAtoZ" xml:space="preserve">
+    <value>Lowercase (A to Z)</value>
+  </data>
+  <data name="NumbersZeroToNine" xml:space="preserve">
+    <value>Numbers (0 to 9)</value>
+  </data>
+  <data name="SpecialCharacters" xml:space="preserve">
+    <value>Special Characters (!@#$%^&amp;*)</value>
+  </data>
 </root>


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
Fix accessibility text for password generator toggles.
The toggles should have a clear announcement that is understandable for assistive technology users.

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **GeneratorPage.xaml:** Added new accessibility text.
* **AppResources.resx:** iOS VoiceOver does not pronounce "a to z" correctly, had to use "A to Z" on lowercase to have the expect result.


## Before you submit
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
