### PR TITLE
[PS-676] Accessibility - "Options" expand/collapse control does not announce state

### DIFF
--- a/src/App/Pages/Send/SendAddEditPage.xaml
+++ b/src/App/Pages/Send/SendAddEditPage.xaml
@@ -250,28 +250,33 @@
                         </StackLayout>
                         <StackLayout
                             Orientation="Horizontal"
-                            Spacing="0">
+                            Spacing="0"
+                            AutomationProperties.IsInAccessibleTree="True"
+                            AutomationProperties.Name="{Binding OptionsAccessilibityText}">
+                            <StackLayout.GestureRecognizers>
+                                <TapGestureRecognizer Tapped="ToggleOptions_Clicked"/>
+                            </StackLayout.GestureRecognizers>
                             <Button
                                 Text="{u:I18n Options}"
                                 x:Name="_btnOptions"
                                 StyleClass="box-row-button"
                                 TextColor="{DynamicResource PrimaryColor}"
                                 Margin="0"
-                                Clicked="ToggleOptions_Clicked"/>
+                                AutomationProperties.IsInAccessibleTree="False"/>
                             <controls:IconButton
                                 x:Name="_btnOptionsUp"
                                 Text="{Binding Source={x:Static core:BitwardenIcons.ChevronUp}}"
                                 StyleClass="box-row-button"
                                 TextColor="{DynamicResource PrimaryColor}"
-                                Clicked="ToggleOptions_Clicked"
-                                IsVisible="{Binding ShowOptions}" />
+                                IsVisible="{Binding ShowOptions}" 
+                                AutomationProperties.IsInAccessibleTree="False"/>
                             <controls:IconButton
                                 x:Name="_btnOptionsDown"
                                 Text="{Binding Source={x:Static core:BitwardenIcons.AngleDown}}"
                                 StyleClass="box-row-button"
                                 TextColor="{DynamicResource PrimaryColor}"
-                                Clicked="ToggleOptions_Clicked"
-                                IsVisible="{Binding ShowOptions, Converter={StaticResource inverseBool}}" />
+                                IsVisible="{Binding ShowOptions, Converter={StaticResource inverseBool}}" 
+                                AutomationProperties.IsInAccessibleTree="False"/>
                         </StackLayout>
                         <StackLayout IsVisible="{Binding ShowOptions}">
                             <StackLayout

--- a/src/App/Pages/Send/SendAddEditPage.xaml
+++ b/src/App/Pages/Send/SendAddEditPage.xaml
@@ -2,6 +2,7 @@
 <pages:BaseContentPage
     xmlns="http://xamarin.com/schemas/2014/forms"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:xct="http://xamarin.com/schemas/2020/toolkit"
     x:Class="Bit.App.Pages.SendAddEditPage"
     xmlns:pages="clr-namespace:Bit.App.Pages"
     xmlns:u="clr-namespace:Bit.App.Utilities"
@@ -253,11 +254,9 @@
                         <StackLayout
                             Orientation="Horizontal"
                             Spacing="0"
+                            xct:TouchEffect.Command="{Binding ToggleOptionsCommand}"
                             AutomationProperties.IsInAccessibleTree="True"
                             AutomationProperties.Name="{Binding OptionsAccessilibityText}">
-                            <StackLayout.GestureRecognizers>
-                                <TapGestureRecognizer Tapped="ToggleOptions_Clicked"/>
-                            </StackLayout.GestureRecognizers>
                             <Button
                                 Text="{u:I18n Options}"
                                 x:Name="_btnOptions"

--- a/src/App/Pages/Send/SendAddEditPage.xaml.cs
+++ b/src/App/Pages/Send/SendAddEditPage.xaml.cs
@@ -209,11 +209,6 @@ namespace Bit.App.Pages
             }
         }
 
-        private void ToggleOptions_Clicked(object sender, EventArgs e)
-        {
-            _vm.ToggleOptions();
-        }
-
         private void ClearExpirationDate_Clicked(object sender, EventArgs e)
         {
             if (DoOnce())

--- a/src/App/Pages/Send/SendAddEditPageViewModel.cs
+++ b/src/App/Pages/Send/SendAddEditPageViewModel.cs
@@ -102,6 +102,7 @@ namespace Bit.App.Pages
         public bool DisableHideEmailControl { get; set; }
         public bool IsAddFromShare { get; set; }
         public string ShareOnSaveText => CopyInsteadOfShareAfterSaving ? AppResources.CopySendLinkOnSave : AppResources.ShareOnSave;
+        public string OptionsAccessilibityText => ShowOptions ? AppResources.OptionsExpanded : AppResources.OptionsCollapsed;
         public List<KeyValuePair<string, SendType>> TypeOptions { get; }
         public List<KeyValuePair<string, string>> DeletionTypeOptions { get; }
         public List<KeyValuePair<string, string>> ExpirationTypeOptions { get; }
@@ -134,7 +135,11 @@ namespace Bit.App.Pages
         public bool ShowOptions
         {
             get => _showOptions;
-            set => SetProperty(ref _showOptions, value);
+            set => SetProperty(ref _showOptions, value,
+                additionalPropertyNames: new[]
+                {
+                    nameof(OptionsAccessilibityText)
+                });
         }
         public int ExpirationDateTypeSelectedIndex
         {

--- a/src/App/Pages/Send/SendAddEditPageViewModel.cs
+++ b/src/App/Pages/Send/SendAddEditPageViewModel.cs
@@ -61,6 +61,7 @@ namespace Bit.App.Pages
             _logger = ServiceContainer.Resolve<ILogger>("logger");
 
             TogglePasswordCommand = new Command(TogglePassword);
+            ToggleOptionsCommand = new Command(ToggleOptions);
 
             TypeOptions = new List<KeyValuePair<string, SendType>>
             {
@@ -91,6 +92,7 @@ namespace Bit.App.Pages
         }
 
         public Command TogglePasswordCommand { get; set; }
+        public Command ToggleOptionsCommand { get; set; }
         public string SendId { get; set; }
         public int SegmentedButtonHeight { get; set; }
         public int SegmentedButtonFontSize { get; set; }

--- a/src/App/Resources/AppResources.Designer.cs
+++ b/src/App/Resources/AppResources.Designer.cs
@@ -3904,5 +3904,17 @@ namespace Bit.App.Resources {
                 return ResourceManager.GetString("ReportCrashLogsDescription", resourceCulture);
             }
         }
+        
+        public static string OptionsExpanded {
+            get {
+                return ResourceManager.GetString("OptionsExpanded", resourceCulture);
+            }
+        }
+        
+        public static string OptionsCollapsed {
+            get {
+                return ResourceManager.GetString("OptionsCollapsed", resourceCulture);
+            }
+        }
     }
 }

--- a/src/App/Resources/AppResources.resx
+++ b/src/App/Resources/AppResources.resx
@@ -2187,4 +2187,10 @@
   <data name="ReportCrashLogsDescription" xml:space="preserve">
     <value>Help Bitwarden improve app stability by allowing crash reports.</value>
   </data>
+  <data name="OptionsExpanded" xml:space="preserve">
+    <value>Options are expanded, tap to collapse.</value>
+  </data>
+  <data name="OptionsCollapsed" xml:space="preserve">
+    <value>Options are collapsed, tap to expand.</value>
+  </data>
 </root>


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
Make options button and chevron button work as a single button. Add accessibility text to describe the state of the layout.

## Code changes
* **src/App/Pages/Send/SendAddEditPage.xaml**: Moved the click event to the parent `StackLayout`. Added accessibility text to `StackLayout`. Removed accessibility on views inside `StackLayout`.
*  **src/App/Pages/Send/SendAddEditPageViewModel.cs**: Added property for the accessibility text. Raise prop change on `ShowOptions` set.

## Before you submit
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
