### PR TITLE
[SG-79] Mobile Vault Filter

### DIFF
--- a/src/App/Controls/CipherViewCell/CipherViewCell.xaml
+++ b/src/App/Controls/CipherViewCell/CipherViewCell.xaml
@@ -108,7 +108,7 @@
     <controls:MiButton
         Grid.Row="0"
         Grid.Column="2"
-        Text="&#xe5d3;"
+        Text="{Binding Source={x:Static core:BitwardenIcons.ViewCellMenu}}"
         StyleClass="list-row-button, list-row-button-platform, btn-disabled"
         Clicked="MoreButton_Clicked"
         VerticalOptions="CenterAndExpand"

--- a/src/App/Controls/SendViewCell/SendViewCell.xaml
+++ b/src/App/Controls/SendViewCell/SendViewCell.xaml
@@ -122,7 +122,7 @@
     <controls:MiButton
         Grid.Row="0"
         Grid.Column="2"
-        Text="&#xe5d3;"
+        Text="{Binding Source={x:Static core:BitwardenIcons.ViewCellMenu}}"
         IsVisible="{Binding ShowOptions, Mode=OneWay}"
         StyleClass="list-row-button, list-row-button-platform, btn-disabled"
         Clicked="MoreButton_Clicked"

--- a/src/App/Pages/TabsPage.cs
+++ b/src/App/Pages/TabsPage.cs
@@ -1,6 +1,8 @@
-﻿using Bit.App.Effects;
+﻿using System.Threading.Tasks;
+using Bit.App.Effects;
 using Bit.App.Models;
 using Bit.App.Resources;
+using Bit.App.Utilities;
 using Bit.Core.Abstractions;
 using Bit.Core.Models.Data;
 using Bit.Core.Utilities;
@@ -78,6 +80,7 @@ namespace Bit.App.Pages
         protected override async void OnAppearing()
         {
             base.OnAppearing();
+            await UpdateVaultButtonTitleAsync();
             if (await _keyConnectorService.UserNeedsMigration())
             {
                 _messagingService.Send("convertAccountToKeyConnector");
@@ -130,6 +133,12 @@ namespace Bit.App.Pages
             {
                 groupingsPage.HideAccountSwitchingOverlayAsync().FireAndForget();
             }
+        }
+
+        private async Task UpdateVaultButtonTitleAsync()
+        {
+            var isShowingVaultFilter = await AppHelpers.IsShowingVaultFilterAsync();
+            _groupingsPage.Title = isShowingVaultFilter ? AppResources.Vaults : AppResources.MyVault;
         }
     }
 }

--- a/src/App/Pages/TabsPage.cs
+++ b/src/App/Pages/TabsPage.cs
@@ -1,8 +1,8 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 using Bit.App.Effects;
 using Bit.App.Models;
 using Bit.App.Resources;
-using Bit.App.Utilities;
 using Bit.Core.Abstractions;
 using Bit.Core.Models.Data;
 using Bit.Core.Utilities;
@@ -15,6 +15,7 @@ namespace Bit.App.Pages
         private readonly IBroadcasterService _broadcasterService;
         private readonly IMessagingService _messagingService;
         private readonly IKeyConnectorService _keyConnectorService;
+        private readonly LazyResolve<ILogger> _logger = new LazyResolve<ILogger>("logger");
 
         private NavigationPage _groupingsPage;
         private NavigationPage _sendGroupingsPage;
@@ -152,8 +153,16 @@ namespace Bit.App.Pages
 
         private async Task UpdateVaultButtonTitleAsync()
         {
-            var isShowingVaultFilter = await AppHelpers.IsShowingVaultFilterAsync();
-            _groupingsPage.Title = isShowingVaultFilter ? AppResources.Vaults : AppResources.MyVault;
+            try
+            {
+                var policyService = ServiceContainer.Resolve<IPolicyService>("policyService");
+                var isShowingVaultFilter = await policyService.ShouldShowVaultFilterAsync();
+                _groupingsPage.Title = isShowingVaultFilter ? AppResources.Vaults : AppResources.MyVault;
+            }
+            catch (Exception ex)
+            {
+                _logger.Value.Exception(ex);
+            }
         }
     }
 }

--- a/src/App/Pages/Vault/GroupingsPage/GroupingsPage.xaml
+++ b/src/App/Pages/Vault/GroupingsPage/GroupingsPage.xaml
@@ -107,6 +107,30 @@
 
             <StackLayout x:Key="mainLayout" x:Name="_mainLayout">
                 <StackLayout
+                    IsVisible="{Binding ShowVaultFilter}"
+                    Orientation="Horizontal"
+                    HorizontalOptions="FillAndExpand"
+                    Margin="0,5,0,0">
+                    <Label
+                        Text="{Binding VaultFilterDescription}"
+                        LineBreakMode="TailTruncation"
+                        Margin="10,0"
+                        StyleClass="text-md, text-muted"
+                        VerticalOptions="Center"
+                        HorizontalOptions="StartAndExpand"
+                        AutomationProperties.IsInAccessibleTree="True"
+                        AutomationProperties.Name="{u:I18n Filter}" />
+                    <controls:MiButton
+                        Text="&#xe5d3;"
+                        StyleClass="list-row-button, list-row-button-platform, btn-disabled"
+                        Clicked="VaultFilter_Clicked"
+                        VerticalOptions="Center"
+                        HorizontalOptions="End"
+                        AutomationProperties.IsInAccessibleTree="True"
+                        AutomationProperties.Name="{u:I18n Filter}" />
+                </StackLayout>
+
+                <StackLayout
                     VerticalOptions="CenterAndExpand"
                     Padding="20, 0"
                     Spacing="20"

--- a/src/App/Pages/Vault/GroupingsPage/GroupingsPage.xaml
+++ b/src/App/Pages/Vault/GroupingsPage/GroupingsPage.xaml
@@ -6,6 +6,7 @@
     xmlns:u="clr-namespace:Bit.App.Utilities"
     xmlns:effects="clr-namespace:Bit.App.Effects"
     xmlns:controls="clr-namespace:Bit.App.Controls"
+    xmlns:core="clr-namespace:Bit.Core;assembly=BitwardenCore"
     x:DataType="pages:GroupingsPageViewModel"
     Title="{Binding PageTitle}"
     x:Name="_page">
@@ -121,9 +122,9 @@
                         AutomationProperties.IsInAccessibleTree="True"
                         AutomationProperties.Name="{u:I18n Filter}" />
                     <controls:MiButton
-                        Text="&#xe5d3;"
+                        Text="{Binding Source={x:Static core:BitwardenIcons.ViewCellMenu}}"
                         StyleClass="list-row-button, list-row-button-platform, btn-disabled"
-                        Clicked="VaultFilter_Clicked"
+                        Command="{Binding VaultFilterCommand}"
                         VerticalOptions="Center"
                         HorizontalOptions="End"
                         AutomationProperties.IsInAccessibleTree="True"

--- a/src/App/Pages/Vault/GroupingsPage/GroupingsPage.xaml.cs
+++ b/src/App/Pages/Vault/GroupingsPage/GroupingsPage.xaml.cs
@@ -27,7 +27,7 @@ namespace Bit.App.Pages
         private PreviousPageInfo _previousPage;
 
         public GroupingsPage(bool mainPage, CipherType? type = null, string folderId = null,
-            string collectionId = null, string pageTitle = null, string vaultFilterSelection = null, 
+            string collectionId = null, string pageTitle = null, string vaultFilterSelection = null,
             PreviousPageInfo previousPage = null, bool deleted = false)
         {
             _pageName = string.Concat(nameof(GroupingsPage), "_", DateTime.UtcNow.Ticks);

--- a/src/App/Pages/Vault/GroupingsPage/GroupingsPage.xaml.cs
+++ b/src/App/Pages/Vault/GroupingsPage/GroupingsPage.xaml.cs
@@ -234,11 +234,6 @@ namespace Bit.App.Pages
             }
         }
 
-        private async void VaultFilter_Clicked(object sender, EventArgs e)
-        {
-            await _vm.VaultFilterOptionsAsync();
-        }
-
         private async void Sync_Clicked(object sender, EventArgs e)
         {
             await _accountListOverlay.HideAsync();

--- a/src/App/Pages/Vault/GroupingsPage/GroupingsPage.xaml.cs
+++ b/src/App/Pages/Vault/GroupingsPage/GroupingsPage.xaml.cs
@@ -27,8 +27,8 @@ namespace Bit.App.Pages
         private PreviousPageInfo _previousPage;
 
         public GroupingsPage(bool mainPage, CipherType? type = null, string folderId = null,
-            string collectionId = null, string pageTitle = null, PreviousPageInfo previousPage = null,
-            bool deleted = false)
+            string collectionId = null, string pageTitle = null, string vaultFilterSelection = null, 
+            PreviousPageInfo previousPage = null, bool deleted = false)
         {
             _pageName = string.Concat(nameof(GroupingsPage), "_", DateTime.UtcNow.Ticks);
             InitializeComponent();
@@ -51,6 +51,10 @@ namespace Bit.App.Pages
             if (pageTitle != null)
             {
                 _vm.PageTitle = pageTitle;
+            }
+            if (vaultFilterSelection != null)
+            {
+                _vm.VaultFilterDescription = vaultFilterSelection;
             }
 
             if (Device.RuntimePlatform == Device.iOS)
@@ -228,6 +232,11 @@ namespace Bit.App.Pages
                 var page = new CiphersPage(_vm.Filter, _vm.MainPage ? null : _vm.PageTitle, deleted: _vm.Deleted);
                 await Navigation.PushModalAsync(new NavigationPage(page));
             }
+        }
+
+        private async void VaultFilter_Clicked(object sender, EventArgs e)
+        {
+            await _vm.VaultFilterOptionsAsync();
         }
 
         private async void Sync_Clicked(object sender, EventArgs e)

--- a/src/App/Pages/Vault/GroupingsPage/GroupingsPageViewModel.cs
+++ b/src/App/Pages/Vault/GroupingsPage/GroupingsPageViewModel.cs
@@ -10,6 +10,7 @@ using Bit.Core.Abstractions;
 using Bit.Core.Enums;
 using Bit.Core.Models.Domain;
 using Bit.Core.Models.View;
+using Bit.Core.Services;
 using Bit.Core.Utilities;
 using Xamarin.CommunityToolkit.ObjectModel;
 using Xamarin.Forms;
@@ -29,7 +30,10 @@ namespace Bit.App.Pages
         private bool _showList;
         private bool _websiteIconsEnabled;
         private bool _syncRefreshing;
+        private bool _showVaultFilter;
+        private string _vaultFilterSelection;
         private string _noDataText;
+        private List<Organization> _organizations;
         private List<CipherView> _allCiphers;
         private Dictionary<string, int> _folderCounts = new Dictionary<string, int>();
         private Dictionary<string, int> _collectionCounts = new Dictionary<string, int>();
@@ -46,6 +50,7 @@ namespace Bit.App.Pages
         private readonly IMessagingService _messagingService;
         private readonly IStateService _stateService;
         private readonly IPasswordRepromptService _passwordRepromptService;
+        private readonly IOrganizationService _organizationService;
         private readonly ILogger _logger;
 
         public GroupingsPageViewModel()
@@ -60,10 +65,10 @@ namespace Bit.App.Pages
             _messagingService = ServiceContainer.Resolve<IMessagingService>("messagingService");
             _stateService = ServiceContainer.Resolve<IStateService>("stateService");
             _passwordRepromptService = ServiceContainer.Resolve<IPasswordRepromptService>("passwordRepromptService");
+            _organizationService = ServiceContainer.Resolve<OrganizationService>("organizationService");
             _logger = ServiceContainer.Resolve<ILogger>("logger");
 
             Loading = true;
-            PageTitle = AppResources.MyVault;
             GroupedItems = new ObservableRangeCollection<IGroupingsPageListItem>();
             RefreshCommand = new Command(async () =>
             {
@@ -87,7 +92,7 @@ namespace Bit.App.Pages
         public bool HasCiphers { get; set; }
         public bool HasFolders { get; set; }
         public bool HasCollections { get; set; }
-        public bool ShowNoFolderCiphers => (NoFolderCiphers?.Count ?? int.MaxValue) < NoFolderListSize &&
+        public bool ShowNoFolderCipherGroup => (NoFolderCiphers?.Count ?? int.MaxValue) < NoFolderListSize &&
             (!Collections?.Any() ?? true);
         public List<CipherView> Ciphers { get; set; }
         public List<CipherView> FavoriteCiphers { get; set; }
@@ -142,6 +147,23 @@ namespace Bit.App.Pages
             get => _websiteIconsEnabled;
             set => SetProperty(ref _websiteIconsEnabled, value);
         }
+        public bool ShowVaultFilter
+        {
+            get => _showVaultFilter;
+            set => SetProperty(ref _showVaultFilter, value);
+        }
+        public string VaultFilterDescription
+        {
+            get
+            {
+                if (_vaultFilterSelection == null || _vaultFilterSelection == AppResources.AllVaults)
+                {
+                    return string.Format(AppResources.VaultFilterDescription, AppResources.VaultFilterDescriptionAll);
+                }
+                return string.Format(AppResources.VaultFilterDescription, _vaultFilterSelection);
+            }
+            set => SetProperty(ref _vaultFilterSelection, value);
+        }
 
         public AccountSwitchingOverlayViewModel AccountSwitchingOverlayViewModel { get; }
 
@@ -172,6 +194,13 @@ namespace Bit.App.Pages
                 return;
             }
 
+            _organizations = await _organizationService.GetAllAsync();
+            if (MainPage)
+            {
+                ShowVaultFilter = await AppHelpers.IsShowingVaultFilterAsync();
+                PageTitle = ShowVaultFilter ? AppResources.Vaults : AppResources.MyVault;
+            }
+
             _doingLoad = true;
             LoadedOnce = true;
             ShowNoData = false;
@@ -185,9 +214,9 @@ namespace Bit.App.Pages
             try
             {
                 await LoadDataAsync();
-                if (ShowNoFolderCiphers && (NestedFolders?.Any() ?? false))
+                if (ShowNoFolderCipherGroup && (NestedFolders?.Any() ?? false))
                 {
-                    // Remove "No Folder" from folder listing
+                    // Remove "No Folder" folder from folders group
                     NestedFolders = NestedFolders.GetRange(0, NestedFolders.Count - 1);
                 }
 
@@ -262,7 +291,7 @@ namespace Bit.App.Pages
                     groupedItems.Add(new GroupingsPageListGroup(ciphersListItems, AppResources.Items,
                         ciphersListItems.Count, uppercaseGroupNames, !MainPage && !groupedItems.Any()));
                 }
-                if (ShowNoFolderCiphers)
+                if (ShowNoFolderCipherGroup)
                 {
                     var noFolderCiphersListItems = NoFolderCiphers.Select(
                         c => new GroupingsPageListItem { Cipher = c }).ToList();
@@ -342,6 +371,24 @@ namespace Bit.App.Pages
             SyncRefreshing = false;
         }
 
+        public async Task VaultFilterOptionsAsync()
+        {
+            var options = new List<string> { AppResources.AllVaults, AppResources.MyVault };
+            if (_organizations.Any())
+            {
+                options.AddRange(_organizations.Select(o => o.Name));
+            }
+            var selection = await Page.DisplayActionSheet(AppResources.FilterByVault, AppResources.Cancel, null, options.ToArray());
+            if (selection == AppResources.Cancel ||
+                (_vaultFilterSelection == null && selection == AppResources.AllVaults) ||
+                (_vaultFilterSelection != null && _vaultFilterSelection == selection))
+            {
+                return;
+            }
+            VaultFilterDescription = selection;
+            await LoadAsync();
+        }
+
         public async Task SelectCipherAsync(CipherView cipher)
         {
             var page = new ViewPage(cipher.Id);
@@ -368,25 +415,26 @@ namespace Bit.App.Pages
                 default:
                     break;
             }
-            var page = new GroupingsPage(false, type, null, null, title);
+            var page = new GroupingsPage(false, type, null, null, title, _vaultFilterSelection);
             await Page.Navigation.PushAsync(page);
         }
 
         public async Task SelectFolderAsync(FolderView folder)
         {
-            var page = new GroupingsPage(false, null, folder.Id ?? "none", null, folder.Name);
+            var page = new GroupingsPage(false, null, folder.Id ?? "none", null, folder.Name, _vaultFilterSelection);
             await Page.Navigation.PushAsync(page);
         }
 
         public async Task SelectCollectionAsync(Core.Models.View.CollectionView collection)
         {
-            var page = new GroupingsPage(false, null, null, collection.Id, collection.Name);
+            var page = new GroupingsPage(false, null, null, collection.Id, collection.Name, _vaultFilterSelection);
             await Page.Navigation.PushAsync(page);
         }
 
         public async Task SelectTrashAsync()
         {
-            var page = new GroupingsPage(false, null, null, null, AppResources.Trash, null, true);
+            var page = new GroupingsPage(false, null, null, null, AppResources.Trash, _vaultFilterSelection, null,
+                true);
             await Page.Navigation.PushAsync(page);
         }
 
@@ -424,8 +472,23 @@ namespace Bit.App.Pages
 
         private async Task LoadDataAsync()
         {
+            string orgId = null;
+            var decCiphers = await _cipherService.GetAllDecryptedAsync();
+            if (IsVaultFilterMyVault)
+            {
+                _allCiphers = decCiphers.Where(c => c.OrganizationId == null).ToList();
+            }
+            else if (IsVaultFilterOrgVault)
+            {
+                orgId = await GetVaultFilterOrgIdAsync();
+                _allCiphers = decCiphers.Where(c => c.OrganizationId == orgId).ToList();
+            }
+            else
+            {
+                _allCiphers = decCiphers;
+            }
+
             NoDataText = AppResources.NoItems;
-            _allCiphers = await _cipherService.GetAllDecryptedAsync();
             HasCiphers = _allCiphers.Any();
             FavoriteCiphers?.Clear();
             NoFolderCiphers?.Clear();
@@ -439,12 +502,27 @@ namespace Bit.App.Pages
 
             if (MainPage)
             {
-                Folders = await _folderService.GetAllDecryptedAsync();
-                NestedFolders = await _folderService.GetAllNestedAsync();
+                var decFolders = await _folderService.GetAllDecryptedAsync();
+                var decCollections = await _collectionService.GetAllDecryptedAsync();
+                if (IsVaultFilterMyVault)
+                {
+                    Folders = BuildFolders(decFolders);
+                    Collections = null;
+                }
+                else if (IsVaultFilterOrgVault && !string.IsNullOrWhiteSpace(orgId))
+                {
+                    Folders = BuildFolders(decFolders);
+                    Collections = decCollections?.Where(c => c.OrganizationId == orgId).ToList();
+                }
+                else
+                {
+                    Folders = decFolders;
+                    Collections = decCollections;
+                }
+                NestedFolders = await _folderService.GetAllNestedAsync(Folders);
                 HasFolders = NestedFolders.Any(f => f.Node?.Id != null);
-                Collections = await _collectionService.GetAllDecryptedAsync();
-                NestedCollections = await _collectionService.GetAllNestedAsync(Collections);
-                HasCollections = NestedCollections.Any();
+                NestedCollections = Collections != null ? await _collectionService.GetAllNestedAsync(Collections) : null;
+                HasCollections = NestedCollections?.Any() ?? false;
             }
             else
             {
@@ -562,6 +640,42 @@ namespace Bit.App.Pages
                     }
                 }
             }
+        }
+
+        private bool IsVaultFilterMyVault => 
+            _vaultFilterSelection != null && _vaultFilterSelection == AppResources.MyVault;
+
+        private bool IsVaultFilterOrgVault =>
+            _vaultFilterSelection != null && _vaultFilterSelection != AppResources.AllVaults &&
+            _vaultFilterSelection != AppResources.MyVault;
+
+        private async Task<string> GetVaultFilterOrgIdAsync()
+        {
+            foreach (var org in _organizations)
+            {
+                if (org.Name == _vaultFilterSelection)
+                {
+                    return org.Id;
+                }
+            }
+            return null;
+        }
+
+        private List<FolderView> BuildFolders(List<FolderView> decFolders)
+        {
+            List<FolderView> folders = null;
+            foreach (var folder in decFolders)
+            {
+                if (_allCiphers.Any(c => c.FolderId == folder.Id))
+                {
+                    if (folders == null)
+                    {
+                        folders = new List<FolderView>();
+                    }
+                    folders.Add(folder);
+                }
+            }
+            return folders;
         }
 
         private async void CipherOptionsAsync(CipherView cipher)

--- a/src/App/Pages/Vault/GroupingsPage/GroupingsPageViewModel.cs
+++ b/src/App/Pages/Vault/GroupingsPage/GroupingsPageViewModel.cs
@@ -642,7 +642,7 @@ namespace Bit.App.Pages
             }
         }
 
-        private bool IsVaultFilterMyVault => 
+        private bool IsVaultFilterMyVault =>
             _vaultFilterSelection != null && _vaultFilterSelection == AppResources.MyVault;
 
         private bool IsVaultFilterOrgVault =>

--- a/src/App/Resources/AppResources.Designer.cs
+++ b/src/App/Resources/AppResources.Designer.cs
@@ -3995,9 +3995,9 @@ namespace Bit.App.Resources {
             }
         }
         
-        public static string VaultFilterDescriptionAll {
+        public static string All {
             get {
-                return ResourceManager.GetString("VaultFilterDescriptionAll", resourceCulture);
+                return ResourceManager.GetString("All", resourceCulture);
             }
         }
     }

--- a/src/App/Resources/AppResources.Designer.cs
+++ b/src/App/Resources/AppResources.Designer.cs
@@ -3970,5 +3970,35 @@ namespace Bit.App.Resources {
                 return ResourceManager.GetString("SpecialCharacters", resourceCulture);
             }
         }
+        
+        public static string FilterByVault {
+            get {
+                return ResourceManager.GetString("FilterByVault", resourceCulture);
+            }
+        }
+        
+        public static string AllVaults {
+            get {
+                return ResourceManager.GetString("AllVaults", resourceCulture);
+            }
+        }
+        
+        public static string Vaults {
+            get {
+                return ResourceManager.GetString("Vaults", resourceCulture);
+            }
+        }
+        
+        public static string VaultFilterDescription {
+            get {
+                return ResourceManager.GetString("VaultFilterDescription", resourceCulture);
+            }
+        }
+        
+        public static string VaultFilterDescriptionAll {
+            get {
+                return ResourceManager.GetString("VaultFilterDescriptionAll", resourceCulture);
+            }
+        }
     }
 }

--- a/src/App/Resources/AppResources.resx
+++ b/src/App/Resources/AppResources.resx
@@ -2232,7 +2232,7 @@
   <data name="VaultFilterDescription" xml:space="preserve">
     <value>Vault: {0}</value>
   </data>
-  <data name="VaultFilterDescriptionAll" xml:space="preserve">
+  <data name="All" xml:space="preserve">
     <value>All</value>
   </data>
 </root>

--- a/src/App/Resources/AppResources.resx
+++ b/src/App/Resources/AppResources.resx
@@ -2220,4 +2220,19 @@
   <data name="SpecialCharacters" xml:space="preserve">
     <value>Special Characters (!@#$%^&amp;*)</value>
   </data>
+  <data name="FilterByVault" xml:space="preserve">
+    <value>Filter items by vault</value>
+  </data>
+  <data name="AllVaults" xml:space="preserve">
+    <value>All Vaults</value>
+  </data>
+  <data name="Vaults" xml:space="preserve">
+    <value>Vaults</value>
+  </data>
+  <data name="VaultFilterDescription" xml:space="preserve">
+    <value>Vault: {0}</value>
+  </data>
+  <data name="VaultFilterDescriptionAll" xml:space="preserve">
+    <value>All</value>
+  </data>
 </root>

--- a/src/App/Utilities/AppHelpers.cs
+++ b/src/App/Utilities/AppHelpers.cs
@@ -15,7 +15,6 @@ using Bit.Core.Enums;
 using Bit.Core.Exceptions;
 using Bit.Core.Models.Data;
 using Bit.Core.Models.View;
-using Bit.Core.Services;
 using Bit.Core.Utilities;
 using Newtonsoft.Json;
 using Xamarin.Essentials;
@@ -381,17 +380,6 @@ namespace Bit.App.Utilities
 
             return await policyService.PolicyAppliesToUser(PolicyType.SendOptions,
                 policy => policy.Data.ContainsKey("disableHideEmail") && (bool)policy.Data["disableHideEmail"]);
-        }
-
-        public static async Task<bool> IsShowingVaultFilterAsync()
-        {
-            var organizationService = ServiceContainer.Resolve<OrganizationService>("organizationService");
-            var policyService = ServiceContainer.Resolve<IPolicyService>("policyService");
-
-            var organizations = await organizationService.GetAllAsync();
-            var personalOwnershipPolicyApplies =
-                await policyService.PolicyAppliesToUser(PolicyType.PersonalOwnership);
-            return (organizations?.Any() ?? false) && !personalOwnershipPolicyApplies;
         }
 
         public static async Task<bool> PerformUpdateTasksAsync(ISyncService syncService,

--- a/src/App/Utilities/AppHelpers.cs
+++ b/src/App/Utilities/AppHelpers.cs
@@ -15,6 +15,7 @@ using Bit.Core.Enums;
 using Bit.Core.Exceptions;
 using Bit.Core.Models.Data;
 using Bit.Core.Models.View;
+using Bit.Core.Services;
 using Bit.Core.Utilities;
 using Newtonsoft.Json;
 using Xamarin.Essentials;
@@ -380,6 +381,17 @@ namespace Bit.App.Utilities
 
             return await policyService.PolicyAppliesToUser(PolicyType.SendOptions,
                 policy => policy.Data.ContainsKey("disableHideEmail") && (bool)policy.Data["disableHideEmail"]);
+        }
+
+        public static async Task<bool> IsShowingVaultFilterAsync()
+        {
+            var organizationService = ServiceContainer.Resolve<OrganizationService>("organizationService");
+            var policyService = ServiceContainer.Resolve<IPolicyService>("policyService");
+            
+            var organizations = await organizationService.GetAllAsync();
+            var personalOwnershipPolicyApplies =
+                    await policyService.PolicyAppliesToUser(PolicyType.PersonalOwnership);
+            return (organizations?.Any() ?? false) && !personalOwnershipPolicyApplies;
         }
 
         public static async Task<bool> PerformUpdateTasksAsync(ISyncService syncService,

--- a/src/App/Utilities/AppHelpers.cs
+++ b/src/App/Utilities/AppHelpers.cs
@@ -387,10 +387,10 @@ namespace Bit.App.Utilities
         {
             var organizationService = ServiceContainer.Resolve<OrganizationService>("organizationService");
             var policyService = ServiceContainer.Resolve<IPolicyService>("policyService");
-            
+
             var organizations = await organizationService.GetAllAsync();
             var personalOwnershipPolicyApplies =
-                    await policyService.PolicyAppliesToUser(PolicyType.PersonalOwnership);
+                await policyService.PolicyAppliesToUser(PolicyType.PersonalOwnership);
             return (organizations?.Any() ?? false) && !personalOwnershipPolicyApplies;
         }
 

--- a/src/Core/Abstractions/IFolderService.cs
+++ b/src/Core/Abstractions/IFolderService.cs
@@ -15,7 +15,7 @@ namespace Bit.Core.Abstractions
         Task<Folder> EncryptAsync(FolderView model, SymmetricCryptoKey key = null);
         Task<List<Folder>> GetAllAsync();
         Task<List<FolderView>> GetAllDecryptedAsync();
-        Task<List<TreeNode<FolderView>>> GetAllNestedAsync();
+        Task<List<TreeNode<FolderView>>> GetAllNestedAsync(List<FolderView> folders = null);
         Task<Folder> GetAsync(string id);
         Task<TreeNode<FolderView>> GetNestedAsync(string id);
         Task ReplaceAsync(Dictionary<string, FolderData> folders);

--- a/src/Core/Abstractions/IPolicyService.cs
+++ b/src/Core/Abstractions/IPolicyService.cs
@@ -20,5 +20,6 @@ namespace Bit.Core.Abstractions
             string orgId);
         Task<bool> PolicyAppliesToUser(PolicyType policyType, Func<Policy, bool> policyFilter = null, string userId = null);
         int? GetPolicyInt(Policy policy, string key);
+        Task<bool> ShouldShowVaultFilterAsync();
     }
 }

--- a/src/Core/BitwardenIcons.cs
+++ b/src/Core/BitwardenIcons.cs
@@ -111,5 +111,6 @@
         public const string EyeSlash = "\xe96d";
         public const string File = "\xe96e";
         public const string Paste = "\xe96f";
+        public const string ViewCellMenu = "\xe5d3";
     }
 }

--- a/src/Core/Services/FolderService.cs
+++ b/src/Core/Services/FolderService.cs
@@ -107,9 +107,12 @@ namespace Bit.Core.Services
             return _decryptedFolderCache;
         }
 
-        public async Task<List<TreeNode<FolderView>>> GetAllNestedAsync()
+        public async Task<List<TreeNode<FolderView>>> GetAllNestedAsync(List<FolderView> folders = null)
         {
-            var folders = await GetAllDecryptedAsync();
+            if (folders == null)
+            {
+                folders = await GetAllDecryptedAsync();
+            }
             var nodes = new List<TreeNode<FolderView>>();
             foreach (var f in folders)
             {

--- a/src/Core/Services/PolicyService.cs
+++ b/src/Core/Services/PolicyService.cs
@@ -193,7 +193,8 @@ namespace Bit.Core.Services
             return new Tuple<ResetPasswordPolicyOptions, bool>(resetPasswordPolicyOptions, policy != null);
         }
 
-        public async Task<bool> PolicyAppliesToUser(PolicyType policyType, Func<Policy, bool> policyFilter, string userId = null)
+        public async Task<bool> PolicyAppliesToUser(PolicyType policyType, Func<Policy, bool> policyFilter = null,
+            string userId = null)
         {
             var policies = await GetAll(policyType, userId);
             if (policies == null)
@@ -244,6 +245,13 @@ namespace Bit.Core.Services
                 }
             }
             return null;
+        }
+
+        public async Task<bool> ShouldShowVaultFilterAsync()
+        {
+            var organizations = await _organizationService.GetAllAsync();
+            var personalOwnershipPolicyApplies = await PolicyAppliesToUser(PolicyType.PersonalOwnership);
+            return (organizations?.Any() ?? false) && !personalOwnershipPolicyApplies;
         }
 
         private bool? GetPolicyBool(Policy policy, string key)


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Added the ability to filter vault ciphers/folders/collections by all/personal/organization when specific conditions are met (account is part of an organization(s) & the Personal Ownership Policy does _not_ apply)


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **GroupingsPage.xaml/xaml.cs/ViewModel.cs:** Added UI & logic for displaying & handling vault filter options & selection
* **TabsPage.cs:** Added `UpdateVaultButtonTitleAsync()` method to change vault button title to `Vaults` or `My Vault` based on filter availability.  Triggered on page appearing as well as sync completion via `BroadcasterService`
* **AppHelpers.cs:** Added `IsShowingVaultFilterAsync()` convenience method
* **FolderService.cs:** Added support for passing in existing `FolderView` list to `GetAllNestedAsync` method to support required flexibility during filter selection

## Screenshots
<!--Required for any UI changes. Delete if not applicable-->
Example 1: Filter conditions apply and selection UI is displayed.  Page and tab vault icon title changed to "Vaults" to prevent confusion with "My Vault" selection.

<img width="818" alt="Screen Shot 2022-05-27 at 12 28 29 PM" src="https://user-images.githubusercontent.com/59324545/170740871-4ec303fc-b252-4658-959b-1a01f5177c4f.png">

Example 2: Specific organization selected by user.  Page and tab vault icon title changed to "Vaults" to prevent confusion with "My Vault" selection.

<img width="817" alt="Screen Shot 2022-05-27 at 12 28 56 PM" src="https://user-images.githubusercontent.com/59324545/170740880-96ab1fce-e35c-4ca6-8966-e8f1d04c2421.png">

Example 3: Filter conditions do _not_ apply to this user so filter selector row is hidden.  Page and tab vault icon title remains "My Vault".

<img width="819" alt="Screen Shot 2022-05-27 at 12 30 33 PM" src="https://user-images.githubusercontent.com/59324545/170740897-e40bebfa-8629-4171-b6c8-b594134e4e14.png">

## Before you submit
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [X] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
