### PR TITLE
PS-689 Android: Accessibility - back buttons in search and vault > bin lack appropriate accessible name

### DIFF
--- a/src/Android/Android.csproj
+++ b/src/Android/Android.csproj
@@ -150,6 +150,7 @@
     <Compile Include="Renderers\SelectableLabelRenderer.cs" />
     <Compile Include="Services\ClipboardService.cs" />
     <Compile Include="Utilities\IntentExtensions.cs" />
+    <Compile Include="Renderers\CustomPageRenderer.cs" />
   </ItemGroup>
   <ItemGroup>
     <AndroidAsset Include="Assets\bwi-font.ttf" />

--- a/src/Android/Renderers/CustomPageRenderer.cs
+++ b/src/Android/Renderers/CustomPageRenderer.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using Android.App;
+using Android.Content;
+using AndroidX.AppCompat.Widget;
+using Bit.App.Resources;
+using Bit.Droid.Renderers;
+using Xamarin.Forms;
+using Xamarin.Forms.Platform.Android;
+
+[assembly: ExportRenderer(typeof(ContentPage), typeof(AndroidNavigationPageRenderer))]
+namespace Bit.Droid.Renderers
+{
+    public class AndroidNavigationPageRenderer : PageRenderer
+    {
+        public AndroidNavigationPageRenderer(Context context) : base(context)
+        {
+        }
+
+        protected override void OnElementChanged(ElementChangedEventArgs<Page> e)
+        {
+            base.OnElementChanged(e);
+
+            Activity context = (Activity)this.Context;
+            var toolbar = context.FindViewById<Toolbar>(Resource.Id.toolbar);
+            if(toolbar != null)
+            {
+                toolbar.NavigationContentDescription = AppResources.GoBack;
+            }
+        }
+    }
+}

--- a/src/Android/Renderers/CustomPageRenderer.cs
+++ b/src/Android/Renderers/CustomPageRenderer.cs
@@ -24,7 +24,7 @@ namespace Bit.Droid.Renderers
             var toolbar = context.FindViewById<Toolbar>(Resource.Id.toolbar);
             if(toolbar != null)
             {
-                toolbar.NavigationContentDescription = AppResources.GoBack;
+                toolbar.NavigationContentDescription = AppResources.TapToGoBack;
             }
         }
     }

--- a/src/Android/Renderers/CustomPageRenderer.cs
+++ b/src/Android/Renderers/CustomPageRenderer.cs
@@ -7,12 +7,12 @@ using Bit.Droid.Renderers;
 using Xamarin.Forms;
 using Xamarin.Forms.Platform.Android;
 
-[assembly: ExportRenderer(typeof(ContentPage), typeof(AndroidNavigationPageRenderer))]
+[assembly: ExportRenderer(typeof(ContentPage), typeof(CustomPageRenderer))]
 namespace Bit.Droid.Renderers
 {
-    public class AndroidNavigationPageRenderer : PageRenderer
+    public class CustomPageRenderer : PageRenderer
     {
-        public AndroidNavigationPageRenderer(Context context) : base(context)
+        public CustomPageRenderer(Context context) : base(context)
         {
         }
 

--- a/src/App/Pages/Vault/CiphersPage.xaml
+++ b/src/App/Pages/Vault/CiphersPage.xaml
@@ -33,7 +33,9 @@
                     Text="&#xe5c4;"
                     VerticalOptions="CenterAndExpand"
                     Clicked="BackButton_Clicked"
-                    x:Name="_backButton" />
+                    x:Name="_backButton"
+                    AutomationProperties.IsInAccessibleTree="True"
+                    AutomationProperties.Name="{u:I18n GoBack}"/>
                 <controls:ExtendedSearchBar
                     x:Name="_searchBar"
                     HorizontalOptions="FillAndExpand"

--- a/src/App/Pages/Vault/CiphersPage.xaml
+++ b/src/App/Pages/Vault/CiphersPage.xaml
@@ -35,7 +35,7 @@
                     Clicked="BackButton_Clicked"
                     x:Name="_backButton"
                     AutomationProperties.IsInAccessibleTree="True"
-                    AutomationProperties.Name="{u:I18n GoBack}"/>
+                    AutomationProperties.Name="{u:I18n TapToGoBack}"/>
                 <controls:ExtendedSearchBar
                     x:Name="_searchBar"
                     HorizontalOptions="FillAndExpand"

--- a/src/App/Resources/AppResources.Designer.cs
+++ b/src/App/Resources/AppResources.Designer.cs
@@ -3959,9 +3959,9 @@ namespace Bit.App.Resources {
             }
         }
         
-        public static string GoBack {
+        public static string TapToGoBack {
             get {
-                return ResourceManager.GetString("GoBack", resourceCulture);
+                return ResourceManager.GetString("TapToGoBack", resourceCulture);
             }
         }
     }

--- a/src/App/Resources/AppResources.Designer.cs
+++ b/src/App/Resources/AppResources.Designer.cs
@@ -3958,5 +3958,11 @@ namespace Bit.App.Resources {
                 return ResourceManager.GetString("SpecialCharacters", resourceCulture);
             }
         }
+        
+        public static string GoBack {
+            get {
+                return ResourceManager.GetString("GoBack", resourceCulture);
+            }
+        }
     }
 }

--- a/src/App/Resources/AppResources.resx
+++ b/src/App/Resources/AppResources.resx
@@ -2214,7 +2214,7 @@
   <data name="SpecialCharacters" xml:space="preserve">
     <value>Special Characters (!@#$%^&amp;*)</value>
   </data>
-  <data name="GoBack" xml:space="preserve">
+  <data name="TapToGoBack" xml:space="preserve">
     <value>Tap to go back</value>
   </data>
 </root>

--- a/src/App/Resources/AppResources.resx
+++ b/src/App/Resources/AppResources.resx
@@ -2214,4 +2214,7 @@
   <data name="SpecialCharacters" xml:space="preserve">
     <value>Special Characters (!@#$%^&amp;*)</value>
   </data>
+  <data name="GoBack" xml:space="preserve">
+    <value>Tap to go back</value>
+  </data>
 </root>


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
Android back buttons throughout the app don't have accessibility text. Add text to be read by the VoiceOver\TalkBack on the back button.

## Code changes
* **src/Android/Renderers/CustomPageRenderer.cs:** Toolbar back button was only accessible through a custom renderer.

## Before you submit
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
