### PR TITLE
[PS-536] Fix vault blank after unlocking and back navigation

### DIFF
--- a/src/App/Pages/Vault/GroupingsPage/GroupingsPageViewModel.cs
+++ b/src/App/Pages/Vault/GroupingsPage/GroupingsPageViewModel.cs
@@ -294,6 +294,9 @@ namespace Bit.App.Pages
                         items.AddRange(itemGroup);
                     }
 
+                    // HACK: [PS-536] Fix to avoid blank list after back navigation on unlocking with previous page info
+                    // because of update to XF v5.0.0.2401
+                    GroupedItems.Clear();
                     GroupedItems.ReplaceRange(items);
                 }
                 else
@@ -316,6 +319,9 @@ namespace Bit.App.Pages
 
                     if (groupedItems.Any())
                     {
+                        // HACK: [PS-536] Fix to avoid blank list after back navigation on unlocking with previous page info
+                        // because of update to XF v5.0.0.2401
+                        GroupedItems.Clear();
                         GroupedItems.ReplaceRange(new List<IGroupingsPageListItem> { new GroupingsPageHeaderListItem(groupedItems[0].Name, groupedItems[0].ItemCount) });
                         GroupedItems.AddRange(items);
                     }

--- a/src/App/Pages/Vault/GroupingsPage/GroupingsPageViewModel.cs
+++ b/src/App/Pages/Vault/GroupingsPage/GroupingsPageViewModel.cs
@@ -294,9 +294,12 @@ namespace Bit.App.Pages
                         items.AddRange(itemGroup);
                     }
 
-                    // HACK: [PS-536] Fix to avoid blank list after back navigation on unlocking with previous page info
-                    // because of update to XF v5.0.0.2401
-                    GroupedItems.Clear();
+                    if (Device.RuntimePlatform == Device.iOS)
+                    {
+                        // HACK: [PS-536] Fix to avoid blank list after back navigation on unlocking with previous page info
+                        // because of update to XF v5.0.0.2401
+                        GroupedItems.Clear();
+                    }
                     GroupedItems.ReplaceRange(items);
                 }
                 else
@@ -319,9 +322,12 @@ namespace Bit.App.Pages
 
                     if (groupedItems.Any())
                     {
-                        // HACK: [PS-536] Fix to avoid blank list after back navigation on unlocking with previous page info
-                        // because of update to XF v5.0.0.2401
-                        GroupedItems.Clear();
+                        if (Device.RuntimePlatform == Device.iOS)
+                        {
+                            // HACK: [PS-536] Fix to avoid blank list after back navigation on unlocking with previous page info
+                            // because of update to XF v5.0.0.2401
+                            GroupedItems.Clear();
+                        }
                         GroupedItems.ReplaceRange(new List<IGroupingsPageListItem> { new GroupingsPageHeaderListItem(groupedItems[0].Name, groupedItems[0].ItemCount) });
                         GroupedItems.AddRange(items);
                     }


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Fix vault blank after unlocking and closing the modal when the user had locked the vault when viewing a cipher. It may fix #1274 as well.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **GroupingsPageViewModel.cs:** Added `Clear` call to the `GroupedItems` collection before replacing in order to invalidate the internal `UICollectionView` layout and the Replace to work as expected. This issue was introduce by the update to XF v5.0.0.2401. This workarounds the issue but we should keep checking this for a better solution or hope the next version fixes it.

## Before you submit
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
