### PR TITLE
Updating icons for Linked and Boolean fields

### DIFF
--- a/src/App/Pages/Vault/ViewPageViewModel.cs
+++ b/src/App/Pages/Vault/ViewPageViewModel.cs
@@ -754,12 +754,12 @@ namespace Bit.App.Pages
             {
                 if (IsBooleanType)
                 {
-                    return _field.Value == "true" ? "" : "";
+                    return _field.Value == "true" ? BitwardenIcons.Square : BitwardenIcons.CheckSquare;
                 }
                 else if (IsLinkedType)
                 {
                     var i18nKey = _cipher.LinkedFieldI18nKey(Field.LinkedId.GetValueOrDefault());
-                    return " " + _i18nService.T(i18nKey);
+                    return BitwardenIcons.Link + _i18nService.T(i18nKey);
                 }
                 else
                 {


### PR DESCRIPTION
Update to icons used for Boolean and Linked to use real icons

## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
Icons on Mobile devices aren't displaying properly for Linked and Boolean type

## Code changes
ViewPageViewModel.cs 
Updated to use Bitwarden defined icons for Boolean and linked types

## Screenshots
![Screen Shot 2022-06-02 at 1 21 30 PM](https://user-images.githubusercontent.com/103955722/171690138-7b235592-34bc-4f73-a692-bea6cba2d56c.png)



## Before you submit
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
