### PR TITLE
Adaptive icon theme support in Android 13

### DIFF
--- a/src/Android/Resources/mipmap-anydpi-v26/ic_launcher.xml
+++ b/src/Android/Resources/mipmap-anydpi-v26/ic_launcher.xml
@@ -2,4 +2,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@color/ic_launcher_background"/>
     <foreground android:drawable="@drawable/ic_launcher_foreground"/>
+    <monochrome android:drawable="@drawable/ic_launcher_foreground"/>
 </adaptive-icon>

--- a/src/Android/Resources/mipmap-anydpi-v26/ic_launcher_round.xml
+++ b/src/Android/Resources/mipmap-anydpi-v26/ic_launcher_round.xml
@@ -2,4 +2,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@color/ic_launcher_background"/>
     <foreground android:drawable="@drawable/ic_launcher_foreground"/>
+    <monochrome android:drawable="@drawable/ic_launcher_foreground"/>
 </adaptive-icon>


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Adds support for launcher icon themes in Android 13.  (Turns out this doesn't require SDK/target updates that were holding us back in Xamarin)  Reference: https://developer.android.com/about/versions/13/features

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **ic_launcher/round.xml:** Added monochrome element to logo vectordrawable for theme support in Android 13

## Screenshots
<!--Required for any UI changes. Delete if not applicable-->
![Screen Shot 2022-06-06 at 10 13 27 AM](https://user-images.githubusercontent.com/59324545/172181378-65af4f96-3bbf-4c79-a858-e35e095f7d82.png)

## Before you submit
- [ ] I have checked for formatting errors (`dotnet tool run dotnet-format --check`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
