### PR TITLE
PS-587 - Fix searchbar search textfield and icon colors for dark themes

### DIFF
--- a/src/iOS.Autofill/LoginSearchViewController.cs
+++ b/src/iOS.Autofill/LoginSearchViewController.cs
@@ -36,6 +36,7 @@ namespace Bit.iOS.Autofill
             if (!ThemeHelpers.LightTheme)
             {
                 SearchBar.KeyboardAppearance = UIKeyboardAppearance.Dark;
+                SearchBar.ApplyDarkThemesColors();
             }
 
             TableView.RowHeight = UITableView.AutomaticDimension;

--- a/src/iOS.Autofill/LoginSearchViewController.cs
+++ b/src/iOS.Autofill/LoginSearchViewController.cs
@@ -33,11 +33,7 @@ namespace Bit.iOS.Autofill
             CancelBarButton.Title = AppResources.Cancel;
             SearchBar.Placeholder = AppResources.Search;
             SearchBar.BackgroundColor = SearchBar.BarTintColor = ThemeHelpers.ListHeaderBackgroundColor;
-            if (!ThemeHelpers.LightTheme)
-            {
-                SearchBar.KeyboardAppearance = UIKeyboardAppearance.Dark;
-                SearchBar.ApplyDarkThemesColors();
-            }
+            SearchBar.UpdateThemeIfNeeded();
 
             TableView.RowHeight = UITableView.AutomaticDimension;
             TableView.EstimatedRowHeight = 44;

--- a/src/iOS.Core/Utilities/UISearchBarExtensions.cs
+++ b/src/iOS.Core/Utilities/UISearchBarExtensions.cs
@@ -4,12 +4,12 @@ namespace Bit.iOS.Core.Utilities
 {
     public static class UISearchBarExtensions
     {
-        public static void ApplyDarkThemesColors(this UISearchBar searchBar)
+        public static void UpdateThemeIfNeeded(this UISearchBar searchBar)
         {
-            var versionParts = UIDevice.CurrentDevice.SystemVersion.Split('.');
-            if (versionParts.Length > 0 && int.TryParse(versionParts[0], out var version))
+            if (!ThemeHelpers.LightTheme)
             {
-                if (version >= 13)
+                searchBar.KeyboardAppearance = UIKeyboardAppearance.Dark;
+                if (UIDevice.CurrentDevice.CheckSystemVersion(13, 0))
                 {
                     searchBar.SearchTextField.TextColor = UIColor.White;
                     searchBar.SearchTextField.LeftView.TintColor = UIColor.White;

--- a/src/iOS.Core/Utilities/UISearchBarExtensions.cs
+++ b/src/iOS.Core/Utilities/UISearchBarExtensions.cs
@@ -1,0 +1,20 @@
+﻿using UIKit;
+
+namespace Bit.iOS.Core.Utilities
+{
+    public static class UISearchBarExtensions
+    {
+        public static void ApplyDarkThemesColors(this UISearchBar searchBar)
+        {
+            var versionParts = UIDevice.CurrentDevice.SystemVersion.Split('.');
+            if (versionParts.Length > 0 && int.TryParse(versionParts[0], out var version))
+            {
+                if (version >= 13)
+                {
+                    searchBar.SearchTextField.TextColor = UIColor.White;
+                    searchBar.SearchTextField.LeftView.TintColor = UIColor.White;
+                }
+            }
+        }
+    }
+}

--- a/src/iOS.Core/iOS.Core.csproj
+++ b/src/iOS.Core/iOS.Core.csproj
@@ -194,6 +194,7 @@
     <Compile Include="Services\ClipboardService.cs" />
     <Compile Include="Utilities\FontElementExtensions.cs" />
     <Compile Include="Effects\ScrollViewContentInsetAdjustmentBehaviorEffect.cs" />
+    <Compile Include="Utilities\UISearchBarExtensions.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\App\App.csproj">


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
With these changes, autofill iOS extension searchbar's search text and icon should appear as white for non light themes.



## Code changes
* **LoginSearchViewController.cs**: Invoked new method extension ApplyDarkThemesColors from UISearchBarExtensions.cs
* **UISearchBarExtensions.cs**: Applied white color to search text and icon only for iOS versions greater or equal than 13 because this solution isn't supported for prior versions.


## Screenshots
Without the fix:
<img width="419" alt="image" src="https://user-images.githubusercontent.com/6855596/172208150-09511f30-922c-4b72-9060-d8e1e04d4f70.png">

With the fix:
Dark theme

<img width="419" alt="image" src="https://user-images.githubusercontent.com/6855596/172208885-fd77d215-4261-4939-bc20-2018c3379bbf.png">

Black theme
<img width="419" alt="image" src="https://user-images.githubusercontent.com/6855596/172209061-f41ddb4d-51a6-4c34-a809-9faa44ad58ff.png">

Nord theme
<img width="419" alt="image" src="https://user-images.githubusercontent.com/6855596/172209178-6c276c61-42e4-4acf-8bee-3915719ca104.png">


## Before you submit
- [x] I have checked for formatting errors (`dotnet tool run dotnet-format --check`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
