### PR TITLE
[PS-785] Added logs for exceptions on UpdateTemplatedCell

### DIFF
--- a/src/App/Controls/ExtendedCollectionView.cs
+++ b/src/App/Controls/ExtendedCollectionView.cs
@@ -4,5 +4,6 @@ namespace Bit.App.Controls
 {
     public class ExtendedCollectionView : CollectionView
     {
+        public string ExtraDataForLogging { get; set; }
     }
 }

--- a/src/App/Pages/Generator/GeneratorHistoryPage.xaml
+++ b/src/App/Pages/Generator/GeneratorHistoryPage.xaml
@@ -48,7 +48,8 @@
                   IsVisible="{Binding ShowNoData, Converter={StaticResource inverseBool}}"
                   ItemsSource="{Binding History}"
                   VerticalOptions="FillAndExpand"
-                  StyleClass="list, list-platform">
+                  StyleClass="list, list-platform"
+                  ExtraDataForLogging="Generator History Page">
             <CollectionView.ItemTemplate>
                 <DataTemplate x:DataType="domain:GeneratedPasswordHistory">
                     <Grid

--- a/src/App/Pages/Send/SendGroupingsPage/SendGroupingsPage.xaml
+++ b/src/App/Pages/Send/SendGroupingsPage/SendGroupingsPage.xaml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <pages:BaseContentPage xmlns="http://xamarin.com/schemas/2014/forms"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     x:Class="Bit.App.Pages.SendGroupingsPage"
@@ -138,7 +138,8 @@
                         ItemTemplate="{StaticResource sendListItemDataTemplateSelector}"
                         SelectionMode="Single"
                         SelectionChanged="RowSelected"
-                        StyleClass="list, list-platform" />
+                        StyleClass="list, list-platform"
+                        ExtraDataForLogging="Send Groupings Page" />
                 </RefreshView>
             </StackLayout>
         </ResourceDictionary>

--- a/src/App/Pages/Send/SendsPage.xaml
+++ b/src/App/Pages/Send/SendsPage.xaml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <pages:BaseContentPage
     xmlns="http://xamarin.com/schemas/2014/forms"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
@@ -66,7 +66,8 @@
                VerticalOptions="FillAndExpand"
                SelectionMode="Single"
                SelectionChanged="RowSelected"
-               StyleClass="list, list-platform">
+               StyleClass="list, list-platform"
+               ExtraDataForLogging="Sends Page">
             <CollectionView.ItemTemplate>
                 <DataTemplate x:DataType="views:SendView">
                     <controls:SendViewCell

--- a/src/App/Pages/Settings/FoldersPage.xaml
+++ b/src/App/Pages/Settings/FoldersPage.xaml
@@ -38,7 +38,8 @@
                           VerticalOptions="FillAndExpand"
                           SelectionMode="Single"
                           SelectionChanged="RowSelected"
-                          StyleClass="list, list-platform">
+                          StyleClass="list, list-platform"
+                          ExtraDataForLogging="Folders Page">
                     <CollectionView.ItemTemplate>
                         <DataTemplate x:DataType="views:FolderView">
                             <controls:ExtendedStackLayout

--- a/src/App/Pages/Settings/SettingsPage/SettingsPage.xaml
+++ b/src/App/Pages/Settings/SettingsPage/SettingsPage.xaml
@@ -113,6 +113,7 @@
         ItemTemplate="{StaticResource listItemDataTemplateSelector}"
         SelectionMode="Single"
         SelectionChanged="RowSelected"
-        StyleClass="list, list-platform" />
+        StyleClass="list, list-platform"
+        ExtraDataForLogging="Settings Page" />
 
 </pages:BaseContentPage>

--- a/src/App/Pages/Vault/AutofillCiphersPage.xaml
+++ b/src/App/Pages/Vault/AutofillCiphersPage.xaml
@@ -85,7 +85,8 @@
                     ItemTemplate="{StaticResource listItemDataTemplateSelector}"
                     SelectionMode="Single"
                     SelectionChanged="RowSelected"
-                    StyleClass="list, list-platform" />
+                    StyleClass="list, list-platform"
+                    ExtraDataForLogging="Autofill Ciphers Page" />
             </StackLayout>
         </ResourceDictionary>
     </ContentPage.Resources>

--- a/src/App/Pages/Vault/CiphersPage.xaml
+++ b/src/App/Pages/Vault/CiphersPage.xaml
@@ -68,7 +68,8 @@
                 VerticalOptions="FillAndExpand"
                 SelectionMode="Single"
                 SelectionChanged="RowSelected"
-                StyleClass="list, list-platform">
+                StyleClass="list, list-platform"
+                ExtraDataForLogging="Ciphers Page">
             <CollectionView.ItemTemplate>
                 <DataTemplate x:DataType="views:CipherView">
                     <controls:CipherViewCell

--- a/src/App/Pages/Vault/GroupingsPage/GroupingsPage.xaml
+++ b/src/App/Pages/Vault/GroupingsPage/GroupingsPage.xaml
@@ -155,7 +155,8 @@
                         ItemTemplate="{StaticResource listItemDataTemplateSelector}"
                         SelectionMode="Single"
                         SelectionChanged="RowSelected"
-                        StyleClass="list, list-platform" />
+                        StyleClass="list, list-platform"
+                        ExtraDataForLogging="Groupings Page" />
                 </RefreshView>
             </StackLayout>
         </ResourceDictionary>

--- a/src/App/Pages/Vault/PasswordHistoryPage.xaml
+++ b/src/App/Pages/Vault/PasswordHistoryPage.xaml
@@ -39,7 +39,8 @@
                   IsVisible="{Binding ShowNoData, Converter={StaticResource inverseBool}}"
                   ItemsSource="{Binding History}"
                   VerticalOptions="FillAndExpand"
-                  StyleClass="list, list-platform">
+                  StyleClass="list, list-platform"
+                  ExtraDataForLogging="Password History Page">
             <CollectionView.ItemTemplate>
                 <DataTemplate x:DataType="views:PasswordHistoryView">
                     <Grid

--- a/src/iOS.Core/Renderers/CollectionView/ExtendedCollectionViewRenderer.cs
+++ b/src/iOS.Core/Renderers/CollectionView/ExtendedCollectionViewRenderer.cs
@@ -1,0 +1,16 @@
+﻿using Bit.App.Controls;
+using Bit.iOS.Core.Renderers.CollectionView;
+using Xamarin.Forms;
+using Xamarin.Forms.Platform.iOS;
+
+[assembly: ExportRenderer(typeof(ExtendedCollectionView), typeof(ExtendedCollectionViewRenderer))]
+namespace Bit.iOS.Core.Renderers.CollectionView
+{
+    public class ExtendedCollectionViewRenderer : GroupableItemsViewRenderer<ExtendedCollectionView, GroupableItemsViewController<ExtendedCollectionView>>
+    {
+        protected override GroupableItemsViewController<ExtendedCollectionView> CreateController(ExtendedCollectionView itemsView, ItemsViewLayout layout)
+        {
+            return new ExtendedGroupableItemsViewController<ExtendedCollectionView>(itemsView, layout);
+        }
+    }
+}

--- a/src/iOS.Core/Renderers/CollectionView/ExtendedGroupableItemsViewController.cs
+++ b/src/iOS.Core/Renderers/CollectionView/ExtendedGroupableItemsViewController.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using Bit.App.Controls;
+using Foundation;
+using Xamarin.Forms.Platform.iOS;
+
+namespace Bit.iOS.Core.Renderers.CollectionView
+{
+    public class ExtendedGroupableItemsViewController<TItemsView> : GroupableItemsViewController<TItemsView>
+        where TItemsView : ExtendedCollectionView
+    {
+        public ExtendedGroupableItemsViewController(TItemsView groupableItemsView, ItemsViewLayout layout)
+            : base(groupableItemsView, layout)
+        {
+        }
+
+        protected override void UpdateTemplatedCell(TemplatedCell cell, NSIndexPath indexPath)
+        {
+            try
+            {
+                base.UpdateTemplatedCell(cell, indexPath);
+            }
+            catch (Exception ex) when (ItemsView?.ExtraDataForLogging != null)
+            {
+                throw new Exception("Error in ExtendedCollectionView, extra data: " + ItemsView.ExtraDataForLogging, ex);
+            }
+        }
+    }
+}

--- a/src/iOS.Core/iOS.Core.csproj
+++ b/src/iOS.Core/iOS.Core.csproj
@@ -138,6 +138,7 @@
   <ItemGroup>
     <Folder Include="Resources\" />
     <Folder Include="Effects\" />
+    <Folder Include="Renderers\CollectionView\" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Constants.cs" />
@@ -194,6 +195,8 @@
     <Compile Include="Services\ClipboardService.cs" />
     <Compile Include="Utilities\FontElementExtensions.cs" />
     <Compile Include="Effects\ScrollViewContentInsetAdjustmentBehaviorEffect.cs" />
+    <Compile Include="Renderers\CollectionView\ExtendedCollectionViewRenderer.cs" />
+    <Compile Include="Renderers\CollectionView\ExtendedGroupableItemsViewController.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\App\App.csproj">


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [ ] New feature development
- [] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [X] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Add extended logs for `CollectionView` on iOS when doing `UpdateTemplatedCell` to have more context on the AppCenter crashes.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **ExtendedCollectionView.cs:** Added `ExtraDataForLogging` property to add any extra information we want from the usage of the collection view.
* **ExtendedCollectionViewRenderer.cs:** Added this renderer in order to override the controller used in the collection view renderer.
* **ExtendedGroupableItemsViewController.cs:** Added this to override the `UpdateTemplatedCell` method and add a try...catch to extend the logging information with the one provided by `ExtraDataForLogging` to have more context on AppCenter crashes.

## Before you submit
- [X] I have checked for formatting errors (`dotnet tool run dotnet-format --check`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
