### PR TITLE
[SG-79] Add filter to search and preselect org in new cipher

### DIFF
--- a/src/App/Pages/Vault/AddEditPage.xaml.cs
+++ b/src/App/Pages/Vault/AddEditPage.xaml.cs
@@ -30,6 +30,7 @@ namespace Bit.App.Pages
             CipherType? type = null,
             string folderId = null,
             string collectionId = null,
+            string organizationId = null,
             string name = null,
             string uri = null,
             bool fromAutofill = false,
@@ -51,6 +52,7 @@ namespace Bit.App.Pages
             _vm.CipherId = cipherId;
             _vm.FolderId = folderId == "none" ? null : folderId;
             _vm.CollectionIds = collectionId != null ? new HashSet<string>(new List<string> { collectionId }) : null;
+            _vm.OrganizationId = organizationId;
             _vm.Type = type;
             _vm.DefaultName = name ?? appOptions?.SaveName;
             _vm.DefaultUri = uri ?? appOptions?.Uri;

--- a/src/App/Pages/Vault/CiphersPage.xaml
+++ b/src/App/Pages/Vault/CiphersPage.xaml
@@ -72,7 +72,7 @@
                 AutomationProperties.IsInAccessibleTree="True"
                 AutomationProperties.Name="{u:I18n Filter}" />
         </StackLayout>
-        <BoxView StyleClass="list-section-separator-bottom, list-section-separator-bottom-platform" />
+        <BoxView StyleClass="box-row-separator" />
 
         <controls:IconLabel IsVisible="{Binding ShowSearchDirection}"
                Text="{Binding Source={x:Static core:BitwardenIcons.Search}}"

--- a/src/App/Pages/Vault/CiphersPage.xaml
+++ b/src/App/Pages/Vault/CiphersPage.xaml
@@ -49,6 +49,31 @@
     </ContentPage.Resources>
 
     <StackLayout x:Name="_mainLayout" Spacing="0" Padding="0">
+        <StackLayout
+            IsVisible="{Binding ShowVaultFilter}"
+            Orientation="Horizontal"
+            HorizontalOptions="FillAndExpand"
+            Margin="0,5,0,0">
+            <Label
+                Text="{Binding VaultFilterDescription}"
+                LineBreakMode="TailTruncation"
+                Margin="10,0"
+                StyleClass="text-md, text-muted"
+                VerticalOptions="Center"
+                HorizontalOptions="StartAndExpand"
+                AutomationProperties.IsInAccessibleTree="True"
+                AutomationProperties.Name="{u:I18n Filter}" />
+            <controls:MiButton
+                Text="{Binding Source={x:Static core:BitwardenIcons.ViewCellMenu}}"
+                StyleClass="list-row-button-text, list-row-button-platform"
+                Command="{Binding VaultFilterCommand}"
+                VerticalOptions="Center"
+                HorizontalOptions="End"
+                AutomationProperties.IsInAccessibleTree="True"
+                AutomationProperties.Name="{u:I18n Filter}" />
+        </StackLayout>
+        <BoxView StyleClass="list-section-separator-bottom, list-section-separator-bottom-platform" />
+
         <controls:IconLabel IsVisible="{Binding ShowSearchDirection}"
                Text="{Binding Source={x:Static core:BitwardenIcons.Search}}"
                StyleClass="text-muted"

--- a/src/App/Pages/Vault/CiphersPage.xaml.cs
+++ b/src/App/Pages/Vault/CiphersPage.xaml.cs
@@ -17,7 +17,8 @@ namespace Bit.App.Pages
         private CiphersPageViewModel _vm;
         private bool _hasFocused;
 
-        public CiphersPage(Func<CipherView, bool> filter, string pageTitle = null, string autofillUrl = null, bool deleted = false)
+        public CiphersPage(Func<CipherView, bool> filter, string pageTitle = null, string vaultFilterSelection = null,
+            string autofillUrl = null, bool deleted = false)
         {
             InitializeComponent();
             _vm = BindingContext as CiphersPageViewModel;
@@ -32,6 +33,10 @@ namespace Bit.App.Pages
             else
             {
                 _vm.PageTitle = AppResources.SearchVault;
+            }
+            if (vaultFilterSelection != null)
+            {
+                _vm.VaultFilterDescription = vaultFilterSelection;
             }
 
             if (Device.RuntimePlatform == Device.iOS)

--- a/src/App/Pages/Vault/CiphersPage.xaml.cs
+++ b/src/App/Pages/Vault/CiphersPage.xaml.cs
@@ -34,10 +34,7 @@ namespace Bit.App.Pages
             {
                 _vm.PageTitle = AppResources.SearchVault;
             }
-            if (vaultFilterSelection != null)
-            {
-                _vm.VaultFilterDescription = vaultFilterSelection;
-            }
+            _vm.VaultFilterDescription = vaultFilterSelection;
 
             if (Device.RuntimePlatform == Device.iOS)
             {

--- a/src/App/Pages/Vault/CiphersPageViewModel.cs
+++ b/src/App/Pages/Vault/CiphersPageViewModel.cs
@@ -246,7 +246,7 @@ namespace Bit.App.Pages
             }
             var selection = await Page.DisplayActionSheet(AppResources.FilterByVault, AppResources.Cancel, null,
                 options.ToArray());
-            if (selection == AppResources.Cancel ||
+            if (selection == null || selection == AppResources.Cancel ||
                 (_vaultFilterSelection == null && selection == AppResources.AllVaults) ||
                 (_vaultFilterSelection != null && _vaultFilterSelection == selection))
             {

--- a/src/App/Pages/Vault/CiphersPageViewModel.cs
+++ b/src/App/Pages/Vault/CiphersPageViewModel.cs
@@ -266,9 +266,9 @@ namespace Bit.App.Pages
             if (IsVaultFilterOrgVault)
             {
                 var orgId = GetVaultFilterOrgId();
-                return  decCiphers.Where(c => c.OrganizationId == orgId).ToList();
+                return decCiphers.Where(c => c.OrganizationId == orgId).ToList();
             }
-            return  decCiphers;
+            return decCiphers;
         }
 
         private bool IsVaultFilterMyVault => _vaultFilterSelection == AppResources.MyVault;

--- a/src/App/Pages/Vault/GroupingsPage/GroupingsPage.xaml
+++ b/src/App/Pages/Vault/GroupingsPage/GroupingsPage.xaml
@@ -123,7 +123,7 @@
                         AutomationProperties.Name="{u:I18n Filter}" />
                     <controls:MiButton
                         Text="{Binding Source={x:Static core:BitwardenIcons.ViewCellMenu}}"
-                        StyleClass="list-row-button, list-row-button-platform, btn-disabled"
+                        StyleClass="list-row-button-text, list-row-button-platform"
                         Command="{Binding VaultFilterCommand}"
                         VerticalOptions="Center"
                         HorizontalOptions="End"

--- a/src/App/Pages/Vault/GroupingsPage/GroupingsPage.xaml.cs
+++ b/src/App/Pages/Vault/GroupingsPage/GroupingsPage.xaml.cs
@@ -263,7 +263,7 @@ namespace Bit.App.Pages
             }
             if (!_vm.Deleted && DoOnce())
             {
-                var page = new AddEditPage(null, _vm.Type, _vm.FolderId, _vm.CollectionId);
+                var page = new AddEditPage(null, _vm.Type, _vm.FolderId, _vm.CollectionId, _vm.GetVaultFilterOrgId());
                 await Navigation.PushModalAsync(new NavigationPage(page));
             }
         }

--- a/src/App/Pages/Vault/GroupingsPage/GroupingsPageViewModel.cs
+++ b/src/App/Pages/Vault/GroupingsPage/GroupingsPageViewModel.cs
@@ -413,6 +413,11 @@ namespace Bit.App.Pages
             await LoadAsync();
         }
 
+        public string GetVaultFilterOrgId()
+        {
+            return _organizations?.FirstOrDefault(o => o.Name == _vaultFilterSelection)?.Id;
+        }
+
         public async Task SelectCipherAsync(CipherView cipher)
         {
             var page = new ViewPage(cipher.Id);
@@ -680,11 +685,6 @@ namespace Bit.App.Pages
 
         private bool IsVaultFilterOrgVault => _vaultFilterSelection != AppResources.AllVaults &&
                                               _vaultFilterSelection != AppResources.MyVault;
-
-        private string GetVaultFilterOrgId()
-        {
-            return _organizations?.FirstOrDefault(o => o.Name == _vaultFilterSelection)?.Id;
-        }
 
         private List<FolderView> BuildFolders(List<FolderView> decFolders)
         {

--- a/src/App/Pages/Vault/GroupingsPage/GroupingsPageViewModel.cs
+++ b/src/App/Pages/Vault/GroupingsPage/GroupingsPageViewModel.cs
@@ -403,7 +403,7 @@ namespace Bit.App.Pages
             }
             var selection = await Page.DisplayActionSheet(AppResources.FilterByVault, AppResources.Cancel, null,
                 options.ToArray());
-            if (selection == AppResources.Cancel ||
+            if (selection == null || selection == AppResources.Cancel ||
                 (_vaultFilterSelection == null && selection == AppResources.AllVaults) ||
                 (_vaultFilterSelection != null && _vaultFilterSelection == selection))
             {

--- a/src/App/Styles/Base.xaml
+++ b/src/App/Styles/Base.xaml
@@ -270,6 +270,16 @@
     </Style>
     <Style TargetType="Button"
            ApplyToDerivedTypes="True"
+           Class="list-row-button-text">
+        <Setter Property="BackgroundColor"
+                Value="Transparent" />
+        <Setter Property="Padding"
+                Value="0" />
+        <Setter Property="TextColor"
+                Value="{DynamicResource ButtonTextColor}" />
+    </Style>
+    <Style TargetType="Button"
+           ApplyToDerivedTypes="True"
            Class="segmented-button">
         <Setter Property="BackgroundColor"
                 Value="Transparent" />


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
- [SG-362] Added vault org filter support to cipher search page
- [SG-356] Pre-select org when creating new cipher from org-filtered list

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **GroupingsPage.xaml:** Updated button style
* **GroupingsPage.xaml.cs:** Pass selected org ID to `AddEditPage`
* **GroupingsPageViewModel.cs:** Make `GetVaultFilterOrgId()` public
* **AddEditPage.xaml.cs:** Add support for `organizationId` in constructor
* **CiphersPage.xaml/xaml.cs/ViewModel.cs:** Added UI & logic for displaying & handling vault filter options & selection
* **Base.xaml:** Added new `list-row-button-text` style to fix color of vault filter button to match mocks

## Before you submit
- [ ] I have checked for formatting errors (`dotnet tool run dotnet-format --check`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)


[SG-362]: https://bitwarden.atlassian.net/browse/SG-362?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SG-356]: https://bitwarden.atlassian.net/browse/SG-356?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ