### PR TITLE
Clipboard handling adjustments for Android 13

### DIFF
--- a/src/Android/MainApplication.cs
+++ b/src/Android/MainApplication.cs
@@ -12,7 +12,6 @@ using Bit.Core.Abstractions;
 using Bit.Core.Services;
 using Bit.Core.Utilities;
 using Bit.Droid.Services;
-using Bit.Droid.Utilities;
 using Plugin.CurrentActivity;
 using Plugin.Fingerprint;
 using Xamarin.Android.Net;
@@ -134,7 +133,8 @@ namespace Bit.Droid
             var stateService = new StateService(mobileStorageService, secureStorageService);
             var stateMigrationService =
                 new StateMigrationService(liteDbStorage, preferencesStorage, secureStorageService);
-            var deviceActionService = new DeviceActionService(stateService, messagingService,
+            var clipboardService = new ClipboardService(stateService);
+            var deviceActionService = new DeviceActionService(clipboardService, stateService, messagingService,
                 broadcasterService, () => ServiceContainer.Resolve<IEventService>("eventService"));
             var platformUtilsService = new MobilePlatformUtilsService(deviceActionService, messagingService,
                 broadcasterService);
@@ -152,7 +152,7 @@ namespace Bit.Droid
             ServiceContainer.Register<IStorageService>("secureStorageService", secureStorageService);
             ServiceContainer.Register<IStateService>("stateService", stateService);
             ServiceContainer.Register<IStateMigrationService>("stateMigrationService", stateMigrationService);
-            ServiceContainer.Register<IClipboardService>("clipboardService", new ClipboardService(stateService));
+            ServiceContainer.Register<IClipboardService>("clipboardService", clipboardService);
             ServiceContainer.Register<IDeviceActionService>("deviceActionService", deviceActionService);
             ServiceContainer.Register<IPlatformUtilsService>("platformUtilsService", platformUtilsService);
             ServiceContainer.Register<IBiometricService>("biometricService", biometricService);

--- a/src/Android/MainApplication.cs
+++ b/src/Android/MainApplication.cs
@@ -136,8 +136,8 @@ namespace Bit.Droid
             var clipboardService = new ClipboardService(stateService);
             var deviceActionService = new DeviceActionService(clipboardService, stateService, messagingService,
                 broadcasterService, () => ServiceContainer.Resolve<IEventService>("eventService"));
-            var platformUtilsService = new MobilePlatformUtilsService(deviceActionService, messagingService,
-                broadcasterService);
+            var platformUtilsService = new MobilePlatformUtilsService(deviceActionService, clipboardService,
+                messagingService, broadcasterService);
             var biometricService = new BiometricService();
             var cryptoFunctionService = new PclCryptoFunctionService(cryptoPrimitiveService);
             var cryptoService = new CryptoService(stateService, cryptoFunctionService);

--- a/src/Android/Services/ClipboardService.cs
+++ b/src/Android/Services/ClipboardService.cs
@@ -41,7 +41,7 @@ namespace Bit.Droid.Services
             await ClearClipboardAlarmAsync(expiresInMs);
         }
 
-        public bool CopyNotificationHandledByOs()
+        public bool IsCopyNotificationHandledByPlatform()
         {
             // Android 13+ provides built-in notification when text is copied to the clipboard
             return (int)Build.VERSION.SdkInt >= 33;

--- a/src/Android/Services/ClipboardService.cs
+++ b/src/Android/Services/ClipboardService.cs
@@ -2,7 +2,7 @@
 using System.Threading.Tasks;
 using Android.App;
 using Android.Content;
-using Bit.Core;
+using Android.OS;
 using Bit.Core.Abstractions;
 using Bit.Droid.Receivers;
 using Plugin.CurrentActivity;
@@ -26,11 +26,39 @@ namespace Bit.Droid.Services
                                            PendingIntentFlags.UpdateCurrent));
         }
 
-        public async Task CopyTextAsync(string text, int expiresInMs = -1)
+        public async Task CopyTextAsync(string text, int expiresInMs = -1, bool isSensitive = true)
         {
-            await Clipboard.SetTextAsync(text);
+             // Xamarin.Essentials.Clipboard currently doesn't support the IS_SENSITIVE flag for API 33+
+            if ((int)Build.VERSION.SdkInt < 33)
+            {
+                await Clipboard.SetTextAsync(text);
+            }
+            else
+            {
+                CopyToClipboard(text, isSensitive);
+            }
 
             await ClearClipboardAlarmAsync(expiresInMs);
+        }
+
+        public bool CopyNotificationHandledByOs()
+        {
+            // Android 13+ provides built-in notification when text is copied to the clipboard
+            return (int)Build.VERSION.SdkInt >= 33;
+        }
+
+        private void CopyToClipboard(string text, bool isSensitive = true)
+        {
+            var activity = (MainActivity)CrossCurrentActivity.Current.Activity;
+            var clipboardManager = activity.GetSystemService(
+                Context.ClipboardService) as Android.Content.ClipboardManager;
+            var clipData = ClipData.NewPlainText("bitwarden", text);
+            if (isSensitive)
+            {
+                clipData.Description.Extras ??= new PersistableBundle();
+                clipData.Description.Extras.PutBoolean("android.content.extra.IS_SENSITIVE", true);
+            }
+            clipboardManager.PrimaryClip = clipData;
         }
 
         private async Task ClearClipboardAlarmAsync(int expiresInMs = -1)

--- a/src/Android/Services/DeviceActionService.cs
+++ b/src/Android/Services/DeviceActionService.cs
@@ -35,6 +35,7 @@ namespace Bit.Droid.Services
 {
     public class DeviceActionService : IDeviceActionService
     {
+        private readonly IClipboardService _clipboardService;
         private readonly IStateService _stateService;
         private readonly IMessagingService _messagingService;
         private readonly IBroadcasterService _broadcasterService;
@@ -47,11 +48,13 @@ namespace Bit.Droid.Services
         private string _userAgent;
 
         public DeviceActionService(
+            IClipboardService clipboardService,
             IStateService stateService,
             IMessagingService messagingService,
             IBroadcasterService broadcasterService,
             Func<IEventService> eventServiceFunc)
         {
+            _clipboardService = clipboardService;
             _stateService = stateService;
             _messagingService = messagingService;
             _broadcasterService = broadcasterService;
@@ -929,18 +932,10 @@ namespace Bit.Droid.Services
                     var totp = await totpService.GetCodeAsync(cipher.Login.Totp);
                     if (totp != null)
                     {
-                        CopyToClipboard(totp);
+                        await _clipboardService.CopyTextAsync(totp);
                     }
                 }
             }
-        }
-
-        private void CopyToClipboard(string text)
-        {
-            var activity = (MainActivity)CrossCurrentActivity.Current.Activity;
-            var clipboardManager = activity.GetSystemService(
-                Context.ClipboardService) as Android.Content.ClipboardManager;
-            clipboardManager.PrimaryClip = ClipData.NewPlainText("bitwarden", text);
         }
 
         public float GetSystemFontSizeScale()

--- a/src/App/Pages/Generator/GeneratorHistoryPageViewModel.cs
+++ b/src/App/Pages/Generator/GeneratorHistoryPageViewModel.cs
@@ -1,7 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Threading.Tasks;
 using Bit.App.Resources;
-using Bit.App.Utilities;
 using Bit.Core.Abstractions;
 using Bit.Core.Models.Domain;
 using Bit.Core.Utilities;
@@ -59,7 +58,7 @@ namespace Bit.App.Pages
         private async void CopyAsync(GeneratedPasswordHistory ph)
         {
             await _clipboardService.CopyTextAsync(ph.Password);
-            AppHelpers.ShowToastForCopiedValue(_platformUtilsService, _clipboardService, AppResources.Password);
+            _platformUtilsService.ShowToastForCopiedValue(AppResources.Password);
         }
 
         public async Task UpdateOnThemeChanged()

--- a/src/App/Pages/Generator/GeneratorHistoryPageViewModel.cs
+++ b/src/App/Pages/Generator/GeneratorHistoryPageViewModel.cs
@@ -58,8 +58,11 @@ namespace Bit.App.Pages
         private async void CopyAsync(GeneratedPasswordHistory ph)
         {
             await _clipboardService.CopyTextAsync(ph.Password);
-            _platformUtilsService.ShowToast("info", null,
+            if (!_clipboardService.CopyNotificationHandledByOs())
+            {
+                _platformUtilsService.ShowToast("info", null,
                 string.Format(AppResources.ValueHasBeenCopied, AppResources.Password));
+            }
         }
 
         public async Task UpdateOnThemeChanged()

--- a/src/App/Pages/Generator/GeneratorHistoryPageViewModel.cs
+++ b/src/App/Pages/Generator/GeneratorHistoryPageViewModel.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Threading.Tasks;
 using Bit.App.Resources;
+using Bit.App.Utilities;
 using Bit.Core.Abstractions;
 using Bit.Core.Models.Domain;
 using Bit.Core.Utilities;
@@ -58,11 +59,7 @@ namespace Bit.App.Pages
         private async void CopyAsync(GeneratedPasswordHistory ph)
         {
             await _clipboardService.CopyTextAsync(ph.Password);
-            if (!_clipboardService.CopyNotificationHandledByOs())
-            {
-                _platformUtilsService.ShowToast("info", null,
-                string.Format(AppResources.ValueHasBeenCopied, AppResources.Password));
-            }
+            AppHelpers.ShowToastForCopiedValue(_platformUtilsService, _clipboardService, AppResources.Password);
         }
 
         public async Task UpdateOnThemeChanged()

--- a/src/App/Pages/Generator/GeneratorPageViewModel.cs
+++ b/src/App/Pages/Generator/GeneratorPageViewModel.cs
@@ -319,8 +319,11 @@ namespace Bit.App.Pages
         public async Task CopyAsync()
         {
             await _clipboardService.CopyTextAsync(Password);
-            _platformUtilsService.ShowToast("success", null,
-                string.Format(AppResources.ValueHasBeenCopied, AppResources.Password));
+            if (!_clipboardService.CopyNotificationHandledByOs())
+            {
+                _platformUtilsService.ShowToast("success", null,
+                    string.Format(AppResources.ValueHasBeenCopied, AppResources.Password));
+            }
         }
 
         private void LoadFromOptions()

--- a/src/App/Pages/Generator/GeneratorPageViewModel.cs
+++ b/src/App/Pages/Generator/GeneratorPageViewModel.cs
@@ -5,7 +5,6 @@ using Bit.App.Utilities;
 using Bit.Core.Abstractions;
 using Bit.Core.Models.Domain;
 using Bit.Core.Utilities;
-using Xamarin.Forms;
 
 namespace Bit.App.Pages
 {
@@ -319,7 +318,7 @@ namespace Bit.App.Pages
         public async Task CopyAsync()
         {
             await _clipboardService.CopyTextAsync(Password);
-            AppHelpers.ShowToastForCopiedValue(_platformUtilsService, _clipboardService, AppResources.Password);
+            _platformUtilsService.ShowToastForCopiedValue(AppResources.Password);
         }
 
         private void LoadFromOptions()

--- a/src/App/Pages/Generator/GeneratorPageViewModel.cs
+++ b/src/App/Pages/Generator/GeneratorPageViewModel.cs
@@ -319,11 +319,7 @@ namespace Bit.App.Pages
         public async Task CopyAsync()
         {
             await _clipboardService.CopyTextAsync(Password);
-            if (!_clipboardService.CopyNotificationHandledByOs())
-            {
-                _platformUtilsService.ShowToast("success", null,
-                    string.Format(AppResources.ValueHasBeenCopied, AppResources.Password));
-            }
+            AppHelpers.ShowToastForCopiedValue(_platformUtilsService, _clipboardService, AppResources.Password);
         }
 
         private void LoadFromOptions()

--- a/src/App/Pages/Vault/PasswordHistoryPageViewModel.cs
+++ b/src/App/Pages/Vault/PasswordHistoryPageViewModel.cs
@@ -1,7 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Threading.Tasks;
 using Bit.App.Resources;
-using Bit.App.Utilities;
 using Bit.Core.Abstractions;
 using Bit.Core.Models.View;
 using Bit.Core.Utilities;
@@ -52,7 +51,7 @@ namespace Bit.App.Pages
         private async void CopyAsync(PasswordHistoryView ph)
         {
             await _clipboardService.CopyTextAsync(ph.Password);
-            AppHelpers.ShowToastForCopiedValue(_platformUtilsService, _clipboardService, AppResources.Password);
+            _platformUtilsService.ShowToastForCopiedValue(AppResources.Password);
         }
     }
 }

--- a/src/App/Pages/Vault/PasswordHistoryPageViewModel.cs
+++ b/src/App/Pages/Vault/PasswordHistoryPageViewModel.cs
@@ -51,8 +51,11 @@ namespace Bit.App.Pages
         private async void CopyAsync(PasswordHistoryView ph)
         {
             await _clipboardService.CopyTextAsync(ph.Password);
-            _platformUtilsService.ShowToast("info", null,
-                string.Format(AppResources.ValueHasBeenCopied, AppResources.Password));
+            if (!_clipboardService.CopyNotificationHandledByOs())
+            {
+                _platformUtilsService.ShowToast("info", null,
+                    string.Format(AppResources.ValueHasBeenCopied, AppResources.Password));
+            }
         }
     }
 }

--- a/src/App/Pages/Vault/PasswordHistoryPageViewModel.cs
+++ b/src/App/Pages/Vault/PasswordHistoryPageViewModel.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Threading.Tasks;
 using Bit.App.Resources;
+using Bit.App.Utilities;
 using Bit.Core.Abstractions;
 using Bit.Core.Models.View;
 using Bit.Core.Utilities;
@@ -51,11 +52,7 @@ namespace Bit.App.Pages
         private async void CopyAsync(PasswordHistoryView ph)
         {
             await _clipboardService.CopyTextAsync(ph.Password);
-            if (!_clipboardService.CopyNotificationHandledByOs())
-            {
-                _platformUtilsService.ShowToast("info", null,
-                    string.Format(AppResources.ValueHasBeenCopied, AppResources.Password));
-            }
+            AppHelpers.ShowToastForCopiedValue(_platformUtilsService, _clipboardService, AppResources.Password);
         }
     }
 }

--- a/src/App/Pages/Vault/ViewPageViewModel.cs
+++ b/src/App/Pages/Vault/ViewPageViewModel.cs
@@ -663,7 +663,7 @@ namespace Bit.App.Pages
                 await _clipboardService.CopyTextAsync(text);
                 if (!string.IsNullOrWhiteSpace(name))
                 {
-                    AppHelpers.ShowToastForCopiedValue(_platformUtilsService, _clipboardService, name);
+                    _platformUtilsService.ShowToastForCopiedValue(name);
                 }
                 if (id == "LoginPassword")
                 {

--- a/src/App/Pages/Vault/ViewPageViewModel.cs
+++ b/src/App/Pages/Vault/ViewPageViewModel.cs
@@ -661,9 +661,9 @@ namespace Bit.App.Pages
             if (text != null)
             {
                 await _clipboardService.CopyTextAsync(text);
-                if (!_clipboardService.CopyNotificationHandledByOs() && !string.IsNullOrWhiteSpace(name))
+                if (!string.IsNullOrWhiteSpace(name))
                 {
-                    _platformUtilsService.ShowToast("info", null, string.Format(AppResources.ValueHasBeenCopied, name));
+                    AppHelpers.ShowToastForCopiedValue(_platformUtilsService, _clipboardService, name);
                 }
                 if (id == "LoginPassword")
                 {

--- a/src/App/Pages/Vault/ViewPageViewModel.cs
+++ b/src/App/Pages/Vault/ViewPageViewModel.cs
@@ -661,7 +661,7 @@ namespace Bit.App.Pages
             if (text != null)
             {
                 await _clipboardService.CopyTextAsync(text);
-                if (!string.IsNullOrWhiteSpace(name))
+                if (!_clipboardService.CopyNotificationHandledByOs() && !string.IsNullOrWhiteSpace(name))
                 {
                     _platformUtilsService.ShowToast("info", null, string.Format(AppResources.ValueHasBeenCopied, name));
                 }

--- a/src/App/Services/MobilePlatformUtilsService.cs
+++ b/src/App/Services/MobilePlatformUtilsService.cs
@@ -20,6 +20,7 @@ namespace Bit.App.Services
         private const int DialogPromiseExpiration = 600000; // 10 minutes
 
         private readonly IDeviceActionService _deviceActionService;
+        private readonly IClipboardService _clipboardService;
         private readonly IMessagingService _messagingService;
         private readonly IBroadcasterService _broadcasterService;
 
@@ -28,10 +29,12 @@ namespace Bit.App.Services
 
         public MobilePlatformUtilsService(
             IDeviceActionService deviceActionService,
+            IClipboardService clipboardService,
             IMessagingService messagingService,
             IBroadcasterService broadcasterService)
         {
             _deviceActionService = deviceActionService;
+            _clipboardService = clipboardService;
             _messagingService = messagingService;
             _broadcasterService = broadcasterService;
         }
@@ -127,6 +130,15 @@ namespace Bit.App.Services
         public bool SupportsDuo()
         {
             return true;
+        }
+
+        public void ShowToastForCopiedValue(string valueNameCopied)
+        {
+            if (!_clipboardService.IsCopyNotificationHandledByPlatform())
+            {
+                ShowToast("info", null,
+                    string.Format(AppResources.ValueHasBeenCopied, valueNameCopied));
+            }
         }
 
         public bool SupportsFido2()

--- a/src/App/Utilities/AppHelpers.cs
+++ b/src/App/Utilities/AppHelpers.cs
@@ -97,22 +97,14 @@ namespace Bit.App.Utilities
             else if (selection == AppResources.CopyUsername)
             {
                 await clipboardService.CopyTextAsync(cipher.Login.Username);
-                if (!clipboardService.CopyNotificationHandledByOs())
-                {
-                    platformUtilsService.ShowToast("info", null,
-                        string.Format(AppResources.ValueHasBeenCopied, AppResources.Username));
-                }
+                ShowToastForCopiedValue(platformUtilsService, clipboardService, AppResources.Username);
             }
             else if (selection == AppResources.CopyPassword)
             {
                 if (cipher.Reprompt == CipherRepromptType.None || await passwordRepromptService.ShowPasswordPromptAsync())
                 {
                     await clipboardService.CopyTextAsync(cipher.Login.Password);
-                    if (!clipboardService.CopyNotificationHandledByOs())
-                    {
-                        platformUtilsService.ShowToast("info", null,
-                            string.Format(AppResources.ValueHasBeenCopied, AppResources.Password));
-                    }
+                    ShowToastForCopiedValue(platformUtilsService, clipboardService, AppResources.Password);
                     var task = eventService.CollectAsync(Core.Enums.EventType.Cipher_ClientCopiedPassword, cipher.Id);
                 }
             }
@@ -125,11 +117,7 @@ namespace Bit.App.Utilities
                     if (!string.IsNullOrWhiteSpace(totp))
                     {
                         await clipboardService.CopyTextAsync(totp);
-                        if (!clipboardService.CopyNotificationHandledByOs())
-                        {
-                            platformUtilsService.ShowToast("info", null,
-                                string.Format(AppResources.ValueHasBeenCopied, AppResources.VerificationCodeTotp));
-                        }
+                        ShowToastForCopiedValue(platformUtilsService, clipboardService, AppResources.VerificationCodeTotp);
                     }
                 }
             }
@@ -142,11 +130,7 @@ namespace Bit.App.Utilities
                 if (cipher.Reprompt == CipherRepromptType.None || await passwordRepromptService.ShowPasswordPromptAsync())
                 {
                     await clipboardService.CopyTextAsync(cipher.Card.Number);
-                    if (!clipboardService.CopyNotificationHandledByOs())
-                    {
-                        platformUtilsService.ShowToast("info", null,
-                            string.Format(AppResources.ValueHasBeenCopied, AppResources.Number));
-                    }
+                    ShowToastForCopiedValue(platformUtilsService, clipboardService, AppResources.Number);
                 }
             }
             else if (selection == AppResources.CopySecurityCode)
@@ -154,22 +138,14 @@ namespace Bit.App.Utilities
                 if (cipher.Reprompt == CipherRepromptType.None || await passwordRepromptService.ShowPasswordPromptAsync())
                 {
                     await clipboardService.CopyTextAsync(cipher.Card.Code);
-                    if (!clipboardService.CopyNotificationHandledByOs())
-                    {
-                        platformUtilsService.ShowToast("info", null,
-                            string.Format(AppResources.ValueHasBeenCopied, AppResources.SecurityCode));
-                    }
+                    ShowToastForCopiedValue(platformUtilsService, clipboardService, AppResources.SecurityCode);
                     var task = eventService.CollectAsync(Core.Enums.EventType.Cipher_ClientCopiedCardCode, cipher.Id);
                 }
             }
             else if (selection == AppResources.CopyNotes)
             {
                 await clipboardService.CopyTextAsync(cipher.Notes);
-                if (!clipboardService.CopyNotificationHandledByOs())
-                {
-                    platformUtilsService.ShowToast("info", null,
-                        string.Format(AppResources.ValueHasBeenCopied, AppResources.Notes));
-                }
+                ShowToastForCopiedValue(platformUtilsService, clipboardService, AppResources.Notes);
             }
             return selection;
         }
@@ -280,10 +256,16 @@ namespace Bit.App.Utilities
             var platformUtilsService = ServiceContainer.Resolve<IPlatformUtilsService>("platformUtilsService");
             var clipboardService = ServiceContainer.Resolve<IClipboardService>("clipboardService");
             await clipboardService.CopyTextAsync(GetSendUrl(send));
-            if (!clipboardService.CopyNotificationHandledByOs())
+            ShowToastForCopiedValue(platformUtilsService, clipboardService, AppResources.SendLink);
+        }
+
+        public static void ShowToastForCopiedValue(IPlatformUtilsService platformUtilsService,
+            IClipboardService clipboardService, string valueNameCopied)
+        {
+            if (!clipboardService.IsCopyNotificationHandledByPlatform())
             {
                 platformUtilsService.ShowToast("info", null,
-                    string.Format(AppResources.ValueHasBeenCopied, AppResources.SendLink));
+                    string.Format(AppResources.ValueHasBeenCopied, valueNameCopied));
             }
         }
 

--- a/src/App/Utilities/AppHelpers.cs
+++ b/src/App/Utilities/AppHelpers.cs
@@ -97,14 +97,14 @@ namespace Bit.App.Utilities
             else if (selection == AppResources.CopyUsername)
             {
                 await clipboardService.CopyTextAsync(cipher.Login.Username);
-                ShowToastForCopiedValue(platformUtilsService, clipboardService, AppResources.Username);
+                platformUtilsService.ShowToastForCopiedValue(AppResources.Username);
             }
             else if (selection == AppResources.CopyPassword)
             {
                 if (cipher.Reprompt == CipherRepromptType.None || await passwordRepromptService.ShowPasswordPromptAsync())
                 {
                     await clipboardService.CopyTextAsync(cipher.Login.Password);
-                    ShowToastForCopiedValue(platformUtilsService, clipboardService, AppResources.Password);
+                    platformUtilsService.ShowToastForCopiedValue(AppResources.Password);
                     var task = eventService.CollectAsync(Core.Enums.EventType.Cipher_ClientCopiedPassword, cipher.Id);
                 }
             }
@@ -117,7 +117,7 @@ namespace Bit.App.Utilities
                     if (!string.IsNullOrWhiteSpace(totp))
                     {
                         await clipboardService.CopyTextAsync(totp);
-                        ShowToastForCopiedValue(platformUtilsService, clipboardService, AppResources.VerificationCodeTotp);
+                        platformUtilsService.ShowToastForCopiedValue(AppResources.VerificationCodeTotp);
                     }
                 }
             }
@@ -130,7 +130,7 @@ namespace Bit.App.Utilities
                 if (cipher.Reprompt == CipherRepromptType.None || await passwordRepromptService.ShowPasswordPromptAsync())
                 {
                     await clipboardService.CopyTextAsync(cipher.Card.Number);
-                    ShowToastForCopiedValue(platformUtilsService, clipboardService, AppResources.Number);
+                    platformUtilsService.ShowToastForCopiedValue(AppResources.Number);
                 }
             }
             else if (selection == AppResources.CopySecurityCode)
@@ -138,14 +138,14 @@ namespace Bit.App.Utilities
                 if (cipher.Reprompt == CipherRepromptType.None || await passwordRepromptService.ShowPasswordPromptAsync())
                 {
                     await clipboardService.CopyTextAsync(cipher.Card.Code);
-                    ShowToastForCopiedValue(platformUtilsService, clipboardService, AppResources.SecurityCode);
+                    platformUtilsService.ShowToastForCopiedValue(AppResources.SecurityCode);
                     var task = eventService.CollectAsync(Core.Enums.EventType.Cipher_ClientCopiedCardCode, cipher.Id);
                 }
             }
             else if (selection == AppResources.CopyNotes)
             {
                 await clipboardService.CopyTextAsync(cipher.Notes);
-                ShowToastForCopiedValue(platformUtilsService, clipboardService, AppResources.Notes);
+                platformUtilsService.ShowToastForCopiedValue(AppResources.Notes);
             }
             return selection;
         }
@@ -256,17 +256,7 @@ namespace Bit.App.Utilities
             var platformUtilsService = ServiceContainer.Resolve<IPlatformUtilsService>("platformUtilsService");
             var clipboardService = ServiceContainer.Resolve<IClipboardService>("clipboardService");
             await clipboardService.CopyTextAsync(GetSendUrl(send));
-            ShowToastForCopiedValue(platformUtilsService, clipboardService, AppResources.SendLink);
-        }
-
-        public static void ShowToastForCopiedValue(IPlatformUtilsService platformUtilsService,
-            IClipboardService clipboardService, string valueNameCopied)
-        {
-            if (!clipboardService.IsCopyNotificationHandledByPlatform())
-            {
-                platformUtilsService.ShowToast("info", null,
-                    string.Format(AppResources.ValueHasBeenCopied, valueNameCopied));
-            }
+            platformUtilsService.ShowToastForCopiedValue(AppResources.SendLink);
         }
 
         public static async Task ShareSendUrlAsync(SendView send)

--- a/src/App/Utilities/AppHelpers.cs
+++ b/src/App/Utilities/AppHelpers.cs
@@ -97,16 +97,22 @@ namespace Bit.App.Utilities
             else if (selection == AppResources.CopyUsername)
             {
                 await clipboardService.CopyTextAsync(cipher.Login.Username);
-                platformUtilsService.ShowToast("info", null,
-                    string.Format(AppResources.ValueHasBeenCopied, AppResources.Username));
+                if (!clipboardService.CopyNotificationHandledByOs())
+                {
+                    platformUtilsService.ShowToast("info", null,
+                        string.Format(AppResources.ValueHasBeenCopied, AppResources.Username));
+                }
             }
             else if (selection == AppResources.CopyPassword)
             {
                 if (cipher.Reprompt == CipherRepromptType.None || await passwordRepromptService.ShowPasswordPromptAsync())
                 {
                     await clipboardService.CopyTextAsync(cipher.Login.Password);
-                    platformUtilsService.ShowToast("info", null,
-                        string.Format(AppResources.ValueHasBeenCopied, AppResources.Password));
+                    if (!clipboardService.CopyNotificationHandledByOs())
+                    {
+                        platformUtilsService.ShowToast("info", null,
+                            string.Format(AppResources.ValueHasBeenCopied, AppResources.Password));
+                    }
                     var task = eventService.CollectAsync(Core.Enums.EventType.Cipher_ClientCopiedPassword, cipher.Id);
                 }
             }
@@ -119,8 +125,11 @@ namespace Bit.App.Utilities
                     if (!string.IsNullOrWhiteSpace(totp))
                     {
                         await clipboardService.CopyTextAsync(totp);
-                        platformUtilsService.ShowToast("info", null,
-                            string.Format(AppResources.ValueHasBeenCopied, AppResources.VerificationCodeTotp));
+                        if (!clipboardService.CopyNotificationHandledByOs())
+                        {
+                            platformUtilsService.ShowToast("info", null,
+                                string.Format(AppResources.ValueHasBeenCopied, AppResources.VerificationCodeTotp));
+                        }
                     }
                 }
             }
@@ -133,8 +142,11 @@ namespace Bit.App.Utilities
                 if (cipher.Reprompt == CipherRepromptType.None || await passwordRepromptService.ShowPasswordPromptAsync())
                 {
                     await clipboardService.CopyTextAsync(cipher.Card.Number);
-                    platformUtilsService.ShowToast("info", null,
-                        string.Format(AppResources.ValueHasBeenCopied, AppResources.Number));
+                    if (!clipboardService.CopyNotificationHandledByOs())
+                    {
+                        platformUtilsService.ShowToast("info", null,
+                            string.Format(AppResources.ValueHasBeenCopied, AppResources.Number));
+                    }
                 }
             }
             else if (selection == AppResources.CopySecurityCode)
@@ -142,16 +154,22 @@ namespace Bit.App.Utilities
                 if (cipher.Reprompt == CipherRepromptType.None || await passwordRepromptService.ShowPasswordPromptAsync())
                 {
                     await clipboardService.CopyTextAsync(cipher.Card.Code);
-                    platformUtilsService.ShowToast("info", null,
-                        string.Format(AppResources.ValueHasBeenCopied, AppResources.SecurityCode));
+                    if (!clipboardService.CopyNotificationHandledByOs())
+                    {
+                        platformUtilsService.ShowToast("info", null,
+                            string.Format(AppResources.ValueHasBeenCopied, AppResources.SecurityCode));
+                    }
                     var task = eventService.CollectAsync(Core.Enums.EventType.Cipher_ClientCopiedCardCode, cipher.Id);
                 }
             }
             else if (selection == AppResources.CopyNotes)
             {
                 await clipboardService.CopyTextAsync(cipher.Notes);
-                platformUtilsService.ShowToast("info", null,
-                    string.Format(AppResources.ValueHasBeenCopied, AppResources.Notes));
+                if (!clipboardService.CopyNotificationHandledByOs())
+                {
+                    platformUtilsService.ShowToast("info", null,
+                        string.Format(AppResources.ValueHasBeenCopied, AppResources.Notes));
+                }
             }
             return selection;
         }
@@ -262,8 +280,11 @@ namespace Bit.App.Utilities
             var platformUtilsService = ServiceContainer.Resolve<IPlatformUtilsService>("platformUtilsService");
             var clipboardService = ServiceContainer.Resolve<IClipboardService>("clipboardService");
             await clipboardService.CopyTextAsync(GetSendUrl(send));
-            platformUtilsService.ShowToast("info", null,
-                string.Format(AppResources.ValueHasBeenCopied, AppResources.SendLink));
+            if (!clipboardService.CopyNotificationHandledByOs())
+            {
+                platformUtilsService.ShowToast("info", null,
+                    string.Format(AppResources.ValueHasBeenCopied, AppResources.SendLink));
+            }
         }
 
         public static async Task ShareSendUrlAsync(SendView send)

--- a/src/Core/Abstractions/IClipboardService.cs
+++ b/src/Core/Abstractions/IClipboardService.cs
@@ -17,8 +17,8 @@ namespace Bit.Core.Abstractions
         Task CopyTextAsync(string text, int expiresInMs = -1, bool isSensitive = true);
 
         /// <summary>
-        /// Returns true if the OS provides its own notification when text is copied to the clipboard
+        /// Returns true if the platform provides its own notification when text is copied to the clipboard
         /// </summary>
-        bool CopyNotificationHandledByOs();
+        bool IsCopyNotificationHandledByPlatform();
     }
 }

--- a/src/Core/Abstractions/IClipboardService.cs
+++ b/src/Core/Abstractions/IClipboardService.cs
@@ -8,9 +8,17 @@ namespace Bit.Core.Abstractions
         /// Copies the <paramref name="text"/> to the Clipboard.
         /// If <paramref name="expiresInMs"/> is set > 0 then the Clipboard will be cleared after this time in milliseconds.
         /// if less than 0 then it takes the configuration that the user set in Options.
+        /// If <paramref name="isSensitive"/> is true the sensitive flag is passed to the clipdata to obfuscate the
+        /// clipboard text in the popup (Android 13+ only)
         /// </summary>
         /// <param name="text">Text to be copied to the Clipboard</param>
         /// <param name="expiresInMs">Expiration time in milliseconds of the copied text</param>
-        Task CopyTextAsync(string text, int expiresInMs = -1);
+        /// <param name="isSensitive">Flag to mark copied text as sensitive</param>
+        Task CopyTextAsync(string text, int expiresInMs = -1, bool isSensitive = true);
+
+        /// <summary>
+        /// Returns true if the OS provides its own notification when text is copied to the clipboard
+        /// </summary>
+        bool CopyNotificationHandledByOs();
     }
 }

--- a/src/Core/Abstractions/IPlatformUtilsService.cs
+++ b/src/Core/Abstractions/IPlatformUtilsService.cs
@@ -23,6 +23,7 @@ namespace Bit.Core.Abstractions
         Task<(string password, bool valid)> ShowPasswordDialogAndGetItAsync(string title, string body, Func<string, Task<bool>> validator);
         void ShowToast(string type, string title, string text, Dictionary<string, object> options = null);
         void ShowToast(string type, string title, string[] text, Dictionary<string, object> options = null);
+        void ShowToastForCopiedValue(string valueNameCopied);
         bool SupportsFido2();
         bool SupportsDuo();
         Task<bool> SupportsBiometricAsync();

--- a/src/iOS.Core/Services/ClipboardService.cs
+++ b/src/iOS.Core/Services/ClipboardService.cs
@@ -16,8 +16,10 @@ namespace Bit.iOS.Core.Services
             _stateService = stateService;
         }
 
-        public async Task CopyTextAsync(string text, int expiresInMs = -1)
+        public async Task CopyTextAsync(string text, int expiresInMs = -1, bool isSensitive = true)
         {
+            // isSensitive is only used by Android for now
+
             int clearSeconds = -1;
             if (expiresInMs < 0)
             {
@@ -35,6 +37,12 @@ namespace Bit.iOS.Core.Services
                 LocalOnly = true,
                 ExpirationDate = clearSeconds > 0 ? NSDate.FromTimeIntervalSinceNow(clearSeconds) : null
             }));
+        }
+
+        public bool CopyNotificationHandledByOs()
+        {
+            // return true for any future versions of iOS that notify the user when text is copied to the clipboard
+            return false;
         }
     }
 }

--- a/src/iOS.Core/Services/ClipboardService.cs
+++ b/src/iOS.Core/Services/ClipboardService.cs
@@ -39,7 +39,7 @@ namespace Bit.iOS.Core.Services
             }));
         }
 
-        public bool CopyNotificationHandledByOs()
+        public bool IsCopyNotificationHandledByPlatform()
         {
             // return true for any future versions of iOS that notify the user when text is copied to the clipboard
             return false;

--- a/src/iOS.Core/Utilities/iOSCoreHelpers.cs
+++ b/src/iOS.Core/Utilities/iOSCoreHelpers.cs
@@ -64,8 +64,8 @@ namespace Bit.iOS.Core.Utilities
                 new StateMigrationService(liteDbStorage, preferencesStorage, secureStorageService);
             var deviceActionService = new DeviceActionService(stateService, messagingService);
             var clipboardService = new ClipboardService(stateService);
-            var platformUtilsService = new MobilePlatformUtilsService(deviceActionService, messagingService,
-                broadcasterService);
+            var platformUtilsService = new MobilePlatformUtilsService(deviceActionService, clipboardService,
+                messagingService, broadcasterService);
             var biometricService = new BiometricService(mobileStorageService);
             var cryptoFunctionService = new PclCryptoFunctionService(cryptoPrimitiveService);
             var cryptoService = new CryptoService(stateService, cryptoFunctionService);


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Android 13 introduces some changes to clipboard behavior when copying text:
https://developer.android.com/about/versions/13/features/copy-paste

This PR does the following:
* Prevent toasts when copying text on Android 13+ so as to not conflict with the new indicator
* Pass the `IS_SENSITIVE` flag to the `ClipboardManager` to prevent showing copied text in the new popup in Android 13+

_**Note 1: Currently this can't be tested in the emulator as the latest image (at least for ARM64) is still internally returning `32` for the API version (should be `33`).  I installed the June 8 beta on a Pixel 4a for testing.**_

_**Note 2: As of the latest beta released yesterday (June 8) the OS behavior doesn't line up with the documented behavior (Instead of obfuscated dots in the popup it shows "Tap to view" which then shows the copied text in a separate clipboard viewer).  I'm unsure if the behavior is still in flux, or the documentation hasn't caught up, or my implementation isn't correct. Regardless these changes prevent copied content from appearing in the clear within the popup.  I'll continue to observe each new release in case that changes before Android 13 goes live.**_

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

Android:
* **ClipboardService.cs:** Added `isSensitive` arg to `CopyTextAsync` method, defaults to `true`.  Added `CopyNotificationHandledByOs` method to establish if the OS has built-in support for notifying the user when something is copied to the clipboard, used to prevent conflicting toasts
* **DeviceActionService.cs (Android):** Added `ClipboardService` for TOTP copying with the new handler (removed private method)
* **MainApplication.cs:** Adjustments to service initialization

iOS:
* **ClipboardService.cs:** Added `isSensitive` arg to `CopyTextAsync` method (unused w/ comment) and `CopyNotificationHandledByOs` method (with comment about future use)

General:
* **All other files:** Check if `CopyNotificationHandledByOs` before showing toasts when copying text to the clipboard

## Screenshots
<!--Required for any UI changes. Delete if not applicable-->

![01](https://user-images.githubusercontent.com/59324545/172939449-a85297c0-0aed-4378-af12-47884de5eb2d.png)


## Before you submit
- [X] I have checked for formatting errors (`dotnet tool run dotnet-format --check`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
