### PR TITLE
[SG-79] [SG-376] Fixed vault filter display issue when personal ownership policy enabled

### DIFF
--- a/src/Core/Services/PolicyService.cs
+++ b/src/Core/Services/PolicyService.cs
@@ -250,8 +250,7 @@ namespace Bit.Core.Services
         public async Task<bool> ShouldShowVaultFilterAsync()
         {
             var organizations = await _organizationService.GetAllAsync();
-            var personalOwnershipPolicyApplies = await PolicyAppliesToUser(PolicyType.PersonalOwnership);
-            return (organizations?.Any() ?? false) && !personalOwnershipPolicyApplies;
+            return organizations?.Any() ?? false;
         }
 
         private bool? GetPolicyBool(Policy policy, string key)


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Fixes issue where the vault filter wouldn't appear if any org a user is a member of has the Personal Ownership policy enabled


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **PolicyService.cs:** Removed personal ownership policy check from `ShouldShowVaultFilterAsync` method (originally added due to a misinterpretation of the original task on my part)


## Before you submit
- [X] I have checked for formatting errors (`dotnet tool run dotnet-format --check`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
