### PR TITLE
[SG-79] [SG-389] Additional logic around vault filter display

### DIFF
--- a/src/App/Pages/Vault/CiphersPageViewModel.cs
+++ b/src/App/Pages/Vault/CiphersPageViewModel.cs
@@ -46,9 +46,6 @@ namespace Bit.App.Pages
 
             Ciphers = new ExtendedObservableCollection<CipherView>();
             CipherOptionsCommand = new Command<CipherView>(CipherOptionsAsync);
-            VaultFilterCommand = new AsyncCommand(VaultFilterOptionsAsync,
-                onException: ex => _logger.Exception(ex),
-                allowsMultipleExecutions: false);
         }
 
         public Command CipherOptionsCommand { get; set; }
@@ -60,6 +57,7 @@ namespace Bit.App.Pages
         protected override ICipherService cipherService => _cipherService;
         protected override IPolicyService policyService => _policyService;
         protected override IOrganizationService organizationService => _organizationService;
+        protected override ILogger logger => _logger;
 
         public bool ShowNoData
         {

--- a/src/App/Pages/Vault/CiphersPageViewModel.cs
+++ b/src/App/Pages/Vault/CiphersPageViewModel.cs
@@ -3,13 +3,11 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Windows.Input;
 using Bit.App.Abstractions;
 using Bit.App.Resources;
 using Bit.Core.Abstractions;
 using Bit.Core.Enums;
 using Bit.Core.Exceptions;
-using Bit.Core.Models.Domain;
 using Bit.Core.Models.View;
 using Bit.Core.Utilities;
 using Xamarin.CommunityToolkit.ObjectModel;
@@ -17,7 +15,7 @@ using Xamarin.Forms;
 
 namespace Bit.App.Pages
 {
-    public class CiphersPageViewModel : BaseViewModel
+    public class CiphersPageViewModel : VaultFilterViewModel
     {
         private readonly IPlatformUtilsService _platformUtilsService;
         private readonly ICipherService _cipherService;
@@ -30,13 +28,9 @@ namespace Bit.App.Pages
         private CancellationTokenSource _searchCancellationTokenSource;
         private readonly ILogger _logger;
 
-        private bool _showVaultFilter;
-        private bool _hideMyVaultFilterOption;
-        private string _vaultFilterSelection;
         private bool _showNoData;
         private bool _showList;
         private bool _websiteIconsEnabled;
-        private List<Organization> _organizations;
 
         public CiphersPageViewModel()
         {
@@ -58,11 +52,14 @@ namespace Bit.App.Pages
         }
 
         public Command CipherOptionsCommand { get; set; }
-        public ICommand VaultFilterCommand { get; }
         public ExtendedObservableCollection<CipherView> Ciphers { get; set; }
         public Func<CipherView, bool> Filter { get; set; }
         public string AutofillUrl { get; set; }
         public bool Deleted { get; set; }
+
+        protected override ICipherService cipherService => _cipherService;
+        protected override IPolicyService policyService => _policyService;
+        protected override IOrganizationService organizationService => _organizationService;
 
         public bool ShowNoData
         {
@@ -81,23 +78,6 @@ namespace Bit.App.Pages
                 nameof(ShowSearchDirection)
             });
         }
-        public bool ShowVaultFilter
-        {
-            get => _showVaultFilter;
-            set => SetProperty(ref _showVaultFilter, value);
-        }
-        public string VaultFilterDescription
-        {
-            get
-            {
-                if (_vaultFilterSelection == null || _vaultFilterSelection == AppResources.AllVaults)
-                {
-                    return string.Format(AppResources.VaultFilterDescription, AppResources.All);
-                }
-                return string.Format(AppResources.VaultFilterDescription, _vaultFilterSelection);
-            }
-            set => SetProperty(ref _vaultFilterSelection, value);
-        }
 
         public bool ShowSearchDirection => !ShowList && !ShowNoData;
 
@@ -109,16 +89,7 @@ namespace Bit.App.Pages
 
         public async Task InitAsync()
         {
-            _organizations = await _organizationService.GetAllAsync();
-            ShowVaultFilter = await _policyService.ShouldShowVaultFilterAsync();
-            if (ShowVaultFilter)
-            {
-                _hideMyVaultFilterOption = await _policyService.PolicyAppliesToUser(PolicyType.PersonalOwnership);
-                if (_vaultFilterSelection == null)
-                {
-                    _vaultFilterSelection = AppResources.AllVaults;
-                }
-            }
+            await InitVaultFilterAsync();
             WebsiteIconsEnabled = !(await _stateService.GetDisableFaviconAsync()).GetValueOrDefault();
             PerformSearchIfPopulated();
         }
@@ -241,52 +212,9 @@ namespace Bit.App.Pages
             }
         }
 
-        private async Task VaultFilterOptionsAsync()
+        protected override async Task OnVaultFilterSelectedAsync()
         {
-            var options = new List<string> { AppResources.AllVaults };
-            if (!_hideMyVaultFilterOption)
-            {
-                options.Add(AppResources.MyVault);
-            }
-            if (_organizations.Any())
-            {
-                options.AddRange(_organizations.OrderBy(o => o.Name).Select(o => o.Name));
-            }
-            var selection = await Page.DisplayActionSheet(AppResources.FilterByVault, AppResources.Cancel, null,
-                options.ToArray());
-            if (selection == null || selection == AppResources.Cancel ||
-                (_vaultFilterSelection == null && selection == AppResources.AllVaults) ||
-                (_vaultFilterSelection != null && _vaultFilterSelection == selection))
-            {
-                return;
-            }
-            VaultFilterDescription = selection;
             PerformSearchIfPopulated();
-        }
-
-        private async Task<List<CipherView>> GetAllCiphersAsync()
-        {
-            var decCiphers = await _cipherService.GetAllDecryptedAsync();
-            if (IsVaultFilterMyVault)
-            {
-                return decCiphers.Where(c => c.OrganizationId == null).ToList();
-            }
-            if (IsVaultFilterOrgVault)
-            {
-                var orgId = GetVaultFilterOrgId();
-                return decCiphers.Where(c => c.OrganizationId == orgId).ToList();
-            }
-            return decCiphers;
-        }
-
-        private bool IsVaultFilterMyVault => _vaultFilterSelection == AppResources.MyVault;
-
-        private bool IsVaultFilterOrgVault => _vaultFilterSelection != AppResources.AllVaults &&
-                                              _vaultFilterSelection != AppResources.MyVault;
-
-        private string GetVaultFilterOrgId()
-        {
-            return _organizations?.FirstOrDefault(o => o.Name == _vaultFilterSelection)?.Id;
         }
 
         private async void CipherOptionsAsync(CipherView cipher)

--- a/src/App/Pages/Vault/GroupingsPage/GroupingsPageViewModel.cs
+++ b/src/App/Pages/Vault/GroupingsPage/GroupingsPageViewModel.cs
@@ -74,9 +74,6 @@ namespace Bit.App.Pages
                 await LoadAsync();
             });
             CipherOptionsCommand = new Command<CipherView>(CipherOptionsAsync);
-            VaultFilterCommand = new AsyncCommand(VaultFilterOptionsAsync,
-                onException: ex => _logger.Exception(ex),
-                allowsMultipleExecutions: false);
 
             AccountSwitchingOverlayViewModel = new AccountSwitchingOverlayViewModel(_stateService, _messagingService, _logger)
             {
@@ -107,6 +104,7 @@ namespace Bit.App.Pages
         protected override ICipherService cipherService => _cipherService;
         protected override IPolicyService policyService => _policyService;
         protected override IOrganizationService organizationService => _organizationService;
+        protected override ILogger logger => _logger;
 
         public bool Refreshing
         {

--- a/src/App/Pages/Vault/GroupingsPage/GroupingsPageViewModel.cs
+++ b/src/App/Pages/Vault/GroupingsPage/GroupingsPageViewModel.cs
@@ -31,6 +31,7 @@ namespace Bit.App.Pages
         private bool _websiteIconsEnabled;
         private bool _syncRefreshing;
         private bool _showVaultFilter;
+        private bool _hideMyVaultFilterOption;
         private string _vaultFilterSelection;
         private string _noDataText;
         private List<Organization> _organizations;
@@ -205,9 +206,13 @@ namespace Bit.App.Pages
             if (MainPage)
             {
                 ShowVaultFilter = await _policyService.ShouldShowVaultFilterAsync();
-                if (ShowVaultFilter && _vaultFilterSelection == null)
+                if (ShowVaultFilter)
                 {
-                    _vaultFilterSelection = AppResources.AllVaults;
+                    _hideMyVaultFilterOption = await _policyService.PolicyAppliesToUser(PolicyType.PersonalOwnership);
+                    if (_vaultFilterSelection == null)
+                    {
+                        _vaultFilterSelection = AppResources.AllVaults;
+                    }
                 }
                 PageTitle = ShowVaultFilter ? AppResources.Vaults : AppResources.MyVault;
             }
@@ -396,7 +401,11 @@ namespace Bit.App.Pages
 
         public async Task VaultFilterOptionsAsync()
         {
-            var options = new List<string> { AppResources.AllVaults, AppResources.MyVault };
+            var options = new List<string> { AppResources.AllVaults };
+            if (!_hideMyVaultFilterOption)
+            {
+                options.Add(AppResources.MyVault);
+            }
             if (_organizations.Any())
             {
                 options.AddRange(_organizations.OrderBy(o => o.Name).Select(o => o.Name));

--- a/src/App/Pages/VaultFilterViewModel.cs
+++ b/src/App/Pages/VaultFilterViewModel.cs
@@ -1,0 +1,109 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Windows.Input;
+using Bit.App.Resources;
+using Bit.Core.Abstractions;
+using Bit.Core.Enums;
+using Bit.Core.Models.Domain;
+using Bit.Core.Models.View;
+
+namespace Bit.App.Pages
+{
+    public abstract class VaultFilterViewModel : BaseViewModel
+    {
+        protected abstract ICipherService cipherService { get; }
+        protected abstract IPolicyService policyService { get; }
+        protected abstract IOrganizationService organizationService { get; }
+
+        protected bool _showVaultFilter;
+        protected bool _hideMyVaultFilterOption;
+        protected string _vaultFilterSelection;
+        protected List<Organization> _organizations;
+
+        public ICommand VaultFilterCommand { get; set; }
+
+        public bool ShowVaultFilter
+        {
+            get => _showVaultFilter;
+            set => SetProperty(ref _showVaultFilter, value);
+        }
+
+        public string VaultFilterDescription
+        {
+            get
+            {
+                if (_vaultFilterSelection == null || _vaultFilterSelection == AppResources.AllVaults)
+                {
+                    return string.Format(AppResources.VaultFilterDescription, AppResources.All);
+                }
+                return string.Format(AppResources.VaultFilterDescription, _vaultFilterSelection);
+            }
+            set => SetProperty(ref _vaultFilterSelection, value);
+        }
+
+        public string GetVaultFilterOrgId()
+        {
+            return _organizations?.FirstOrDefault(o => o.Name == _vaultFilterSelection)?.Id;
+        }
+
+        protected bool IsVaultFilterMyVault => _vaultFilterSelection == AppResources.MyVault;
+
+        protected bool IsVaultFilterOrgVault => _vaultFilterSelection != AppResources.AllVaults &&
+                                                _vaultFilterSelection != AppResources.MyVault;
+
+        protected async Task InitVaultFilterAsync()
+        {
+            _organizations = await organizationService.GetAllAsync();
+            ShowVaultFilter = await policyService.ShouldShowVaultFilterAsync();
+            if (ShowVaultFilter)
+            {
+                _hideMyVaultFilterOption = await policyService.PolicyAppliesToUser(PolicyType.PersonalOwnership);
+                if (_vaultFilterSelection == null)
+                {
+                    _vaultFilterSelection = AppResources.AllVaults;
+                }
+            }
+        }
+
+        protected async Task<List<CipherView>> GetAllCiphersAsync()
+        {
+            var decCiphers = await cipherService.GetAllDecryptedAsync();
+            if (IsVaultFilterMyVault)
+            {
+                return decCiphers.Where(c => c.OrganizationId == null).ToList();
+            }
+            if (IsVaultFilterOrgVault)
+            {
+                var orgId = GetVaultFilterOrgId();
+                return decCiphers.Where(c => c.OrganizationId == orgId).ToList();
+            }
+            return decCiphers;
+        }
+
+        protected async Task VaultFilterOptionsAsync()
+        {
+            var options = new List<string> { AppResources.AllVaults };
+            if (!_hideMyVaultFilterOption)
+            {
+                options.Add(AppResources.MyVault);
+            }
+            if (_organizations.Any())
+            {
+                options.AddRange(_organizations.OrderBy(o => o.Name).Select(o => o.Name));
+            }
+            var selection = await Page.DisplayActionSheet(AppResources.FilterByVault, AppResources.Cancel, null,
+                options.ToArray());
+            if (selection == null || selection == AppResources.Cancel ||
+                (_vaultFilterSelection == null && selection == AppResources.AllVaults) ||
+                (_vaultFilterSelection != null && _vaultFilterSelection == selection))
+            {
+                return;
+            }
+            VaultFilterDescription = selection;
+            await OnVaultFilterSelectedAsync();
+        }
+
+        protected abstract Task OnVaultFilterSelectedAsync();
+    }
+}

--- a/src/App/Pages/VaultFilterViewModel.cs
+++ b/src/App/Pages/VaultFilterViewModel.cs
@@ -7,6 +7,7 @@ using Bit.Core.Abstractions;
 using Bit.Core.Enums;
 using Bit.Core.Models.Domain;
 using Bit.Core.Models.View;
+using Xamarin.CommunityToolkit.ObjectModel;
 
 namespace Bit.App.Pages
 {
@@ -15,11 +16,19 @@ namespace Bit.App.Pages
         protected abstract ICipherService cipherService { get; }
         protected abstract IPolicyService policyService { get; }
         protected abstract IOrganizationService organizationService { get; }
+        protected abstract ILogger logger { get; }
 
         protected bool _showVaultFilter;
         protected bool _hideMyVaultFilterOption;
         protected string _vaultFilterSelection;
         protected List<Organization> _organizations;
+
+        public VaultFilterViewModel()
+        {
+            VaultFilterCommand = new AsyncCommand(VaultFilterOptionsAsync,
+                onException: ex => logger.Exception(ex),
+                allowsMultipleExecutions: false);
+        }
 
         public ICommand VaultFilterCommand { get; set; }
 

--- a/src/Core/Services/PolicyService.cs
+++ b/src/Core/Services/PolicyService.cs
@@ -249,6 +249,12 @@ namespace Bit.Core.Services
 
         public async Task<bool> ShouldShowVaultFilterAsync()
         {
+            var personalOwnershipPolicyApplies = await PolicyAppliesToUser(PolicyType.PersonalOwnership);
+            var singleOrgPolicyApplies = await PolicyAppliesToUser(PolicyType.OnlyOrg);
+            if (personalOwnershipPolicyApplies && singleOrgPolicyApplies)
+            {
+                return false;
+            }
             var organizations = await _organizationService.GetAllAsync();
             return organizations?.Any() ?? false;
         }


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
- Hide the "My Vault" option if the Personal Ownership Policy is enabled in an organization
- Hide the vault filters altogether if the Personal Ownership & Single Org policies are both enabled in an organization

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **GroupingsPageViewModel/CiphersPageViewModel.cs:** Added `_hideMyVaultFilterOption` bool based on `_policyService.PolicyAppliesToUser(PolicyType.PersonalOwnership)`
* **PolicyService.cs:** Added additional policy checks in `ShouldShowVaultFilterAsync()` method

## Before you submit
- [X] I have checked for formatting errors (`dotnet tool run dotnet-format --check`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
