### PR TITLE
[SG-386] iOS Update user state when coming from background

### DIFF
--- a/src/Android/MainApplication.cs
+++ b/src/Android/MainApplication.cs
@@ -130,7 +130,7 @@ namespace Bit.Droid
             var secureStorageService = new SecureStorageService();
             var cryptoPrimitiveService = new CryptoPrimitiveService();
             var mobileStorageService = new MobileStorageService(preferencesStorage, liteDbStorage);
-            var stateService = new StateService(mobileStorageService, secureStorageService);
+            var stateService = new StateService(mobileStorageService, secureStorageService, messagingService);
             var stateMigrationService =
                 new StateMigrationService(liteDbStorage, preferencesStorage, secureStorageService);
             var clipboardService = new ClipboardService(stateService);

--- a/src/App/App.xaml.cs
+++ b/src/App/App.xaml.cs
@@ -202,6 +202,7 @@ namespace Bit.App
 
         private async Task ResumedAsync()
         {
+            await _stateService.CheckExtensionActiveUserAndSwitchIfNeededAsync();
             await _vaultTimeoutService.CheckVaultTimeoutAsync();
             _messagingService.Send("startEventTimer");
             await UpdateThemeAsync();

--- a/src/App/Controls/AccountSwitchingOverlay/AccountSwitchingOverlayViewModel.cs
+++ b/src/App/Controls/AccountSwitchingOverlay/AccountSwitchingOverlayViewModel.cs
@@ -45,23 +45,28 @@ namespace Bit.App.Controls
 
         public ICommand LongPressAccountCommand { get; }
 
+        public bool FromIOSExtension { get; set; }
+
         private async Task SelectAccountAsync(AccountViewCellViewModel item)
         {
-            if (item.AccountView.IsAccount)
+            if (!item.AccountView.IsAccount)
             {
-                if (!item.AccountView.IsActive)
+                _messagingService.Send(AccountsManagerMessageCommands.ADD_ACCOUNT);
+                return;
+            }
+
+            if (!item.AccountView.IsActive)
+            {
+                await _stateService.SetActiveUserAsync(item.AccountView.UserId);
+                _messagingService.Send(AccountsManagerMessageCommands.SWITCHED_ACCOUNT);
+                if (FromIOSExtension)
                 {
-                    await _stateService.SetActiveUserAsync(item.AccountView.UserId);
-                    _messagingService.Send("switchedAccount");
-                }
-                else if (AllowActiveAccountSelection)
-                {
-                    _messagingService.Send("switchedAccount");
+                    await _stateService.SaveExtensionActiveUserIdToStorageAsync(item.AccountView.UserId);
                 }
             }
-            else
+            else if (AllowActiveAccountSelection)
             {
-                _messagingService.Send("addAccount");
+                _messagingService.Send(AccountsManagerMessageCommands.SWITCHED_ACCOUNT);
             }
         }
 

--- a/src/App/Services/MobileStorageService.cs
+++ b/src/App/Services/MobileStorageService.cs
@@ -25,6 +25,7 @@ namespace Bit.App.Services
             Constants.LastBuildKey,
             Constants.ClearCiphersCacheKey,
             Constants.BiometricIntegrityKey,
+            Constants.iOSExtensionActiveUserIdKey,
             Constants.iOSAutoFillClearCiphersCacheKey,
             Constants.iOSAutoFillBiometricIntegrityKey,
             Constants.iOSExtensionClearCiphersCacheKey,
@@ -32,8 +33,7 @@ namespace Bit.App.Services
             Constants.iOSShareExtensionClearCiphersCacheKey,
             Constants.iOSShareExtensionBiometricIntegrityKey,
             Constants.RememberedEmailKey,
-            Constants.RememberedOrgIdentifierKey,
-            Constants.iOSExtensionActiveUserIdKey
+            Constants.RememberedOrgIdentifierKey
         };
 
         public MobileStorageService(

--- a/src/App/Services/MobileStorageService.cs
+++ b/src/App/Services/MobileStorageService.cs
@@ -33,6 +33,7 @@ namespace Bit.App.Services
             Constants.iOSShareExtensionBiometricIntegrityKey,
             Constants.RememberedEmailKey,
             Constants.RememberedOrgIdentifierKey,
+            Constants.iOSExtensionActiveUserIdKey
         };
 
         public MobileStorageService(

--- a/src/App/Utilities/AccountManagement/AccountsManager.cs
+++ b/src/App/Utilities/AccountManagement/AccountsManager.cs
@@ -6,21 +6,11 @@ using Bit.App.Resources;
 using Bit.Core.Abstractions;
 using Bit.Core.Enums;
 using Bit.Core.Models.Domain;
+using Bit.Core.Utilities;
 using Xamarin.Forms;
 
 namespace Bit.App.Utilities.AccountManagement
 {
-    public static class AccountsManagerMessageCommands
-    {
-        public const string LOCKED = "locked";
-        public const string LOCK_VAULT = "lockVault";
-        public const string LOGOUT = "logout";
-        public const string LOGGED_OUT = "loggedOut";
-        public const string ADD_ACCOUNT = "addAccount";
-        public const string ACCOUNT_ADDED = "accountAdded";
-        public const string SWITCHED_ACCOUNT = "switchedAccount";
-    }
-
     public class AccountsManager : IAccountsManager
     {
         private readonly IBroadcasterService _broadcasterService;
@@ -209,7 +199,7 @@ namespace Bit.App.Utilities.AccountManagement
         private async Task SwitchedAccountAsync()
         {
             await AppHelpers.OnAccountSwitchAsync();
-            Device.BeginInvokeOnMainThread(async () =>
+            await Device.InvokeOnMainThreadAsync(async () =>
             {
                 if (await _vaultTimeoutService.ShouldTimeoutAsync())
                 {

--- a/src/Core/Abstractions/IStateService.cs
+++ b/src/Core/Abstractions/IStateService.cs
@@ -14,6 +14,7 @@ namespace Bit.Core.Abstractions
         Task<string> GetActiveUserIdAsync();
         Task<bool> IsActiveAccountAsync(string userId = null);
         Task SetActiveUserAsync(string userId);
+        Task CheckExtensionActiveUserAndSwitchIfNeededAsync();
         Task<bool> IsAuthenticatedAsync(string userId = null);
         Task<string> GetUserIdAsync(string email);
         Task RefreshAccountViewsAsync(bool allowAddAccountRow);
@@ -145,5 +146,6 @@ namespace Bit.Core.Abstractions
         Task SetRefreshTokenAsync(string value, bool skipTokenStorage, string userId = null);
         Task<string> GetTwoFactorTokenAsync(string email = null);
         Task SetTwoFactorTokenAsync(string value, string email = null);
+        Task SaveExtensionActiveUserIdToStorageAsync(string userId);
     }
 }

--- a/src/Core/Constants.cs
+++ b/src/Core/Constants.cs
@@ -25,6 +25,7 @@
         public static string iOSExtensionBiometricIntegrityKey = "iOSExtensionBiometricIntegrityState";
         public static string iOSShareExtensionClearCiphersCacheKey = "iOSShareExtensionClearCiphersCache";
         public static string iOSShareExtensionBiometricIntegrityKey = "iOSShareExtensionBiometricIntegrityState";
+        public static string iOSExtensionActiveUserIdKey = "iOSExtensionActiveUserId";
         public static string EventCollectionKey = "eventCollection";
         public static string RememberedEmailKey = "rememberedEmail";
         public static string RememberedOrgIdentifierKey = "rememberedOrgIdentifier";

--- a/src/Core/Services/StateService.cs
+++ b/src/Core/Services/StateService.cs
@@ -15,16 +15,20 @@ namespace Bit.Core.Services
     {
         private readonly IStorageService _storageService;
         private readonly IStorageService _secureStorageService;
+        private readonly IMessagingService _messagingService;
 
         private State _state;
         private bool _migrationChecked;
 
         public List<AccountView> AccountViews { get; set; }
 
-        public StateService(IStorageService storageService, IStorageService secureStorageService)
+        public StateService(IStorageService storageService,
+                            IStorageService secureStorageService,
+                            IMessagingService messagingService)
         {
             _storageService = storageService;
             _secureStorageService = secureStorageService;
+            _messagingService = messagingService;
         }
 
         public async Task<string> GetActiveUserIdAsync()
@@ -65,6 +69,28 @@ namespace Bit.Core.Services
             await SetRememberedEmailAsync(await GetEmailAsync());
             await SetRememberedOrgIdentifierAsync(await GetRememberedOrgIdentifierAsync());
             await SetPreAuthEnvironmentUrlsAsync(await GetEnvironmentUrlsAsync());
+        }
+
+        public async Task CheckExtensionActiveUserAndSwitchIfNeededAsync()
+        {
+            var extensionUserId = await GetExtensionActiveUserIdFromStorageAsync();
+            if (string.IsNullOrEmpty(extensionUserId))
+            {
+                return;
+            }
+
+            if (_state?.ActiveUserId == extensionUserId)
+            {
+                // Clear the value in case the user changes the active user from the app
+                // so if that happens and the user sends the app to background and comes back
+                // the user is not changed again.
+                await SaveExtensionActiveUserIdToStorageAsync(null);
+                return;
+            }
+
+            await SetActiveUserAsync(extensionUserId);
+            await SaveExtensionActiveUserIdToStorageAsync(null);
+            _messagingService.Send(AccountsManagerMessageCommands.SWITCHED_ACCOUNT);
         }
 
         public async Task<bool> IsAuthenticatedAsync(string userId = null)
@@ -1508,6 +1534,16 @@ namespace Bit.Core.Services
         private async Task SaveStateToStorageAsync(State state)
         {
             await _storageService.SaveAsync(Constants.StateKey, state);
+        }
+
+        private async Task<string> GetExtensionActiveUserIdFromStorageAsync()
+        {
+            return await _storageService.GetAsync<string>(Constants.iOSExtensionActiveUserIdKey);
+        }
+
+        public async Task SaveExtensionActiveUserIdToStorageAsync(string userId)
+        {
+            await _storageService.SaveAsync(Constants.iOSExtensionActiveUserIdKey, userId);
         }
 
         private async Task CheckStateAsync()

--- a/src/Core/Utilities/AccountsManagerMessageCommands.cs
+++ b/src/Core/Utilities/AccountsManagerMessageCommands.cs
@@ -1,0 +1,13 @@
+﻿namespace Bit.Core.Utilities
+{
+    public static class AccountsManagerMessageCommands
+    {
+        public const string LOCKED = "locked";
+        public const string LOCK_VAULT = "lockVault";
+        public const string LOGOUT = "logout";
+        public const string LOGGED_OUT = "loggedOut";
+        public const string ADD_ACCOUNT = "addAccount";
+        public const string ACCOUNT_ADDED = "accountAdded";
+        public const string SWITCHED_ACCOUNT = "switchedAccount";
+    }
+}

--- a/src/iOS.Core/Utilities/AccountSwitchingOverlayHelper.cs
+++ b/src/iOS.Core/Utilities/AccountSwitchingOverlayHelper.cs
@@ -35,7 +35,10 @@ namespace Bit.iOS.Core.Utilities
                 LongPressAccountEnabled = false
             };
 
-            var vm = new AccountSwitchingOverlayViewModel(_stateService, _messagingService, _logger);
+            var vm = new AccountSwitchingOverlayViewModel(_stateService, _messagingService, _logger)
+            {
+                FromIOSExtension = true
+            };
             overlay.BindingContext = vm;
 
             var renderer = Platform.CreateRenderer(overlay.Content);

--- a/src/iOS.Core/Utilities/iOSCoreHelpers.cs
+++ b/src/iOS.Core/Utilities/iOSCoreHelpers.cs
@@ -59,7 +59,7 @@ namespace Bit.iOS.Core.Utilities
                 () => ServiceContainer.Resolve<IAppIdService>("appIdService").GetAppIdAsync());
             var cryptoPrimitiveService = new CryptoPrimitiveService();
             var mobileStorageService = new MobileStorageService(preferencesStorage, liteDbStorage);
-            var stateService = new StateService(mobileStorageService, secureStorageService);
+            var stateService = new StateService(mobileStorageService, secureStorageService, messagingService);
             var stateMigrationService =
                 new StateMigrationService(liteDbStorage, preferencesStorage, secureStorageService);
             var deviceActionService = new DeviceActionService(stateService, messagingService);


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
On iOS, when coming from background to the app we should check if any extension has switched users, and if so, change the user as well on the app.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **MainApplication.cs:** Updated `StateService` to include the messenger
* **App.xaml.cs:** Calls check for extension user id change when resuming the app (background to foreground)
* **AccountSwitchingOverlayViewModel.cs:** Added `FromIOSExtension` and if that's the case save the user id if the account has been switched. Also, refactored a bit the if to have less branches and applied the constants.
* **AccountsManager.cs:** Changed invoking on main thread to be awaited, thus the exception can bubble up
* **Constants.cs:** Added `iOSExtensionActiveUserIdKey` to be used to store the active user id on the extension if it has changed so that it can be updated on the main app when coming to foreground again.
* **StateService.cs:** Added `CheckExtensionActiveUserAndSwitchIfNeededAsync()` to do the actual verification and switch the account if necessary and the method to get/save the extension active user id.
* **AccountsManagerMessageCommands.cs:** Moved to `Core` project to be used in `StateService`
* **AccountSwitchingOverlayHelper.cs:** Applied the `FromIOSExtension` to `true` to enable saving the extension user id
* **iOSCoreHelpers.cs:** Updated `StateService` to include the messenger
* **MobileStorageService.cs:** Added `iOSExtensionActiveUserIdKey` to the preference storage keys

## Before you submit
- [X] I have checked for formatting errors (`dotnet tool run dotnet-format --check`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
