### PR TITLE
[SG-390] Fix for missing org items with single org & personal ownership enabled

### DIFF
--- a/src/App/Pages/VaultFilterViewModel.cs
+++ b/src/App/Pages/VaultFilterViewModel.cs
@@ -64,7 +64,6 @@ namespace Bit.App.Pages
 
         protected async Task InitVaultFilterAsync()
         {
-            ShowVaultFilter = await policyService.ShouldShowVaultFilterAsync();
             _organizations = await organizationService.GetAllAsync();
             if (_organizations?.Any() ?? false)
             {
@@ -79,6 +78,8 @@ namespace Bit.App.Pages
                     VaultFilterDescription = AppResources.AllVaults;
                 }
             }
+            await Task.Delay(100);
+            ShowVaultFilter = await policyService.ShouldShowVaultFilterAsync();
         }
 
         protected async Task<List<CipherView>> GetAllCiphersAsync()

--- a/src/App/Pages/VaultFilterViewModel.cs
+++ b/src/App/Pages/VaultFilterViewModel.cs
@@ -20,7 +20,6 @@ namespace Bit.App.Pages
 
         protected bool _showVaultFilter;
         protected bool _personalOwnershipPolicyApplies;
-        protected bool _singleOrgPolicyApplies;
         protected string _vaultFilterSelection;
         protected List<Organization> _organizations;
 
@@ -68,8 +67,8 @@ namespace Bit.App.Pages
             if (_organizations?.Any() ?? false)
             {
                 _personalOwnershipPolicyApplies = await policyService.PolicyAppliesToUser(PolicyType.PersonalOwnership);
-                _singleOrgPolicyApplies = await policyService.PolicyAppliesToUser(PolicyType.OnlyOrg);
-                if (_personalOwnershipPolicyApplies && _singleOrgPolicyApplies)
+                var singleOrgPolicyApplies = await policyService.PolicyAppliesToUser(PolicyType.OnlyOrg);
+                if (_personalOwnershipPolicyApplies && singleOrgPolicyApplies)
                 {
                     VaultFilterDescription = _organizations.First().Name;
                 }


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
This fixes an issue where org items were not appearing when the vault filter control was hidden due to the single org and personal ownership policies both being enabled.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **VaultFilterViewModel.cs:** Update logic to handle mixed policy variations/changes better on initial load and refresh.  A delay is required before setting `ShowVaultFilter` to properly draw the org name in the vault filter if the filter was previously hidden but now shown after a refresh.


## Before you submit
- [X] I have checked for formatting errors (`dotnet tool run dotnet-format --check`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
