### PR TITLE
[SG-392] Fix for vault filter selection carryover to secondary page

### DIFF
--- a/src/App/Pages/Vault/CiphersPageViewModel.cs
+++ b/src/App/Pages/Vault/CiphersPageViewModel.cs
@@ -88,6 +88,7 @@ namespace Bit.App.Pages
         public async Task InitAsync()
         {
             await InitVaultFilterAsync();
+            await ShowVaultFilterIfNeededAsync();
             WebsiteIconsEnabled = !(await _stateService.GetDisableFaviconAsync()).GetValueOrDefault();
             PerformSearchIfPopulated();
         }

--- a/src/App/Pages/Vault/CiphersPageViewModel.cs
+++ b/src/App/Pages/Vault/CiphersPageViewModel.cs
@@ -87,8 +87,7 @@ namespace Bit.App.Pages
 
         public async Task InitAsync()
         {
-            await InitVaultFilterAsync();
-            await ShowVaultFilterIfNeededAsync();
+            await InitVaultFilterAsync(true);
             WebsiteIconsEnabled = !(await _stateService.GetDisableFaviconAsync()).GetValueOrDefault();
             PerformSearchIfPopulated();
         }

--- a/src/App/Pages/Vault/GroupingsPage/GroupingsPageViewModel.cs
+++ b/src/App/Pages/Vault/GroupingsPage/GroupingsPageViewModel.cs
@@ -181,9 +181,10 @@ namespace Bit.App.Pages
                 return;
             }
 
+            await InitVaultFilterAsync();
             if (MainPage)
             {
-                await InitVaultFilterAsync();
+                await ShowVaultFilterIfNeededAsync();
                 PageTitle = ShowVaultFilter ? AppResources.Vaults : AppResources.MyVault;
             }
 

--- a/src/App/Pages/Vault/GroupingsPage/GroupingsPageViewModel.cs
+++ b/src/App/Pages/Vault/GroupingsPage/GroupingsPageViewModel.cs
@@ -181,10 +181,9 @@ namespace Bit.App.Pages
                 return;
             }
 
-            await InitVaultFilterAsync();
+            await InitVaultFilterAsync(MainPage);
             if (MainPage)
             {
-                await ShowVaultFilterIfNeededAsync();
                 PageTitle = ShowVaultFilter ? AppResources.Vaults : AppResources.MyVault;
             }
 

--- a/src/App/Pages/VaultFilterViewModel.cs
+++ b/src/App/Pages/VaultFilterViewModel.cs
@@ -77,6 +77,10 @@ namespace Bit.App.Pages
                     VaultFilterDescription = AppResources.AllVaults;
                 }
             }
+        }
+
+        protected async Task ShowVaultFilterIfNeededAsync()
+        {
             await Task.Delay(100);
             ShowVaultFilter = await policyService.ShouldShowVaultFilterAsync();
         }

--- a/src/App/Pages/VaultFilterViewModel.cs
+++ b/src/App/Pages/VaultFilterViewModel.cs
@@ -61,7 +61,7 @@ namespace Bit.App.Pages
         protected bool IsVaultFilterOrgVault => _vaultFilterSelection != AppResources.AllVaults &&
                                                 _vaultFilterSelection != AppResources.MyVault;
 
-        protected async Task InitVaultFilterAsync()
+        protected async Task InitVaultFilterAsync(bool shouldUpdateShowVaultFilter)
         {
             _organizations = await organizationService.GetAllAsync();
             if (_organizations?.Any() ?? false)
@@ -77,12 +77,11 @@ namespace Bit.App.Pages
                     VaultFilterDescription = AppResources.AllVaults;
                 }
             }
-        }
-
-        protected async Task ShowVaultFilterIfNeededAsync()
-        {
-            await Task.Delay(100);
-            ShowVaultFilter = await policyService.ShouldShowVaultFilterAsync();
+            if (shouldUpdateShowVaultFilter)
+            {
+                await Task.Delay(100);
+                ShowVaultFilter = await policyService.ShouldShowVaultFilterAsync();
+            }
         }
 
         protected async Task<List<CipherView>> GetAllCiphersAsync()


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
`InitVaultFilterAsync` wasn't being called on the secondary view page, resulting in missing data.  In order to do that from `GroupingsPage` the logic for setting the `ShowVaultFilter` property was broken out into its own method, and only called from the MainPage.  Both methods are called back to back on `CiphersPage` to maintain previous behavior.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **GroupingsPageViewModel.cs:** Call `InitVaultFilterAsync` regardless of page, and `ShowVaultFilterIfNeededAsync` on MainPage only
* **CiphersPageViewModel.cs:** Call `InitVaultFilterAsync` and `ShowVaultFilterIfNeededAsync` back to back to maintain previous behavior
* **VaultFilterViewModel.cs:** Separate setting of `ShowVaultFilter` property to its own method `ShowVaultFilterIfNeededAsync`

## Before you submit
- [X] I have checked for formatting errors (`dotnet tool run dotnet-format --check`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
