### PR TITLE
[SG-393] Fix for missing personal items added prior to joining org with personal ownership policy

### DIFF
--- a/src/App/Pages/VaultFilterViewModel.cs
+++ b/src/App/Pages/VaultFilterViewModel.cs
@@ -68,11 +68,7 @@ namespace Bit.App.Pages
             {
                 _personalOwnershipPolicyApplies = await policyService.PolicyAppliesToUser(PolicyType.PersonalOwnership);
                 var singleOrgPolicyApplies = await policyService.PolicyAppliesToUser(PolicyType.OnlyOrg);
-                if (_personalOwnershipPolicyApplies && singleOrgPolicyApplies)
-                {
-                    VaultFilterDescription = _organizations.First().Name;
-                }
-                else if (_vaultFilterSelection == null)
+                if (_vaultFilterSelection == null || (_personalOwnershipPolicyApplies && singleOrgPolicyApplies))
                 {
                     VaultFilterDescription = AppResources.AllVaults;
                 }


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
This fixes the issue where personal items added prior to joining an org with the personal ownership policy enabled were not being shown if the single org policy was also enabled.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **VaultFilterViewModel.cs:** Removed the forced filter set to org when both policies are enabled, instead forced to "All Vaults".


## Before you submit
- [X] I have checked for formatting errors (`dotnet tool run dotnet-format --check`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
