### PR TITLE
[SG-396] Fix tappable area after hiding account switching on Autofill

### DIFF
--- a/src/App/Controls/AccountSwitchingOverlay/AccountSwitchingOverlayView.xaml.cs
+++ b/src/App/Controls/AccountSwitchingOverlay/AccountSwitchingOverlayView.xaml.cs
@@ -65,6 +65,8 @@ namespace Bit.App.Controls
 
         public bool LongPressAccountEnabled { get; set; } = true;
 
+        public Action AfterHide { get; set; }
+
         public async Task ToggleVisibilityAsync()
         {
             if (IsVisible)
@@ -137,6 +139,8 @@ namespace Bit.App.Controls
 
                 // remove overlay
                 IsVisible = false;
+
+                AfterHide?.Invoke();
             });
         }
 

--- a/src/iOS.Core/Utilities/AccountSwitchingOverlayHelper.cs
+++ b/src/iOS.Core/Utilities/AccountSwitchingOverlayHelper.cs
@@ -32,7 +32,14 @@ namespace Bit.iOS.Core.Utilities
         {
             var overlay = new AccountSwitchingOverlayView()
             {
-                LongPressAccountEnabled = false
+                LongPressAccountEnabled = false,
+                AfterHide = () =>
+                {
+                    if (containerView != null)
+                    {
+                        containerView.Hidden = true;
+                    }
+                }
             };
 
             var vm = new AccountSwitchingOverlayViewModel(_stateService, _messagingService, _logger)
@@ -40,6 +47,7 @@ namespace Bit.iOS.Core.Utilities
                 FromIOSExtension = true
             };
             overlay.BindingContext = vm;
+            overlay.IsVisible = false;
 
             var renderer = Platform.CreateRenderer(overlay.Content);
             renderer.SetElementSize(new Size(containerView.Frame.Size.Width, containerView.Frame.Size.Height));
@@ -63,8 +71,13 @@ namespace Bit.iOS.Core.Utilities
         public void OnToolbarItemActivated(AccountSwitchingOverlayView accountSwitchingOverlayView, UIView containerView)
         {
             var overlayVisible = accountSwitchingOverlayView.IsVisible;
+            if (!overlayVisible)
+            {
+                // So that the animation doesn't break we only care about showing it
+                // and the hiding if done through AccountSwitchingOverlayView -> AfterHide
+                containerView.Hidden = false;
+            }
             accountSwitchingOverlayView.ToggleVisibililtyCommand.Execute(null);
-            containerView.Hidden = false;
             containerView.UserInteractionEnabled = !overlayVisible;
             containerView.Subviews[0].UserInteractionEnabled = !overlayVisible;
         }


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
On Autofill, after hiding the account switching overlay the user can't select any items. So this fixes the tap area.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **AccountSwitchingOverlayView.xaml.cs:** Added `AfterHide` action to invoke after hiding the account switching overlay
* **AccountSwitchingOverlayHelper.cs:** Hide the container of the account switching overlay after the overlay hidden animation finishes. Fix one tiny animation issue when displaying the overlay

## Before you submit
- [X] I have checked for formatting errors (`dotnet tool run dotnet-format --check`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
