### PR TITLE
[EC-303] Add warning when vault timeout is set to "Never"

### DIFF
--- a/src/App/Pages/Settings/SettingsPage/SettingsPageViewModel.cs
+++ b/src/App/Pages/Settings/SettingsPage/SettingsPageViewModel.cs
@@ -257,6 +257,10 @@ namespace Bit.App.Pages
                 }
                 var cleanSelection = selection.Replace("✓ ", string.Empty);
                 var selectionOption = _vaultTimeouts.FirstOrDefault(o => o.Key == cleanSelection);
+                if (selectionOption.Value == null && selectionOption.Value != oldTimeout)
+                {
+                    await _platformUtilsService.ShowDialogAsync(AppResources.NeverLockWarning, null, AppResources.Ok);
+                }
                 _vaultTimeoutDisplayValue = selectionOption.Key;
                 newTimeout = selectionOption.Value;
             }

--- a/src/App/Resources/AppResources.Designer.cs
+++ b/src/App/Resources/AppResources.Designer.cs
@@ -4034,5 +4034,13 @@ namespace Bit.App.Resources {
                 return ResourceManager.GetString("All", resourceCulture);
             }
         }
+
+        public static string NeverLockWarning
+        {
+            get
+            {
+                return ResourceManager.GetString("NeverLockWarning", resourceCulture);
+            }
+        }
     }
 }

--- a/src/App/Resources/AppResources.resx
+++ b/src/App/Resources/AppResources.resx
@@ -2254,4 +2254,7 @@
   <data name="All" xml:space="preserve">
     <value>All</value>
   </data>
+  <data name="NeverLockWarning" xml:space="preserve">
+    <value>Setting your lock options to "Never" stores your vault's encryption key on your device. If you use this option you should ensure that you keep your device properly protected.</value>
+  </data>
 </root>


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [X] Other

## Objective
Added a warning when the user selects vault timeout value "Never". Similar to what already happens on the browser client.

## Code changes
* **src/App/Pages/Settings/SettingsPage/SettingsPageViewModel.cs** Added the condition to check the newly selected option on the vault timeout settings
* **src/App/Resources/AppResources.Designer.cs** Added the static string NeverLockWarning to get the text from AppResources.resx
* **src/App/Resources/AppResources.resx** Added the message warning the user about setting the lockout option to "Never"

## Screenshots
<img width="434" alt="image" src="https://user-images.githubusercontent.com/108268980/177525460-80c68ac1-a018-4654-b301-283faf95489a.png">
<img width="376" alt="image" src="https://user-images.githubusercontent.com/108268980/177525938-4ec91143-158d-4c92-9cdc-f0c8a71165eb.png">

## Before you submit
- [X] I have checked for formatting errors (`dotnet tool run dotnet-format --check`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
