### PR TITLE
[PS-1051] Add user verification to reset password request

### DIFF
--- a/src/App/Pages/Accounts/SetPasswordPageViewModel.cs
+++ b/src/App/Pages/Accounts/SetPasswordPageViewModel.cs
@@ -219,7 +219,8 @@ namespace Bit.App.Pages
                     // Request
                     var resetRequest = new OrganizationUserResetPasswordEnrollmentRequest
                     {
-                        ResetPasswordKey = encryptedKey.EncryptedString
+                        ResetPasswordKey = encryptedKey.EncryptedString,
+                        MasterPasswordHash = masterPasswordHash,
                     };
                     var userId = await _stateService.GetActiveUserIdAsync();
                     // Enroll user

--- a/src/Core/Models/Request/OrganizationUserResetPasswordEnrollmentRequest.cs
+++ b/src/Core/Models/Request/OrganizationUserResetPasswordEnrollmentRequest.cs
@@ -2,6 +2,7 @@
 {
     public class OrganizationUserResetPasswordEnrollmentRequest
     {
+        public string MasterPasswordHash { get; set; }
         public string ResetPasswordKey { get; set; }
     }
 }


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
Add user verification to reset password request We only need master password hash because this is currently only used for sso password setting after auto-provisioning. Key Connector is not involved in these accounts

## Before you submit
- [x] I have checked for formatting errors (`dotnet tool run dotnet-format --check`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
