### PR TITLE
[EC-308] Fix crash on avatar image creation on iOS Autofill

### DIFF
--- a/src/iOS.Core/Utilities/AccountSwitchingOverlayHelper.cs
+++ b/src/iOS.Core/Utilities/AccountSwitchingOverlayHelper.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 using Bit.App.Controls;
 using Bit.Core.Abstractions;
 using Bit.Core.Utilities;
@@ -10,6 +11,8 @@ namespace Bit.iOS.Core.Utilities
 {
     public class AccountSwitchingOverlayHelper
     {
+        const string DEFAULT_SYSTEM_AVATAR_IMAGE = "person.2";
+
         IStateService _stateService;
         IMessagingService _messagingService;
         ILogger _logger;
@@ -23,9 +26,22 @@ namespace Bit.iOS.Core.Utilities
 
         public async Task<UIImage> CreateAvatarImageAsync()
         {
-            var avatarImageSource = new AvatarImageSource(await _stateService.GetNameAsync(), await _stateService.GetEmailAsync());
-            var avatarUIImage = await avatarImageSource.GetNativeImageAsync();
-            return avatarUIImage.ImageWithRenderingMode(UIImageRenderingMode.AlwaysOriginal);
+            try
+            {
+                if (_stateService is null)
+                {
+                    throw new NullReferenceException(nameof(_stateService));
+                }
+
+                var avatarImageSource = new AvatarImageSource(await _stateService.GetNameAsync(), await _stateService.GetEmailAsync());
+                var avatarUIImage = await avatarImageSource.GetNativeImageAsync();
+                return avatarUIImage?.ImageWithRenderingMode(UIImageRenderingMode.AlwaysOriginal) ?? UIImage.GetSystemImage(DEFAULT_SYSTEM_AVATAR_IMAGE);
+            }
+            catch (Exception ex)
+            {
+                _logger.Exception(ex);
+                return UIImage.GetSystemImage(DEFAULT_SYSTEM_AVATAR_IMAGE);
+            }
         }
 
         public AccountSwitchingOverlayView CreateAccountSwitchingOverlayView(UIView containerView)

--- a/src/iOS.Core/Utilities/ImageSourceExtensions.cs
+++ b/src/iOS.Core/Utilities/ImageSourceExtensions.cs
@@ -1,9 +1,9 @@
 ﻿using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Bit.Core.Services;
 using UIKit;
 using Xamarin.Forms;
-using Xamarin.Forms.Internals;
 using Xamarin.Forms.Platform.iOS;
 
 namespace Bit.iOS.Core.Utilities
@@ -17,25 +17,29 @@ namespace Bit.iOS.Core.Utilities
         public static async Task<UIImage> GetNativeImageAsync(this ImageSource source, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (source == null || source.IsEmpty)
+            {
                 return null;
+            }
 
             var handler = Xamarin.Forms.Internals.Registrar.Registered.GetHandlerForObject<IImageSourceHandler>(source);
             if (handler == null)
+            {
+                LoggerHelper.LogEvenIfCantBeResolved(new InvalidOperationException("GetNativeImageAsync failed cause IImageSourceHandler couldn't be found"));
                 return null;
+            }
 
             try
             {
                 float scale = (float)UIScreen.MainScreen.Scale;
-
                 return await handler.LoadImageAsync(source, scale: scale, cancelationToken: cancellationToken);
             }
             catch (OperationCanceledException)
             {
-                Log.Warning("Image loading", "Image load cancelled");
+                LoggerHelper.LogEvenIfCantBeResolved(new OperationCanceledException("GetNativeImageAsync was cancelled"));
             }
             catch (Exception ex)
             {
-                Log.Warning("Image loading", $"Image load failed: {ex}");
+                LoggerHelper.LogEvenIfCantBeResolved(new InvalidOperationException("GetNativeImageAsync failed", ex));
             }
 
             return null;


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Fixes crash produced when creating the avatar image on iOS Autofill


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **AccountSwitchingOverlayHelper.cs:** Added exception handling, default image to return and some logging
* **ImageSourceExtensions.cs:** Added proper logging

## Screenshots
<!--Required for any UI changes. Delete if not applicable-->

When an error occurs on creating the avatar image then the default one will be displayed

<img width="314" alt="Default avatar image" src="https://user-images.githubusercontent.com/15682323/177834142-d052c986-b22a-4e9f-a92b-8f6e8d1c4216.PNG">

## Before you submit
- [X] I have checked for formatting errors (`dotnet tool run dotnet-format --check`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
