### PR TITLE
[PS-1074] Use correct icon for checked/unchecked boolean

### DIFF
--- a/src/App/Pages/Vault/ViewPageViewModel.cs
+++ b/src/App/Pages/Vault/ViewPageViewModel.cs
@@ -750,7 +750,7 @@ namespace Bit.App.Pages
             {
                 if (IsBooleanType)
                 {
-                    return _field.Value == "true" ? BitwardenIcons.Square : BitwardenIcons.CheckSquare;
+                    return _field.Value == "true" ? BitwardenIcons.CheckSquare : BitwardenIcons.Square;
                 }
                 else if (IsLinkedType)
                 {


### PR DESCRIPTION
Closes https://github.com/bitwarden/mobile/issues/1985

## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
Fixes the problem of boolean custom fields showing the opposite of their value at the moment


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **src/App/Pages/Vault/ViewPageViewModel.cs:** Swap around the icons used

## Before you submit
- [x] I have checked for formatting errors (`dotnet tool run dotnet-format --check`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
