### PR TITLE
[EC-323] Fix error when getting the first letters on avatar image creation

### DIFF
--- a/src/App/Controls/AvatarImageSource.cs
+++ b/src/App/Controls/AvatarImageSource.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using SkiaSharp;
@@ -131,21 +132,23 @@ namespace Bit.App.Controls
 
         private string GetFirstLetters(string data, int charCount)
         {
-            var parts = data.Split();
+            var sanitizedData = data.Trim();
+            var parts = sanitizedData.Split(new char[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
+
             if (parts.Length > 1 && charCount <= 2)
             {
-                var text = "";
-                for (int i = 0; i < charCount; i++)
+                var text = string.Empty;
+                for (var i = 0; i < charCount; i++)
                 {
-                    text += parts[i].Substring(0, 1);
+                    text += parts[i][0];
                 }
                 return text;
             }
-            if (data.Length > 2)
+            if (sanitizedData.Length > 2)
             {
-                return data.Substring(0, 2);
+                return sanitizedData.Substring(0, 2);
             }
-            return data;
+            return sanitizedData;
         }
 
         private Color StringToColor(string str)


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Fix getting the first letters on avatar image creation. There are some cases when more spaces are added, at the beginning, at the end or in the middle that causes the method to fail.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **AvatarImageSource.cs:** Sanitized data on getting first letters so that it doesn't fail when more spaces are added

## Before you submit
- [X] I have checked for formatting errors (`dotnet tool run dotnet-format --check`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
