### PR TITLE
Add version change check in the version bump workflow

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -19,12 +19,6 @@ jobs:
       - name: Create Version Branch
         run: |
           git switch -c version_bump_${{ github.event.inputs.version_number }}
-          git push -u origin version_bump_${{ github.event.inputs.version_number }}
-
-      - name: Checkout Version Branch
-        uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
-        with:
-          ref: version_bump_${{ github.event.inputs.version_number }}
 
       - name: Bump Version - Android XML
         uses: bitwarden/gh-actions/version-bump@03ad9a873c39cdc95dd8d77dbbda67f84db43945
@@ -56,16 +50,32 @@ jobs:
           version: ${{ github.event.inputs.version_number }}
           file_path: "./src/iOS/Info.plist"
 
-      - name: Commit files
+      - name: Setup git
         run: |
           git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
+
+      - name: Check if version changed
+        id: version-changed
+        run: |
+          if [ -n "$(git status --porcelain)" ]; then
+            echo "::set-output name=changes_to_commit::TRUE"
+          else
+            echo "::set-output name=changes_to_commit::FALSE"
+            echo "No changes to commit!";
+          fi
+
+      - name: Commit files
+        if: ${{ steps.version-changed.outputs.changes_to_commit == 'TRUE' }}
+        run: |
           git commit -m "Bumped version to ${{ github.event.inputs.version_number }}" -a
 
       - name: Push changes
+        if: ${{ steps.version-changed.outputs.changes_to_commit == 'TRUE' }}
         run: git push -u origin version_bump_${{ github.event.inputs.version_number }}
 
       - name: Create Version PR
+        if: ${{ steps.version-changed.outputs.changes_to_commit == 'TRUE' }}
         env:
           PR_BRANCH: "version_bump_${{ github.event.inputs.version_number }}"
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [x] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
Change the version bump workflow. If the project version already matches what is trying to be bumped to, quit the pipeline successfully. Workflow checks if there is anything to commit after running the script to update the version. If not, it skips PR with version bump creation.

JIRA task: https://bitwarden.atlassian.net/browse/DEVOPS-872

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **.github/workflows/version-bump.yml:** Add git status check to determine if any file changed on a version bump. Delete version bump branch checkout step as it's already done with git switch command.

## Screenshots
<!--Required for any UI changes. Delete if not applicable-->



## Before you submit
- [ ] I have checked for formatting errors (`dotnet tool run dotnet-format --check`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
