### PR TITLE
Add publish options to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,7 +83,7 @@ jobs:
     name: F-Droid Release
     runs-on: ubuntu-20.04
     needs: release
-    if: inputs.fdroid_publish == 'true'
+    if: inputs.fdroid_publish
     steps:
       - name: Checkout repo
         uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579  # v2.4.0


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [X] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
At times, we find that we need to re-run a workflow to publish to an app store. We need the ability to have more selection over the specific stores. This adds a boolean input for the f-droid step, which defaults to true.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **.github/workflows/release.yml:** Add input option for f-droid release.

## Screenshots
<!--Required for any UI changes. Delete if not applicable-->
![image](https://user-images.githubusercontent.com/77340197/179073332-27f5a0a7-8155-41ae-8f63-a9902753481b.png)



## Before you submit
- [X] I have checked for formatting errors (`dotnet tool run dotnet-format --check`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [X] This change has particular **deployment requirements** (notify the DevOps team)
