### PR TITLE
[SG-467] Fix environment url validations

### DIFF
--- a/src/App/Pages/Accounts/EnvironmentPageViewModel.cs
+++ b/src/App/Pages/Accounts/EnvironmentPageViewModel.cs
@@ -70,7 +70,23 @@ namespace Bit.App.Pages
         {
             bool IsUrlValid(string url)
             {
-                return string.IsNullOrEmpty(url) || Uri.IsWellFormedUriString(url, UriKind.Absolute);
+                if (string.IsNullOrEmpty(url))
+                {
+                    return true;
+                }
+
+                if(url.StartsWith("https://"))
+                {
+                    url = url.Remove(0, 8);
+                }
+                else
+                {
+                    if (url.StartsWith("http://"))
+                    {
+                        url = url.Remove(0, 7);
+                    }
+                }
+                return Uri.IsWellFormedUriString(url, UriKind.Relative);
             }
 
             return IsUrlValid(BaseUrl)

--- a/src/App/Pages/Accounts/EnvironmentPageViewModel.cs
+++ b/src/App/Pages/Accounts/EnvironmentPageViewModel.cs
@@ -70,23 +70,7 @@ namespace Bit.App.Pages
         {
             bool IsUrlValid(string url)
             {
-                if (string.IsNullOrEmpty(url))
-                {
-                    return true;
-                }
-
-                if(url.StartsWith("https://"))
-                {
-                    url = url.Remove(0, 8);
-                }
-                else
-                {
-                    if (url.StartsWith("http://"))
-                    {
-                        url = url.Remove(0, 7);
-                    }
-                }
-                return Uri.IsWellFormedUriString(url, UriKind.Relative);
+                return string.IsNullOrEmpty(url) || Uri.IsWellFormedUriString(url, UriKind.RelativeOrAbsolute);
             }
 
             return IsUrlValid(BaseUrl)


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
Fixed the validation of environment urls in Environment Settings page to also validate URLs without http:// or https://  allowing the successful saving of URLs with and without http:// or https:// .



## Code changes
**src/App/Pages/Accounts/EnvironmentPageViewModel.cs**: Fixed validation from checking if URL is UriKind.Absolute to check if URL is UriKind.RelativeOrAbsolute.


## Screenshots


## Before you submit
- [X] I have checked for formatting errors (`dotnet tool run dotnet-format --check`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
