### PR TITLE
[PS-1080] Added text alternative to Boolean custom field icon

### DIFF
--- a/src/App/Pages/Vault/ViewPage.xaml
+++ b/src/App/Pages/Vault/ViewPage.xaml
@@ -571,6 +571,7 @@
                                                 IsVisible="{Binding IsLinkedType}" />
                                             <controls:IconLabel
                                                 Text="{Binding ValueText, Mode=OneWay}"
+                                                AutomationProperties.IsInAccessibleTree="true"
                                                 AutomationProperties.Name="{Binding ValueAccessibilityText, Mode=OneWay}"
                                                 StyleClass="box-value"
                                                 Grid.Row="1"

--- a/src/App/Pages/Vault/ViewPageViewModel.cs
+++ b/src/App/Pages/Vault/ViewPageViewModel.cs
@@ -751,7 +751,7 @@ namespace Bit.App.Pages
             {
                 if (IsBooleanType)
                 {
-                    return _field.Value == "true" ? BitwardenIcons.CheckSquare : BitwardenIcons.Square;
+                    return _field.BoolValue ? BitwardenIcons.CheckSquare : BitwardenIcons.Square;
                 }
                 else if (IsLinkedType)
                 {
@@ -771,7 +771,7 @@ namespace Bit.App.Pages
             {
                 if (IsBooleanType)
                 {
-                    return _field.Value == "true" ? AppResources.Enabled : AppResources.Disabled;
+                    return _field.BoolValue ? AppResources.Enabled : AppResources.Disabled;
                 }
 
                 return ValueText;

--- a/src/Core/Models/View/FieldView.cs
+++ b/src/Core/Models/View/FieldView.cs
@@ -19,5 +19,6 @@ namespace Bit.Core.Models.View
         public string MaskedValue => Value != null ? "••••••••" : null;
         public bool NewField { get; set; }
         public LinkedIdType? LinkedId { get; set; }
+        public bool BoolValue => bool.TryParse(Value, out var b) && b;
     }
 }


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
Screen Reader should be able to read if the Boolean icon value on custom fields is Enabled or Disabled

## Code changes

* **ViewPage.xaml**: Added `AutomationProperties.Name` accessibility property to the CustomField boolean IconLabel.
* **ViewPageViewModel**: Added a new property named `ValueAccessibilityText` that has the value to use on the xaml accessibility property.

## Before you submit
- [x] I have checked for formatting errors (`dotnet tool run dotnet-format --check`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
