### PR TITLE
[EC-341] Fix show alternative 2FA on iOS extensions

### DIFF
--- a/src/App/Pages/Accounts/TwoFactorPage.xaml
+++ b/src/App/Pages/Accounts/TwoFactorPage.xaml
@@ -17,15 +17,19 @@
         <ToolbarItem Text="{u:I18n Cancel}" Clicked="Close_Clicked" Order="Primary" Priority="-1"
                      x:Name="_cancelItem" />
     </ContentPage.ToolbarItems>
-
+            
     <ContentPage.Resources>
         <ResourceDictionary>
             <u:InverseBoolConverter x:Key="inverseBool" />
             <u:IsNullConverter x:Key="isNull" />
-            <ToolbarItem Icon="more_vert.png" Clicked="More_Clicked" Order="Primary"
-                x:Name="_moreItem" x:Key="moreItem"
-                 AutomationProperties.IsInAccessibleTree="True"
-                 AutomationProperties.Name="{u:I18n Options}" />
+            <ToolbarItem 
+                x:Name="_moreItem"
+                x:Key="moreItem"
+                Icon="more_vert.png"
+                Order="Primary"
+                Command="{Binding MoreCommand}"
+                AutomationProperties.IsInAccessibleTree="True"
+                AutomationProperties.Name="{u:I18n Options}" />
             <ToolbarItem Text="{u:I18n UseAnotherTwoStepMethod}" 
                 Clicked="Methods_Clicked" 
                 Order="Secondary"

--- a/src/App/Pages/Accounts/TwoFactorPage.xaml.cs
+++ b/src/App/Pages/Accounts/TwoFactorPage.xaml.cs
@@ -2,7 +2,6 @@
 using System.Threading.Tasks;
 using Bit.App.Controls;
 using Bit.App.Models;
-using Bit.App.Resources;
 using Bit.App.Utilities;
 using Bit.Core.Abstractions;
 using Bit.Core.Utilities;
@@ -132,21 +131,6 @@ namespace Bit.App.Pages
         private async void Methods_Clicked(object sender, EventArgs e)
         {
             if (DoOnce())
-            {
-                await _vm.AnotherMethodAsync();
-            }
-        }
-
-        private async void More_Clicked(object sender, EventArgs e)
-        {
-            if (!DoOnce())
-            {
-                return;
-            }
-
-            var selection = await DisplayActionSheet(AppResources.Options, AppResources.Cancel, null, AppResources.UseAnotherTwoStepMethod);
-
-            if (selection == AppResources.UseAnotherTwoStepMethod)
             {
                 await _vm.AnotherMethodAsync();
             }

--- a/src/iOS.Autofill/CredentialProviderViewController.cs
+++ b/src/iOS.Autofill/CredentialProviderViewController.cs
@@ -18,6 +18,7 @@ using CoreNFC;
 using Foundation;
 using UIKit;
 using Xamarin.Forms;
+using Xamarin.Forms.Platform.iOS;
 
 namespace Bit.iOS.Autofill
 {

--- a/src/iOS.Autofill/iOS.Autofill.csproj
+++ b/src/iOS.Autofill/iOS.Autofill.csproj
@@ -254,6 +254,17 @@
     <BundleResource Include="Resources\logo_white%403x.png" />
   </ItemGroup>
   <ItemGroup>
+    <BundleResource Include="..\iOS\Resources\more_vert.png">
+      <Link>Resources\more_vert.png</Link>
+    </BundleResource>
+    <BundleResource Include="..\iOS\Resources\more_vert%402x.png">
+      <Link>Resources\more_vert%402x.png</Link>
+    </BundleResource>
+    <BundleResource Include="..\iOS\Resources\more_vert%403x.png">
+      <Link>Resources\more_vert%403x.png</Link>
+    </BundleResource>
+  </ItemGroup>
+  <ItemGroup>
     <PackageReference Include="Microsoft.AppCenter.Crashes">
       <Version>4.4.0</Version>
     </PackageReference>

--- a/src/iOS.Core/Services/DeviceActionService.cs
+++ b/src/iOS.Core/Services/DeviceActionService.cs
@@ -84,6 +84,12 @@ namespace Bit.iOS.Core.Services
                 HideLoadingAsync().GetAwaiter().GetResult();
             }
 
+            var vc = GetPresentedViewController();
+            if (vc is null)
+            {
+                return Task.CompletedTask;
+            }    
+
             var result = new TaskCompletionSource<int>();
 
             var loadingIndicator = new UIActivityIndicatorView(new CGRect(10, 5, 50, 50));
@@ -96,8 +102,7 @@ namespace Bit.iOS.Core.Services
             _progressAlert.View.TintColor = UIColor.Black;
             _progressAlert.View.Add(loadingIndicator);
 
-            var vc = GetPresentedViewController();
-            vc?.PresentViewController(_progressAlert, false, () => result.TrySetResult(0));
+            vc.PresentViewController(_progressAlert, false, () => result.TrySetResult(0));
             return result.Task;
         }
 
@@ -205,6 +210,12 @@ namespace Bit.iOS.Core.Services
             string text = null, string okButtonText = null, string cancelButtonText = null,
             bool numericKeyboard = false, bool autofocus = true, bool password = false)
         {
+            var vc = GetPresentedViewController();
+            if (vc is null)
+            {
+                return null;
+            }
+
             var result = new TaskCompletionSource<string>();
             var alert = UIAlertController.Create(title ?? string.Empty, description, UIAlertControllerStyle.Alert);
             UITextField input = null;
@@ -234,8 +245,7 @@ namespace Bit.iOS.Core.Services
                     input.KeyboardAppearance = UIKeyboardAppearance.Dark;
                 }
             });
-            var vc = GetPresentedViewController();
-            vc?.PresentViewController(alert, true, null);
+            vc.PresentViewController(alert, true, null);
             return result.Task;
         }
 
@@ -312,6 +322,12 @@ namespace Bit.iOS.Core.Services
 
         public Task<string> DisplayAlertAsync(string title, string message, string cancel, params string[] buttons)
         {
+            var vc = GetPresentedViewController();
+            if (vc is null)
+            {
+                return null;
+            }
+
             var result = new TaskCompletionSource<string>();
             var alert = UIAlertController.Create(title ?? string.Empty, message, UIAlertControllerStyle.Alert);
             if (!string.IsNullOrWhiteSpace(cancel))
@@ -328,8 +344,7 @@ namespace Bit.iOS.Core.Services
                     result.TrySetResult(button);
                 }));
             }
-            var vc = GetPresentedViewController();
-            vc?.PresentViewController(alert, true, null);
+            vc.PresentViewController(alert, true, null);
             return result.Task;
         }
 
@@ -340,8 +355,12 @@ namespace Bit.iOS.Core.Services
             {
                 return app.MainPage.DisplayActionSheet(title, cancel, destruction, buttons);
             }
-            var result = new TaskCompletionSource<string>();
             var vc = GetPresentedViewController();
+            if (vc is null)
+            {
+                return null;
+            }
+            var result = new TaskCompletionSource<string>();
             var sheet = UIAlertController.Create(title, null, UIAlertControllerStyle.ActionSheet);
             if (UIDevice.CurrentDevice.UserInterfaceIdiom == UIUserInterfaceIdiom.Pad)
             {

--- a/src/iOS.Core/iOS.Core.csproj
+++ b/src/iOS.Core/iOS.Core.csproj
@@ -203,7 +203,6 @@
     <Compile Include="Utilities\UISearchBarExtensions.cs" />
     <Compile Include="Renderers\CollectionView\CollectionException.cs" />
     <Compile Include="Renderers\CollectionView\ExtendedGroupableItemsViewDelegator.cs" />
-    <Compile Include="Utilities\UIViewControllerExtensions.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\App\App.csproj">

--- a/src/iOS.Core/iOS.Core.csproj
+++ b/src/iOS.Core/iOS.Core.csproj
@@ -203,6 +203,7 @@
     <Compile Include="Utilities\UISearchBarExtensions.cs" />
     <Compile Include="Renderers\CollectionView\CollectionException.cs" />
     <Compile Include="Renderers\CollectionView\ExtendedGroupableItemsViewDelegator.cs" />
+    <Compile Include="Utilities\UIViewControllerExtensions.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\App\App.csproj">

--- a/src/iOS.Extension/iOS.Extension.csproj
+++ b/src/iOS.Extension/iOS.Extension.csproj
@@ -230,6 +230,15 @@
     <BundleResource Include="Resources\yubikey.png" />
     <BundleResource Include="Resources\yubikey%403x.png" />
     <BundleResource Include="Resources\yubikey%402x.png" />
+    <BundleResource Include="..\iOS\Resources\more_vert.png">
+      <Link>Resources\more_vert.png</Link>
+    </BundleResource>
+    <BundleResource Include="..\iOS\Resources\more_vert%402x.png">
+      <Link>Resources\more_vert%402x.png</Link>
+    </BundleResource>
+    <BundleResource Include="..\iOS\Resources\more_vert%403x.png">
+      <Link>Resources\more_vert%403x.png</Link>
+    </BundleResource>
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AppCenter.Crashes">

--- a/src/iOS.ShareExtension/iOS.ShareExtension.csproj
+++ b/src/iOS.ShareExtension/iOS.ShareExtension.csproj
@@ -227,6 +227,15 @@
     <BundleResource Include="..\iOS\Resources\logo.png">
       <Link>Resources\logo.png</Link>
     </BundleResource>
+    <BundleResource Include="..\iOS\Resources\more_vert.png">
+      <Link>Resources\more_vert.png</Link>
+    </BundleResource>
+    <BundleResource Include="..\iOS\Resources\more_vert%402x.png">
+      <Link>Resources\more_vert%402x.png</Link>
+    </BundleResource>
+    <BundleResource Include="..\iOS\Resources\more_vert%403x.png">
+      <Link>Resources\more_vert%403x.png</Link>
+    </BundleResource>
     <BundleResource Include="..\iOS\Resources\bwi-font.ttf">
       <Link>Resources\bwi-font.ttf</Link>
     </BundleResource>


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
On iOS Extensions when 2FA view is presented, it should allow to change between different 2FA if setup.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **TwoFactorPage.xaml:** Changed Toolbar item More Clicked event to Command
* **TwoFactorPage.xaml.cs:** Removed More_Clicked event and moved logic to VM command
* **TwoFactorPageViewModel.cs:** Added MoreCommand with the logic of the More_Clicked and changed it to use `DeviceActionService` instead of directly `Page` to show the action sheet in order for it to work on the extensions.
* **iOS.Autofill.csproj:** Added reference to the "more"/"three dots" images to get in the bundle
* **DeviceActionService.cs:** Improved null check of the ViewController, if that one was null on some cases the Task was not finishing given that it was not setting the result.
* **iOS.Extension.csproj:** Added reference to the "more"/"three dots" images to get in the bundle
* **iOS.ShareExtension.csproj:** Added reference to the "more"/"three dots" images to get in the bundle

## Before you submit
- [X] I have checked for formatting errors (`dotnet tool run dotnet-format --check`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
