### PR TITLE
[PS-1227] About information not available when logged out

### DIFF
--- a/src/App/Pages/Accounts/EnvironmentPage.xaml
+++ b/src/App/Pages/Accounts/EnvironmentPage.xaml
@@ -91,6 +91,28 @@
                     Text="{u:I18n CustomEnvironmentFooter}"
                     StyleClass="box-footer-label" />
             </StackLayout>
+            <StackLayout StyleClass="box">
+                <StackLayout StyleClass="box-row-header">
+                    <Label Text="{u:I18n Other, Header=True}"
+                           StyleClass="box-header, box-header-platform" />
+                    <StackLayout StyleClass="box-row">
+                        <Label Text="{u:I18n About}"
+                               StyleClass="box-label" >
+                            <Label.GestureRecognizers>
+                                <TapGestureRecognizer Command="{Binding AboutCommand}" />
+                            </Label.GestureRecognizers>
+                        </Label>
+                    </StackLayout>
+                    <StackLayout StyleClass="box-row">
+                        <Label Text="{u:I18n HelpAndFeedback}"
+                               StyleClass="box-label">
+                            <Label.GestureRecognizers>
+                                <TapGestureRecognizer Command="{Binding HelpAndFeedbackCommand}" />
+                            </Label.GestureRecognizers>
+                        </Label>
+                    </StackLayout>
+                </StackLayout>        
+            </StackLayout>
         </StackLayout>
     </ScrollView>
 

--- a/src/App/Pages/Accounts/EnvironmentPageViewModel.cs
+++ b/src/App/Pages/Accounts/EnvironmentPageViewModel.cs
@@ -2,20 +2,24 @@
 using System.Threading.Tasks;
 using System.Windows.Input;
 using Bit.App.Resources;
+using Bit.App.Utilities;
 using Bit.Core.Abstractions;
 using Bit.Core.Utilities;
 using Xamarin.CommunityToolkit.ObjectModel;
+using Xamarin.Forms;
 
 namespace Bit.App.Pages
 {
     public class EnvironmentPageViewModel : BaseViewModel
     {
         private readonly IEnvironmentService _environmentService;
+        private readonly IPlatformUtilsService _platformUtilsService;
         readonly LazyResolve<ILogger> _logger = new LazyResolve<ILogger>("logger");
 
         public EnvironmentPageViewModel()
         {
             _environmentService = ServiceContainer.Resolve<IEnvironmentService>("environmentService");
+            _platformUtilsService = ServiceContainer.Resolve<IPlatformUtilsService>("platformUtilsService");
 
             PageTitle = AppResources.Settings;
             BaseUrl = _environmentService.BaseUrl;
@@ -25,9 +29,13 @@ namespace Bit.App.Pages
             IconsUrl = _environmentService.IconsUrl;
             NotificationsUrls = _environmentService.NotificationsUrl;
             SubmitCommand = new AsyncCommand(SubmitAsync, onException: ex => OnSubmitException(ex), allowsMultipleExecutions: false);
+            AboutCommand = new AsyncCommand(AppHelpers.ShowAppVersionAsync, allowsMultipleExecutions: false);
+            HelpAndFeedbackCommand = new AsyncCommand(HelpAndFeedbackAsync, allowsMultipleExecutions: false);
         }
 
         public ICommand SubmitCommand { get; }
+        public ICommand AboutCommand { get; }
+        public ICommand HelpAndFeedbackCommand { get; }
         public string BaseUrl { get; set; }
         public string ApiUrl { get; set; }
         public string IdentityUrl { get; set; }
@@ -84,6 +92,11 @@ namespace Bit.App.Pages
         {
             _logger.Value.Exception(ex);
             Page.DisplayAlert(AppResources.AnErrorHasOccurred, AppResources.GenericErrorMessage, AppResources.Ok);
+        }
+
+        private async Task HelpAndFeedbackAsync()
+        {
+            await Device.InvokeOnMainThreadAsync(() => _platformUtilsService.LaunchUri("https://bitwarden.com/help/"));
         }
     }
 }

--- a/src/App/Pages/Settings/SettingsPage/SettingsPageViewModel.cs
+++ b/src/App/Pages/Settings/SettingsPage/SettingsPageViewModel.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using Bit.App.Abstractions;
 using Bit.App.Pages.Accounts;
 using Bit.App.Resources;
+using Bit.App.Utilities;
 using Bit.Core.Abstractions;
 using Bit.Core.Enums;
 using Bit.Core.Models.Domain;
@@ -138,28 +139,7 @@ namespace Bit.App.Pages
 
         public async Task AboutAsync()
         {
-            var debugText = string.Format("{0}: {1} ({2})", AppResources.Version,
-                _platformUtilsService.GetApplicationVersion(), _deviceActionService.GetBuildNumber());
-
-#if DEBUG
-            var pushNotificationsRegistered = ServiceContainer.Resolve<IPushNotificationService>("pushNotificationService").IsRegisteredForPush;
-            var pnServerRegDate = await _stateService.GetPushLastRegistrationDateAsync();
-            var pnServerError = await _stateService.GetPushInstallationRegistrationErrorAsync();
-
-            var pnServerRegDateMessage = default(DateTime) == pnServerRegDate ? "-" : $"{pnServerRegDate.GetValueOrDefault().ToShortDateString()}-{pnServerRegDate.GetValueOrDefault().ToShortTimeString()} UTC";
-            var errorMessage = string.IsNullOrEmpty(pnServerError) ? string.Empty : $"Push Notifications Server Registration error: {pnServerError}";
-
-            var text = string.Format("© Bitwarden Inc. 2015-{0}\n\n{1}\nPush Notifications registered:{2}\nPush Notifications Server Last Date :{3}\n{4}", DateTime.Now.Year, debugText, pushNotificationsRegistered, pnServerRegDateMessage, errorMessage);
-#else
-            var text = string.Format("© Bitwarden Inc. 2015-{0}\n\n{1}", DateTime.Now.Year, debugText);
-#endif
-
-            var copy = await _platformUtilsService.ShowDialogAsync(text, AppResources.Bitwarden, AppResources.Copy,
-                AppResources.Close);
-            if (copy)
-            {
-                await _clipboardService.CopyTextAsync(debugText);
-            }
+            await AppHelpers.ShowAppVersionAsync();
         }
 
         public void Help()


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
This PR fixes the #2010 issue. It adds the "About" and "Help and Feedback" buttons to the settings pages when the user is logged out. Allowing  to check the app version as well as copying it to the clipboard. In addition to that the user has an easy access to the Bitwarden help page.

**Important**:
The "Help and Feedback" button is not necessary to fix the issue, but I thought it would be important to add it since I didn't find it when the user is logged out too. What do you think?

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **EnvironmentPage.xaml:** Added the "About" and "Help and feedback" buttons in a new block called "Other" at the end of the EnvironmentPage. I followed the same style of the SettingsPage.
* **EnvironmentPageViewModel.cs:** Added the commands that will trigger the actions of the buttons added in the EnvironmentPage.
* **SettingsPageViewModel.cs:** Removed the code that triggers the button "About". Its code was moved to the AppHelpers class.
* **AppHelpers.cs:** Added the "ShowAppVersionAsync" function, which will be used to show the app version at any place of the app. Such as: SettingsPage and EnvironmentPage.

## Screenshots

![Screenshot_1659319906](https://user-images.githubusercontent.com/4616241/182062395-13f80d1d-d03f-4313-bf24-998f53c3567f.png)

## Before you submit
- [x] I have checked for formatting errors (`dotnet tool run dotnet-format --check`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
