### PR TITLE
[PS-1228] Android: Label of terms of service and privacy policy switch is too close to the actual switch in the sign-up screen

### DIFF
--- a/src/App/Pages/Accounts/RegisterPage.xaml
+++ b/src/App/Pages/Accounts/RegisterPage.xaml
@@ -132,7 +132,7 @@
                         IsToggled="{Binding AcceptPolicies}"
                         StyleClass="box-value"
                         HorizontalOptions="Start"
-                        Margin="{Binding SwitchMargin}"/>
+                        Margin="0, 0, 10, 0"/>
                     <Label StyleClass="box-footer-label"
                            HorizontalOptions="Fill">
                         <Label.FormattedText>

--- a/src/App/Pages/Accounts/RegisterPageViewModel.cs
+++ b/src/App/Pages/Accounts/RegisterPageViewModel.cs
@@ -61,14 +61,6 @@ namespace Bit.App.Pages
             get => _acceptPolicies;
             set => SetProperty(ref _acceptPolicies, value);
         }
-
-        public Thickness SwitchMargin
-        {
-            get => Device.RuntimePlatform == Device.Android
-                ? new Thickness(0, 0, 0, 0)
-                : new Thickness(0, 0, 10, 0);
-        }
-
         public bool ShowTerms { get; set; }
         public Command SubmitCommand { get; }
         public Command TogglePasswordCommand { get; }


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
This PR fixes the #2009 issue. It adds a margin between the switch and the privacy policy text in the sign-up screen.

## Code changes

* **RegisterPage.xaml:** Removed the binding property for the margin and changed to a fixed value. Since I haven't found any style for the switch, I kept the definition here.
* **RegisterPageViewModel.xaml:** Since now the value is the same for iOS and Android, the property is no longer necessary.

## Screenshots

![Screenshot_1659324516](https://user-images.githubusercontent.com/4616241/182067006-3d4e075d-6f84-4453-a506-d74b8cc35406.png)

## Before you submit
- [x] I have checked for formatting errors (`dotnet tool run dotnet-format --check`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
