### PR TITLE
[SG-416] Authenticator toggle remake 

### DIFF
--- a/src/Android/Properties/AndroidManifest.xml
+++ b/src/Android/Properties/AndroidManifest.xml
@@ -11,7 +11,6 @@
 	<uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" />
     <uses-permission android:name="android.permission.VIBRATE" />
 	<uses-permission android:name="com.samsung.android.providers.context.permission.WRITE_USE_APP_FEATURE_SURVEY" />
-	<uses-permission android:name="android.permission.VIBRATE" />
 	<uses-feature android:name="android.hardware.camera" android:required="false" />
 	<uses-feature android:name="android.hardware.camera.autofocus" android:required="false" />
 	<application android:label="Bitwarden" android:theme="@style/LaunchTheme" android:allowBackup="false" tools:replace="android:allowBackup" android:icon="@mipmap/ic_launcher" android:roundIcon="@mipmap/ic_launcher_round" android:networkSecurityConfig="@xml/network_security_config">

--- a/src/Android/Properties/AndroidManifest.xml
+++ b/src/Android/Properties/AndroidManifest.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" xmlns:tools="http://schemas.android.com/tools" android:versionCode="1" android:versionName="2022.6.3" android:installLocation="internalOnly" package="com.x8bit.bitwarden">
 	<uses-sdk android:minSdkVersion="21" android:targetSdkVersion="30" />
 	<uses-permission android:name="android.permission.INTERNET" />
@@ -9,7 +9,7 @@
 	<uses-permission android:name="android.permission.USE_BIOMETRIC" />
 	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 	<uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" />
-    <uses-permission android:name="android.permission.VIBRATE" />
+	<uses-permission android:name="android.permission.VIBRATE" />
 	<uses-permission android:name="com.samsung.android.providers.context.permission.WRITE_USE_APP_FEATURE_SURVEY" />
 	<uses-feature android:name="android.hardware.camera" android:required="false" />
 	<uses-feature android:name="android.hardware.camera.autofocus" android:required="false" />

--- a/src/App/Pages/Vault/GroupingsPage/GroupingsPage.xaml
+++ b/src/App/Pages/Vault/GroupingsPage/GroupingsPage.xaml
@@ -140,30 +140,6 @@
                         AutomationProperties.IsInAccessibleTree="True"
                         AutomationProperties.Name="{u:I18n Filter}" />
                 </StackLayout>
-
-                <StackLayout
-                    IsVisible="{Binding ShowTotpFilter}"
-                    Orientation="Horizontal"
-                    Margin="0,5,10,0">
-                    <Label
-                        Text="{u:I18n DisplayItemsContainingTOTP}"
-                        LineBreakMode="TailTruncation"
-                        Margin="10,0"
-                        StyleClass="text-md, text-muted"
-                        VerticalOptions="Center"
-                        HorizontalOptions="StartAndExpand" />
-                    <Switch
-                        IsToggled="{Binding TotpFilterEnable}"
-                        StyleClass="box-value"
-                        HorizontalOptions="End">
-                        <Switch.Behaviors>
-                            <xct:EventToCommandBehavior
-                                EventName="Toggled"
-                                Command="{Binding TotpFilterCommand}" />
-                        </Switch.Behaviors>
-                    </Switch>
-                </StackLayout>
-
                 <StackLayout
                     VerticalOptions="CenterAndExpand"
                     Padding="20, 0"

--- a/src/App/Pages/Vault/GroupingsPage/GroupingsPage.xaml.cs
+++ b/src/App/Pages/Vault/GroupingsPage/GroupingsPage.xaml.cs
@@ -202,46 +202,53 @@ namespace Bit.App.Pages
 
         private async void RowSelected(object sender, SelectionChangedEventArgs e)
         {
-            ((ExtendedCollectionView)sender).SelectedItem = null;
-            if (!DoOnce())
+            try
             {
-                return;
-            }
+                ((ExtendedCollectionView)sender).SelectedItem = null;
+                if (!DoOnce())
+                {
+                    return;
+                }
 
-            if (e.CurrentSelection?.FirstOrDefault() is GroupingsPageTOTPListItem totpItem)
-            {
-                await _vm.SelectCipherAsync(totpItem.Cipher);
-                return;
-            }
+                if (e.CurrentSelection?.FirstOrDefault() is GroupingsPageTOTPListItem totpItem)
+                {
+                    await _vm.SelectCipherAsync(totpItem.Cipher);
+                    return;
+                }
 
-            if (!(e.CurrentSelection?.FirstOrDefault() is GroupingsPageListItem item))
-            {
-                return;
-            }
+                if (!(e.CurrentSelection?.FirstOrDefault() is GroupingsPageListItem item))
+                {
+                    return;
+                }
 
-            if (item.IsTrash)
-            {
-                await _vm.SelectTrashAsync();
+                if (item.IsTrash)
+                {
+                    await _vm.SelectTrashAsync();
+                }
+                else if (item.IsTotpCode)
+                {
+                    await _vm.SelectTotpCodesAsync();
+                }
+                else if (item.Cipher != null)
+                {
+                    await _vm.SelectCipherAsync(item.Cipher);
+                }
+                else if (item.Folder != null)
+                {
+                    await _vm.SelectFolderAsync(item.Folder);
+                }
+                else if (item.Collection != null)
+                {
+                    await _vm.SelectCollectionAsync(item.Collection);
+                }
+                else if (item.Type != null)
+                {
+                    await _vm.SelectTypeAsync(item.Type.Value);
+                }
             }
-            else if (item.IsTotpCode)
+            catch (Exception ex)
             {
-                await _vm.SelectTotpCodesAsync();
-            }
-            else if (item.Cipher != null)
-            {
-                await _vm.SelectCipherAsync(item.Cipher);
-            }
-            else if (item.Folder != null)
-            {
-                await _vm.SelectFolderAsync(item.Folder);
-            }
-            else if (item.Collection != null)
-            {
-                await _vm.SelectCollectionAsync(item.Collection);
-            }
-            else if (item.Type != null)
-            {
-                await _vm.SelectTypeAsync(item.Type.Value);
+                LoggerHelper.LogEvenIfCantBeResolved(ex);
             }
         }
 

--- a/src/App/Pages/Vault/GroupingsPage/GroupingsPage.xaml.cs
+++ b/src/App/Pages/Vault/GroupingsPage/GroupingsPage.xaml.cs
@@ -29,7 +29,7 @@ namespace Bit.App.Pages
 
         public GroupingsPage(bool mainPage, CipherType? type = null, string folderId = null,
             string collectionId = null, string pageTitle = null, string vaultFilterSelection = null,
-            PreviousPageInfo previousPage = null, bool deleted = false)
+            PreviousPageInfo previousPage = null, bool deleted = false, bool showTotp = false)
         {
             _pageName = string.Concat(nameof(GroupingsPage), "_", DateTime.UtcNow.Ticks);
             InitializeComponent();
@@ -48,6 +48,7 @@ namespace Bit.App.Pages
             _vm.FolderId = folderId;
             _vm.CollectionId = collectionId;
             _vm.Deleted = deleted;
+            _vm.ShowTotp = showTotp;
             _previousPage = previousPage;
             if (pageTitle != null)
             {
@@ -69,7 +70,7 @@ namespace Bit.App.Pages
                 ToolbarItems.Add(_lockItem);
                 ToolbarItems.Add(_exitItem);
             }
-            if (deleted)
+            if (deleted || showTotp)
             {
                 _absLayout.Children.Remove(_fab);
                 ToolbarItems.Remove(_addItem);
@@ -193,7 +194,7 @@ namespace Bit.App.Pages
         {
             base.OnDisappearing();
             IsBusy = false;
-            _vm.StopCiphersTotpTick();
+            _vm.StopCiphersTotpTick().FireAndForget();
             _broadcasterService.Unsubscribe(_pageName);
             _vm.DisableRefreshing();
             _accountAvatar?.OnDisappearing();
@@ -221,6 +222,10 @@ namespace Bit.App.Pages
             if (item.IsTrash)
             {
                 await _vm.SelectTrashAsync();
+            }
+            else if (item.IsTotpCode)
+            {
+                await _vm.SelectTotpCodesAsync();
             }
             else if (item.Cipher != null)
             {

--- a/src/App/Pages/Vault/GroupingsPage/GroupingsPage.xaml.cs
+++ b/src/App/Pages/Vault/GroupingsPage/GroupingsPage.xaml.cs
@@ -22,6 +22,7 @@ namespace Bit.App.Pages
         private readonly IVaultTimeoutService _vaultTimeoutService;
         private readonly ICipherService _cipherService;
         private readonly IDeviceActionService _deviceActionService;
+        private readonly IPlatformUtilsService _platformUtilsService;
         private readonly GroupingsPageViewModel _vm;
         private readonly string _pageName;
 
@@ -41,6 +42,7 @@ namespace Bit.App.Pages
             _vaultTimeoutService = ServiceContainer.Resolve<IVaultTimeoutService>("vaultTimeoutService");
             _cipherService = ServiceContainer.Resolve<ICipherService>("cipherService");
             _deviceActionService = ServiceContainer.Resolve<IDeviceActionService>("deviceActionService");
+            _platformUtilsService = ServiceContainer.Resolve<IPlatformUtilsService>("platformUtilsService");
             _vm = BindingContext as GroupingsPageViewModel;
             _vm.Page = this;
             _vm.MainPage = mainPage;
@@ -249,6 +251,7 @@ namespace Bit.App.Pages
             catch (Exception ex)
             {
                 LoggerHelper.LogEvenIfCantBeResolved(ex);
+                _platformUtilsService.ShowDialogAsync(AppResources.AnErrorHasOccurred, AppResources.GenericErrorMessage, AppResources.Ok).FireAndForget();
             }
         }
 

--- a/src/App/Pages/Vault/GroupingsPage/GroupingsPageListItem.cs
+++ b/src/App/Pages/Vault/GroupingsPage/GroupingsPageListItem.cs
@@ -17,6 +17,7 @@ namespace Bit.App.Pages
         public string ItemCount { get; set; }
         public bool FuzzyAutofill { get; set; }
         public bool IsTrash { get; set; }
+        public bool IsTotpCode { get; set; }
 
         public string Name
         {
@@ -37,6 +38,10 @@ namespace Bit.App.Pages
                 else if (Collection != null)
                 {
                     _name = Collection.Name;
+                }
+                else if (IsTotpCode)
+                {
+                    _name = AppResources.VerificationCodes;
                 }
                 else if (Type != null)
                 {
@@ -81,6 +86,10 @@ namespace Bit.App.Pages
                 else if (Collection != null)
                 {
                     _icon = BitwardenIcons.Collection;
+                }
+                else if (IsTotpCode)
+                {
+                    _icon = BitwardenIcons.Clock;
                 }
                 else if (Type != null)
                 {

--- a/src/App/Pages/Vault/GroupingsPage/GroupingsPageViewModel.cs
+++ b/src/App/Pages/Vault/GroupingsPage/GroupingsPageViewModel.cs
@@ -384,7 +384,7 @@ namespace Bit.App.Pages
 
         private void AddTotpGroupItem(bool canAccessPremium, List<GroupingsPageListGroup> groupedItems, bool uppercaseGroupNames)
         {
-            if (canAccessPremium && (TOTPCiphers?.Any() ?? false))
+            if (canAccessPremium && TOTPCiphers?.Any() == true)
             {
                 groupedItems.Insert(0, new GroupingsPageListGroup(
                     AppResources.Totp, 1, uppercaseGroupNames, false)

--- a/src/App/Pages/Vault/GroupingsPage/GroupingsPageViewModel.cs
+++ b/src/App/Pages/Vault/GroupingsPage/GroupingsPageViewModel.cs
@@ -300,7 +300,7 @@ namespace Bit.App.Pages
                         collectionListItems.Count, uppercaseGroupNames, !MainPage));
                 }
                 if (Ciphers?.Any() ?? false)
-                {   
+                {
                     CreateCipherGroupedItems(groupedItems);
                 }
                 if (ShowTotp && (!TOTPCiphers?.Any() ?? false))
@@ -535,7 +535,7 @@ namespace Bit.App.Pages
             NoDataText = AppResources.NoItems;
             _allCiphers = await GetAllCiphersAsync();
             HasCiphers = _allCiphers.Any();
-            TOTPCiphers = _allCiphers.Where(c =>c.IsDeleted == Deleted && c.Type == CipherType.Login && !string.IsNullOrEmpty(c.Login?.Totp)).ToList();
+            TOTPCiphers = _allCiphers.Where(c => c.IsDeleted == Deleted && c.Type == CipherType.Login && !string.IsNullOrEmpty(c.Login?.Totp)).ToList();
             FavoriteCiphers?.Clear();
             NoFolderCiphers?.Clear();
             _folderCounts.Clear();

--- a/src/App/Pages/Vault/GroupingsPage/GroupingsPageViewModel.cs
+++ b/src/App/Pages/Vault/GroupingsPage/GroupingsPageViewModel.cs
@@ -231,19 +231,7 @@ namespace Bit.App.Pages
                 }
                 if (MainPage)
                 {
-                    if (TOTPCiphers.Any() && canAccessPremium)
-                    {
-                        groupedItems.Add(new GroupingsPageListGroup(
-                        AppResources.Totp, 1, uppercaseGroupNames, false)
-                        {
-                            new GroupingsPageListItem
-                            {
-                                IsTotpCode = true,
-                                Type = CipherType.Login,
-                                ItemCount = TOTPCiphers.Count().ToString("N0")
-                            }
-                        });
-                    }
+                    AddTotpGroupItem(canAccessPremium, groupedItems, uppercaseGroupNames);
 
                     groupedItems.Add(new GroupingsPageListGroup(
                         AppResources.Types, 4, uppercaseGroupNames, !hasFavorites)
@@ -391,6 +379,23 @@ namespace Bit.App.Pages
                 ShowNoData = (MainPage && !HasCiphers) || !groupedItems.Any();
                 ShowList = !ShowNoData;
                 DisableRefreshing();
+            }
+        }
+
+        private void AddTotpGroupItem(bool canAccessPremium, List<GroupingsPageListGroup> groupedItems, bool uppercaseGroupNames)
+        {
+            if (canAccessPremium && (TOTPCiphers?.Any() ?? false))
+            {
+                groupedItems.Add(new GroupingsPageListGroup(
+                    AppResources.Totp, 1, uppercaseGroupNames, false)
+                        {
+                            new GroupingsPageListItem
+                            {
+                                IsTotpCode = true,
+                                Type = CipherType.Login,
+                                ItemCount = TOTPCiphers.Count().ToString("N0")
+                            }
+                        });
             }
         }
 

--- a/src/App/Pages/Vault/GroupingsPage/GroupingsPageViewModel.cs
+++ b/src/App/Pages/Vault/GroupingsPage/GroupingsPageViewModel.cs
@@ -98,9 +98,6 @@ namespace Bit.App.Pages
         public bool HasCiphers { get; set; }
         public bool HasFolders { get; set; }
         public bool HasCollections { get; set; }
-        public string ShowTotpCodesAccessibilityText => TotpFilterEnable ?
-            AppResources.AuthenticationCodesListIsVisibleActivateToShowCipherList
-            : AppResources.CipherListIsVisibleActivateToShowAuthenticationCodesList;
         public bool ShowNoFolderCipherGroup => NoFolderCiphers != null
                                                && NoFolderCiphers.Count < NoFolderListSize
                                                && (Collections is null || !Collections.Any());
@@ -168,11 +165,6 @@ namespace Bit.App.Pages
             get => _showTotpFilter;
             set => SetProperty(ref _showTotpFilter, value);
         }
-        public bool TotpFilterEnable
-        {
-            get => _totpFilterEnable;
-            set => SetProperty(ref _totpFilterEnable, value);
-        }
         public AccountSwitchingOverlayViewModel AccountSwitchingOverlayViewModel { get; }
         public ObservableRangeCollection<IGroupingsPageListItem> GroupedItems { get; set; }
         public Command RefreshCommand { get; set; }
@@ -239,7 +231,7 @@ namespace Bit.App.Pages
                 }
                 if (MainPage)
                 {
-                    if (TOTPCiphers.Any())
+                    if (TOTPCiphers.Any() && canAccessPremium)
                     {
                         groupedItems.Add(new GroupingsPageListGroup(
                         AppResources.Totp, 1, uppercaseGroupNames, false)
@@ -308,8 +300,13 @@ namespace Bit.App.Pages
                         collectionListItems.Count, uppercaseGroupNames, !MainPage));
                 }
                 if (Ciphers?.Any() ?? false)
-                {
+                {   
                     CreateCipherGroupedItems(groupedItems);
+                }
+                if (ShowTotp && (!TOTPCiphers?.Any() ?? false))
+                {
+                    Page.Navigation.PopAsync();
+                    return;
                 }
                 if (ShowNoFolderCipherGroup)
                 {

--- a/src/App/Pages/Vault/GroupingsPage/GroupingsPageViewModel.cs
+++ b/src/App/Pages/Vault/GroupingsPage/GroupingsPageViewModel.cs
@@ -82,9 +82,6 @@ namespace Bit.App.Pages
             VaultFilterCommand = new AsyncCommand(VaultFilterOptionsAsync,
                 onException: ex => _logger.Exception(ex),
                 allowsMultipleExecutions: false);
-            TotpFilterCommand = new AsyncCommand(LoadAsync,
-                onException: ex => _logger.Exception(ex),
-                allowsMultipleExecutions: false);
 
             AccountSwitchingOverlayViewModel = new AccountSwitchingOverlayViewModel(_stateService, _messagingService, _logger)
             {
@@ -108,6 +105,7 @@ namespace Bit.App.Pages
                                                && NoFolderCiphers.Count < NoFolderListSize
                                                && (Collections is null || !Collections.Any());
         public List<CipherView> Ciphers { get; set; }
+        public List<CipherView> TOTPCiphers { get; set; }
         public List<CipherView> FavoriteCiphers { get; set; }
         public List<CipherView> NoFolderCiphers { get; set; }
         public List<FolderView> Folders { get; set; }
@@ -165,7 +163,7 @@ namespace Bit.App.Pages
             get => _websiteIconsEnabled;
             set => SetProperty(ref _websiteIconsEnabled, value);
         }
-        public bool ShowTotpFilter
+        public bool ShowTotp
         {
             get => _showTotpFilter;
             set => SetProperty(ref _showTotpFilter, value);
@@ -179,7 +177,6 @@ namespace Bit.App.Pages
         public ObservableRangeCollection<IGroupingsPageListItem> GroupedItems { get; set; }
         public Command RefreshCommand { get; set; }
         public Command<CipherView> CipherOptionsCommand { get; set; }
-        public ICommand TotpFilterCommand { get; }
         public bool LoadedOnce { get; set; }
 
         public async Task LoadAsync()
@@ -218,7 +215,6 @@ namespace Bit.App.Pages
             Loading = true;
             ShowList = false;
             ShowAddCipherButton = !Deleted;
-            ShowTotpFilter = Type == CipherType.Login && canAccessPremium;
 
             var groupedItems = new List<GroupingsPageListGroup>();
             var page = Page as GroupingsPage;
@@ -243,6 +239,20 @@ namespace Bit.App.Pages
                 }
                 if (MainPage)
                 {
+                    if (TOTPCiphers.Any())
+                    {
+                        groupedItems.Add(new GroupingsPageListGroup(
+                        AppResources.Totp, 1, uppercaseGroupNames, false)
+                        {
+                            new GroupingsPageListItem
+                            {
+                                IsTotpCode = true,
+                                Type = CipherType.Login,
+                                ItemCount = TOTPCiphers.Count().ToString("N0")
+                            }
+                        });
+                    }
+
                     groupedItems.Add(new GroupingsPageListGroup(
                         AppResources.Types, 4, uppercaseGroupNames, !hasFavorites)
                     {
@@ -391,10 +401,9 @@ namespace Bit.App.Pages
         {
             var uppercaseGroupNames = _deviceActionService.DeviceType == DeviceType.iOS;
             _totpTickCts?.Cancel();
-            if (TotpFilterEnable)
+            if (ShowTotp)
             {
-                var ciphersListItems = Ciphers.Where(c => c.IsDeleted == Deleted && !string.IsNullOrEmpty(c.Login.Totp))
-                    .Select(c => new GroupingsPageTOTPListItem(c, true)).ToList();
+                var ciphersListItems = TOTPCiphers.Select(c => new GroupingsPageTOTPListItem(c, true)).ToList();
                 groupedItems.Add(new GroupingsPageListGroup(ciphersListItems, AppResources.Items,
                     ciphersListItems.Count, uppercaseGroupNames, !MainPage && !groupedItems.Any()));
 
@@ -485,6 +494,13 @@ namespace Bit.App.Pages
             await Page.Navigation.PushAsync(page);
         }
 
+        public async Task SelectTotpCodesAsync()
+        {
+            var page = new GroupingsPage(false, CipherType.Login, null, null, AppResources.VerificationCodes, _vaultFilterSelection, null,
+                false, true);
+            await Page.Navigation.PushAsync(page);
+        }
+
         public async Task ExitAsync()
         {
             var confirmed = await _platformUtilsService.ShowDialogAsync(AppResources.ExitConfirmation,
@@ -522,6 +538,7 @@ namespace Bit.App.Pages
             NoDataText = AppResources.NoItems;
             _allCiphers = await GetAllCiphersAsync();
             HasCiphers = _allCiphers.Any();
+            TOTPCiphers = _allCiphers.Where(c =>c.IsDeleted == Deleted && c.Type == CipherType.Login && !string.IsNullOrEmpty(c.Login?.Totp)).ToList();
             FavoriteCiphers?.Clear();
             NoFolderCiphers?.Clear();
             _folderCounts.Clear();
@@ -546,6 +563,10 @@ namespace Bit.App.Pages
                 {
                     Filter = c => c.IsDeleted;
                     NoDataText = AppResources.NoItemsTrash;
+                }
+                else if (ShowTotp)
+                {
+                    Filter = c => c.Type == CipherType.Login && !c.IsDeleted && !string.IsNullOrEmpty(c.Login?.Totp);
                 }
                 else if (Type != null)
                 {

--- a/src/App/Pages/Vault/GroupingsPage/GroupingsPageViewModel.cs
+++ b/src/App/Pages/Vault/GroupingsPage/GroupingsPageViewModel.cs
@@ -386,7 +386,7 @@ namespace Bit.App.Pages
         {
             if (canAccessPremium && (TOTPCiphers?.Any() ?? false))
             {
-                groupedItems.Add(new GroupingsPageListGroup(
+                groupedItems.Insert(0, new GroupingsPageListGroup(
                     AppResources.Totp, 1, uppercaseGroupNames, false)
                         {
                             new GroupingsPageListItem

--- a/src/App/Resources/AppResources.Designer.cs
+++ b/src/App/Resources/AppResources.Designer.cs
@@ -4127,18 +4127,6 @@ namespace Bit.App.Resources {
             }
         }
         
-        public static string CipherListIsVisibleActivateToShowAuthenticationCodesList {
-            get {
-                return ResourceManager.GetString("CipherListIsVisibleActivateToShowAuthenticationCodesList", resourceCulture);
-            }
-        }
-        
-        public static string AuthenticationCodesListIsVisibleActivateToShowCipherList {
-            get {
-                return ResourceManager.GetString("AuthenticationCodesListIsVisibleActivateToShowCipherList", resourceCulture);
-            }
-        }
-        
         public static string EnvironmentPageUrlsError {
             get {
                 return ResourceManager.GetString("EnvironmentPageUrlsError", resourceCulture);

--- a/src/App/Resources/AppResources.Designer.cs
+++ b/src/App/Resources/AppResources.Designer.cs
@@ -4049,9 +4049,15 @@ namespace Bit.App.Resources {
             }
         }
         
-        public static string DisplayItemsContainingTOTP {
+        public static string Totp {
             get {
-                return ResourceManager.GetString("DisplayItemsContainingTOTP", resourceCulture);
+                return ResourceManager.GetString("Totp", resourceCulture);
+            }
+        }
+        
+        public static string VerificationCodes {
+            get {
+                return ResourceManager.GetString("VerificationCodes", resourceCulture);
             }
         }
         

--- a/src/App/Resources/AppResources.resx
+++ b/src/App/Resources/AppResources.resx
@@ -2262,8 +2262,11 @@ Scanning will happen automatically.</value>
   <data name="All" xml:space="preserve">
     <value>All</value>
   </data>
-  <data name="DisplayItemsContainingTOTP" xml:space="preserve">
-    <value>Display items containing TOTP</value>
+  <data name="Totp" xml:space="preserve">
+    <value>TOTP</value>
+  </data>
+  <data name="VerificationCodes" xml:space="preserve">
+    <value>Verification Codes</value>
   </data>
   <data name="PremiumSubscriptionRequired" xml:space="preserve">
     <value>Premium subscription required</value>

--- a/src/App/Resources/AppResources.resx
+++ b/src/App/Resources/AppResources.resx
@@ -2302,12 +2302,6 @@ select Add TOTP to store the key safely</value>
   <data name="NeverLockWarning" xml:space="preserve">
     <value>Setting your lock options to “Never” keeps your vault available to anyone with access to your device. If you use this option, you should ensure that you keep your device properly protected.</value>
   </data>
-  <data name="CipherListIsVisibleActivateToShowAuthenticationCodesList" xml:space="preserve">
-    <value>Cipher list is visible, activate to show authentication codes list.</value>
-  </data>
-  <data name="AuthenticationCodesListIsVisibleActivateToShowCipherList" xml:space="preserve">
-    <value>Authentication codes list is visible, activate to show cipher list.</value>
-  </data>
   <data name="EnvironmentPageUrlsError" xml:space="preserve">
     <value>One or more of the URLs entered are invalid. Please revise it and try to save again.</value>
   </data>


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
After demo the authenticator feature, it was decided that the way we were showing the TOTP codes needed a rework. If the user is premium, It now has a vault entry that navigates to a new page only for TOTP codes.

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **src/App/Pages/Vault/GroupingsPage/GroupingsPageViewModel.cs:306:**
When the user only has one Cipher with TOTP and removes the configuration in the edit page, when he comes back from edit, it will be redirected to the main vault page.

## Screenshots
<!--Required for any UI changes. Delete if not applicable-->
<img width="385" alt="image" src="https://user-images.githubusercontent.com/4648522/182808490-85ad2339-e28e-41e0-b8c4-208ac0a0827b.png">
<img width="390" alt="image" src="https://user-images.githubusercontent.com/4648522/182810785-cdc59116-6a4d-4f3e-baf1-31a70fb416a4.png">



## Before you submit
- [X] I have checked for formatting errors (`dotnet tool run dotnet-format --check`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
