### PR TITLE
[PS-1252] Fix Content Type for file upload

### DIFF
--- a/src/Core/Services/BitwardenFileUploadService.cs
+++ b/src/Core/Services/BitwardenFileUploadService.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Net.Mime;
 using System.Threading.Tasks;
 using Bit.Core.Models.Domain;
 
@@ -18,7 +20,7 @@ namespace Bit.Core.Services
         {
             var fd = new MultipartFormDataContent($"--BWMobileFormBoundary{DateTime.UtcNow.Ticks}")
             {
-                { new ByteArrayContent(encryptedFileData.Buffer), "data", encryptedFileName }
+                { new ByteArrayContent(encryptedFileData.Buffer) { Headers = { ContentType = new MediaTypeHeaderValue(MediaTypeNames.Application.Octet) } }, "data", encryptedFileName }
             };
 
             await apiCall(fd);


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
Fixes https://github.com/bitwarden/mobile/issues/2018

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **BitwardenFileUploadService.cs ** Sets the content-type of the data/file upload to application/octet-stream to be consistent with other bitwarden client.


## Before you submit
- [x] I have checked for formatting errors (`dotnet tool run dotnet-format --check`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
