### PR TITLE
[SG-381] Passwordless - Add setting to Mobile

### DIFF
--- a/src/Android/Services/AndroidPushNotificationService.cs
+++ b/src/Android/Services/AndroidPushNotificationService.cs
@@ -23,6 +23,11 @@ namespace Bit.Droid.Services
 
         public bool IsRegisteredForPush => NotificationManagerCompat.From(Android.App.Application.Context)?.AreNotificationsEnabled() ?? false;
 
+        public Task<bool> GetNotificationsSettingsEnabledAsync()
+        {
+            return Task.FromResult(IsRegisteredForPush);
+        }
+
         public async Task<string> GetTokenAsync()
         {
             return await _stateService.GetPushCurrentTokenAsync();

--- a/src/Android/Services/AndroidPushNotificationService.cs
+++ b/src/Android/Services/AndroidPushNotificationService.cs
@@ -23,7 +23,7 @@ namespace Bit.Droid.Services
 
         public bool IsRegisteredForPush => NotificationManagerCompat.From(Android.App.Application.Context)?.AreNotificationsEnabled() ?? false;
 
-        public Task<bool> GetNotificationsSettingsEnabledAsync()
+        public Task<bool> AreNotificationsSettingsEnabledAsync()
         {
             return Task.FromResult(IsRegisteredForPush);
         }

--- a/src/Android/Services/DeviceActionService.cs
+++ b/src/Android/Services/DeviceActionService.cs
@@ -964,5 +964,14 @@ namespace Bit.Droid.Services
             }
             activity.RunOnUiThread(() => activity.Window.AddFlags(WindowManagerFlags.Secure));
         }
+
+        public void OpenAppSettings()
+        {
+            var intent = new Intent(Android.Provider.Settings.ActionApplicationDetailsSettings);
+            intent.AddFlags(ActivityFlags.NewTask);
+            var uri = Android.Net.Uri.FromParts("package", Application.Context.PackageName, null);
+            intent.SetData(uri);
+            Application.Context.StartActivity(intent);
+        }
     }
 }

--- a/src/App/Abstractions/IDeviceActionService.cs
+++ b/src/App/Abstractions/IDeviceActionService.cs
@@ -49,5 +49,6 @@ namespace Bit.App.Abstractions
         float GetSystemFontSizeScale();
         Task OnAccountSwitchCompleteAsync();
         Task SetScreenCaptureAllowedAsync();
+        void OpenAppSettings();
     }
 }

--- a/src/App/Abstractions/IPushNotificationService.cs
+++ b/src/App/Abstractions/IPushNotificationService.cs
@@ -5,7 +5,7 @@ namespace Bit.App.Abstractions
     public interface IPushNotificationService
     {
         bool IsRegisteredForPush { get; }
-        Task<bool> GetNotificationsSettingsEnabledAsync();
+        Task<bool> AreNotificationsSettingsEnabledAsync();
         Task<string> GetTokenAsync();
         Task RegisterAsync();
         Task UnregisterAsync();

--- a/src/App/Abstractions/IPushNotificationService.cs
+++ b/src/App/Abstractions/IPushNotificationService.cs
@@ -5,6 +5,7 @@ namespace Bit.App.Abstractions
     public interface IPushNotificationService
     {
         bool IsRegisteredForPush { get; }
+        Task<bool> GetNotificationsSettingsEnabledAsync();
         Task<string> GetTokenAsync();
         Task RegisterAsync();
         Task UnregisterAsync();

--- a/src/App/Pages/Settings/SettingsPage/SettingsPageViewModel.cs
+++ b/src/App/Pages/Settings/SettingsPage/SettingsPageViewModel.cs
@@ -348,7 +348,7 @@ namespace Bit.App.Pages
             await _stateService.SetApprovePasswordlessLoginsAsync(_approvePasswordlessLoginRequests);
             if(_approvePasswordlessLoginRequests && !_pushNotificationService.IsRegisteredForPush)
             {
-                var openAppSettingsResult = await _platformUtilsService.ShowDialogAsync(AppResources.OpenSettingsAlert,title: "", confirmText: AppResources.OpenSettings, cancelText: AppResources.Cancel);
+                var openAppSettingsResult = await _platformUtilsService.ShowDialogAsync(AppResources.ReceivePushNotificationsForNewLoginRequests, title: string.Empty, confirmText: AppResources.Settings, cancelText: AppResources.NoThanks);
 
                 if (openAppSettingsResult)
                 {

--- a/src/App/Pages/Settings/SettingsPage/SettingsPageViewModel.cs
+++ b/src/App/Pages/Settings/SettingsPage/SettingsPageViewModel.cs
@@ -337,7 +337,7 @@ namespace Bit.App.Pages
                     CreateSelectableOption(AppResources.No, !_approvePasswordlessLoginRequests),
             };
 
-            var selection = await Page.DisplayActionSheet(AppResources.SubmitCrashLogsDescription, AppResources.Cancel, null, options);
+            var selection = await Page.DisplayActionSheet(AppResources.UseThisDeviceToApproveLoginRequests, AppResources.Cancel, null, options);
 
             if (selection == null || selection == AppResources.Cancel)
             {

--- a/src/App/Pages/Settings/SettingsPage/SettingsPageViewModel.cs
+++ b/src/App/Pages/Settings/SettingsPage/SettingsPageViewModel.cs
@@ -346,18 +346,26 @@ namespace Bit.App.Pages
 
             _approvePasswordlessLoginRequests = CompareSelection(selection, AppResources.Yes);
             await _stateService.SetApprovePasswordlessLoginsAsync(_approvePasswordlessLoginRequests);
-            if(_approvePasswordlessLoginRequests && !_pushNotificationService.IsRegisteredForPush)
-            {
-                var openAppSettingsResult = await _platformUtilsService.ShowDialogAsync(AppResources.ReceivePushNotificationsForNewLoginRequests, title: string.Empty, confirmText: AppResources.Settings, cancelText: AppResources.NoThanks);
-
-                if (openAppSettingsResult)
-                {
-                    _deviceActionService.OpenAppSettings();
-                    _pushNotificationService.RegisterAsync().FireAndForget();
-                }
-            }
 
             BuildList();
+
+            if (!_approvePasswordlessLoginRequests)
+            {
+                return;
+            }
+
+            var notificationsSettingsEnabled = await _pushNotificationService.GetNotificationsSettingsEnabledAsync();
+            if (notificationsSettingsEnabled)
+            {
+                return;
+            }
+
+            var openAppSettingsResult = await _platformUtilsService.ShowDialogAsync(AppResources.ReceivePushNotificationsForNewLoginRequests, title: string.Empty, confirmText: AppResources.Settings, cancelText: AppResources.NoThanks);
+            if (openAppSettingsResult)
+            {
+                _deviceActionService.OpenAppSettings();
+            }
+
         }
 
         public async Task VaultTimeoutActionAsync()

--- a/src/App/Pages/Settings/SettingsPage/SettingsPageViewModel.cs
+++ b/src/App/Pages/Settings/SettingsPage/SettingsPageViewModel.cs
@@ -30,7 +30,7 @@ namespace Bit.App.Pages
         private readonly IKeyConnectorService _keyConnectorService;
         private readonly IClipboardService _clipboardService;
         private readonly ILogger _loggerService;
-
+        private readonly IPushNotificationService _pushNotificationService;
         private const int CustomVaultTimeoutValue = -100;
 
         private bool _supportsBiometric;
@@ -42,6 +42,7 @@ namespace Bit.App.Pages
         private string _vaultTimeoutActionDisplayValue;
         private bool _showChangeMasterPassword;
         private bool _reportLoggingEnabled;
+        private bool _approvePasswordlessLoginRequests;
 
         private List<KeyValuePair<string, int?>> _vaultTimeouts =
             new List<KeyValuePair<string, int?>>
@@ -83,6 +84,7 @@ namespace Bit.App.Pages
             _keyConnectorService = ServiceContainer.Resolve<IKeyConnectorService>("keyConnectorService");
             _clipboardService = ServiceContainer.Resolve<IClipboardService>("clipboardService");
             _loggerService = ServiceContainer.Resolve<ILogger>("logger");
+            _pushNotificationService = ServiceContainer.Resolve<IPushNotificationService>("pushNotificationService");
 
             GroupedItems = new ObservableRangeCollection<ISettingsPageListItem>();
             PageTitle = AppResources.Settings;
@@ -133,6 +135,7 @@ namespace Bit.App.Pages
             _showChangeMasterPassword = IncludeLinksWithSubscriptionInfo() &&
                 !await _keyConnectorService.GetUsesKeyConnector();
             _reportLoggingEnabled = await _loggerService.IsEnabled();
+            _approvePasswordlessLoginRequests = await _stateService.GetApprovePasswordlessLoginsAsync();
             BuildList();
         }
 
@@ -326,6 +329,37 @@ namespace Bit.App.Pages
             BuildList();
         }
 
+        public async Task ApproveLoginRequestsAsync()
+        {
+            var options = new[]
+            {
+                    CreateSelectableOption(AppResources.Yes, _approvePasswordlessLoginRequests),
+                    CreateSelectableOption(AppResources.No, !_approvePasswordlessLoginRequests),
+            };
+
+            var selection = await Page.DisplayActionSheet(AppResources.SubmitCrashLogsDescription, AppResources.Cancel, null, options);
+
+            if (selection == null || selection == AppResources.Cancel)
+            {
+                return;
+            }
+
+            _approvePasswordlessLoginRequests = CompareSelection(selection, AppResources.Yes);
+            await _stateService.SetApprovePasswordlessLoginsAsync(_approvePasswordlessLoginRequests);
+            if(_approvePasswordlessLoginRequests && !_pushNotificationService.IsRegisteredForPush)
+            {
+                var openAppSettingsResult = await _platformUtilsService.ShowDialogAsync(AppResources.OpenSettingsAlert,title: "", confirmText: AppResources.OpenSettings, cancelText: AppResources.Cancel);
+
+                if (openAppSettingsResult)
+                {
+                    _deviceActionService.OpenAppSettings();
+                    _pushNotificationService.RegisterAsync().FireAndForget();
+                }
+            }
+
+            BuildList();
+        }
+
         public async Task VaultTimeoutActionAsync()
         {
             var options = _vaultTimeoutActions.Select(o =>
@@ -502,6 +536,12 @@ namespace Bit.App.Pages
                     Name = AppResources.UnlockWithPIN,
                     SubLabel = _pin ? AppResources.On : AppResources.Off,
                     ExecuteAsync = () => UpdatePinAsync()
+                },
+                new SettingsPageListItem
+                {
+                    Name = AppResources.ApproveLoginRequests,
+                    SubLabel = _approvePasswordlessLoginRequests ? AppResources.On : AppResources.Off,
+                    ExecuteAsync = () => ApproveLoginRequestsAsync()
                 },
                 new SettingsPageListItem
                 {

--- a/src/App/Pages/Settings/SettingsPage/SettingsPageViewModel.cs
+++ b/src/App/Pages/Settings/SettingsPage/SettingsPageViewModel.cs
@@ -84,7 +84,7 @@ namespace Bit.App.Pages
             _keyConnectorService = ServiceContainer.Resolve<IKeyConnectorService>("keyConnectorService");
             _clipboardService = ServiceContainer.Resolve<IClipboardService>("clipboardService");
             _loggerService = ServiceContainer.Resolve<ILogger>("logger");
-            _pushNotificationService = ServiceContainer.Resolve<IPushNotificationService>("pushNotificationService");
+            _pushNotificationService = ServiceContainer.Resolve<IPushNotificationService>();
 
             GroupedItems = new ObservableRangeCollection<ISettingsPageListItem>();
             PageTitle = AppResources.Settings;
@@ -337,7 +337,7 @@ namespace Bit.App.Pages
                     CreateSelectableOption(AppResources.No, !_approvePasswordlessLoginRequests),
             };
 
-            var selection = await Page.DisplayActionSheet(AppResources.UseThisDeviceToApproveLoginRequests, AppResources.Cancel, null, options);
+            var selection = await Page.DisplayActionSheet(AppResources.UseThisDeviceToApproveLoginRequestsMadeFromOtherDevices, AppResources.Cancel, null, options);
 
             if (selection == null || selection == AppResources.Cancel)
             {
@@ -349,13 +349,7 @@ namespace Bit.App.Pages
 
             BuildList();
 
-            if (!_approvePasswordlessLoginRequests)
-            {
-                return;
-            }
-
-            var notificationsSettingsEnabled = await _pushNotificationService.GetNotificationsSettingsEnabledAsync();
-            if (notificationsSettingsEnabled)
+            if (!_approvePasswordlessLoginRequests || await _pushNotificationService.AreNotificationsSettingsEnabledAsync())
             {
                 return;
             }
@@ -365,7 +359,6 @@ namespace Bit.App.Pages
             {
                 _deviceActionService.OpenAppSettings();
             }
-
         }
 
         public async Task VaultTimeoutActionAsync()

--- a/src/App/Resources/AppResources.Designer.cs
+++ b/src/App/Resources/AppResources.Designer.cs
@@ -4156,5 +4156,23 @@ namespace Bit.App.Resources {
                 return ResourceManager.GetString("LogInDenied", resourceCulture);
             }
         }
+        
+        public static string ApproveLoginRequests {
+            get {
+                return ResourceManager.GetString("ApproveLoginRequests", resourceCulture);
+            }
+        }
+        
+        public static string OpenSettingsAlert {
+            get {
+                return ResourceManager.GetString("OpenSettingsAlert", resourceCulture);
+            }
+        }
+        
+        public static string OpenSettings {
+            get {
+                return ResourceManager.GetString("OpenSettings", resourceCulture);
+            }
+        }
     }
 }

--- a/src/App/Resources/AppResources.Designer.cs
+++ b/src/App/Resources/AppResources.Designer.cs
@@ -4163,9 +4163,9 @@ namespace Bit.App.Resources {
             }
         }
         
-        public static string UseThisDeviceToApproveLoginRequests {
+        public static string UseThisDeviceToApproveLoginRequestsMadeFromOtherDevices {
             get {
-                return ResourceManager.GetString("UseThisDeviceToApproveLoginRequests", resourceCulture);
+                return ResourceManager.GetString("UseThisDeviceToApproveLoginRequestsMadeFromOtherDevices", resourceCulture);
             }
         }
         

--- a/src/App/Resources/AppResources.Designer.cs
+++ b/src/App/Resources/AppResources.Designer.cs
@@ -4163,15 +4163,21 @@ namespace Bit.App.Resources {
             }
         }
         
-        public static string OpenSettingsAlert {
+        public static string AllowNotifications {
             get {
-                return ResourceManager.GetString("OpenSettingsAlert", resourceCulture);
+                return ResourceManager.GetString("AllowNotifications", resourceCulture);
             }
         }
         
-        public static string OpenSettings {
+        public static string ReceivePushNotificationsForNewLoginRequests {
             get {
-                return ResourceManager.GetString("OpenSettings", resourceCulture);
+                return ResourceManager.GetString("ReceivePushNotificationsForNewLoginRequests", resourceCulture);
+            }
+        }
+        
+        public static string NoThanks {
+            get {
+                return ResourceManager.GetString("NoThanks", resourceCulture);
             }
         }
     }

--- a/src/App/Resources/AppResources.Designer.cs
+++ b/src/App/Resources/AppResources.Designer.cs
@@ -4163,6 +4163,12 @@ namespace Bit.App.Resources {
             }
         }
         
+        public static string UseThisDeviceToApproveLoginRequests {
+            get {
+                return ResourceManager.GetString("UseThisDeviceToApproveLoginRequests", resourceCulture);
+            }
+        }
+        
         public static string AllowNotifications {
             get {
                 return ResourceManager.GetString("AllowNotifications", resourceCulture);

--- a/src/App/Resources/AppResources.resx
+++ b/src/App/Resources/AppResources.resx
@@ -2317,4 +2317,13 @@
   <data name="LogInDenied" xml:space="preserve">
     <value>Log in denied</value>
   </data>
+  <data name="ApproveLoginRequests" xml:space="preserve">
+    <value>Approve login requests</value>
+  </data>
+  <data name="OpenSettingsAlert" xml:space="preserve">
+    <value>Bitwarden lets you use passwordless login by using push notifications. For the best possible experience, please enable push notifications in the application settings.</value>
+  </data>
+  <data name="OpenSettings" xml:space="preserve">
+    <value>Open Settings</value>
+  </data>
 </root>

--- a/src/App/Resources/AppResources.resx
+++ b/src/App/Resources/AppResources.resx
@@ -2320,6 +2320,9 @@
   <data name="ApproveLoginRequests" xml:space="preserve">
     <value>Approve login requests</value>
   </data>
+  <data name="UseThisDeviceToApproveLoginRequests" xml:space="preserve">
+    <value>Use this device to approve login requests made from other devices.</value>
+  </data>
   <data name="AllowNotifications" xml:space="preserve">
     <value>Allow notifications</value>
   </data>

--- a/src/App/Resources/AppResources.resx
+++ b/src/App/Resources/AppResources.resx
@@ -2320,10 +2320,13 @@
   <data name="ApproveLoginRequests" xml:space="preserve">
     <value>Approve login requests</value>
   </data>
-  <data name="OpenSettingsAlert" xml:space="preserve">
-    <value>Bitwarden lets you use passwordless login by using push notifications. For the best possible experience, please enable push notifications in the application settings.</value>
+  <data name="AllowNotifications" xml:space="preserve">
+    <value>Allow notifications</value>
   </data>
-  <data name="OpenSettings" xml:space="preserve">
-    <value>Open Settings</value>
+  <data name="ReceivePushNotificationsForNewLoginRequests" xml:space="preserve">
+    <value>Receive push notifications for new login requests</value>
+  </data>
+  <data name="NoThanks" xml:space="preserve">
+    <value>No thanks</value>
   </data>
 </root>

--- a/src/App/Resources/AppResources.resx
+++ b/src/App/Resources/AppResources.resx
@@ -2320,7 +2320,7 @@
   <data name="ApproveLoginRequests" xml:space="preserve">
     <value>Approve login requests</value>
   </data>
-  <data name="UseThisDeviceToApproveLoginRequests" xml:space="preserve">
+  <data name="UseThisDeviceToApproveLoginRequestsMadeFromOtherDevices" xml:space="preserve">
     <value>Use this device to approve login requests made from other devices.</value>
   </data>
   <data name="AllowNotifications" xml:space="preserve">

--- a/src/App/Services/NoopPushNotificationService.cs
+++ b/src/App/Services/NoopPushNotificationService.cs
@@ -7,6 +7,11 @@ namespace Bit.App.Services
     {
         public bool IsRegisteredForPush => false;
 
+        public Task<bool> GetNotificationsSettingsEnabledAsync()
+        {
+            return Task.FromResult(false);
+        }
+
         public Task<string> GetTokenAsync()
         {
             return Task.FromResult(null as string);

--- a/src/App/Services/NoopPushNotificationService.cs
+++ b/src/App/Services/NoopPushNotificationService.cs
@@ -7,7 +7,7 @@ namespace Bit.App.Services
     {
         public bool IsRegisteredForPush => false;
 
-        public Task<bool> GetNotificationsSettingsEnabledAsync()
+        public Task<bool> AreNotificationsSettingsEnabledAsync()
         {
             return Task.FromResult(false);
         }

--- a/src/Core/Abstractions/IStateService.cs
+++ b/src/Core/Abstractions/IStateService.cs
@@ -151,5 +151,7 @@ namespace Bit.Core.Abstractions
         Task<bool> GetScreenCaptureAllowedAsync(string userId = null);
         Task SetScreenCaptureAllowedAsync(bool value, string userId = null);
         Task SaveExtensionActiveUserIdToStorageAsync(string userId);
+        Task<bool> GetApprovePasswordlessLoginsAsync(string userId = null);
+        Task SetApprovePasswordlessLoginsAsync(bool? value, string userId = null);
     }
 }

--- a/src/Core/Constants.cs
+++ b/src/Core/Constants.cs
@@ -29,7 +29,6 @@
         public static string EventCollectionKey = "eventCollection";
         public static string RememberedEmailKey = "rememberedEmail";
         public static string RememberedOrgIdentifierKey = "rememberedOrgIdentifier";
-        public static string ApprovePasswordlessLogins = "approvePasswordlessLogins";
         public const string FingerprintPhraseSeparator = "-";
         public const int SelectFileRequestCode = 42;
         public const int SelectFilePermissionRequestCode = 43;
@@ -85,5 +84,6 @@
         public static string ProtectedPinKey(string userId) => $"protectedPin_{userId}";
         public static string LastSyncKey(string userId) => $"lastSync_{userId}";
         public static string BiometricUnlockKey(string userId) => $"biometricUnlock_{userId}";
+        public static string ApprovePasswordlessLoginsKey(string userId) => $"approvePasswordlessLogins_{userId}";
     }
 }

--- a/src/Core/Constants.cs
+++ b/src/Core/Constants.cs
@@ -29,6 +29,7 @@
         public static string EventCollectionKey = "eventCollection";
         public static string RememberedEmailKey = "rememberedEmail";
         public static string RememberedOrgIdentifierKey = "rememberedOrgIdentifier";
+        public static string ApprovePasswordlessLogins = "approvePasswordlessLogins";
         public const string FingerprintPhraseSeparator = "-";
         public const int SelectFileRequestCode = 42;
         public const int SelectFilePermissionRequestCode = 43;

--- a/src/Core/Services/StateService.cs
+++ b/src/Core/Services/StateService.cs
@@ -1244,12 +1244,11 @@ namespace Bit.Core.Services
             await SetValueAsync(key, value, reconciledOptions);
         }
 
-
         public async Task<bool> GetApprovePasswordlessLoginsAsync(string userId = null)
         {
             var reconciledOptions = ReconcileOptions(new StorageOptions { UserId = userId },
                 await GetDefaultStorageOptionsAsync());
-            var key = Constants.ApprovePasswordlessLogins;
+            var key = Constants.ApprovePasswordlessLoginsKey(reconciledOptions.UserId);
             return await GetValueAsync<bool?>(key, reconciledOptions) ?? false;
         }
 
@@ -1257,7 +1256,7 @@ namespace Bit.Core.Services
         {
             var reconciledOptions = ReconcileOptions(new StorageOptions { UserId = userId },
                 await GetDefaultStorageOptionsAsync());
-            var key = Constants.ApprovePasswordlessLogins;
+            var key = Constants.ApprovePasswordlessLoginsKey(reconciledOptions.UserId);
             await SetValueAsync(key, value, reconciledOptions);
         }
         // Helpers
@@ -1475,6 +1474,7 @@ namespace Bit.Core.Services
                 await SetAutoDarkThemeAsync(null, userId);
                 await SetAddSitePromptShownAsync(null, userId);
                 await SetPasswordGenerationOptionsAsync(null, userId);
+                await SetApprovePasswordlessLoginsAsync(null, userId);
             }
         }
 

--- a/src/Core/Services/StateService.cs
+++ b/src/Core/Services/StateService.cs
@@ -1244,6 +1244,22 @@ namespace Bit.Core.Services
             await SetValueAsync(key, value, reconciledOptions);
         }
 
+
+        public async Task<bool> GetApprovePasswordlessLoginsAsync(string userId = null)
+        {
+            var reconciledOptions = ReconcileOptions(new StorageOptions { UserId = userId },
+                await GetDefaultStorageOptionsAsync());
+            var key = Constants.ApprovePasswordlessLogins;
+            return await GetValueAsync<bool?>(key, reconciledOptions) ?? false;
+        }
+
+        public async Task SetApprovePasswordlessLoginsAsync(bool? value, string userId = null)
+        {
+            var reconciledOptions = ReconcileOptions(new StorageOptions { UserId = userId },
+                await GetDefaultStorageOptionsAsync());
+            var key = Constants.ApprovePasswordlessLogins;
+            await SetValueAsync(key, value, reconciledOptions);
+        }
         // Helpers
 
         private async Task<T> GetValueAsync<T>(string key, StorageOptions options)
@@ -1439,6 +1455,7 @@ namespace Bit.Core.Services
             await SetEncryptedPasswordGenerationHistoryAsync(null, userId);
             await SetEncryptedSendsAsync(null, userId);
             await SetSettingsAsync(null, userId);
+            await SetApprovePasswordlessLoginsAsync(null, userId);
 
             if (userInitiated)
             {

--- a/src/iOS.Core/Services/DeviceActionService.cs
+++ b/src/iOS.Core/Services/DeviceActionService.cs
@@ -624,5 +624,11 @@ namespace Bit.iOS.Core.Services
                 _deviceActionService.PickedDocument(url);
             }
         }
+
+        public void OpenAppSettings()
+        {
+            var url = new NSUrl(UIApplication.OpenSettingsUrlString);
+            UIApplication.SharedApplication.OpenUrl(url);
+        }
     }
 }

--- a/src/iOS/Services/iOSPushNotificationService.cs
+++ b/src/iOS/Services/iOSPushNotificationService.cs
@@ -19,13 +19,10 @@ namespace Bit.iOS.Services
 
         public bool IsRegisteredForPush => UIApplication.SharedApplication.IsRegisteredForRemoteNotifications;
 
-        public async Task<bool> GetNotificationsSettingsEnabledAsync()
+        public async Task<bool> AreNotificationsSettingsEnabledAsync()
         {
-            var tcs = new TaskCompletionSource<bool>();
-            UNUserNotificationCenter.Current.GetNotificationSettings((settings) => {
-                tcs.SetResult(settings.AlertSetting == UNNotificationSetting.Enabled);
-            });
-            return await tcs.Task;
+            var settings = await UNUserNotificationCenter.Current.GetNotificationSettingsAsync();
+            return settings.AlertSetting == UNNotificationSetting.Enabled;
         }
 
         public async Task RegisterAsync()

--- a/src/iOS/Services/iOSPushNotificationService.cs
+++ b/src/iOS/Services/iOSPushNotificationService.cs
@@ -19,6 +19,15 @@ namespace Bit.iOS.Services
 
         public bool IsRegisteredForPush => UIApplication.SharedApplication.IsRegisteredForRemoteNotifications;
 
+        public async Task<bool> GetNotificationsSettingsEnabledAsync()
+        {
+            var tcs = new TaskCompletionSource<bool>();
+            UNUserNotificationCenter.Current.GetNotificationSettings((settings) => {
+                tcs.SetResult(settings.AlertSetting == UNNotificationSetting.Enabled);
+            });
+            return await tcs.Task;
+        }
+
         public async Task RegisterAsync()
         {
             Debug.WriteLine($"{TAG} RegisterAsync");


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Add a setting to the Bitwarden mobile app under the “Security” section: “Approve login requests”
Default state is Disabled.
When user Enables the option, check to see if the Bitwarden app has notification permissions. If not, request them. Even if the user does not enable notifications, the Approve login requests feature is enabled.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **src/iOS/Services/iOSPushNotificationService.cs:** Added new method because iOS has different approach on notifications status. I needed a way to tell if the user had blocked the "alert notifications" in order to redirect to the settings.
 
## Screenshots
<!--Required for any UI changes. Delete if not applicable-->
New entry in the security section of settings tab:
<img width="358" alt="image" src="https://user-images.githubusercontent.com/4648522/184619462-c5298064-0467-4191-a7d7-3b9f2eacfb4b.png">
Dialog to provide additional information and enable/disable the feature:
<img width="360" alt="image" src="https://user-images.githubusercontent.com/4648522/184653480-9dadbbaa-4107-4a71-933c-4a95d26e44eb.png">
If the user doesn't have notification "Alert" enable, show this dialog to open settings directly:
<img width="359" alt="image" src="https://user-images.githubusercontent.com/4648522/184619543-1c46229e-f294-4d1c-9a3a-418d5a87e1bc.png">



## Before you submit
- [x] I have checked for formatting errors (`dotnet tool run dotnet-format --check`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
