### PR TITLE
[PS-1009] Changed keyboard on Passphrase generator to not allow emojis

### DIFF
--- a/src/Android/Android.csproj
+++ b/src/Android/Android.csproj
@@ -151,6 +151,7 @@
     <Compile Include="Services\ClipboardService.cs" />
     <Compile Include="Utilities\IntentExtensions.cs" />
     <Compile Include="Renderers\CustomPageRenderer.cs" />
+    <Compile Include="Effects\NoEmojiKeyboardEffect.cs" />
   </ItemGroup>
   <ItemGroup>
     <AndroidAsset Include="Assets\bwi-font.ttf" />

--- a/src/Android/Effects/NoEmojiKeyboardEffect.cs
+++ b/src/Android/Effects/NoEmojiKeyboardEffect.cs
@@ -1,17 +1,17 @@
-﻿using Bit.Droid.Effects;
+﻿using Android.Widget;
+using Bit.Droid.Effects;
 using Xamarin.Forms;
 using Xamarin.Forms.Platform.Android;
 
-[assembly: ExportEffect(typeof(NoEmojiKeyboardEffect), "NoEmojiKeyboardEffect")]
+[assembly: ExportEffect(typeof(NoEmojiKeyboardEffect), nameof(NoEmojiKeyboardEffect))]
 namespace Bit.Droid.Effects
 {
     public class NoEmojiKeyboardEffect : PlatformEffect
     {
         protected override void OnAttached()
         {
-            if (Element is Entry && Control is FormsEditText editText)
+            if (Control != null && Control is EditText editText)
             {
-                editText.ImeOptions = Android.Views.InputMethods.ImeAction.Done;
                 editText.InputType = Android.Text.InputTypes.ClassText | Android.Text.InputTypes.TextVariationVisiblePassword | Android.Text.InputTypes.TextFlagMultiLine;
             }
         }

--- a/src/Android/Effects/NoEmojiKeyboardEffect.cs
+++ b/src/Android/Effects/NoEmojiKeyboardEffect.cs
@@ -1,0 +1,24 @@
+﻿using Bit.Droid.Effects;
+using Xamarin.Forms;
+using Xamarin.Forms.Platform.Android;
+
+[assembly: ExportEffect(typeof(NoEmojiKeyboardEffect), "NoEmojiKeyboardEffect")]
+namespace Bit.Droid.Effects
+{
+    public class NoEmojiKeyboardEffect : PlatformEffect
+    {
+        protected override void OnAttached()
+        {
+            if (Element is Entry && Control is FormsEditText editText)
+            {
+                editText.ImeOptions = Android.Views.InputMethods.ImeAction.Done;
+                editText.InputType = Android.Text.InputTypes.ClassText | Android.Text.InputTypes.TextVariationVisiblePassword | Android.Text.InputTypes.TextFlagMultiLine;
+            }
+        }
+
+        protected override void OnDetached()
+        {
+        }
+    }
+}
+

--- a/src/Android/Effects/NoEmojiKeyboardEffect.cs
+++ b/src/Android/Effects/NoEmojiKeyboardEffect.cs
@@ -10,7 +10,7 @@ namespace Bit.Droid.Effects
     {
         protected override void OnAttached()
         {
-            if (Control != null && Control is EditText editText)
+            if (Control is EditText editText)
             {
                 editText.InputType = Android.Text.InputTypes.ClassText | Android.Text.InputTypes.TextVariationVisiblePassword | Android.Text.InputTypes.TextFlagMultiLine;
             }

--- a/src/App/Effects/NoEmojiKeyboardEffect.cs
+++ b/src/App/Effects/NoEmojiKeyboardEffect.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using Xamarin.Forms;
+
+namespace Bit.App.Effects
+{
+    public class NoEmojiKeyboardEffect : RoutingEffect
+    {
+        public NoEmojiKeyboardEffect()
+            : base("Bitwarden.NoEmojiKeyboardEffect")
+        { }
+    }
+}

--- a/src/App/Pages/Generator/GeneratorPage.xaml
+++ b/src/App/Pages/Generator/GeneratorPage.xaml
@@ -6,6 +6,7 @@
     xmlns:pages="clr-namespace:Bit.App.Pages"
     xmlns:controls="clr-namespace:Bit.App.Controls"
     xmlns:u="clr-namespace:Bit.App.Utilities"
+    xmlns:effects="clr-namespace:Bit.App.Effects"
     x:DataType="pages:GeneratorPageViewModel"
     Title="{Binding PageTitle}">
     <ContentPage.BindingContext>
@@ -128,7 +129,12 @@
                                 Text="{Binding WordSeparator}"
                                 IsSpellCheckEnabled="False"
                                 IsTextPredictionEnabled="False"
-                                StyleClass="box-value" />
+                                StyleClass="box-value"
+                                >
+                                <Entry.Effects>
+                                    <effects:NoEmojiKeyboardEffect />
+                                </Entry.Effects>
+                            </Entry>
                         </StackLayout>
                         <StackLayout StyleClass="box-row, box-row-switch">
                             <Label

--- a/src/App/Pages/Generator/GeneratorPage.xaml
+++ b/src/App/Pages/Generator/GeneratorPage.xaml
@@ -129,8 +129,7 @@
                                 Text="{Binding WordSeparator}"
                                 IsSpellCheckEnabled="False"
                                 IsTextPredictionEnabled="False"
-                                StyleClass="box-value"
-                                >
+                                StyleClass="box-value">
                                 <Entry.Effects>
                                     <effects:NoEmojiKeyboardEffect />
                                 </Entry.Effects>

--- a/src/iOS.Core/Effects/NoEmojiKeyboardEffect.cs
+++ b/src/iOS.Core/Effects/NoEmojiKeyboardEffect.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using Bit.iOS.Core.Effects;
+using UIKit;
+using Xamarin.Forms;
+using Xamarin.Forms.Platform.iOS;
+
+[assembly: ExportEffect(typeof(NoEmojiKeyboardEffect), nameof(NoEmojiKeyboardEffect))]
+namespace Bit.iOS.Core.Effects
+{
+    public class NoEmojiKeyboardEffect : PlatformEffect
+    {
+        protected override void OnAttached()
+        {
+            if (Element != null && Control is UITextField textField)
+            {
+                textField.KeyboardType = UIKeyboardType.ASCIICapable;
+            }
+        }
+
+        protected override void OnDetached()
+        {
+        }
+    }
+}
+

--- a/src/iOS.Core/iOS.Core.csproj
+++ b/src/iOS.Core/iOS.Core.csproj
@@ -203,6 +203,7 @@
     <Compile Include="Utilities\UISearchBarExtensions.cs" />
     <Compile Include="Renderers\CollectionView\CollectionException.cs" />
     <Compile Include="Renderers\CollectionView\ExtendedGroupableItemsViewDelegator.cs" />
+    <Compile Include="Effects\NoEmojiKeyboardEffect.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\App\App.csproj">


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
Remove the possibility of adding emojis on the word separator at Generator when passphrase is selected


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **NoEmojiKeyboardEffect.cs:** Created effect with settings to not show emojis on the keyboard, both on iOS and Android.
* **GeneratorPage.cs:** Added NoEmojiKeyboardEffect to the passphrase generator Entry

## Screenshots

![Screenshot_1660582307](https://user-images.githubusercontent.com/109146700/184679702-17835507-d6c0-4aea-8fd8-2cb92e57ef18.png)
![Simulator Screen Shot - iPhone 11 Pro Max - 2022-08-15 at 17 52 36](https://user-images.githubusercontent.com/109146700/184679714-87b4984e-238e-4e34-bbba-f2357f48f8b1.png)



## Before you submit
- [x] I have checked for formatting errors (`dotnet tool run dotnet-format --check`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
