### PR TITLE
[PS-1352] Fix ignore diacritics in search

### DIFF
--- a/src/Core/Services/SearchService.cs
+++ b/src/Core/Services/SearchService.cs
@@ -77,7 +77,7 @@ namespace Bit.Core.Services
             ct.ThrowIfCancellationRequested();
             var matchedCiphers = new List<CipherView>();
             var lowPriorityMatchedCiphers = new List<CipherView>();
-            query = (query.Trim().ToLower().RemoveDiacritics());
+            query = query.Trim().ToLower().RemoveDiacritics();
 
             foreach (var c in ciphers)
             {

--- a/src/Core/Utilities/StringExtensions.cs
+++ b/src/Core/Utilities/StringExtensions.cs
@@ -6,8 +6,13 @@ namespace Bit.Core.Utilities
 {
     public static class StringExtensions
     {
-        public static string RemoveDiacritics(this String text)
+        public static string RemoveDiacritics(this string text)
         {
+            if (string.IsNullOrWhiteSpace(text))
+            {
+                return text;
+            }
+
             var normalizedString = text.Normalize(NormalizationForm.FormD);
             var stringBuilder = new StringBuilder(capacity: normalizedString.Length);
 
@@ -20,14 +25,10 @@ namespace Bit.Core.Utilities
                     stringBuilder.Append(c);
                 }
             }
-            Console.Write(stringBuilder.Length);
-            Console.WriteLine(stringBuilder.ToString().Normalize(NormalizationForm.FormC));
-
 
             return stringBuilder
                 .ToString()
                 .Normalize(NormalizationForm.FormC);
-
         }
     }
 }


### PR DESCRIPTION
This change updates the search function to ignore diacritical marks in search results. Marks are stripped from both the search input and results.

## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
Fixes #2008

Search results should match on base characters, ignoring any accents or other glyphs applied to the search term or the stored data. 



## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->
`/src/Core/Utilities/StringExtensions.cs` - Added new file to contain String extension to normalize strings by removing diacritics.

`/src/Core/Services/SerachService.cs` - Applied String extension to search term, item name and item subtitle. 




## Before you submit
- [X] I have checked for formatting errors (`dotnet tool run dotnet-format --check`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
