### PR TITLE
[SG-598] Copying TOTP Code from Verification Codes page copies space between sets of numbers

### DIFF
--- a/src/App/Pages/Vault/GroupingsPage/GroupingsPageTOTPListItem.cs
+++ b/src/App/Pages/Vault/GroupingsPage/GroupingsPageTOTPListItem.cs
@@ -105,7 +105,7 @@ namespace Bit.App.Pages
 
         public async Task CopyToClipboardAsync()
         {
-            await _clipboardService.CopyTextAsync(TotpCodeFormatted);
+            await _clipboardService.CopyTextAsync(TotpCodeFormatted?.Replace(" ", string.Empty));
             _platformUtilsService.ShowToast("info", null, string.Format(AppResources.ValueHasBeenCopied, AppResources.VerificationCodeTotp));
         }
 


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Fix Bug: 
When copying the TOTP code from the “Verification Codes” page, the code is copied in the format “### ###”. In order to fix this problem, removing the space is necessary.

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->
Replaced the space dividing the two parts of the code from the copied string.

## Before you submit
- [ ] I have checked for formatting errors (`dotnet tool run dotnet-format --check`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
