### PR TITLE
[SG-599] "Cannot read authenticator key" if URI is not included before TOTP Secret

### DIFF
--- a/src/App/Pages/Vault/ScanPage.xaml.cs
+++ b/src/App/Pages/Vault/ScanPage.xaml.cs
@@ -170,27 +170,10 @@ namespace Bit.App.Pages
 
         private void AddAuthenticationKey_OnClicked(object sender, EventArgs e)
         {
-            var text = ViewModel.TotpAuthenticationKey;
-            if (!string.IsNullOrWhiteSpace(text))
+            if (!string.IsNullOrWhiteSpace(ViewModel.TotpAuthenticationKey))
             {
-                if (text.StartsWith("otpauth://totp"))
-                {
-                    _callback(text);
-                    return;
-                }
-                else if (Uri.TryCreate(text, UriKind.Absolute, out Uri uri) &&
-                         !string.IsNullOrWhiteSpace(uri?.Query))
-                {
-                    var queryParts = uri.Query.Substring(1).ToLowerInvariant().Split('&');
-                    foreach (var part in queryParts)
-                    {
-                        if (part.StartsWith("secret="))
-                        {
-                            _callback(part.Substring(7)?.ToUpperInvariant());
-                            return;
-                        }
-                    }
-                }
+                _callback(ViewModel.TotpAuthenticationKey);
+                return;
             }
             _callback(null);
         }


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
User needs to be able to add TOTP authentication key manually without the need to include the full URI. 

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->
Removed unnecessary verification for manually adding TOTP Secret Key

## Before you submit
- [ ] I have checked for formatting errors (`dotnet tool run dotnet-format --check`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
