### PR TITLE
[SG-472] Add configuration for new notification type

### DIFF
--- a/src/Android/MainActivity.cs
+++ b/src/Android/MainActivity.cs
@@ -415,8 +415,10 @@ namespace Bit.Droid
             }
 
             var channel = new NotificationChannel(Constants.AndroidNotificationChannelId, AppResources.AllNotifications, NotificationImportance.Default);
-            var notificationManager = (NotificationManager)GetSystemService(NotificationService);
-            notificationManager?.CreateNotificationChannel(channel);
+            if(GetSystemService(NotificationService) is NotificationManager notificationManager)
+            {
+                notificationManager.CreateNotificationChannel(channel);
+            }
 #endif
         }
     }

--- a/src/Android/MainActivity.cs
+++ b/src/Android/MainActivity.cs
@@ -11,6 +11,7 @@ using Android.Runtime;
 using AndroidX.Core.Content;
 using Bit.App.Abstractions;
 using Bit.App.Models;
+using Bit.App.Resources;
 using Bit.App.Utilities;
 using Bit.Core;
 using Bit.Core.Abstractions;
@@ -81,8 +82,8 @@ namespace Bit.Droid
             Xamarin.Essentials.Platform.Init(this, savedInstanceState);
             Xamarin.Forms.Forms.Init(this, savedInstanceState);
             _appOptions = GetOptions();
+            CreateNotificationChannel();
             LoadApplication(new App.App(_appOptions));
-
 
             _broadcasterService.Subscribe(_activityKey, (message) =>
             {
@@ -400,6 +401,23 @@ namespace Bit.Droid
             var alarmManager = GetSystemService(AlarmService) as AlarmManager;
             alarmManager.Cancel(_eventUploadPendingIntent);
             await _eventService.UploadEventsAsync();
+        }
+
+        private void CreateNotificationChannel()
+        {
+#if !FDROID
+            if (Build.VERSION.SdkInt < BuildVersionCodes.O)
+            {
+                // Notification channels are new in API 26 (and not a part of the
+                // support library). There is no need to create a notification
+                // channel on older versions of Android.
+                return;
+            }
+
+            var channel = new NotificationChannel(Constants.AndroidNotificationChannelId, AppResources.AllNotifications, NotificationImportance.Default);
+            var notificationManager = (NotificationManager)GetSystemService(NotificationService);
+            notificationManager?.CreateNotificationChannel(channel);
+#endif
         }
     }
 }

--- a/src/Android/Push/FirebaseMessagingService.cs
+++ b/src/Android/Push/FirebaseMessagingService.cs
@@ -1,7 +1,9 @@
 #if !FDROID
+using System;
 using Android.App;
 using Bit.App.Abstractions;
 using Bit.Core.Abstractions;
+using Bit.Core.Services;
 using Bit.Core.Utilities;
 using Firebase.Messaging;
 using Newtonsoft.Json;
@@ -16,34 +18,41 @@ namespace Bit.Droid.Push
     {
         public async override void OnNewToken(string token)
         {
-            var stateService = ServiceContainer.Resolve<IStateService>("stateService");
-            var pushNotificationService = ServiceContainer.Resolve<IPushNotificationService>("pushNotificationService");
+            try { 
+                var stateService = ServiceContainer.Resolve<IStateService>("stateService");
+                var pushNotificationService = ServiceContainer.Resolve<IPushNotificationService>("pushNotificationService");
             
-            await stateService.SetPushRegisteredTokenAsync(token);
-            await pushNotificationService.RegisterAsync();
+                await stateService.SetPushRegisteredTokenAsync(token);
+                await pushNotificationService.RegisterAsync();
+            }
+            catch (Exception ex)
+            {
+                Logger.Instance.Exception(ex);
+            }
         }
         
         public async override void OnMessageReceived(RemoteMessage message)
         {
-            if (message?.Data == null)
-            {
-                return;
-            }
-            var data = message.Data.ContainsKey("data") ? message.Data["data"] : null;
-            if (data == null)
-            {
-                return;
-            }
             try
             {
+                if (message?.Data == null)
+                {
+                    return;
+                }
+                var data = message.Data.ContainsKey("data") ? message.Data["data"] : null;
+                if (data == null)
+                {
+                    return;
+                }
+
                 var obj = JObject.Parse(data);
                 var listener = ServiceContainer.Resolve<IPushNotificationListenerService>(
                     "pushNotificationListenerService");
                 await listener.OnMessageAsync(obj, Device.Android);
             }
-            catch (JsonReaderException ex)
+            catch (Exception ex)
             {
-                System.Diagnostics.Debug.WriteLine(ex.ToString());
+                Logger.Instance.Exception(ex);
             }
         }
     }

--- a/src/Android/Services/AndroidPushNotificationService.cs
+++ b/src/Android/Services/AndroidPushNotificationService.cs
@@ -58,16 +58,23 @@ namespace Bit.Droid.Services
 
         public void DismissLocalNotification(string notificationId)
         {
-            var notificationManager = NotificationManagerCompat.From(Android.App.Application.Context);
-            notificationManager.Cancel(int.Parse(notificationId));
+            if (int.TryParse(notificationId, out int intNotificationId))
+            {
+                var notificationManager = NotificationManagerCompat.From(Android.App.Application.Context);
+                notificationManager.Cancel(intNotificationId);
+            }
         }
 
-        public void SendLocalNotification(string title, string message, string notificationId = null)
+        public void SendLocalNotification(string title, string message, string notificationId)
         {
-            notificationId = notificationId ?? new Random().Next(1000, 999999).ToString();
+            if (string.IsNullOrEmpty(notificationId))
+            {
+                throw new ArgumentNullException("notificationId cannot be null or empty.");
+            }
+            
             var context = Android.App.Application.Context;
             var intent = new Intent(context, typeof(MainActivity));
-            var pendingIntent = PendingIntent.GetActivity(context, new Random().Next(1000, 999999), intent, PendingIntentFlags.OneShot);
+            var pendingIntent = PendingIntent.GetActivity(context, 20220801, intent, PendingIntentFlags.OneShot);
             var builder = new NotificationCompat.Builder(context, Constants.AndroidNotificationChannelId)
                .SetContentIntent(pendingIntent)
                .SetContentTitle(title)
@@ -75,10 +82,8 @@ namespace Bit.Droid.Services
                .SetSmallIcon(Resource.Mipmap.ic_launcher)
                .SetAutoCancel(true);
 
-            // Build the notification:
-            var notification = builder.Build();
             var notificationManager = NotificationManagerCompat.From(context);
-            notificationManager.Notify(int.Parse(notificationId), notification);
+            notificationManager.Notify(int.Parse(notificationId), builder.Build());
         }
     }
 }

--- a/src/Android/Services/AndroidPushNotificationService.cs
+++ b/src/Android/Services/AndroidPushNotificationService.cs
@@ -1,8 +1,11 @@
 ﻿#if !FDROID
 using System;
 using System.Threading.Tasks;
+using Android.App;
+using Android.Content;
 using AndroidX.Core.App;
 using Bit.App.Abstractions;
+using Bit.Core;
 using Bit.Core.Abstractions;
 using Xamarin.Forms;
 
@@ -51,6 +54,31 @@ namespace Bit.Droid.Services
         {
             // Do we ever need to unregister?
             return Task.FromResult(0);
+        }
+
+        public void DismissLocalNotification(string notificationId)
+        {
+            var notificationManager = NotificationManagerCompat.From(Android.App.Application.Context);
+            notificationManager.Cancel(int.Parse(notificationId));
+        }
+
+        public void SendLocalNotification(string title, string message, string notificationId = null)
+        {
+            notificationId = notificationId ?? new Random().Next(1000, 999999).ToString();
+            var context = Android.App.Application.Context;
+            var intent = new Intent(context, typeof(MainActivity));
+            var pendingIntent = PendingIntent.GetActivity(context, new Random().Next(1000, 999999), intent, PendingIntentFlags.OneShot);
+            var builder = new NotificationCompat.Builder(context, Constants.AndroidNotificationChannelId)
+               .SetContentIntent(pendingIntent)
+               .SetContentTitle(title)
+               .SetContentText(message)
+               .SetSmallIcon(Resource.Mipmap.ic_launcher)
+               .SetAutoCancel(true);
+
+            // Build the notification:
+            var notification = builder.Build();
+            var notificationManager = NotificationManagerCompat.From(context);
+            notificationManager.Notify(int.Parse(notificationId), notification);
         }
     }
 }

--- a/src/App/Abstractions/IPushNotificationService.cs
+++ b/src/App/Abstractions/IPushNotificationService.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace Bit.App.Abstractions
 {
@@ -9,5 +10,7 @@ namespace Bit.App.Abstractions
         Task<string> GetTokenAsync();
         Task RegisterAsync();
         Task UnregisterAsync();
+        void SendLocalNotification(string title, string message, string notificationId = null);
+        void DismissLocalNotification(string notificationId);
     }
 }

--- a/src/App/Abstractions/IPushNotificationService.cs
+++ b/src/App/Abstractions/IPushNotificationService.cs
@@ -10,7 +10,7 @@ namespace Bit.App.Abstractions
         Task<string> GetTokenAsync();
         Task RegisterAsync();
         Task UnregisterAsync();
-        void SendLocalNotification(string title, string message, string notificationId = null);
+        void SendLocalNotification(string title, string message, string notificationId);
         void DismissLocalNotification(string notificationId);
     }
 }

--- a/src/App/App.xaml.cs
+++ b/src/App/App.xaml.cs
@@ -147,10 +147,10 @@ namespace Bit.App
                 }
             });
         }
-        
+
         private async Task CheckPasswordlessLoginRequestsAsync()
         {
-            if(await _vaultTimeoutService.IsLockedAsync())
+            if (await _vaultTimeoutService.IsLockedAsync())
             {
                 return;
             }

--- a/src/App/App.xaml.cs
+++ b/src/App/App.xaml.cs
@@ -25,9 +25,7 @@ namespace Bit.App
         private readonly IStateService _stateService;
         private readonly IVaultTimeoutService _vaultTimeoutService;
         private readonly ISyncService _syncService;
-        private readonly IPlatformUtilsService _platformUtilsService;
         private readonly IAuthService _authService;
-        private readonly IStorageService _secureStorageService;
         private readonly IDeviceActionService _deviceActionService;
         private readonly IAccountsManager _accountsManager;
 
@@ -47,8 +45,6 @@ namespace Bit.App
             _vaultTimeoutService = ServiceContainer.Resolve<IVaultTimeoutService>("vaultTimeoutService");
             _syncService = ServiceContainer.Resolve<ISyncService>("syncService");
             _authService = ServiceContainer.Resolve<IAuthService>("authService");
-            _platformUtilsService = ServiceContainer.Resolve<IPlatformUtilsService>("platformUtilsService");
-            _secureStorageService = ServiceContainer.Resolve<IStorageService>("secureStorageService");
             _deviceActionService = ServiceContainer.Resolve<IDeviceActionService>("deviceActionService");
             _accountsManager = ServiceContainer.Resolve<IAccountsManager>("accountsManager");
 
@@ -140,12 +136,37 @@ namespace Bit.App
                                 new NavigationPage(new RemoveMasterPasswordPage()));
                         });
                     }
+                    else if (message.Command == "passwordlessLoginRequest" || message.Command == "unlocked")
+                    {
+                        Device.BeginInvokeOnMainThread(() => CheckPasswordlessLoginRequestsAsync().FireAndForget());
+                    }
                 }
                 catch (Exception ex)
                 {
                     LoggerHelper.LogEvenIfCantBeResolved(ex);
                 }
             });
+        }
+        
+        private async Task CheckPasswordlessLoginRequestsAsync()
+        {
+            if(await _vaultTimeoutService.IsLockedAsync())
+            {
+                return;
+            }
+
+            var notification = await _stateService.GetPasswordlessLoginNotificationAsync();
+            if (notification == null)
+            {
+                return;
+            }
+            // Delay to wait for the vault page to appear
+            await Task.Delay(2000);
+            //TODO Temporary until merge from services
+            var loginRequestData = await _authService.GetLogInPasswordlessRequestsAsync();
+            var page = new LoginPasswordlessPage(new LoginPasswordlessDetails());
+            await _stateService.SetPasswordlessLoginNotificationAsync(null);
+            await Application.Current.MainPage.Navigation.PushModalAsync(new NavigationPage(page));
         }
 
         public AppOptions Options { get; private set; }

--- a/src/App/App.xaml.cs
+++ b/src/App/App.xaml.cs
@@ -138,7 +138,7 @@ namespace Bit.App
                     }
                     else if (message.Command == "passwordlessLoginRequest" || message.Command == "unlocked")
                     {
-                        Device.BeginInvokeOnMainThread(() => CheckPasswordlessLoginRequestsAsync().FireAndForget());
+                        CheckPasswordlessLoginRequestsAsync().FireAndForget();
                     }
                 }
                 catch (Exception ex)
@@ -173,7 +173,7 @@ namespace Bit.App
                 DeviceType = loginRequestData.RequestDeviceType
             });
             await _stateService.SetPasswordlessLoginNotificationAsync(null);
-            await Application.Current.MainPage.Navigation.PushModalAsync(new NavigationPage(page));
+            Device.BeginInvokeOnMainThread(async () => await Application.Current.MainPage.Navigation.PushModalAsync(new NavigationPage(page)));
         }
 
         public AppOptions Options { get; private set; }

--- a/src/App/App.xaml.cs
+++ b/src/App/App.xaml.cs
@@ -173,7 +173,7 @@ namespace Bit.App
                 DeviceType = loginRequestData.RequestDeviceType
             });
             await _stateService.SetPasswordlessLoginNotificationAsync(null);
-            Device.BeginInvokeOnMainThread(async () => await Application.Current.MainPage.Navigation.PushModalAsync(new NavigationPage(page)));
+            await Device.InvokeOnMainThreadAsync(async () => await Application.Current.MainPage.Navigation.PushModalAsync(new NavigationPage(page)));
         }
 
         public AppOptions Options { get; private set; }

--- a/src/App/App.xaml.cs
+++ b/src/App/App.xaml.cs
@@ -160,11 +160,18 @@ namespace Bit.App
             {
                 return;
             }
+
             // Delay to wait for the vault page to appear
             await Task.Delay(2000);
-            //TODO Temporary until merge from services
-            var loginRequestData = await _authService.GetLogInPasswordlessRequestsAsync();
-            var page = new LoginPasswordlessPage(new LoginPasswordlessDetails());
+            var loginRequestData = await _authService.GetPasswordlessLoginRequestByIdAsync(notification.Id);
+            var page = new LoginPasswordlessPage(new LoginPasswordlessDetails()
+            {
+                IpAddress = loginRequestData.RequestIpAddress,
+                Email = await _stateService.GetEmailAsync(),
+                FingerprintPhrase = loginRequestData.RequestFingerprint,
+                RequestDate = loginRequestData.CreationDate,
+                DeviceType = loginRequestData.RequestDeviceType
+            });
             await _stateService.SetPasswordlessLoginNotificationAsync(null);
             await Application.Current.MainPage.Navigation.PushModalAsync(new NavigationPage(page));
         }

--- a/src/App/Pages/Accounts/LoginPasswordlessPage.xaml
+++ b/src/App/Pages/Accounts/LoginPasswordlessPage.xaml
@@ -49,18 +49,12 @@
                 Margin="0,0,0,21"/>
             <Label
                 Text="{u:I18n IpAddress}"
+                IsVisible="{Binding ShowIpAddress}"
                 FontSize="Small"
                 FontAttributes="Bold"/>
             <Label
                 Text="{Binding LoginRequest.IpAddress}"
-                FontSize="Small"
-                Margin="0,0,0,21"/>
-            <Label
-                Text="{u:I18n Near}"
-                FontSize="Small"
-                FontAttributes="Bold"/>
-            <Label
-                Text="{Binding LoginRequest.NearLocation}"
+                IsVisible="{Binding ShowIpAddress}"
                 FontSize="Small"
                 Margin="0,0,0,21"/>
             <Label

--- a/src/App/Pages/Accounts/LoginPasswordlessViewModel.cs
+++ b/src/App/Pages/Accounts/LoginPasswordlessViewModel.cs
@@ -51,6 +51,8 @@ namespace Bit.App.Pages
 
         public string TimeOfRequestText => CreateRequestDate(LoginRequest.RequestDate);
 
+        public bool ShowIpAddress => !string.IsNullOrEmpty(LoginRequest?.IpAddress);
+        
         public LoginPasswordlessDetails LoginRequest
         {
             get => _resquest;
@@ -150,7 +152,5 @@ namespace Bit.App.Pages
         public DeviceType DeviceType { get; set; }
 
         public string IpAddress { get; set; }
-
-        public string NearLocation { get; set; }
     }
 }

--- a/src/App/Pages/Accounts/LoginPasswordlessViewModel.cs
+++ b/src/App/Pages/Accounts/LoginPasswordlessViewModel.cs
@@ -52,7 +52,7 @@ namespace Bit.App.Pages
         public string TimeOfRequestText => CreateRequestDate(LoginRequest.RequestDate);
 
         public bool ShowIpAddress => !string.IsNullOrEmpty(LoginRequest?.IpAddress);
-        
+
         public LoginPasswordlessDetails LoginRequest
         {
             get => _resquest;

--- a/src/App/Pages/Accounts/LoginPasswordlessViewModel.cs
+++ b/src/App/Pages/Accounts/LoginPasswordlessViewModel.cs
@@ -17,6 +17,7 @@ namespace Bit.App.Pages
     {
         private IDeviceActionService _deviceActionService;
         private IAuthService _authService;
+        private IPushNotificationService _pushNotificationService;
         private IPlatformUtilsService _platformUtilsService;
         private ILogger _logger;
         private LoginPasswordlessDetails _resquest;
@@ -26,6 +27,7 @@ namespace Bit.App.Pages
             _deviceActionService = ServiceContainer.Resolve<IDeviceActionService>("deviceActionService");
             _platformUtilsService = ServiceContainer.Resolve<IPlatformUtilsService>("platformUtilsService");
             _authService = ServiceContainer.Resolve<IAuthService>("authService");
+            _pushNotificationService = ServiceContainer.Resolve<IPushNotificationService>();
             _logger = ServiceContainer.Resolve<ILogger>("logger");
 
             PageTitle = AppResources.LogInRequested;
@@ -113,6 +115,7 @@ namespace Bit.App.Pages
             var res = await _authService.LogInPasswordlessAcceptAsync();
             await _deviceActionService.HideLoadingAsync();
             await Page.Navigation.PopModalAsync();
+            _pushNotificationService.DismissLocalNotification(Constants.PasswordlessNotificationId);
             _platformUtilsService.ShowToast("info", null, AppResources.LogInAccepted);
         }
 
@@ -122,6 +125,7 @@ namespace Bit.App.Pages
             var res = await _authService.LogInPasswordlessRejectAsync();
             await _deviceActionService.HideLoadingAsync();
             await Page.Navigation.PopModalAsync();
+            _pushNotificationService.DismissLocalNotification(Constants.PasswordlessNotificationId);
             _platformUtilsService.ShowToast("info", null, AppResources.LogInDenied);
         }
 

--- a/src/App/Resources/AppResources.Designer.cs
+++ b/src/App/Resources/AppResources.Designer.cs
@@ -4186,5 +4186,17 @@ namespace Bit.App.Resources {
                 return ResourceManager.GetString("NoThanks", resourceCulture);
             }
         }
+        
+        public static string ConfimLogInAttempForX {
+            get {
+                return ResourceManager.GetString("ConfimLogInAttempForX", resourceCulture);
+            }
+        }
+        
+        public static string AllNotifications {
+            get {
+                return ResourceManager.GetString("AllNotifications", resourceCulture);
+            }
+        }
     }
 }

--- a/src/App/Resources/AppResources.resx
+++ b/src/App/Resources/AppResources.resx
@@ -2330,7 +2330,7 @@
     <value>No thanks</value>
   </data>
   <data name="ConfimLogInAttempForX" xml:space="preserve">
-    <value>Confirm log in attempt for</value>
+    <value>Confirm log in attempt for {0}</value>
   </data>
   <data name="AllNotifications" xml:space="preserve">
     <value>All notifications</value>

--- a/src/App/Resources/AppResources.resx
+++ b/src/App/Resources/AppResources.resx
@@ -2284,9 +2284,6 @@
   <data name="LogInAttemptByXOnY" xml:space="preserve">
     <value>Log in attempt by {0} on {1}</value>
   </data>
-  <data name="FingerprintPhrase" xml:space="preserve">
-    <value>Fingerprint phrase</value>
-  </data>
   <data name="DeviceType" xml:space="preserve">
     <value>Device Type</value>
   </data>
@@ -2331,5 +2328,11 @@
   </data>
   <data name="NoThanks" xml:space="preserve">
     <value>No thanks</value>
+  </data>
+  <data name="ConfimLogInAttempForX" xml:space="preserve">
+    <value>Confirm log in attempt for</value>
+  </data>
+  <data name="AllNotifications" xml:space="preserve">
+    <value>All notifications</value>
   </data>
 </root>

--- a/src/App/Services/NoopPushNotificationService.cs
+++ b/src/App/Services/NoopPushNotificationService.cs
@@ -30,6 +30,6 @@ namespace Bit.App.Services
 
         public void DismissLocalNotification(string notificationId) { }
 
-        public void SendLocalNotification(string title, string message, string notificationId = null) { }
+        public void SendLocalNotification(string title, string message, string notificationId) { }
     }
 }

--- a/src/App/Services/NoopPushNotificationService.cs
+++ b/src/App/Services/NoopPushNotificationService.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
 using Bit.App.Abstractions;
 
 namespace Bit.App.Services
@@ -26,5 +27,9 @@ namespace Bit.App.Services
         {
             return Task.FromResult(0);
         }
+
+        public void DismissLocalNotification(string notificationId) { }
+
+        public void SendLocalNotification(string title, string message, string notificationId = null) { }
     }
 }

--- a/src/App/Services/PushNotificationListenerService.cs
+++ b/src/App/Services/PushNotificationListenerService.cs
@@ -139,7 +139,7 @@ namespace Bit.App.Services
                     }
 
                     // if there is a request modal opened ignore all incoming requests
-                    if(App.Current.MainPage.Navigation.ModalStack.Any(p => ((NavigationPage)p).CurrentPage is LoginPasswordlessPage))
+                    if (App.Current.MainPage.Navigation.ModalStack.Any(p => ((NavigationPage)p).CurrentPage is LoginPasswordlessPage))
                     {
                         return;
                     }

--- a/src/App/Services/PushNotificationListenerService.cs
+++ b/src/App/Services/PushNotificationListenerService.cs
@@ -139,7 +139,7 @@ namespace Bit.App.Services
                     }
 
                     // if there is a request modal opened ignore all incoming requests
-                    if (App.Current.MainPage.Navigation.ModalStack.Any(p => ((NavigationPage)p).CurrentPage is LoginPasswordlessPage))
+                    if (App.Current.MainPage.Navigation.ModalStack.Any(p => p is NavigationPage navPage && navPage.CurrentPage is LoginPasswordlessPage))
                     {
                         return;
                     }
@@ -147,7 +147,7 @@ namespace Bit.App.Services
                     await _stateService.SetPasswordlessLoginNotificationAsync(passwordlessLoginMessage, passwordlessLoginMessage?.UserId);
                     var userEmail = await _stateService.GetEmailAsync(passwordlessLoginMessage?.UserId);
 
-                    _pushNotificationService.SendLocalNotification(AppResources.LogInRequested, $"{AppResources.ConfimLogInAttempForX} {userEmail}.", Constants.PasswordlessNotificationId);
+                    _pushNotificationService.SendLocalNotification(AppResources.LogInRequested, String.Format(AppResources.ConfimLogInAttempForX, userEmail), Constants.PasswordlessNotificationId);
                     _messagingService.Send("passwordlessLoginRequest", passwordlessLoginMessage);
                     break;
                 default:

--- a/src/Core/Abstractions/IStateService.cs
+++ b/src/Core/Abstractions/IStateService.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Bit.Core.Enums;
 using Bit.Core.Models.Data;
 using Bit.Core.Models.Domain;
+using Bit.Core.Models.Response;
 using Bit.Core.Models.View;
 
 namespace Bit.Core.Abstractions
@@ -153,5 +154,7 @@ namespace Bit.Core.Abstractions
         Task SaveExtensionActiveUserIdToStorageAsync(string userId);
         Task<bool> GetApprovePasswordlessLoginsAsync(string userId = null);
         Task SetApprovePasswordlessLoginsAsync(bool? value, string userId = null);
+        Task<PasswordlessRequestNotification> GetPasswordlessLoginNotificationAsync(string userId = null);
+        Task SetPasswordlessLoginNotificationAsync(PasswordlessRequestNotification value, string userId = null);
     }
 }

--- a/src/Core/Constants.cs
+++ b/src/Core/Constants.cs
@@ -30,6 +30,8 @@
         public static string RememberedEmailKey = "rememberedEmail";
         public static string RememberedOrgIdentifierKey = "rememberedOrgIdentifier";
         public const string FingerprintPhraseSeparator = "-";
+        public const string PasswordlessNotificationId = "26072022";
+        public const string AndroidNotificationChannelId = "general_notification_channel";
         public const int SelectFileRequestCode = 42;
         public const int SelectFilePermissionRequestCode = 43;
         public const int SaveFileRequestCode = 44;
@@ -85,5 +87,6 @@
         public static string LastSyncKey(string userId) => $"lastSync_{userId}";
         public static string BiometricUnlockKey(string userId) => $"biometricUnlock_{userId}";
         public static string ApprovePasswordlessLoginsKey(string userId) => $"approvePasswordlessLogins_{userId}";
+        public static string PasswordlessLoginNofiticationKey(string userId) => $"passwordlessLoginNofitication_{userId}";
     }
 }

--- a/src/Core/Enums/NotificationType.cs
+++ b/src/Core/Enums/NotificationType.cs
@@ -16,5 +16,12 @@
         SyncSettings = 10,
 
         LogOut = 11,
+
+        SyncSendCreate = 12,
+        SyncSendUpdate = 13,
+        SyncSendDelete = 14,
+
+        AuthRequest = 15,
+        AuthRequestResponse = 16,
     }
 }

--- a/src/Core/Models/Response/NotificationResponse.cs
+++ b/src/Core/Models/Response/NotificationResponse.cs
@@ -33,4 +33,10 @@ namespace Bit.Core.Models.Response
         public string UserId { get; set; }
         public DateTime Date { get; set; }
     }
+
+    public class PasswordlessRequestNotification
+    {
+        public string UserId { get; set; }
+        public string Id { get; set; }
+    }
 }

--- a/src/Core/Models/Response/PasswordlessLoginResponse.cs
+++ b/src/Core/Models/Response/PasswordlessLoginResponse.cs
@@ -6,19 +6,13 @@ namespace Bit.Core.Models.Response
     public class PasswordlessLoginResponse
     {
         public string Id { get; set; }
-
         public string PublicKey { get; set; }
-
         public DeviceType RequestDeviceType { get; set; }
-
         public string RequestIpAddress { get; set; }
-
+        public string RequestFingerprint { get; set; }
         public string Key { get; set; }
-
         public string MasterPasswordHash { get; set; }
-
         public DateTime CreationDate { get; set; }
-
         public bool RequestApproved { get; set; }
     }
 }

--- a/src/Core/Services/StateService.cs
+++ b/src/Core/Services/StateService.cs
@@ -7,6 +7,7 @@ using Bit.Core.Abstractions;
 using Bit.Core.Enums;
 using Bit.Core.Models.Data;
 using Bit.Core.Models.Domain;
+using Bit.Core.Models.Response;
 using Bit.Core.Models.View;
 using Bit.Core.Utilities;
 
@@ -1257,6 +1258,22 @@ namespace Bit.Core.Services
             var reconciledOptions = ReconcileOptions(new StorageOptions { UserId = userId },
                 await GetDefaultStorageOptionsAsync());
             var key = Constants.ApprovePasswordlessLoginsKey(reconciledOptions.UserId);
+            await SetValueAsync(key, value, reconciledOptions);
+        }
+
+        public async Task<PasswordlessRequestNotification> GetPasswordlessLoginNotificationAsync(string userId = null)
+        {
+            var reconciledOptions = ReconcileOptions(new StorageOptions { UserId = userId },
+                await GetDefaultStorageOptionsAsync());
+            var key = Constants.PasswordlessLoginNofiticationKey(reconciledOptions.UserId);
+            return await GetValueAsync<PasswordlessRequestNotification>(key, reconciledOptions);
+        }
+
+        public async Task SetPasswordlessLoginNotificationAsync(PasswordlessRequestNotification value, string userId = null)
+        {
+            var reconciledOptions = ReconcileOptions(new StorageOptions { UserId = userId },
+                await GetDefaultStorageOptionsAsync());
+            var key = Constants.PasswordlessLoginNofiticationKey(reconciledOptions.UserId);
             await SetValueAsync(key, value, reconciledOptions);
         }
         // Helpers

--- a/src/iOS/AppDelegate.cs
+++ b/src/iOS/AppDelegate.cs
@@ -304,7 +304,6 @@ namespace Bit.iOS
             iOSCoreHelpers.InitLogger();
             _pushHandler = new iOSPushNotificationHandler(
                 ServiceContainer.Resolve<IPushNotificationListenerService>("pushNotificationListenerService"));
-            UNUserNotificationCenter.Current.Delegate = _pushHandler;
             _nfcDelegate = new Core.NFCReaderDelegate((success, message) =>
                 _messagingService.Send("gotYubiKeyOTP", message));
 

--- a/src/iOS/AppDelegate.cs
+++ b/src/iOS/AppDelegate.cs
@@ -16,6 +16,7 @@ using Bit.iOS.Services;
 using CoreNFC;
 using Foundation;
 using UIKit;
+using UserNotifications;
 using Xamarin.Forms;
 using Xamarin.Forms.Platform.iOS;
 
@@ -56,7 +57,6 @@ namespace Bit.iOS
             LoadApplication(new App.App(null));
             iOSCoreHelpers.AppearanceAdjustments();
             ZXing.Net.Mobile.Forms.iOS.Platform.Init();
-
             _broadcasterService.Subscribe(nameof(AppDelegate), async (message) =>
             {
                 try
@@ -304,6 +304,7 @@ namespace Bit.iOS
             iOSCoreHelpers.InitLogger();
             _pushHandler = new iOSPushNotificationHandler(
                 ServiceContainer.Resolve<IPushNotificationListenerService>("pushNotificationListenerService"));
+            UNUserNotificationCenter.Current.Delegate = _pushHandler;
             _nfcDelegate = new Core.NFCReaderDelegate((success, message) =>
                 _messagingService.Send("gotYubiKeyOTP", message));
 

--- a/src/iOS/Services/iOSPushNotificationHandler.cs
+++ b/src/iOS/Services/iOSPushNotificationHandler.cs
@@ -83,6 +83,7 @@ namespace Bit.iOS.Services
         public void WillPresentNotification(UNUserNotificationCenter center, UNNotification notification, Action<UNNotificationPresentationOptions> completionHandler)
         {
             Debug.WriteLine($"{TAG} WillPresentNotification {notification?.Request?.Content?.UserInfo}");
+            OnMessageReceived(notification?.Request?.Content?.UserInfo);
             completionHandler(UNNotificationPresentationOptions.Alert);
         }
 

--- a/src/iOS/Services/iOSPushNotificationHandler.cs
+++ b/src/iOS/Services/iOSPushNotificationHandler.cs
@@ -83,8 +83,6 @@ namespace Bit.iOS.Services
         public void WillPresentNotification(UNUserNotificationCenter center, UNNotification notification, Action<UNNotificationPresentationOptions> completionHandler)
         {
             Debug.WriteLine($"{TAG} WillPresentNotification {notification?.Request?.Content?.UserInfo}");
-
-            OnMessageReceived(notification?.Request?.Content?.UserInfo);
             completionHandler(UNNotificationPresentationOptions.Alert);
         }
 

--- a/src/iOS/Services/iOSPushNotificationService.cs
+++ b/src/iOS/Services/iOSPushNotificationService.cs
@@ -1,4 +1,7 @@
-﻿using System.Diagnostics;
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
 using System.Threading.Tasks;
 using Bit.App.Abstractions;
 using Foundation;
@@ -63,6 +66,37 @@ namespace Bit.iOS.Services
             NSUserDefaults.StandardUserDefaults.SetString(string.Empty, TokenSetting);
             NSUserDefaults.StandardUserDefaults.Synchronize();
             return Task.FromResult(0);
+        }
+
+        public void SendLocalNotification(string title, string message, string notificationId = null)
+        {
+            var content = new UNMutableNotificationContent()
+            {
+                Title = title,
+                Body = message
+            };
+
+            notificationId = notificationId ?? new Random().Next(1000, 999999).ToString();
+
+            var request = UNNotificationRequest.FromIdentifier(notificationId, content, null);
+            UNUserNotificationCenter.Current.AddNotificationRequest(request, (err) =>
+            {
+                if (err != null)
+                {
+                    throw new Exception($"Failed to schedule notification: {err}");
+                }
+            });
+        }
+
+        public void DismissLocalNotification(string notificationId)
+        {
+            if (string.IsNullOrEmpty(notificationId))
+            {
+                return;
+            }
+
+            UNUserNotificationCenter.Current.RemovePendingNotificationRequests(new string[] { notificationId });
+            UNUserNotificationCenter.Current.RemoveDeliveredNotifications(new string[] { notificationId });
         }
     }
 }

--- a/src/iOS/Services/iOSPushNotificationService.cs
+++ b/src/iOS/Services/iOSPushNotificationService.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
 using Bit.App.Abstractions;
+using Bit.Core.Services;
 using Foundation;
 using UIKit;
 using UserNotifications;
@@ -68,22 +69,25 @@ namespace Bit.iOS.Services
             return Task.FromResult(0);
         }
 
-        public void SendLocalNotification(string title, string message, string notificationId = null)
+        public void SendLocalNotification(string title, string message, string notificationId)
         {
+            if (string.IsNullOrEmpty(notificationId))
+            {
+                throw new ArgumentNullException("notificationId cannot be null or empty.");
+            }
+
             var content = new UNMutableNotificationContent()
             {
                 Title = title,
                 Body = message
             };
 
-            notificationId = notificationId ?? new Random().Next(1000, 999999).ToString();
-
             var request = UNNotificationRequest.FromIdentifier(notificationId, content, null);
             UNUserNotificationCenter.Current.AddNotificationRequest(request, (err) =>
             {
                 if (err != null)
                 {
-                    throw new Exception($"Failed to schedule notification: {err}");
+                    Logger.Instance.Exception(new Exception($"Failed to schedule notification: {err}"));
                 }
             });
         }


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Configure the mobile app to be able to receive and process a new notification type associated with passwordless login. 
Added configuration to be able to show local notifications to the user and dismiss them. 

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->
* **src/App/App.xaml.cs:**
Added subscription in the broadcast service for `unlock` and `passwordlessLoginRequest`. Every time the user unlocks its vault, if there is any pending request, then the app should show the accept/decline modal. If the user in within the app and a new passwordless login notification arrives, it will broadcast a `passwordlessLoginRequest` message, showing the  the accept/decline modal.
* **src/Android/Services/IPushNotificationService.cs:**  
`SendLocalNotification` `DismissLocalNotification` added methods to the interface and following platform implementation. These methods are used to manage device notifications.  

## Screenshots
<img width="375" alt="image" src="https://user-images.githubusercontent.com/4648522/187905384-3576bc6b-dda7-4eb2-afa6-489edb07fd39.png">

## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
