### PR TITLE
[SG-666][SG-667] Email is not prefilled and username isn't generated automatically

### DIFF
--- a/src/App/Pages/Generator/GeneratorPageViewModel.cs
+++ b/src/App/Pages/Generator/GeneratorPageViewModel.cs
@@ -50,8 +50,6 @@ namespace Bit.App.Pages
         private bool _showFirefoxRelayApiAccessToken;
         private bool _showAnonAddyApiAccessToken;
         private bool _showSimpleLoginApiKey;
-        private UsernameEmailType _catchAllEmailTypeSelected;
-        private UsernameEmailType _plusAddressedEmailTypeSelected;
         private bool _editMode;
 
         public GeneratorPageViewModel()
@@ -688,6 +686,10 @@ namespace Bit.App.Pages
             if (regenerate && UsernameTypeSelected != UsernameType.ForwardedEmailAlias)
             {
                 await RegenerateUsernameAsync();
+            }
+            else
+            {
+                Username = Constants.DefaultUsernameGenerated;
             }
         }
 

--- a/src/App/Pages/Vault/CipherAddEditPageViewModel.cs
+++ b/src/App/Pages/Vault/CipherAddEditPageViewModel.cs
@@ -605,7 +605,7 @@ namespace Bit.App.Pages
                 return;
             }
 
-            var website = (bool)(Cipher?.Login?.HasUris) ? Cipher?.Login?.Uris[0].Host : null;
+            var website = Cipher?.Login?.Uris?.FirstOrDefault()?.Host;
 
             var page = new GeneratorPage(false, async (username) =>
             {


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
With this changes email is now prefilled when selecting Plus Adressed Email username type, the username is generated automatically upon navigation and if the chosen item has an URI we pass it correctly as a field for Plus Adressed Email or Catch-all Email username types.



## Code changes
* **GeneratorPageViewModel.cs:** Now we fetch the user's email and generate automatically the username for all username types except UsernameType.ForwardedEmailAlias.
* **CipherAddEditPageViewModel.cs:** Fixed the field sent to the generator page.




## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
