### PR TITLE
[SG-691] Login request is not displayed after changing accounts

### DIFF
--- a/src/Android/MainApplication.cs
+++ b/src/Android/MainApplication.cs
@@ -72,8 +72,9 @@ namespace Bit.Droid
                     ServiceContainer.Resolve<IStateService>("stateService"),
                     ServiceContainer.Resolve<IPlatformUtilsService>("platformUtilsService"),
                     ServiceContainer.Resolve<IAuthService>("authService"),
-                    ServiceContainer.Resolve<ILogger>("logger"));
-                ServiceContainer.Register<IAccountsManager>("accountsManager", accountsManager);
+                    ServiceContainer.Resolve<ILogger>("logger"),
+                    ServiceContainer.Resolve<IMessagingService>("messagingService"));
+                    ServiceContainer.Register<IAccountsManager>("accountsManager", accountsManager);
             }
 #if !FDROID
             if (Build.VERSION.SdkInt <= BuildVersionCodes.Kitkat)

--- a/src/App/App.xaml.cs
+++ b/src/App/App.xaml.cs
@@ -140,7 +140,7 @@ namespace Bit.App
                                 new NavigationPage(new RemoveMasterPasswordPage()));
                         });
                     }
-                    else if (message.Command == "passwordlessLoginRequest" || message.Command == "unlocked")
+                    else if (message.Command == "passwordlessLoginRequest" || message.Command == "unlocked" || message.Command == "accountSwitched")
                     {
                         CheckPasswordlessLoginRequestsAsync().FireAndForget();
                     }

--- a/src/App/App.xaml.cs
+++ b/src/App/App.xaml.cs
@@ -140,7 +140,7 @@ namespace Bit.App
                                 new NavigationPage(new RemoveMasterPasswordPage()));
                         });
                     }
-                    else if (message.Command == "passwordlessLoginRequest" || message.Command == "unlocked" || message.Command == "accountSwitched")
+                    else if (message.Command == "passwordlessLoginRequest" || message.Command == "unlocked" || message.Command == AccountsManagerMessageCommands.ACCOUNT_SWITCH_COMPLETED)
                     {
                         CheckPasswordlessLoginRequestsAsync().FireAndForget();
                     }

--- a/src/App/Utilities/AccountManagement/AccountsManager.cs
+++ b/src/App/Utilities/AccountManagement/AccountsManager.cs
@@ -215,8 +215,7 @@ namespace Bit.App.Utilities.AccountManagement
                 }
                 await Task.Delay(50);
                 await _accountsManagerHost.UpdateThemeAsync();
-
-                _messagingService.Send("accountSwitched");
+                _messagingService.Send(AccountsManagerMessageCommands.ACCOUNT_SWITCH_COMPLETED);
             });
         }
     }

--- a/src/App/Utilities/AccountManagement/AccountsManager.cs
+++ b/src/App/Utilities/AccountManagement/AccountsManager.cs
@@ -20,7 +20,7 @@ namespace Bit.App.Utilities.AccountManagement
         private readonly IPlatformUtilsService _platformUtilsService;
         private readonly IAuthService _authService;
         private readonly ILogger _logger;
-
+        private readonly IMessagingService _messagingService;
         Func<AppOptions> _getOptionsFunc;
         private IAccountsManagerHost _accountsManagerHost;
 
@@ -30,7 +30,8 @@ namespace Bit.App.Utilities.AccountManagement
                                IStateService stateService,
                                IPlatformUtilsService platformUtilsService,
                                IAuthService authService,
-                               ILogger logger)
+                               ILogger logger,
+                               IMessagingService messagingService)
         {
             _broadcasterService = broadcasterService;
             _vaultTimeoutService = vaultTimeoutService;
@@ -39,6 +40,7 @@ namespace Bit.App.Utilities.AccountManagement
             _platformUtilsService = platformUtilsService;
             _authService = authService;
             _logger = logger;
+            _messagingService = messagingService;
         }
 
         private AppOptions Options => _getOptionsFunc?.Invoke() ?? new AppOptions { IosExtension = true };
@@ -213,6 +215,8 @@ namespace Bit.App.Utilities.AccountManagement
                 }
                 await Task.Delay(50);
                 await _accountsManagerHost.UpdateThemeAsync();
+
+                _messagingService.Send("accountSwitched");
             });
         }
     }

--- a/src/Core/Utilities/AccountsManagerMessageCommands.cs
+++ b/src/Core/Utilities/AccountsManagerMessageCommands.cs
@@ -9,5 +9,6 @@
         public const string ADD_ACCOUNT = "addAccount";
         public const string ACCOUNT_ADDED = "accountAdded";
         public const string SWITCHED_ACCOUNT = "switchedAccount";
+        public const string ACCOUNT_SWITCH_COMPLETED = "accountSwitchCompleted";
     }
 }

--- a/src/iOS.Core/Utilities/iOSCoreHelpers.cs
+++ b/src/iOS.Core/Utilities/iOSCoreHelpers.cs
@@ -222,7 +222,8 @@ namespace Bit.iOS.Core.Utilities
                 ServiceContainer.Resolve<IStateService>("stateService"),
                 ServiceContainer.Resolve<IPlatformUtilsService>("platformUtilsService"),
                 ServiceContainer.Resolve<IAuthService>("authService"),
-                ServiceContainer.Resolve<ILogger>("logger"));
+                ServiceContainer.Resolve<ILogger>("logger"),
+                ServiceContainer.Resolve<IMessagingService>("messagingService"));
             ServiceContainer.Register<IAccountsManager>("accountsManager", accountsManager);
 
             if (postBootstrapFunc != null)


### PR DESCRIPTION
… to trigger a check for login requests.

## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
When the user have more than one account logged in and sends a login request for the not active (still unlocked) account , The user sees the push notification but when switches to the account that received the request the user is not being redirected to the login request screen.

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->
Passwordless request check was not being triggered because there was no "unlock" message being broadcasted. Added new broadcast message when account is switched to trigger passwordless login requests check.

## Screenshots
<!--Required for any UI changes. Delete if not applicable-->



## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
