### PR TITLE
[SG-702] Tapping Push Notification does not open the account the request is for

### DIFF
--- a/src/Android/MainActivity.cs
+++ b/src/Android/MainActivity.cs
@@ -153,7 +153,7 @@ namespace Bit.Droid
             if (Intent?.GetStringExtra(Constants.NotificationData) is string notificationDataJson)
             {
                 var notificationType = JToken.Parse(notificationDataJson).SelectToken(Constants.NotificationDataType);
-                if (notificationType!= null && (string)notificationType == PasswordlessNotificationData.TYPE)
+                if (notificationType != null && (string)notificationType == PasswordlessNotificationData.TYPE)
                 {
                     _pushNotificationListenerService.OnNotificationTapped(PasswordlessNotificationData.TYPE, JsonConvert.DeserializeObject<PasswordlessNotificationData>(notificationDataJson)).FireAndForget();
                 }

--- a/src/Android/MainActivity.cs
+++ b/src/Android/MainActivity.cs
@@ -20,6 +20,8 @@ using Bit.Core.Enums;
 using Bit.Core.Utilities;
 using Bit.Droid.Receivers;
 using Bit.Droid.Utilities;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using Xamarin.Essentials;
 using ZXing.Net.Mobile.Android;
 using FileProvider = AndroidX.Core.Content.FileProvider;
@@ -148,9 +150,13 @@ namespace Bit.Droid
                 .GetAwaiter()
                 .GetResult();
 
-            if (Intent?.GetStringExtra(Constants.PasswordlessNotificationType) is string notificationDataJson)
+            if (Intent?.GetStringExtra(Constants.NotificationData) is string notificationDataJson)
             {
-                _pushNotificationListenerService.OnNotificationTapped(Constants.PasswordlessNotificationType, notificationDataJson).FireAndForget();
+                var notificationType = JToken.Parse(notificationDataJson).SelectToken(Constants.NotificationDataType);
+                if (notificationType!= null && (string)notificationType == PasswordlessNotificationData.TYPE)
+                {
+                    _pushNotificationListenerService.OnNotificationTapped(PasswordlessNotificationData.TYPE, JsonConvert.DeserializeObject<PasswordlessNotificationData>(notificationDataJson)).FireAndForget();
+                }
             }
         }
 

--- a/src/Android/MainActivity.cs
+++ b/src/Android/MainActivity.cs
@@ -153,9 +153,9 @@ namespace Bit.Droid
             if (Intent?.GetStringExtra(Constants.NotificationData) is string notificationDataJson)
             {
                 var notificationType = JToken.Parse(notificationDataJson).SelectToken(Constants.NotificationDataType);
-                if (notificationType != null && (string)notificationType == PasswordlessNotificationData.TYPE)
+                if (notificationType.ToString() == PasswordlessNotificationData.TYPE)
                 {
-                    _pushNotificationListenerService.OnNotificationTapped(PasswordlessNotificationData.TYPE, JsonConvert.DeserializeObject<PasswordlessNotificationData>(notificationDataJson)).FireAndForget();
+                    _pushNotificationListenerService.OnNotificationTapped(JsonConvert.DeserializeObject<PasswordlessNotificationData>(notificationDataJson)).FireAndForget();
                 }
             }
         }

--- a/src/Android/MainActivity.cs
+++ b/src/Android/MainActivity.cs
@@ -39,6 +39,7 @@ namespace Bit.Droid
         private IStateService _stateService;
         private IAppIdService _appIdService;
         private IEventService _eventService;
+        private IPushNotificationListenerService _pushNotificationListenerService;
         private ILogger _logger;
         private PendingIntent _eventUploadPendingIntent;
         private AppOptions _appOptions;
@@ -61,6 +62,7 @@ namespace Bit.Droid
             _stateService = ServiceContainer.Resolve<IStateService>("stateService");
             _appIdService = ServiceContainer.Resolve<IAppIdService>("appIdService");
             _eventService = ServiceContainer.Resolve<IEventService>("eventService");
+            _pushNotificationListenerService = ServiceContainer.Resolve<IPushNotificationListenerService>();
             _logger = ServiceContainer.Resolve<ILogger>("logger");
 
             TabLayoutResource = Resource.Layout.Tabbar;
@@ -145,6 +147,11 @@ namespace Bit.Droid
             AndroidHelpers.SetPreconfiguredRestrictionSettingsAsync(this)
                 .GetAwaiter()
                 .GetResult();
+
+            if (Intent?.GetStringExtra(Constants.PasswordlessNotificationType) is string notificationDataJson)
+            {
+                _pushNotificationListenerService.OnNotificationTapped(Constants.PasswordlessNotificationType, notificationDataJson).FireAndForget();
+            }
         }
 
         protected override void OnNewIntent(Intent intent)

--- a/src/Android/Services/AndroidPushNotificationService.cs
+++ b/src/Android/Services/AndroidPushNotificationService.cs
@@ -72,7 +72,7 @@ namespace Bit.Droid.Services
 
         public void SendLocalNotification(string title, string message, BaseNotificationData data)
         {
-            if (string.IsNullOrEmpty(data.NotificationId))
+            if (string.IsNullOrEmpty(data.Id))
             {
                 throw new ArgumentNullException("notificationId cannot be null or empty.");
             }
@@ -93,11 +93,11 @@ namespace Bit.Droid.Services
 
             if (data is PasswordlessNotificationData passwordlessNotificationData && passwordlessNotificationData.TimeoutInMinutes > 0)
             {
-                builder.SetTimeoutAfter(((PasswordlessNotificationData)data).TimeoutInMinutes * 60000);
+                builder.SetTimeoutAfter(passwordlessNotificationData.TimeoutInMinutes * 60000);
             }
 
             var notificationManager = NotificationManagerCompat.From(context);
-            notificationManager.Notify(int.Parse(data.NotificationId), builder.Build());
+            notificationManager.Notify(int.Parse(data.Id), builder.Build());
         }
     }
 }

--- a/src/Android/Services/AndroidPushNotificationService.cs
+++ b/src/Android/Services/AndroidPushNotificationService.cs
@@ -7,6 +7,7 @@ using Android.Content;
 using Android.OS;
 using AndroidX.Core.App;
 using Bit.App.Abstractions;
+using Bit.App.Models;
 using Bit.Core;
 using Bit.Core.Abstractions;
 using Bit.Droid.Utilities;
@@ -69,19 +70,16 @@ namespace Bit.Droid.Services
             }
         }
 
-        public void SendLocalNotification(string title, string message, string notificationId, string notificationType, Dictionary<string, string> notificationData = null, int notificationTimeoutMinutes = 0)
+        public void SendLocalNotification(string title, string message, BaseNotificationData data)
         {
-            if (string.IsNullOrEmpty(notificationId))
+            if (string.IsNullOrEmpty(data.NotificationId))
             {
                 throw new ArgumentNullException("notificationId cannot be null or empty.");
             }
             
             var context = Android.App.Application.Context;
             var intent = new Intent(context, typeof(MainActivity));
-            if(notificationData != null)
-            {
-                intent.PutExtra(notificationType, JsonConvert.SerializeObject(notificationData));
-            }
+            intent.PutExtra(Constants.NotificationData, JsonConvert.SerializeObject(data));
 
             var pendingIntentFlags = AndroidHelpers.AddPendingIntentMutabilityFlag(PendingIntentFlags.UpdateCurrent, true);
             var pendingIntent = PendingIntent.GetActivity(context, 20220801, intent, pendingIntentFlags);
@@ -93,13 +91,13 @@ namespace Bit.Droid.Services
                .SetColor((int)Android.Graphics.Color.White)
                .SetAutoCancel(true);
 
-            if (notificationTimeoutMinutes > 0)
+            if (data is PasswordlessNotificationData passwordlessNotificationData && passwordlessNotificationData.TimeoutInMinutes > 0)
             {
-                builder.SetTimeoutAfter(notificationTimeoutMinutes * 60000);
+                builder.SetTimeoutAfter(((PasswordlessNotificationData)data).TimeoutInMinutes * 60000);
             }
 
             var notificationManager = NotificationManagerCompat.From(context);
-            notificationManager.Notify(int.Parse(notificationId), builder.Build());
+            notificationManager.Notify(int.Parse(data.NotificationId), builder.Build());
         }
     }
 }

--- a/src/App/Abstractions/IPushNotificationListenerService.cs
+++ b/src/App/Abstractions/IPushNotificationListenerService.cs
@@ -9,6 +9,7 @@ namespace Bit.App.Abstractions
         Task OnRegisteredAsync(string token, string device);
         void OnUnregistered(string device);
         void OnError(string message, string device);
+        Task OnNotificationTapped(string type, string data);
         bool ShouldShowNotification();
     }
 }

--- a/src/App/Abstractions/IPushNotificationListenerService.cs
+++ b/src/App/Abstractions/IPushNotificationListenerService.cs
@@ -10,7 +10,7 @@ namespace Bit.App.Abstractions
         Task OnRegisteredAsync(string token, string device);
         void OnUnregistered(string device);
         void OnError(string message, string device);
-        Task OnNotificationTapped(string type, BaseNotificationData data);
+        Task OnNotificationTapped(BaseNotificationData data);
         bool ShouldShowNotification();
     }
 }

--- a/src/App/Abstractions/IPushNotificationListenerService.cs
+++ b/src/App/Abstractions/IPushNotificationListenerService.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading.Tasks;
+using Bit.App.Models;
 using Newtonsoft.Json.Linq;
 
 namespace Bit.App.Abstractions
@@ -9,7 +10,7 @@ namespace Bit.App.Abstractions
         Task OnRegisteredAsync(string token, string device);
         void OnUnregistered(string device);
         void OnError(string message, string device);
-        Task OnNotificationTapped(string type, string data);
+        Task OnNotificationTapped(string type, BaseNotificationData data);
         bool ShouldShowNotification();
     }
 }

--- a/src/App/Abstractions/IPushNotificationService.cs
+++ b/src/App/Abstractions/IPushNotificationService.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Threading.Tasks;
+using Bit.App.Models;
 
 namespace Bit.App.Abstractions
 {
@@ -10,7 +11,7 @@ namespace Bit.App.Abstractions
         Task<string> GetTokenAsync();
         Task RegisterAsync();
         Task UnregisterAsync();
-        void SendLocalNotification(string title, string message, string notificationId, string notificationType, Dictionary<string, string> notificationData = null, int notificationTimeoutMinutes = 0);
+        void SendLocalNotification(string title, string message, BaseNotificationData data);
         void DismissLocalNotification(string notificationId);
     }
 }

--- a/src/App/Abstractions/IPushNotificationService.cs
+++ b/src/App/Abstractions/IPushNotificationService.cs
@@ -10,7 +10,7 @@ namespace Bit.App.Abstractions
         Task<string> GetTokenAsync();
         Task RegisterAsync();
         Task UnregisterAsync();
-        void SendLocalNotification(string title, string message, string notificationId, string notificationType, Dictionary<string, string> notificationData = null, int notificationTimeoutMinutes = 0;
+        void SendLocalNotification(string title, string message, string notificationId, string notificationType, Dictionary<string, string> notificationData = null, int notificationTimeoutMinutes = 0);
         void DismissLocalNotification(string notificationId);
     }
 }

--- a/src/App/Abstractions/IPushNotificationService.cs
+++ b/src/App/Abstractions/IPushNotificationService.cs
@@ -10,7 +10,7 @@ namespace Bit.App.Abstractions
         Task<string> GetTokenAsync();
         Task RegisterAsync();
         Task UnregisterAsync();
-        void SendLocalNotification(string title, string message, string notificationId);
+        void SendLocalNotification(string title, string message, string notificationId, string notificationType, Dictionary<string, string> notificationData = null, int notificationTimeoutMinutes = 0;
         void DismissLocalNotification(string notificationId);
     }
 }

--- a/src/App/Models/NotificationData.cs
+++ b/src/App/Models/NotificationData.cs
@@ -1,0 +1,24 @@
+﻿using System;
+namespace Bit.App.Models
+{
+    public abstract class BaseNotificationData
+    {
+        public abstract string Type { get; }
+
+    }
+
+    public class PasswordlessNotificationData : BaseNotificationData
+    {
+        public const string TYPE = "passwordlessNotificationData";
+
+        public override string Type => TYPE;
+
+        public int TimeoutInMinutes { get; set; }
+
+        public string UserEmail { get; set; }
+
+        public string NotificationId { get; set; }
+    }
+
+}
+

--- a/src/App/Models/NotificationData.cs
+++ b/src/App/Models/NotificationData.cs
@@ -3,21 +3,20 @@ namespace Bit.App.Models
 {
     public abstract class BaseNotificationData
     {
-        public abstract string Type { get; }
+        public abstract string NotificationType { get; }
 
+        public string NotificationId { get; set; }
     }
 
     public class PasswordlessNotificationData : BaseNotificationData
     {
         public const string TYPE = "passwordlessNotificationData";
 
-        public override string Type => TYPE;
+        public override string NotificationType => TYPE;
 
         public int TimeoutInMinutes { get; set; }
 
         public string UserEmail { get; set; }
-
-        public string NotificationId { get; set; }
     }
 
 }

--- a/src/App/Models/NotificationData.cs
+++ b/src/App/Models/NotificationData.cs
@@ -3,16 +3,16 @@ namespace Bit.App.Models
 {
     public abstract class BaseNotificationData
     {
-        public abstract string NotificationType { get; }
+        public abstract string Type { get; }
 
-        public string NotificationId { get; set; }
+        public string Id { get; set; }
     }
 
     public class PasswordlessNotificationData : BaseNotificationData
     {
         public const string TYPE = "passwordlessNotificationData";
 
-        public override string NotificationType => TYPE;
+        public override string Type => TYPE;
 
         public int TimeoutInMinutes { get; set; }
 

--- a/src/App/Pages/Accounts/LoginPasswordlessViewModel.cs
+++ b/src/App/Pages/Accounts/LoginPasswordlessViewModel.cs
@@ -72,15 +72,29 @@ namespace Bit.App.Pages
 
         public void StopRequestTimeUpdater()
         {
-            _requestTimeCts?.Cancel();
-            _requestTimeCts?.Dispose();
+            try
+            {
+                _requestTimeCts?.Cancel();
+                _requestTimeCts?.Dispose();
+            }
+            catch (Exception ex)
+            {
+                _logger.Exception(ex);
+            }
         }
 
         public void StartRequestTimeUpdater()
         {
-            _requestTimeCts?.Cancel();
-            _requestTimeCts = new CancellationTokenSource();
-            _requestTimeTask = new TimerTask(_logger, UpdateRequestTime, _requestTimeCts).RunPeriodic(TimeSpan.FromMinutes(REQUEST_TIME_UPDATE_PERIOD_IN_MINUTES));
+            try
+            {
+                _requestTimeCts?.Cancel();
+                _requestTimeCts = new CancellationTokenSource();
+                _requestTimeTask = new TimerTask(_logger, UpdateRequestTime, _requestTimeCts).RunPeriodic(TimeSpan.FromMinutes(REQUEST_TIME_UPDATE_PERIOD_IN_MINUTES));
+            }
+            catch (Exception ex)
+            {
+                _logger.Exception(ex);
+            }
         }
 
         private async Task UpdateRequestTime()

--- a/src/App/Services/NoopPushNotificationListenerService.cs
+++ b/src/App/Services/NoopPushNotificationListenerService.cs
@@ -28,5 +28,10 @@ namespace Bit.App.Services
         {
             return false;
         }
+
+        public Task OnNotificationTapped(string type, string data)
+        {
+            return Task.FromResult(0);
+        }
     }
 }

--- a/src/App/Services/NoopPushNotificationListenerService.cs
+++ b/src/App/Services/NoopPushNotificationListenerService.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading.Tasks;
 using Bit.App.Abstractions;
+using Bit.App.Models;
 using Newtonsoft.Json.Linq;
 
 namespace Bit.App.Services
@@ -29,7 +30,7 @@ namespace Bit.App.Services
             return false;
         }
 
-        public Task OnNotificationTapped(string type, string data)
+        public Task OnNotificationTapped(string type, BaseNotificationData data)
         {
             return Task.FromResult(0);
         }

--- a/src/App/Services/NoopPushNotificationListenerService.cs
+++ b/src/App/Services/NoopPushNotificationListenerService.cs
@@ -30,7 +30,7 @@ namespace Bit.App.Services
             return false;
         }
 
-        public Task OnNotificationTapped(string type, BaseNotificationData data)
+        public Task OnNotificationTapped(BaseNotificationData data)
         {
             return Task.FromResult(0);
         }

--- a/src/App/Services/NoopPushNotificationService.cs
+++ b/src/App/Services/NoopPushNotificationService.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Threading.Tasks;
 using Bit.App.Abstractions;
+using Bit.App.Models;
 
 namespace Bit.App.Services
 {
@@ -30,6 +31,6 @@ namespace Bit.App.Services
 
         public void DismissLocalNotification(string notificationId) { }
 
-        public void SendLocalNotification(string title, string message, string notificationId, string notificationType, Dictionary<string, string> notificationData = null, int notificationTimeoutMinutes = 0) { }
+        public void SendLocalNotification(string title, string message, BaseNotificationData data) { }
     }
 }

--- a/src/App/Services/NoopPushNotificationService.cs
+++ b/src/App/Services/NoopPushNotificationService.cs
@@ -30,6 +30,6 @@ namespace Bit.App.Services
 
         public void DismissLocalNotification(string notificationId) { }
 
-        public void SendLocalNotification(string title, string message, string notificationId) { }
+        public void SendLocalNotification(string title, string message, string notificationId, string notificationType, Dictionary<string, string> notificationData = null, int notificationTimeoutMinutes = 0) { }
     }
 }

--- a/src/App/Services/PushNotificationListenerService.cs
+++ b/src/App/Services/PushNotificationListenerService.cs
@@ -153,7 +153,7 @@ namespace Bit.App.Services
 
                     var notificationData = new PasswordlessNotificationData()
                     {
-                        NotificationId = Constants.PasswordlessNotificationId,
+                        Id = Constants.PasswordlessNotificationId,
                         TimeoutInMinutes = Constants.PasswordlessNotificationTimeoutInMinutes,
                         UserEmail = userEmail,
                     };

--- a/src/App/Services/PushNotificationListenerService.cs
+++ b/src/App/Services/PushNotificationListenerService.cs
@@ -224,7 +224,7 @@ namespace Bit.App.Services
             Debug.WriteLine($"{TAG} error - {message}");
         }
 
-        public async Task OnNotificationTapped(string type, BaseNotificationData data)
+        public async Task OnNotificationTapped(BaseNotificationData data)
         {
             Resolve();
             try

--- a/src/App/Services/PushNotificationListenerService.cs
+++ b/src/App/Services/PushNotificationListenerService.cs
@@ -149,7 +149,6 @@ namespace Bit.App.Services
                     await _stateService.SetPasswordlessLoginNotificationAsync(passwordlessLoginMessage, passwordlessLoginMessage?.UserId);
                     var userEmail = await _stateService.GetEmailAsync(passwordlessLoginMessage?.UserId);
                     var notificationData = new Dictionary<string, string>();
-                    notificationData.Add("type", Constants.PasswordlessNotificationType);
                     notificationData.Add("userEmail", userEmail);
                     notificationData.Add("notificationId", passwordlessLoginMessage.Id);
 

--- a/src/Core/Constants.cs
+++ b/src/Core/Constants.cs
@@ -32,7 +32,8 @@
         public static string RememberedOrgIdentifierKey = "rememberedOrgIdentifier";
         public const string PasswordlessNotificationId = "26072022";
         public const string AndroidNotificationChannelId = "general_notification_channel";
-        public const string PasswordlessNotificationType = "passwordlessNotification";
+        public const string NotificationData = "notificationData";
+        public const string NotificationDataType = "NotificationType";
         public const int SelectFileRequestCode = 42;
         public const int SelectFilePermissionRequestCode = 43;
         public const int SaveFileRequestCode = 44;

--- a/src/Core/Constants.cs
+++ b/src/Core/Constants.cs
@@ -32,6 +32,7 @@
         public static string RememberedOrgIdentifierKey = "rememberedOrgIdentifier";
         public const string PasswordlessNotificationId = "26072022";
         public const string AndroidNotificationChannelId = "general_notification_channel";
+        public const string PasswordlessNotificationType = "passwordlessNotification";
         public const int SelectFileRequestCode = 42;
         public const int SelectFilePermissionRequestCode = 43;
         public const int SaveFileRequestCode = 44;

--- a/src/iOS/Services/iOSPushNotificationHandler.cs
+++ b/src/iOS/Services/iOSPushNotificationHandler.cs
@@ -86,7 +86,7 @@ namespace Bit.iOS.Services
             {
                 OnMessageReceived(response?.Notification?.Request?.Content?.UserInfo);
                 var values = UserValuesToJObject(response?.Notification?.Request?.Content?.UserInfo);
-                if(values.TryGetValue("Type", out JToken notificationType) && notificationType != null)
+                if(values.TryGetValue("type", out JToken notificationType) && notificationType != null)
                 {
                     _pushNotificationListenerService.OnNotificationTapped(notificationType.ToString(), values.ToString(Formatting.None));
                 }

--- a/src/iOS/Services/iOSPushNotificationHandler.cs
+++ b/src/iOS/Services/iOSPushNotificationHandler.cs
@@ -32,7 +32,19 @@ namespace Bit.iOS.Services
             {
                 Debug.WriteLine($"{TAG} - OnMessageReceived.");
 
-                var values = UserValuesToJObject(userInfo);
+                var json = DictionaryToJson(userInfo);
+                var values = JObject.Parse(json);
+                var keyAps = new NSString("aps");
+                if (userInfo.ContainsKey(keyAps) && userInfo.ValueForKey(keyAps) is NSDictionary aps)
+                {
+                    foreach (var apsKey in aps)
+                    {
+                        if (!values.TryGetValue(apsKey.Key.ToString(), out JToken temp))
+                        {
+                            values.Add(apsKey.Key.ToString(), apsKey.Value.ToString());
+                        }
+                    }
+                }
                 _pushNotificationListenerService.OnMessageAsync(values, Device.iOS);
             }
             catch (Exception ex)
@@ -102,26 +114,6 @@ namespace Bit.iOS.Services
 
             // Inform caller it has been handled
             completionHandler();
-        }
-
-        private static JObject UserValuesToJObject(NSDictionary userInfo)
-        {
-            var json = DictionaryToJson(userInfo);
-            Console.WriteLine(json);
-            var values = JObject.Parse(json);
-            var keyAps = new NSString("aps");
-            if (userInfo.ContainsKey(keyAps) && userInfo.ValueForKey(keyAps) is NSDictionary aps)
-            {
-                foreach (var apsKey in aps)
-                {
-                    if (!values.TryGetValue(apsKey.Key.ToString(), out JToken temp))
-                    {
-                        values.Add(apsKey.Key.ToString(), apsKey.Value.ToString());
-                    }
-                }
-            }
-
-            return values;
         }
     }
 }

--- a/src/iOS/Services/iOSPushNotificationHandler.cs
+++ b/src/iOS/Services/iOSPushNotificationHandler.cs
@@ -3,6 +3,7 @@ using System.Diagnostics;
 using Bit.App.Abstractions;
 using Bit.App.Models;
 using Bit.Core;
+using Bit.Core.Enums;
 using Bit.Core.Services;
 using CoreData;
 using Foundation;
@@ -105,9 +106,9 @@ namespace Bit.iOS.Services
                 {
                     var token = JToken.Parse(NSString.FromObject(nsObject).ToString());
                     var typeToken = token.SelectToken(Constants.NotificationDataType);
-                    if (typeToken != null && (string)typeToken == PasswordlessNotificationData.TYPE)
+                    if (typeToken.ToString() == PasswordlessNotificationData.TYPE)
                     {
-                        _pushNotificationListenerService.OnNotificationTapped(PasswordlessNotificationData.TYPE, token.ToObject<PasswordlessNotificationData>());
+                        _pushNotificationListenerService.OnNotificationTapped(token.ToObject<PasswordlessNotificationData>());
                     }
                 }
             }

--- a/src/iOS/Services/iOSPushNotificationService.cs
+++ b/src/iOS/Services/iOSPushNotificationService.cs
@@ -69,7 +69,7 @@ namespace Bit.iOS.Services
             return Task.FromResult(0);
         }
 
-        public void SendLocalNotification(string title, string message, string notificationId)
+        public void SendLocalNotification(string title, string message, string notificationId, string notificationType, Dictionary<string, string> notificationData = null, int notificationTimeoutMinutes = 0)
         {
             if (string.IsNullOrEmpty(notificationId))
             {
@@ -81,6 +81,12 @@ namespace Bit.iOS.Services
                 Title = title,
                 Body = message
             };
+
+            if (notificationData != null)
+            {
+                notificationData.Add("type", notificationType);
+                content.UserInfo = NSDictionary.FromObjectsAndKeys(notificationData.Values.ToArray(), notificationData.Keys.ToArray());
+            }
 
             var request = UNNotificationRequest.FromIdentifier(notificationId, content, null);
             UNUserNotificationCenter.Current.AddNotificationRequest(request, (err) =>

--- a/src/iOS/Services/iOSPushNotificationService.cs
+++ b/src/iOS/Services/iOSPushNotificationService.cs
@@ -4,8 +4,13 @@ using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
 using Bit.App.Abstractions;
+using Bit.App.Models;
+using Bit.App.Services;
+using Bit.Core;
 using Bit.Core.Services;
 using Foundation;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using UIKit;
 using UserNotifications;
 
@@ -69,9 +74,9 @@ namespace Bit.iOS.Services
             return Task.FromResult(0);
         }
 
-        public void SendLocalNotification(string title, string message, string notificationId, string notificationType, Dictionary<string, string> notificationData = null, int notificationTimeoutMinutes = 0)
+        public void SendLocalNotification(string title, string message, BaseNotificationData data)
         {
-            if (string.IsNullOrEmpty(notificationId))
+            if (string.IsNullOrEmpty(data.NotificationId))
             {
                 throw new ArgumentNullException("notificationId cannot be null or empty.");
             }
@@ -82,13 +87,12 @@ namespace Bit.iOS.Services
                 Body = message
             };
 
-            if (notificationData != null)
+            if (data != null)
             {
-                notificationData.Add("type", notificationType);
-                content.UserInfo = NSDictionary.FromObjectsAndKeys(notificationData.Values.ToArray(), notificationData.Keys.ToArray());
+                content.UserInfo = NSDictionary.FromObjectAndKey(NSData.FromString(JsonConvert.SerializeObject(data), NSStringEncoding.UTF8), new NSString(Constants.NotificationData));
             }
 
-            var request = UNNotificationRequest.FromIdentifier(notificationId, content, null);
+            var request = UNNotificationRequest.FromIdentifier(data.NotificationId, content, null);
             UNUserNotificationCenter.Current.AddNotificationRequest(request, (err) =>
             {
                 if (err != null)

--- a/src/iOS/Services/iOSPushNotificationService.cs
+++ b/src/iOS/Services/iOSPushNotificationService.cs
@@ -76,7 +76,7 @@ namespace Bit.iOS.Services
 
         public void SendLocalNotification(string title, string message, BaseNotificationData data)
         {
-            if (string.IsNullOrEmpty(data.NotificationId))
+            if (string.IsNullOrEmpty(data.Id))
             {
                 throw new ArgumentNullException("notificationId cannot be null or empty.");
             }
@@ -92,7 +92,7 @@ namespace Bit.iOS.Services
                 content.UserInfo = NSDictionary.FromObjectAndKey(NSData.FromString(JsonConvert.SerializeObject(data), NSStringEncoding.UTF8), new NSString(Constants.NotificationData));
             }
 
-            var request = UNNotificationRequest.FromIdentifier(data.NotificationId, content, null);
+            var request = UNNotificationRequest.FromIdentifier(data.Id, content, null);
             UNUserNotificationCenter.Current.AddNotificationRequest(request, (err) =>
             {
                 if (err != null)


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Tapping Push Notification does not take you to account the request is for.

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->
Added new method in `src/App/Services/PushNotificationListenerService.cs` to handle notification tap logic.

## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
