### PR TITLE
[PS-1601] Disable spellcheck and autocorrect in search bars

### DIFF
--- a/src/App/Pages/Send/SendsPage.xaml
+++ b/src/App/Pages/Send/SendsPage.xaml
@@ -39,6 +39,8 @@
                     HorizontalOptions="FillAndExpand"
                     TextChanged="SearchBar_TextChanged"
                     SearchButtonPressed="SearchBar_SearchButtonPressed"
+                    IsSpellCheckEnabled="False"
+                    IsTextPredictionEnabled="False"
                     Placeholder="{Binding PageTitle}" />
             </StackLayout>
             <BoxView StyleClass="list-section-separator-bottom, list-section-separator-bottom-platform"

--- a/src/App/Pages/Vault/CiphersPage.xaml
+++ b/src/App/Pages/Vault/CiphersPage.xaml
@@ -41,6 +41,8 @@
                     HorizontalOptions="FillAndExpand"
                     TextChanged="SearchBar_TextChanged"
                     SearchButtonPressed="SearchBar_SearchButtonPressed"
+                    IsSpellCheckEnabled="False"
+                    IsTextPredictionEnabled="False"
                     Placeholder="{Binding PageTitle}" />
             </StackLayout>
             <BoxView StyleClass="list-section-separator-bottom, list-section-separator-bottom-platform"


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] New feature development
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Disables spellcheck and autocorrect when searching vault or sends. Fixes issue described here: https://community.bitwarden.com/t/autocorrection-in-search-field/39767

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **src/Pages/Send/SendsPage.xaml:** Disabled spellcheck and text prediction in ExtendedSearchBar
* **src/Pages/Vault/CiphersPage.xaml:** Disabled spellcheck and text prediction in ExtendedSearchBar

## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
