### PR TITLE
[SG-705] Popup when a request for authentication comes in on a logged-in account that is not active

### DIFF
--- a/src/App/Resources/AppResources.resx
+++ b/src/App/Resources/AppResources.resx
@@ -2464,4 +2464,7 @@ select Add TOTP to store the key safely</value>
   <data name="LoginRequestHasAlreadyExpired" xml:space="preserve">
     <value>Login request has already expired.</value>
   </data>
+  <data name="LoginAttemptFromXDoYouWantToSwitch" xml:space="preserve">
+    <value>Login attempt from {0}. Do you want to switch to this account?</value>
+  </data>
 </root>

--- a/src/App/Services/PushNotificationListenerService.cs
+++ b/src/App/Services/PushNotificationListenerService.cs
@@ -146,7 +146,7 @@ namespace Bit.App.Services
                         return;
                     }
 
-                    await _stateService.Value.SetPasswordlessLoginNotificationAsync(passwordlessLoginMessage, passwordlessLoginMessage?.UserId);
+                    await _stateService.Value.SetPasswordlessLoginNotificationAsync(passwordlessLoginMessage);
                     var userEmail = await _stateService.Value.GetEmailAsync(passwordlessLoginMessage?.UserId);
 
                     var notificationData = new PasswordlessNotificationData()
@@ -247,14 +247,10 @@ namespace Bit.App.Services
             {
                 if (data is PasswordlessNotificationData passwordlessNotificationData)
                 {
-                    var notificationUserId = await _stateService.Value.GetUserIdAsync(passwordlessNotificationData.UserEmail);
-                    if (notificationUserId != null)
+                    var savedNotification = await _stateService.Value.GetPasswordlessLoginNotificationAsync();
+                    if (savedNotification != null)
                     {
-                        var savedNotification = await _stateService.Value.GetPasswordlessLoginNotificationAsync(notificationUserId);
-                        if (savedNotification != null)
-                        {
-                            await _stateService.Value.SetPasswordlessLoginNotificationAsync(null, notificationUserId);
-                        }
+                        await _stateService.Value.SetPasswordlessLoginNotificationAsync(null);
                     }
                 }
             }

--- a/src/Core/Abstractions/IStateService.cs
+++ b/src/Core/Abstractions/IStateService.cs
@@ -154,8 +154,8 @@ namespace Bit.Core.Abstractions
         Task SaveExtensionActiveUserIdToStorageAsync(string userId);
         Task<bool> GetApprovePasswordlessLoginsAsync(string userId = null);
         Task SetApprovePasswordlessLoginsAsync(bool? value, string userId = null);
-        Task<PasswordlessRequestNotification> GetPasswordlessLoginNotificationAsync(string userId = null);
-        Task SetPasswordlessLoginNotificationAsync(PasswordlessRequestNotification value, string userId = null);
+        Task<PasswordlessRequestNotification> GetPasswordlessLoginNotificationAsync();
+        Task SetPasswordlessLoginNotificationAsync(PasswordlessRequestNotification value);
         Task<UsernameGenerationOptions> GetUsernameGenerationOptionsAsync(string userId = null);
         Task SetUsernameGenerationOptionsAsync(UsernameGenerationOptions value, string userId = null);
     }

--- a/src/Core/Constants.cs
+++ b/src/Core/Constants.cs
@@ -30,6 +30,7 @@
         public static string EventCollectionKey = "eventCollection";
         public static string RememberedEmailKey = "rememberedEmail";
         public static string RememberedOrgIdentifierKey = "rememberedOrgIdentifier";
+        public static string PasswordlessLoginNofiticationKey = "passwordlessLoginNofiticationKey";
         public const string PasswordlessNotificationId = "26072022";
         public const string AndroidNotificationChannelId = "general_notification_channel";
         public const string NotificationData = "notificationData";
@@ -91,7 +92,6 @@
         public static string LastSyncKey(string userId) => $"lastSync_{userId}";
         public static string BiometricUnlockKey(string userId) => $"biometricUnlock_{userId}";
         public static string ApprovePasswordlessLoginsKey(string userId) => $"approvePasswordlessLogins_{userId}";
-        public static string PasswordlessLoginNofiticationKey(string userId) => $"passwordlessLoginNofitication_{userId}";
         public static string UsernameGenOptionsKey(string userId) => $"usernameGenerationOptions_{userId}";
     }
 }

--- a/src/Core/Services/StateService.cs
+++ b/src/Core/Services/StateService.cs
@@ -1277,20 +1277,18 @@ namespace Bit.Core.Services
             await SetValueAsync(key, value, reconciledOptions);
         }
 
-        public async Task<PasswordlessRequestNotification> GetPasswordlessLoginNotificationAsync(string userId = null)
+        public async Task<PasswordlessRequestNotification> GetPasswordlessLoginNotificationAsync()
         {
-            var reconciledOptions = ReconcileOptions(new StorageOptions { UserId = userId },
-                await GetDefaultStorageOptionsAsync());
-            var key = Constants.PasswordlessLoginNofiticationKey(reconciledOptions.UserId);
-            return await GetValueAsync<PasswordlessRequestNotification>(key, reconciledOptions);
+            var options = await GetDefaultStorageOptionsAsync();
+            var key = Constants.PushRegisteredTokenKey;
+            return await GetValueAsync<PasswordlessRequestNotification>(key, options);
         }
 
-        public async Task SetPasswordlessLoginNotificationAsync(PasswordlessRequestNotification value, string userId = null)
+        public async Task SetPasswordlessLoginNotificationAsync(PasswordlessRequestNotification value)
         {
-            var reconciledOptions = ReconcileOptions(new StorageOptions { UserId = userId },
-                await GetDefaultStorageOptionsAsync());
-            var key = Constants.PasswordlessLoginNofiticationKey(reconciledOptions.UserId);
-            await SetValueAsync(key, value, reconciledOptions);
+            var options = await GetDefaultStorageOptionsAsync();
+            var key = Constants.PushRegisteredTokenKey;
+            await SetValueAsync(key, value, options);
         }
         // Helpers
 


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Add popup notification when a request for authentication comes in on a logged-in account that is not active.

## Code changes
Changed the `GetPasswordlessLoginNotificationAsync` to not be user specific to make it easier to check the user the request was from instead of having to iterate between all available users in the device and perform checks. 

## Screenshots
<!--Required for any UI changes. Delete if not applicable-->
![image](https://user-images.githubusercontent.com/4648522/195816316-86224680-3fe9-4b5e-b216-4736602483de.png)



## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
