### PR TITLE
[PS-1689] Add support for copying some identity fields

### DIFF
--- a/src/App/Pages/Vault/CipherDetailsPage.xaml
+++ b/src/App/Pages/Vault/CipherDetailsPage.xaml
@@ -415,48 +415,136 @@
                             </StackLayout>
                             <BoxView StyleClass="box-row-separator"
                                      IsVisible="{Binding Cipher.Identity.Company, Converter={StaticResource stringHasValue}}" />
-                            <StackLayout StyleClass="box-row"
-                                         IsVisible="{Binding Cipher.Identity.SSN, Converter={StaticResource stringHasValue}}">
+                            <Grid StyleClass="box-row"
+                                  IsVisible="{Binding Cipher.Identity.SSN, Converter={StaticResource stringHasValue}}">
+                                <Grid.RowDefinitions>
+                                    <RowDefinition Height="Auto" />
+                                    <RowDefinition Height="*" />
+                                </Grid.RowDefinitions>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*" />
+                                    <ColumnDefinition Width="Auto" />
+                                </Grid.ColumnDefinitions>
                                 <Label
                                     Text="{u:I18n SSN}"
-                                    StyleClass="box-label" />
+                                    StyleClass="box-label"
+                                    Grid.Row="0"
+                                    Grid.Column="0" />
                                 <Label
                                     Text="{Binding Cipher.Identity.SSN, Mode=OneWay}"
-                                    StyleClass="box-value" />
-                            </StackLayout>
+                                    StyleClass="box-value"
+                                    Grid.Row="1"
+                                    Grid.Column="0" />
+                                <controls:IconButton
+                                    StyleClass="box-row-button, box-row-button-platform"
+                                    Text="{Binding Source={x:Static core:BitwardenIcons.Clone}}"
+                                    Command="{Binding CopySSN}"
+                                    CommandParameter="SSN"
+                                    Grid.Row="0"
+                                    Grid.Coluumn="1"
+                                    Grid.RowSpan="2"
+                                    AutomationProperties.IsInAccessibleTree="True"
+                                    AutomationProperties.Name="{u:I18n CopySSN}" />
+                            </Grid>
                             <BoxView StyleClass="box-row-separator"
                                      IsVisible="{Binding Cipher.Identity.SSN, Converter={StaticResource stringHasValue}}" />
-                            <StackLayout StyleClass="box-row"
-                                         IsVisible="{Binding Cipher.Identity.PassportNumber, Converter={StaticResource stringHasValue}}">
+                            <Grid StyleClass="box-row"
+                                  IsVisible="{Binding Cipher.Identity.PassportNumber, Converter={StaticResource stringHasValue}}">
+                                <Grid.RowDefinitions>
+                                    <RowDefinition Height="Auto" />
+                                    <RowDefinition Height="*" />
+                                </Grid.RowDefinitions>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*" />
+                                    <ColumnDefinition Width="Auto" />
+                                </Grid.ColumnDefinitions>
                                 <Label
                                     Text="{u:I18n PassportNumber}"
-                                    StyleClass="box-label" />
+                                    StyleClass="box-label"
+                                    Grid.Row="0"
+                                    Grid.Column="0"/>
                                 <Label
                                     Text="{Binding Cipher.Identity.PassportNumber, Mode=OneWay}"
-                                    StyleClass="box-value" />
-                            </StackLayout>
+                                    StyleClass="box-value"
+                                    Grid.Row="1"
+                                    Grid.Column="0"/>
+                                <controls:IconButton
+                                    StyleClass="box-row-button, box-row-button-platform"
+                                    Text="{Binding Source={x:Static core:BitwardenIcons.Clone}}"
+                                    Command="{Binding CopyPassportNumber}"
+                                    CommandParameter="PassportNumber"
+                                    Grid.Row="0"
+                                    Grid.Column="1"
+                                    Grid.RowSpan="2"
+                                    AutomationProperties.IsInAccessibleTree="True"
+                                    AutomationProperties.Name="{u:I18n CopyPassportNumber}" />
+                            </Grid>
                             <BoxView StyleClass="box-row-separator"
                                      IsVisible="{Binding Cipher.Identity.PassportNumber, Converter={StaticResource stringHasValue}}" />
-                            <StackLayout StyleClass="box-row"
-                                         IsVisible="{Binding Cipher.Identity.LicenseNumber, Converter={StaticResource stringHasValue}}">
+                            <Grid StyleClass="box-row"
+                                  IsVisible="{Binding Cipher.Identity.LicenseNumber, Converter={StaticResource stringHasValue}}">
+                                <Grid.RowDefinitions>
+                                    <RowDefinition Height="Auto" />
+                                    <RowDefinition Height="*" />
+                                </Grid.RowDefinitions>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*" />
+                                    <ColumnDefinition Width="Auto" />
+                                </Grid.ColumnDefinitions>
                                 <Label
                                     Text="{u:I18n LicenseNumber}"
-                                    StyleClass="box-label" />
+                                    StyleClass="box-label"
+                                    Grid.Row="0"
+                                    Grid.Column="0" />
                                 <Label
                                     Text="{Binding Cipher.Identity.LicenseNumber, Mode=OneWay}"
-                                    StyleClass="box-value" />
-                            </StackLayout>
+                                    StyleClass="box-value"
+                                    Grid.Row="1"
+                                    Grid.Column="0" />
+                                <controls:IconButton
+                                    StyleClass="box-row-button, box-row-button-platform"
+                                    Text="{Binding Source={x:Static core:BitwardenIcons.Clone}}"
+                                    Command="{Binding CopyCommand}"
+                                    CommandParameter="LicenseNumber"
+                                    Grid.Row="0"
+                                    Grid.Column="1"
+                                    Grid.RowSpan="2"
+                                    AutomationProperties.IsInAccessibleTree="True"
+                                    AutomationProperties.Name="{u:I18n CopyLicenseNumber}" />
+                            </Grid>
                             <BoxView StyleClass="box-row-separator"
                                      IsVisible="{Binding Cipher.Identity.LicenseNumber, Converter={StaticResource stringHasValue}}" />
-                            <StackLayout StyleClass="box-row"
-                                         IsVisible="{Binding Cipher.Identity.Email, Converter={StaticResource stringHasValue}}">
+                            <Grid StyleClass="box-row"
+                                  IsVisible="{Binding Cipher.Identity.Email, Converter={StaticResource stringHasValue}}">
+                                <Grid.RowDefinitions>
+                                    <RowDefinition Height="Auto" />
+                                    <RowDefinition Height="*" />
+                                </Grid.RowDefinitions>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*" />
+                                    <ColumnDefinition Width="Auto" />
+                                </Grid.ColumnDefinitions>
                                 <Label
                                     Text="{u:I18n Email}"
-                                    StyleClass="box-label" />
+                                    StyleClass="box-label"
+                                    Grid.Row="0"
+                                    Grid.Column="0" />
                                 <Label
                                     Text="{Binding Cipher.Identity.Email, Mode=OneWay}"
-                                    StyleClass="box-value" />
-                            </StackLayout>
+                                    StyleClass="box-value"
+                                    Grid.Row="1"
+                                    Grid.Column="0" />
+                                <controls:IconButton
+                                    StyleClass="box-row-button, box-row-button-platform"
+                                    Text="{Binding Source={x:Static core:BitwardenIcons.Clone}}"
+                                    Command="{Binding CopyCommand}"
+                                    CommandParameter="Email"
+                                    Grid.Row="0",
+                                    Grid.Column="1"
+                                    Grid.RowSpan="2"
+                                    AutomationProperties.IsInAccessibleTree="True"
+                                    AutomationProperties.Name="{u:I18n CopyEmail}" />
+                            </Grid>
                             <BoxView StyleClass="box-row-separator"
                                      IsVisible="{Binding Cipher.Identity.Email, Converter={StaticResource stringHasValue}}" />
                             <StackLayout StyleClass="box-row"

--- a/src/App/Pages/Vault/CipherDetailsPageViewModel.cs
+++ b/src/App/Pages/Vault/CipherDetailsPageViewModel.cs
@@ -640,6 +640,26 @@ namespace Bit.App.Pages
                 text = Cipher.Card.Code;
                 name = AppResources.SecurityCode;
             }
+            else if (id == "LicenseNumber")
+            {
+                text = Cipher.Identity.LicenseNumber;
+                name = AppResources.LicenseNumber;
+            }
+            else if (id == "Email")
+            {
+                text = Cipher.Identity.Email;
+                name = AppResources.Email;
+            }
+            else if (id == "PassportNumber")
+            {
+                text = Cipher.Identity.PassportNumber;
+                name = AppResources.PassportNumber;
+            }
+            else if (id == "SSN")
+            {
+                text = Cipher.Identity.SSN;
+                name = AppResources.SSN;
+            }
 
             if (text != null)
             {

--- a/src/App/Resources/AppResources.Designer.cs
+++ b/src/App/Resources/AppResources.Designer.cs
@@ -1506,6 +1506,24 @@ namespace Bit.App.Resources {
                 return ResourceManager.GetString("Copy", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Copy Email.
+        /// </summary>
+        public static string CopyEmail {
+            get {
+                return ResourceManager.GetString("CopyEmail", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Copy License Number.
+        /// </summary>
+        public static string CopyLicenseNumber {
+            get {
+                return ResourceManager.GetString("CopyLicenseNumber", resourceCulture);
+            }
+        }
         
         /// <summary>
         ///   Looks up a localized string similar to Copy Link.
@@ -1535,6 +1553,15 @@ namespace Bit.App.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Copy passport number.
+        /// </summary>
+        public static string CopyPassportNumber {
+            get {
+                return ResourceManager.GetString("CopyPassportNumber", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to Copy Password.
         /// </summary>
         public static string CopyPassword {
@@ -1558,6 +1585,15 @@ namespace Bit.App.Resources {
         public static string CopySendLinkOnSave {
             get {
                 return ResourceManager.GetString("CopySendLinkOnSave", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Copy social security number.
+        /// </summary>
+        public static string CopySSN {
+            get {
+                return ResourceManager.GetString("CopySSN", resourceCulture);
             }
         }
         

--- a/src/App/Resources/AppResources.resx
+++ b/src/App/Resources/AppResources.resx
@@ -2464,4 +2464,20 @@ select Add TOTP to store the key safely</value>
   <data name="LoginRequestHasAlreadyExpired" xml:space="preserve">
     <value>Login request has already expired.</value>
   </data>
+  <data name="CopyLicenseNumber" xml:space="preserve">
+    <value>Copy license numebr</value>
+    <comment>The button text that allows a user to copy the identity's license number to their clipboard.</comment>
+  </data>
+  <data name="CopyEmail" xml:space="preserve">
+    <value>Copy email</value>
+    <comment>The button text that allows a user to copy the identity's email address to their clipboard.</comment>
+  </data>
+  <data name="CopyPassportNumber" xml:space="preserve">
+    <value>Copy passport number</value>
+    <comment>The button text that allows a user to copy the identity's passport number to their clipboard.</comment>
+  </data>
+  <data name="CopySSN" xml:space="preserve">
+    <value>Copy social security number</value>
+    <comment>The button text that allows a user to copy the identity's social security number to their clipboard.</comment>
+  </data>
 </root>

--- a/src/App/Utilities/AppHelpers.cs
+++ b/src/App/Utilities/AppHelpers.cs
@@ -121,6 +121,26 @@ namespace Bit.App.Utilities
                     }
                 }
             }
+            else if (selection == AppResources.CopyLicenseNumber)
+            {
+                await clipboardService.CopyTextAsync(cipher.Identity.LicenseNumber);
+                platformUtilsService.ShowToastForCopiedValue(AppResources.LicenseNumber);
+            }
+            else if (selection == AppResources.CopyEmail)
+            {
+                await clipboardService.CopyTextAsync(cipher.Identity.Email);
+                platformUtilsService.ShowToastForCopiedValue(AppResources.Email);
+            }
+            else if (selection == AppResources.CopyPassportNumber)
+            {
+                await clipboardService.CopyTextAsync(cipher.Identity.PassportNumber);
+                platformUtilsService.ShowToastForCopiedValue(AppResources.PassportNumber);
+            }
+            else if (selection == AppResources.CopySSN)
+            {
+                await clipboardService.CopyTextAsync(cipher.Identity.SSN);
+                platformUtilsService.ShowToastForCopiedValue(AppResources.SSN);
+            }
             else if (selection == AppResources.Launch)
             {
                 platformUtilsService.LaunchUri(cipher.Login.LaunchUri);


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

This allows for copying the identity's email address, passport number,
SSN, and license number; it follows the pattern primarily for copying
username and card details.

Implements part of https://community.bitwarden.com/t/allow-copying-of-default-identity-fields/1109

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **src/App/Pages/Vault/CipherDetailsPage.xaml**: Updated the views to add the copy button
* **src/App/Pages/Vault/CipherDetailsPageViewModel.cs**: Adds support for the new commands, following the pattern for Username
* **src/App/Resources/AppResources.Designer.cs**: Adds the new resources
* **src/App/Resources/AppResources.resx**: Adds the new strings
* **src/App/Utilities/AppHelpers.cs**: Adds helpers for the actions

* **file.ext:** Description of what was changed and why

## Screenshots
<!--Required for any UI changes. Delete if not applicable-->



## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
