### PR TITLE
[SG-747] Add Android QA build to mobile build pipeline

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,7 +91,6 @@ jobs:
               Write-Host "components were not installed"
               exit 1
           }
-          
       - name: Print environment
         run: |
           nuget help | grep Version
@@ -104,7 +103,6 @@ jobs:
         uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846
         with:
           fetch-depth: 0
-            
       - name: Decrypt secrets
         env:
           DECRYPT_FILE_PASSWORD: ${{ secrets.DECRYPT_FILE_PASSWORD }}
@@ -118,7 +116,6 @@ jobs:
           gpg --quiet --batch --yes --decrypt --passphrase="$DECRYPT_FILE_PASSWORD" \
             --output $HOME/secrets/play_creds.json ./.github/secrets/play_creds.json.gpg
         shell: bash
-        
       - name: Decrypt secrets - Google Services
         if: ${{ matrix.variant == 'prod' }}
         env:
@@ -127,7 +124,6 @@ jobs:
           gpg --quiet --batch --yes --decrypt --passphrase="$DECRYPT_FILE_PASSWORD" \
             --output ./src/Android/google-services.json ./.github/secrets/google-services.json.gpg
         shell: bash
-        
       - name: Increment version
         run: |
           BUILD_NUMBER=$((3000 + $GITHUB_RUN_NUMBER))
@@ -184,7 +180,6 @@ jobs:
           {
             $packageName = "com.x8bit.bitwarden.${{ matrix.variant }}";
           }
-          
           Write-Output "########################################"
           Write-Output "##### Sign Google Play Bundle Release Configuration"
           Write-Output "########################################"
@@ -200,7 +195,6 @@ jobs:
 
           $signedAabPath = $($env:GITHUB_WORKSPACE + "/src/Android/bin/Release/$($packageName)-Signed.aab");
           $signedAabDestPath = $($env:GITHUB_WORKSPACE + "/$($packageName).aab");
-          
           Copy-Item $signedAabPath $signedAabDestPath
 
           Write-Output "########################################"
@@ -217,11 +211,10 @@ jobs:
           Write-Output "########################################"
 
           $signedApkPath = $($env:GITHUB_WORKSPACE + "/src/Android/bin/Release/$($packageName)-Signed.apk");
-          $signedApkDestPath = $($env:GITHUB_WORKSPACE + "/$($packageName).apk"); 
+          $signedApkDestPath = $($env:GITHUB_WORKSPACE + "/$($packageName).apk");
 
           Copy-Item $signedApkPath $signedApkDestPath
         shell: pwsh
-        
       - name: Upload Prod .aab artifact
         if: ${{ matrix.variant == 'prod' }}
         uses: actions/upload-artifact@6673cd052c4cd6fcf4b4e6e60ea986c889389535


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [X] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Workflow needs to create 2 android apks, which can be installed side-by-side (`prod` and `qa`) and each receives push notifications from the respective environment.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **Decrypt Secrets step:** Separated into two steps. Google-Services file is only decrypted in `prod` to allow the `qa` build to receive notifications from the QA Cloud.
* **Deploy to PlayStore step:** Before fix, if condition was always returning true.

## Screenshots
<!--Required for any UI changes. Delete if not applicable-->



## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
