### PR TITLE
[SG-769] Fix crash by ensuring that token for decoding is refreshed before use

### DIFF
--- a/src/App/Pages/Generator/GeneratorPageViewModel.cs
+++ b/src/App/Pages/Generator/GeneratorPageViewModel.cs
@@ -606,6 +606,7 @@ namespace Bit.App.Pages
             LoadFromOptions();
 
             _usernameOptions = await _usernameGenerationService.GetOptionsAsync();
+            await _tokenService.PrepareTokenForDecodingAsync();
             _usernameOptions.PlusAddressedEmail = _tokenService.GetEmail();
             _usernameOptions.EmailWebsite = EmailWebsite;
             _usernameOptions.CatchAllEmailType = _usernameOptions.PlusAddressedEmailType = string.IsNullOrWhiteSpace(EmailWebsite) || !EditMode ? UsernameEmailType.Random : UsernameEmailType.Website;

--- a/src/Core/Abstractions/ITokenService.cs
+++ b/src/Core/Abstractions/ITokenService.cs
@@ -28,5 +28,6 @@ namespace Bit.Core.Abstractions
         Task SetTwoFactorTokenAsync(string token, string email);
         bool TokenNeedsRefresh(int minutes = 5);
         int TokenSecondsRemaining();
+        Task PrepareTokenForDecodingAsync();
     }
 }

--- a/src/Core/Services/TokenService.cs
+++ b/src/Core/Services/TokenService.cs
@@ -44,6 +44,11 @@ namespace Bit.Core.Services
             return _accessTokenForDecoding;
         }
 
+        public async Task PrepareTokenForDecodingAsync()
+        {
+            _accessTokenForDecoding = await _stateService.GetAccessTokenAsync();
+        }
+
         public async Task SetRefreshTokenAsync(string refreshToken)
         {
             await _stateService.SetRefreshTokenAsync(refreshToken, await SkipTokenStorage());


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
Added a call to refresh the token used for decoding before getting the user's email in order to fix a crash.



## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->
* **ITokenService.cs**
* **TokenService.cs :**  Added new method to refresh token without returning it.
* **GeneratorPageViewModel.cs :**  Made sure token is refreshed before using it to get user's email.



## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
