### PR TITLE
Fix for avatar sequence issue on iOS account switching modal

### DIFF
--- a/src/App/Controls/AvatarImageSource.cs
+++ b/src/App/Controls/AvatarImageSource.cs
@@ -23,13 +23,13 @@ namespace Bit.App.Controls
 
             if (obj is AvatarImageSource avatar)
             {
-                return avatar._text == _text;
+                return avatar._id == _id && avatar._text == _text;
             }
 
             return base.Equals(obj);
         }
 
-        public override int GetHashCode() => _text?.GetHashCode() ?? -1;
+        public override int GetHashCode() => _id?.GetHashCode() ?? _text?.GetHashCode() ?? -1;
 
         public AvatarImageSource(string userId = null, string name = null, string email = null)
         {


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
The order of avatars (not accounts) would invert each time the account switching list was opened on iOS.  Missed it the first time through due to the subtle earth-tones all my test accounts ended up with.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **AvatarImageSource.cs:** Added missing `_id` check to `Equals` fixed the object comparison (thanks @fedemkr )

## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
