### PR TITLE
[SG-800] Selecting notification for inactive account on iOS while app is open does not display the request

### DIFF
--- a/src/App/App.xaml.cs
+++ b/src/App/App.xaml.cs
@@ -221,7 +221,7 @@ namespace Bit.App
             }
 
             var notificationUserEmail = await _stateService.GetEmailAsync(notification.UserId);
-            await Device.InvokeOnMainThreadAsync(async () =>
+            Device.BeginInvokeOnMainThread(async () =>
             {
                 var result = await _deviceActionService.DisplayAlertAsync(AppResources.LogInRequested, string.Format(AppResources.LoginAttemptFromXDoYouWantToSwitchToThisAccount, notificationUserEmail), AppResources.Cancel, AppResources.Ok);
                 if (result == AppResources.Ok)

--- a/src/App/App.xaml.cs
+++ b/src/App/App.xaml.cs
@@ -223,11 +223,18 @@ namespace Bit.App
             var notificationUserEmail = await _stateService.GetEmailAsync(notification.UserId);
             Device.BeginInvokeOnMainThread(async () =>
             {
-                var result = await _deviceActionService.DisplayAlertAsync(AppResources.LogInRequested, string.Format(AppResources.LoginAttemptFromXDoYouWantToSwitchToThisAccount, notificationUserEmail), AppResources.Cancel, AppResources.Ok);
-                if (result == AppResources.Ok)
+                try
                 {
-                    await _stateService.SetActiveUserAsync(notification.UserId);
-                    _messagingService.Send(AccountsManagerMessageCommands.SWITCHED_ACCOUNT);
+                    var result = await _deviceActionService.DisplayAlertAsync(AppResources.LogInRequested, string.Format(AppResources.LoginAttemptFromXDoYouWantToSwitchToThisAccount, notificationUserEmail), AppResources.Cancel, AppResources.Ok);
+                    if (result == AppResources.Ok)
+                    {
+                        await _stateService.SetActiveUserAsync(notification.UserId);
+                        _messagingService.Send(AccountsManagerMessageCommands.SWITCHED_ACCOUNT);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    LoggerHelper.LogEvenIfCantBeResolved(ex);
                 }
             });
             return true;


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Fix bug where If the user never answers the switch accounts pop up, the lock is never released. This was problematic because when tapping a notification while pop-up was showing, the user navigates to the other account automatically and the pop-up is never dismissed.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->
Removed await to allow the execution flow and lock to be released.



## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
