### PR TITLE
[SG-802] iOS clicking push notification after login request has appeared makes it disappear

### DIFF
--- a/src/App/Services/PushNotificationListenerService.cs
+++ b/src/App/Services/PushNotificationListenerService.cs
@@ -228,7 +228,8 @@ namespace Bit.App.Services
                 if (data is PasswordlessNotificationData passwordlessNotificationData)
                 {
                     var notificationUserId = await _stateService.Value.GetUserIdAsync(passwordlessNotificationData.UserEmail);
-                    if (notificationUserId != null)
+                    var notificationSaved = await _stateService.Value.GetPasswordlessLoginNotificationAsync();
+                    if (notificationUserId != null && notificationSaved != null)
                     {
                         await _stateService.Value.SetActiveUserAsync(notificationUserId);
                         _messagingService.Value.Send(AccountsManagerMessageCommands.SWITCHED_ACCOUNT);


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Fix bug when tapping a login request at the same time the modal is appearing.

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->
On notification tap check if there is a pending login request.

## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
