### PR TITLE
Remove 'Remove Account' option from login page

### DIFF
--- a/src/App/Pages/Accounts/LoginPage.xaml
+++ b/src/App/Pages/Accounts/LoginPage.xaml
@@ -31,15 +31,6 @@
     <ContentPage.Resources>
         <ResourceDictionary>
             <u:InverseBoolConverter x:Key="inverseBool" />
-            <ToolbarItem Icon="more_vert.png" Clicked="More_Clicked" Order="Primary"
-                x:Name="_moreItem" x:Key="moreItem"
-                 AutomationProperties.IsInAccessibleTree="True"
-                 AutomationProperties.Name="{u:I18n Options}" />
-            <ToolbarItem Text="{u:I18n GetPasswordHint}"
-                x:Key="getPasswordHint"
-                x:Name="_getPasswordHint"
-                Clicked="Hint_Clicked" 
-                Order="Secondary" />
 
             <ScrollView x:Name="_mainLayout" x:Key="mainLayout">
                 <StackLayout Spacing="0">

--- a/src/App/Pages/Accounts/LoginPage.xaml.cs
+++ b/src/App/Pages/Accounts/LoginPage.xaml.cs
@@ -44,15 +44,6 @@ namespace Bit.App.Pages
             _vm.Email = email;
             MasterPasswordEntry = _masterPassword;
 
-            if (Device.RuntimePlatform == Device.iOS)
-            {
-                ToolbarItems.Add(_moreItem);
-            }
-            else
-            {
-                ToolbarItems.Add(_getPasswordHint);
-            }
-
             if (_appOptions?.IosExtension ?? false)
             {
                 _vm.ShowCancelButton = true;
@@ -131,33 +122,12 @@ namespace Bit.App.Pages
             }
         }
 
-        private async void RemoveAccount_Clicked(object sender, EventArgs e)
-        {
-            await _accountListOverlay.HideAsync();
-            if (DoOnce())
-            {
-                await _vm.RemoveAccountAsync();
-            }
-        }
 
         private void Cancel_Clicked(object sender, EventArgs e)
         {
             if (DoOnce())
             {
                 _vm.CloseAction();
-            }
-        }
-
-        private async void More_Clicked(object sender, EventArgs e)
-        {
-            try
-            {
-                await _accountListOverlay.HideAsync();
-                _vm.MoreCommand.Execute(null);
-            }
-            catch (Exception ex)
-            {
-                _logger.Value.Exception(ex);
             }
         }
 

--- a/src/App/Pages/Accounts/LoginPageViewModel.cs
+++ b/src/App/Pages/Accounts/LoginPageViewModel.cs
@@ -53,7 +53,6 @@ namespace Bit.App.Pages
             PageTitle = AppResources.Bitwarden;
             TogglePasswordCommand = new Command(TogglePassword);
             LogInCommand = new Command(async () => await LogInAsync());
-            MoreCommand = new AsyncCommand(MoreAsync, onException: _logger.Exception, allowsMultipleExecutions: false);
 
             AccountSwitchingOverlayViewModel = new AccountSwitchingOverlayViewModel(_stateService, _messagingService, _logger)
             {
@@ -113,7 +112,6 @@ namespace Bit.App.Pages
 
         public Command LogInCommand { get; }
         public Command TogglePasswordCommand { get; }
-        public ICommand MoreCommand { get; internal set; }
         public string ShowPasswordIcon => ShowPassword ? BitwardenIcons.EyeSlash : BitwardenIcons.Eye;
         public string PasswordVisibilityAccessibilityText => ShowPassword ? AppResources.PasswordIsVisibleTapToHide : AppResources.PasswordIsNotVisibleTapToShow;
         public string LoggingInAsText => string.Format(AppResources.LoggingInAsX, Email);
@@ -239,17 +237,6 @@ namespace Bit.App.Pages
                     await _platformUtilsService.ShowDialogAsync(e.Error.GetSingleMessage(),
                         AppResources.AnErrorHasOccurred, AppResources.Ok);
                 }
-            }
-        }
-
-        private async Task MoreAsync()
-        {
-            var buttons = new[] { AppResources.GetPasswordHint };
-            var selection = await _deviceActionService.DisplayActionSheetAsync(AppResources.Options, AppResources.Cancel, null, buttons);
-
-            if (selection == AppResources.GetPasswordHint)
-            {
-                await ShowMasterPasswordHintAsync();
             }
         }
 


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
Remove options from the login page altogether as the items in it are redundant with the updates.

## Code changes

- **src/App/Pages/Accounts/LoginPage.xaml:** Remove options
- **src/App/Pages/Accounts/LoginPage.xaml.cs:** Remove Android specific check on the removeAccount option
- **src/App/Pages/Accounts/LoginPageViewModel.cs:** Remove options

## Screenshots
![Screen Shot 2022-11-09 at 10 34 36 AM](https://user-images.githubusercontent.com/8926729/200876582-b275d653-287e-4649-b25c-b6b991e72d4b.png)



## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
