### PR TITLE
[SG-808] Only show 'remove account' option if user is in Accounts list

### DIFF
--- a/src/App/Pages/Accounts/LoginPageViewModel.cs
+++ b/src/App/Pages/Accounts/LoginPageViewModel.cs
@@ -37,7 +37,6 @@ namespace Bit.App.Pages
         private string _masterPassword;
         private bool _isEmailEnabled;
         private bool _isKnownDevice;
-        private bool _savedEmail;
 
         public LoginPageViewModel()
         {
@@ -143,7 +142,6 @@ namespace Bit.App.Pages
                 {
                     Email = await _stateService.GetRememberedEmailAsync();
                 }
-
                 var deviceIdentifier = await _appIdService.GetAppIdAsync();
                 IsKnownDevice = await _apiService.GetKnownDeviceAsync(Email, deviceIdentifier);
                 await _deviceActionService.HideLoadingAsync();
@@ -291,7 +289,6 @@ namespace Bit.App.Pages
             {
                 var confirmed = await _platformUtilsService.ShowDialogAsync(AppResources.RemoveAccountConfirmation,
                     AppResources.RemoveAccount, AppResources.Yes, AppResources.Cancel);
-
                 if (confirmed)
                 {
                     _messagingService.Send("logout");

--- a/src/App/Pages/Accounts/LoginPageViewModel.cs
+++ b/src/App/Pages/Accounts/LoginPageViewModel.cs
@@ -259,7 +259,8 @@ namespace Bit.App.Pages
         private async Task MoreAsync()
         {
             var buttons = IsEmailEnabled || !SavedEmail
-                ? new[] { AppResources.GetPasswordHint } : new[] { AppResources.GetPasswordHint, AppResources.RemoveAccount };
+                ? new[] { AppResources.GetPasswordHint }
+                : new[] { AppResources.GetPasswordHint, AppResources.RemoveAccount };
             var selection = await _deviceActionService.DisplayActionSheetAsync(AppResources.Options, AppResources.Cancel, null, buttons);
 
             if (selection == AppResources.GetPasswordHint)

--- a/src/App/Pages/Accounts/LoginPageViewModel.cs
+++ b/src/App/Pages/Accounts/LoginPageViewModel.cs
@@ -111,12 +111,6 @@ namespace Bit.App.Pages
             set => SetProperty(ref _isKnownDevice, value);
         }
 
-        public bool SavedEmail
-        {
-            get => _savedEmail;
-            set => SetProperty(ref _savedEmail, value);
-        }
-
         public bool IsIosExtension { get; set; }
 
         public AccountSwitchingOverlayViewModel AccountSwitchingOverlayViewModel { get; }
@@ -149,7 +143,6 @@ namespace Bit.App.Pages
                 {
                     Email = await _stateService.GetRememberedEmailAsync();
                 }
-                SavedEmail = _stateService.AccountViews != null && _stateService.AccountViews.Any(e => e.Email == Email);
 
                 var deviceIdentifier = await _appIdService.GetAppIdAsync();
                 IsKnownDevice = await _apiService.GetKnownDeviceAsync(Email, deviceIdentifier);
@@ -258,7 +251,8 @@ namespace Bit.App.Pages
 
         private async Task MoreAsync()
         {
-            var buttons = IsEmailEnabled || !SavedEmail
+            var emailExists = _stateService.AccountViews != null && _stateService.AccountViews.Any(e => e.Email == Email);
+            var buttons = IsEmailEnabled || !emailExists
                 ? new[] { AppResources.GetPasswordHint }
                 : new[] { AppResources.GetPasswordHint, AppResources.RemoveAccount };
             var selection = await _deviceActionService.DisplayActionSheetAsync(AppResources.Options, AppResources.Cancel, null, buttons);
@@ -297,8 +291,6 @@ namespace Bit.App.Pages
             {
                 var confirmed = await _platformUtilsService.ShowDialogAsync(AppResources.RemoveAccountConfirmation,
                     AppResources.RemoveAccount, AppResources.Yes, AppResources.Cancel);
-
-                SavedEmail = _stateService.AccountViews != null && _stateService.AccountViews.Any(e => e.Email == Email);
 
                 if (confirmed)
                 {

--- a/src/App/Pages/Accounts/LoginPageViewModel.cs
+++ b/src/App/Pages/Accounts/LoginPageViewModel.cs
@@ -149,8 +149,7 @@ namespace Bit.App.Pages
                 {
                     Email = await _stateService.GetRememberedEmailAsync();
                 }
-                var accountEmails = _stateService.AccountViews != null ? _stateService.AccountViews.Select(a => a.Email).ToList() : new List<string>();
-                SavedEmail = accountEmails.Contains(Email);
+                SavedEmail = _stateService.AccountViews != null && _stateService.AccountViews.Any(e => e.Email == Email);
 
                 var deviceIdentifier = await _appIdService.GetAppIdAsync();
                 IsKnownDevice = await _apiService.GetKnownDeviceAsync(Email, deviceIdentifier);
@@ -298,8 +297,7 @@ namespace Bit.App.Pages
                 var confirmed = await _platformUtilsService.ShowDialogAsync(AppResources.RemoveAccountConfirmation,
                     AppResources.RemoveAccount, AppResources.Yes, AppResources.Cancel);
 
-                var accountEmails = _stateService.AccountViews != null ? _stateService.AccountViews.Select(a => a.Email).ToList() : new List<string>();
-                SavedEmail = accountEmails.Contains(Email);
+                SavedEmail = _stateService.AccountViews != null && _stateService.AccountViews.Any(e => e.Email == Email);
 
                 if (confirmed)
                 {


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
Only show 'remove account' if the account already exists in the accounts list


## Code changes

* **src/App/Pages/Accounts/LoginPageViewModel.cs:** Add `SavedEmail` property that checks if the email belongs to an account in the accounts list and only show `remove account` if they are there.



## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
