### PR TITLE
[SG-823] Set push token on login

### DIFF
--- a/src/App/Services/PushNotificationListenerService.cs
+++ b/src/App/Services/PushNotificationListenerService.cs
@@ -187,10 +187,8 @@ namespace Bit.App.Services
                 Debug.WriteLine($"{TAG} Registered device with server.");
 
                 await _stateService.Value.SetPushLastRegistrationDateAsync(DateTime.UtcNow);
-                if (deviceType == Device.Android)
-                {
-                    await _stateService.Value.SetPushCurrentTokenAsync(token);
-                }
+
+                await _stateService.Value.SetPushCurrentTokenAsync(token);
             }
 #if DEBUG
             catch (ApiException apiEx)

--- a/src/Core/Models/Request/DeviceRequest.cs
+++ b/src/Core/Models/Request/DeviceRequest.cs
@@ -5,10 +5,11 @@ namespace Bit.Core.Models.Request
 {
     public class DeviceRequest
     {
-        public DeviceRequest(string appId, IPlatformUtilsService platformUtilsService)
+        public DeviceRequest(string appId, string pushToken, IPlatformUtilsService platformUtilsService)
         {
             Type = platformUtilsService.GetDevice();
             Name = platformUtilsService.GetDeviceString();
+            PushToken = pushToken;
             Identifier = appId;
         }
 

--- a/src/Core/Services/AuthService.cs
+++ b/src/Core/Services/AuthService.cs
@@ -300,7 +300,8 @@ namespace Bit.Core.Services
         {
             var storedTwoFactorToken = await _tokenService.GetTwoFactorTokenAsync(email);
             var appId = await _appIdService.GetAppIdAsync();
-            var deviceRequest = new DeviceRequest(appId, _platformUtilsService);
+            var pushToken = await _stateService.GetPushCurrentTokenAsync();
+            var deviceRequest = new DeviceRequest(appId, pushToken, _platformUtilsService);
 
             string[] emailPassword;
             string[] codeCodeVerifier;


### PR DESCRIPTION
https://bitwarden.atlassian.net/browse/SG-823

## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
One of the ways that a push token can be sent to the server (to subsequently be passed to the Azure Notification Hub) is on a login request.  The server-side code will check for the Device information on the `POST` body and update the push token for the given user and device, if it exists.

This change is to populate the `PushToken` property on that object before it is sent on the request.  Previously, all properties were set on the object except for the push token.

## Code changes

**DeviceRequest.cs:** Added parameter to constructor for push token.
**AuthService.cs:** Looked up current push token from state service and passed that in to the object that is used to send the push token on the login request.
**PushNotificationListenerService.cs:**: Previously, `SetCurrentPushTokenAsync()` was only called if we were on an Android device, as it was only used for handling Android's re-generation of tokens (we compare Registered vs. Current tokens and update when they don't match).  However, now we need a way to keep the current token in state even for iOS devices, as we'll be using it on login requests.

https://github.com/bitwarden/server/pull/2404 is also associated with this same problem.

## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
