### PR TITLE
[SG-778] Adjust mobile client to handle previously-responded-to passwordless request

### DIFF
--- a/src/App/App.xaml.cs
+++ b/src/App/App.xaml.cs
@@ -206,6 +206,8 @@ namespace Bit.App
                 RequestDate = loginRequestData.CreationDate,
                 DeviceType = loginRequestData.RequestDeviceType,
                 Origin = loginRequestData.Origin,
+                Approved = loginRequestData.RequestApproved,
+                ResponseDate = loginRequestData.ResponseDate
             });
             await _stateService.SetPasswordlessLoginNotificationAsync(null);
             _pushNotificationService.DismissLocalNotification(Constants.PasswordlessNotificationId);

--- a/src/App/App.xaml.cs
+++ b/src/App/App.xaml.cs
@@ -205,9 +205,7 @@ namespace Bit.App
                 FingerprintPhrase = loginRequestData.RequestFingerprint,
                 RequestDate = loginRequestData.CreationDate,
                 DeviceType = loginRequestData.RequestDeviceType,
-                Origin = loginRequestData.Origin,
-                Approved = loginRequestData.RequestApproved,
-                ResponseDate = loginRequestData.ResponseDate
+                Origin = loginRequestData.Origin
             });
             await _stateService.SetPasswordlessLoginNotificationAsync(null);
             _pushNotificationService.DismissLocalNotification(Constants.PasswordlessNotificationId);

--- a/src/App/Pages/Accounts/LoginPasswordlessRequestViewModel.cs
+++ b/src/App/Pages/Accounts/LoginPasswordlessRequestViewModel.cs
@@ -128,7 +128,7 @@ namespace Bit.App.Pages
             {
                 var response = await _authService.GetPasswordlessLoginResponseAsync(_requestId, _requestAccessCode);
 
-                if (!response.RequestApproved)
+                if (response.RequestApproved == null || !response.RequestApproved.Value)
                 {
                     return;
                 }

--- a/src/App/Pages/Accounts/LoginPasswordlessViewModel.cs
+++ b/src/App/Pages/Accounts/LoginPasswordlessViewModel.cs
@@ -116,6 +116,13 @@ namespace Bit.App.Pages
                 await Page.Navigation.PopModalAsync();
                 return;
             }
+            var loginRequestData = await _authService.GetPasswordlessLoginRequestByIdAsync(LoginRequest.Id);
+            if (loginRequestData.RequestApproved.HasValue && loginRequestData.ResponseDate.HasValue)
+            {
+                await _platformUtilsService.ShowDialogAsync(AppResources.ThisRequestIsNoLongerValid);
+                await Page.Navigation.PopModalAsync();
+                return;
+            }
 
             await _deviceActionService.ShowLoadingAsync(AppResources.Loading);
             await _authService.PasswordlessLoginAsync(LoginRequest.Id, LoginRequest.PubKey, approveRequest);

--- a/src/App/Pages/Accounts/LoginPasswordlessViewModel.cs
+++ b/src/App/Pages/Accounts/LoginPasswordlessViewModel.cs
@@ -116,6 +116,7 @@ namespace Bit.App.Pages
                 await Page.Navigation.PopModalAsync();
                 return;
             }
+
             var loginRequestData = await _authService.GetPasswordlessLoginRequestByIdAsync(LoginRequest.Id);
             if (loginRequestData.RequestApproved.HasValue && loginRequestData.ResponseDate.HasValue)
             {
@@ -178,9 +179,5 @@ namespace Bit.App.Pages
         public string DeviceType { get; set; }
 
         public string IpAddress { get; set; }
-
-        public bool? Approved { get; set; }
-
-        public DateTime? ResponseDate { get; set; }
     }
 }

--- a/src/App/Pages/Accounts/LoginPasswordlessViewModel.cs
+++ b/src/App/Pages/Accounts/LoginPasswordlessViewModel.cs
@@ -171,5 +171,9 @@ namespace Bit.App.Pages
         public string DeviceType { get; set; }
 
         public string IpAddress { get; set; }
+
+        public bool? Approved { get; set; }
+
+        public DateTime? ResponseDate { get; set; }
     }
 }

--- a/src/App/Resources/AppResources.Designer.cs
+++ b/src/App/Resources/AppResources.Designer.cs
@@ -5877,6 +5877,15 @@ namespace Bit.App.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to This request is no longer valid.
+        /// </summary>
+        public static string ThisRequestIsNoLongerValid {
+            get {
+                return ResourceManager.GetString("ThisRequestIsNoLongerValid", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to 3 days.
         /// </summary>
         public static string ThreeDays {

--- a/src/App/Resources/AppResources.resx
+++ b/src/App/Resources/AppResources.resx
@@ -2509,4 +2509,7 @@ Do you want to switch to this account?</value>
   <data name="ViewAllLoginOptions" xml:space="preserve">
     <value>View all log in options</value>
   </data>
+  <data name="ThisRequestIsNoLongerValid" xml:space="preserve">
+    <value>This request is no longer valid</value>
+  </data>
 </root>

--- a/src/Core/Models/Response/PasswordlessLoginResponse.cs
+++ b/src/Core/Models/Response/PasswordlessLoginResponse.cs
@@ -13,7 +13,8 @@ namespace Bit.Core.Models.Response
         public string Key { get; set; }
         public string MasterPasswordHash { get; set; }
         public DateTime CreationDate { get; set; }
-        public bool RequestApproved { get; set; }
+        public DateTime? ResponseDate { get; set; }
+        public bool? RequestApproved { get; set; }
         public string Origin { get; set; }
         public string RequestAccessCode { get; set; }
         public Tuple<byte[], byte[]> RequestKeyPair { get; set; }


### PR DESCRIPTION
Depends on  #https://github.com/bitwarden/server/pull/2412
## Type of change
- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
When responding to a previously answered passwordless device, show a message saying the request is not longer valid.

## Screenshots
<!--Required for any UI changes. Delete if not applicable-->
<img width="435" alt="image" src="https://user-images.githubusercontent.com/4648522/201733773-d291e492-ab05-4423-bcc5-17c851ec0404.png">


## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
