### PR TITLE
[SG-816] Get all login requests and pick the most recent

### DIFF
--- a/src/App/App.xaml.cs
+++ b/src/App/App.xaml.cs
@@ -169,6 +169,13 @@ namespace Bit.App
 
         private async Task SyncPasswordlessLoginRequestsAsync()
         {
+            var activeUserId = await _stateService.GetActiveUserIdAsync();
+            // if the user has not enabled passwordless logins ignore requests
+            if (!await _stateService.GetApprovePasswordlessLoginsAsync(activeUserId))
+            {
+                return;
+            }
+
             var loginRequests = await _authService.GetPasswordlessLoginRequestsAsync();
             if (loginRequests == null || !loginRequests.Any())
             {
@@ -187,7 +194,7 @@ namespace Bit.App
             await _stateService.SetPasswordlessLoginNotificationAsync(new PasswordlessRequestNotification()
             {
                 Id = validLoginRequest.Id,
-                UserId = await _stateService.GetActiveUserIdAsync()
+                UserId = activeUserId
             });
 
             _messagingService.Send(Constants.PasswordlessLoginRequestKey);

--- a/src/App/App.xaml.cs
+++ b/src/App/App.xaml.cs
@@ -208,7 +208,7 @@ namespace Bit.App
             });
             await _stateService.SetPasswordlessLoginNotificationAsync(null);
             _pushNotificationService.DismissLocalNotification(Constants.PasswordlessNotificationId);
-            if (loginRequestData.CreationDate.ToUniversalTime().AddMinutes(Constants.PasswordlessNotificationTimeoutInMinutes) > DateTime.UtcNow)
+            if (!loginRequestData.IsExpired)
             {
                 await Device.InvokeOnMainThreadAsync(() => Application.Current.MainPage.Navigation.PushModalAsync(new NavigationPage(page)));
             }

--- a/src/App/App.xaml.cs
+++ b/src/App/App.xaml.cs
@@ -185,7 +185,7 @@ namespace Bit.App
             var validLoginRequests = loginRequests.Where(l => l.RequestApproved == null && l.ResponseDate == null
                 && l.CreationDate.ToUniversalTime().AddMinutes(Constants.PasswordlessNotificationTimeoutInMinutes) > DateTime.UtcNow).ToList();
 
-            if (validLoginRequests == null)
+            if (validLoginRequests == null || !validLoginRequests.Any())
             {
                 return;
             }

--- a/src/App/Pages/Accounts/LoginPasswordlessRequestViewModel.cs
+++ b/src/App/Pages/Accounts/LoginPasswordlessRequestViewModel.cs
@@ -128,7 +128,7 @@ namespace Bit.App.Pages
             {
                 var response = await _authService.GetPasswordlessLoginResponseAsync(_requestId, _requestAccessCode);
 
-                if (!response.RequestApproved)
+                if (response.RequestApproved == null || !response.RequestApproved.Value)
                 {
                     return;
                 }

--- a/src/App/Pages/Accounts/LoginPasswordlessViewModel.cs
+++ b/src/App/Pages/Accounts/LoginPasswordlessViewModel.cs
@@ -100,7 +100,7 @@ namespace Bit.App.Pages
         private async Task UpdateRequestTime()
         {
             TriggerPropertyChanged(nameof(TimeOfRequestText));
-            if (DateTime.UtcNow > LoginRequest?.RequestDate.ToUniversalTime().AddMinutes(Constants.PasswordlessNotificationTimeoutInMinutes))
+            if (LoginRequest?.IsExpired ?? false)
             {
                 StopRequestTimeUpdater();
                 await _platformUtilsService.ShowDialogAsync(AppResources.LoginRequestHasAlreadyExpired);
@@ -110,7 +110,7 @@ namespace Bit.App.Pages
 
         private async Task PasswordlessLoginAsync(bool approveRequest)
         {
-            if (LoginRequest.RequestDate.ToUniversalTime().AddMinutes(Constants.PasswordlessNotificationTimeoutInMinutes) <= DateTime.UtcNow)
+            if (LoginRequest.IsExpired)
             {
                 await _platformUtilsService.ShowDialogAsync(AppResources.LoginRequestHasAlreadyExpired);
                 await Page.Navigation.PopModalAsync();
@@ -179,5 +179,7 @@ namespace Bit.App.Pages
         public string DeviceType { get; set; }
 
         public string IpAddress { get; set; }
+
+        public bool IsExpired => RequestDate.ToUniversalTime().AddMinutes(Constants.PasswordlessNotificationTimeoutInMinutes) < DateTime.UtcNow;
     }
 }

--- a/src/Core/Abstractions/IApiService.cs
+++ b/src/Core/Abstractions/IApiService.cs
@@ -83,6 +83,7 @@ namespace Bit.Core.Abstractions
         Task<SendResponse> PutSendAsync(string id, SendRequest request);
         Task<SendResponse> PutSendRemovePasswordAsync(string id);
         Task DeleteSendAsync(string id);
+        Task<List<PasswordlessLoginResponse>> GetAuthRequestAsync();
         Task<PasswordlessLoginResponse> GetAuthRequestAsync(string id);
         Task<PasswordlessLoginResponse> GetAuthResponseAsync(string id, string accessCode);
         Task<PasswordlessLoginResponse> PutAuthRequestAsync(string id, string key, string masterPasswordHash, string deviceIdentifier, bool requestApproved);

--- a/src/Core/Abstractions/IAuthService.cs
+++ b/src/Core/Abstractions/IAuthService.cs
@@ -29,6 +29,7 @@ namespace Bit.Core.Abstractions
         Task<AuthResult> LogInTwoFactorAsync(TwoFactorProviderType twoFactorProvider, string twoFactorToken, string captchaToken, bool? remember = null);
         Task<AuthResult> LogInPasswordlessAsync(string email, string accessCode, string authRequestId, byte[] decryptionKey, string userKeyCiphered, string localHashedPasswordCiphered);
 
+        Task<List<PasswordlessLoginResponse>> GetPasswordlessLoginRequestsAsync();
         Task<PasswordlessLoginResponse> GetPasswordlessLoginRequestByIdAsync(string id);
         Task<PasswordlessLoginResponse> GetPasswordlessLoginResponseAsync(string id, string accessCode);
         Task<PasswordlessLoginResponse> PasswordlessLoginAsync(string id, string pubKey, bool requestApproved);

--- a/src/Core/Models/Response/PasswordlessLoginResponse.cs
+++ b/src/Core/Models/Response/PasswordlessLoginResponse.cs
@@ -21,8 +21,7 @@ namespace Bit.Core.Models.Response
         public string RequestAccessCode { get; set; }
         public Tuple<byte[], byte[]> RequestKeyPair { get; set; }
 
-        public bool IsAnswered => RequestApproved != null
-                                    && ResponseDate != null;
+        public bool IsAnswered => RequestApproved != null && ResponseDate != null;
 
         public bool IsExpired => CreationDate.ToUniversalTime().AddMinutes(Constants.PasswordlessNotificationTimeoutInMinutes) < DateTime.UtcNow;
     }

--- a/src/Core/Models/Response/PasswordlessLoginResponse.cs
+++ b/src/Core/Models/Response/PasswordlessLoginResponse.cs
@@ -20,6 +20,11 @@ namespace Bit.Core.Models.Response
         public string Origin { get; set; }
         public string RequestAccessCode { get; set; }
         public Tuple<byte[], byte[]> RequestKeyPair { get; set; }
+
+        public bool IsAnswered => RequestApproved != null
+                                    && ResponseDate != null;
+
+        public bool IsExpired => CreationDate.ToUniversalTime().AddMinutes(Constants.PasswordlessNotificationTimeoutInMinutes) < DateTime.UtcNow;
     }
 
     public class PasswordlessLoginsResponse

--- a/src/Core/Models/Response/PasswordlessLoginResponse.cs
+++ b/src/Core/Models/Response/PasswordlessLoginResponse.cs
@@ -13,7 +13,8 @@ namespace Bit.Core.Models.Response
         public string Key { get; set; }
         public string MasterPasswordHash { get; set; }
         public DateTime CreationDate { get; set; }
-        public bool RequestApproved { get; set; }
+        public DateTime? ResponseDate { get; set; }
+        public bool? RequestApproved { get; set; }
         public string Origin { get; set; }
         public string RequestAccessCode { get; set; }
         public Tuple<byte[], byte[]> RequestKeyPair { get; set; }

--- a/src/Core/Models/Response/PasswordlessLoginResponse.cs
+++ b/src/Core/Models/Response/PasswordlessLoginResponse.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.Collections.Generic;
 using Bit.Core.Enums;
+using Bit.Core.Models.Data;
 
 namespace Bit.Core.Models.Response
 {
@@ -18,5 +20,10 @@ namespace Bit.Core.Models.Response
         public string Origin { get; set; }
         public string RequestAccessCode { get; set; }
         public Tuple<byte[], byte[]> RequestKeyPair { get; set; }
+    }
+
+    public class PasswordlessLoginsResponse
+    {
+        public List<PasswordlessLoginResponse> Data { get; set; }
     }
 }

--- a/src/Core/Services/ApiService.cs
+++ b/src/Core/Services/ApiService.cs
@@ -536,9 +536,10 @@ namespace Bit.Core.Services
 
         #region PasswordlessLogin
 
-        public Task<List<PasswordlessLoginResponse>> GetAuthRequestAsync()
+        public async Task<List<PasswordlessLoginResponse>> GetAuthRequestAsync()
         {
-            return SendAsync<object, List<PasswordlessLoginResponse>>(HttpMethod.Get, $"/auth-requests/", null, true, true);
+            var response = await SendAsync<object, PasswordlessLoginsResponse>(HttpMethod.Get, $"/auth-requests/", null, true, true);
+            return response.Data;
         }
 
         public Task<PasswordlessLoginResponse> GetAuthRequestAsync(string id)

--- a/src/Core/Services/ApiService.cs
+++ b/src/Core/Services/ApiService.cs
@@ -536,6 +536,11 @@ namespace Bit.Core.Services
 
         #region PasswordlessLogin
 
+        public Task<List<PasswordlessLoginResponse>> GetAuthRequestAsync()
+        {
+            return SendAsync<object, List<PasswordlessLoginResponse>>(HttpMethod.Get, $"/auth-requests/", null, true, true);
+        }
+
         public Task<PasswordlessLoginResponse> GetAuthRequestAsync(string id)
         {
             return SendAsync<object, PasswordlessLoginResponse>(HttpMethod.Get, $"/auth-requests/{id}", null, true, true);

--- a/src/Core/Services/AuthService.cs
+++ b/src/Core/Services/AuthService.cs
@@ -485,6 +485,11 @@ namespace Bit.Core.Services
             SelectedTwoFactorProviderType = null;
         }
 
+        public async Task<List<PasswordlessLoginResponse>> GetPasswordlessLoginRequestsAsync()
+        {
+            return await _apiService.GetAuthRequestAsync();
+        }
+
         public async Task<PasswordlessLoginResponse> GetPasswordlessLoginRequestByIdAsync(string id)
         {
             return await _apiService.GetAuthRequestAsync(id);

--- a/src/Core/Services/SyncService.cs
+++ b/src/Core/Services/SyncService.cs
@@ -24,6 +24,7 @@ namespace Bit.Core.Services
         private readonly IPolicyService _policyService;
         private readonly ISendService _sendService;
         private readonly IKeyConnectorService _keyConnectorService;
+        private readonly ILogger _logger;
         private readonly Func<Tuple<string, bool, bool>, Task> _logoutCallbackAsync;
 
         public SyncService(
@@ -39,6 +40,7 @@ namespace Bit.Core.Services
             IPolicyService policyService,
             ISendService sendService,
             IKeyConnectorService keyConnectorService,
+            ILogger logger,
             Func<Tuple<string, bool, bool>, Task> logoutCallbackAsync)
         {
             _stateService = stateService;
@@ -53,6 +55,7 @@ namespace Bit.Core.Services
             _policyService = policyService;
             _sendService = sendService;
             _keyConnectorService = keyConnectorService;
+            _logger = logger;
             _logoutCallbackAsync = logoutCallbackAsync;
         }
 
@@ -419,7 +422,7 @@ namespace Bit.Core.Services
             }
             catch (Exception ex)
             {
-                LoggerHelper.LogEvenIfCantBeResolved(ex);
+                _logger.Exception(ex);
             }
         }
     }

--- a/src/Core/Services/SyncService.cs
+++ b/src/Core/Services/SyncService.cs
@@ -108,6 +108,7 @@ namespace Bit.Core.Services
                 await SyncSettingsAsync(userId, response.Domains);
                 await SyncPoliciesAsync(response.Policies);
                 await SyncSendsAsync(userId, response.Sends);
+                await SyncPasswordlessLoginRequestsAsync(userId);
                 await SetLastSyncAsync(now);
                 return SyncCompleted(true);
             }
@@ -381,6 +382,40 @@ namespace Bit.Core.Services
             var sends = response?.ToDictionary(s => s.Id, s => new SendData(s, userId)) ??
                 new Dictionary<string, SendData>();
             await _sendService.ReplaceAsync(sends);
+        }
+
+        private async Task SyncPasswordlessLoginRequestsAsync(string userId)
+        {
+            // if the user has not enabled passwordless logins ignore requests
+            if (!await _stateService.GetApprovePasswordlessLoginsAsync(userId))
+            {
+                return;
+            }
+
+            var loginRequests = await _apiService.GetAuthRequestAsync();
+            if (loginRequests == null || !loginRequests.Any())
+            {
+                return;
+            }
+
+            var validLoginRequest = loginRequests.Where(l => l.RequestApproved == null
+                                                 && l.ResponseDate == null
+                                                 && l.CreationDate.ToUniversalTime().AddMinutes(Constants.PasswordlessNotificationTimeoutInMinutes) > DateTime.UtcNow)
+                                     .OrderByDescending(x => x.CreationDate)
+                                     .FirstOrDefault();
+
+            if (validLoginRequest is null)
+            {
+                return;
+            }
+
+            await _stateService.SetPasswordlessLoginNotificationAsync(new PasswordlessRequestNotification()
+            {
+                Id = validLoginRequest.Id,
+                UserId = userId
+            });
+
+            _messagingService.Send(Constants.PasswordlessLoginRequestKey);
         }
     }
 }

--- a/src/Core/Utilities/ServiceContainer.cs
+++ b/src/Core/Utilities/ServiceContainer.cs
@@ -29,6 +29,8 @@ namespace Bit.Core.Utilities
             var messagingService = Resolve<IMessagingService>("messagingService");
             var cryptoFunctionService = Resolve<ICryptoFunctionService>("cryptoFunctionService");
             var cryptoService = Resolve<ICryptoService>("cryptoService");
+            var logger = Resolve<ILogger>();
+
             SearchService searchService = null;
 
             var tokenService = new TokenService(stateService);
@@ -67,7 +69,7 @@ namespace Bit.Core.Utilities
                 });
             var syncService = new SyncService(stateService, apiService, settingsService, folderService, cipherService,
                 cryptoService, collectionService, organizationService, messagingService, policyService, sendService,
-                keyConnectorService, (extras) =>
+                keyConnectorService, logger, (extras) =>
                 {
                     messagingService.Send("logout", extras);
                     return Task.CompletedTask;


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
If the user for some reason did not receive the notification to login with the device, sync the vault will fetch all login requests and pick the most recent and valid one.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **SyncService.cs:** when vault sync is triggered, get all login requests and set in the stateService the most recent. After that triggers a normal passwordless login request flow.

## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
