### PR TITLE
[SG-831] Pull Down Sync does not retrieve pending AuthRequests

### DIFF
--- a/src/App/Pages/Settings/SyncPageViewModel.cs
+++ b/src/App/Pages/Settings/SyncPageViewModel.cs
@@ -91,6 +91,7 @@ namespace Bit.App.Pages
             {
                 await _deviceActionService.ShowLoadingAsync(AppResources.Syncing);
                 var success = await _syncService.FullSyncAsync(true);
+                await _syncService.SyncPasswordlessLoginRequestsAsync();
                 await _deviceActionService.HideLoadingAsync();
                 if (success)
                 {

--- a/src/App/Pages/Settings/SyncPageViewModel.cs
+++ b/src/App/Pages/Settings/SyncPageViewModel.cs
@@ -90,8 +90,8 @@ namespace Bit.App.Pages
             try
             {
                 await _deviceActionService.ShowLoadingAsync(AppResources.Syncing);
-                var success = await _syncService.FullSyncAsync(true);
                 await _syncService.SyncPasswordlessLoginRequestsAsync();
+                var success = await _syncService.FullSyncAsync(true);
                 await _deviceActionService.HideLoadingAsync();
                 if (success)
                 {

--- a/src/App/Pages/Vault/GroupingsPage/GroupingsPageViewModel.cs
+++ b/src/App/Pages/Vault/GroupingsPage/GroupingsPageViewModel.cs
@@ -189,7 +189,8 @@ namespace Bit.App.Pages
             if (await _stateService.GetSyncOnRefreshAsync() && Refreshing && !SyncRefreshing)
             {
                 SyncRefreshing = true;
-                await _syncService.FullSyncAsync(true);
+                await _syncService.SyncPasswordlessLoginRequestsAsync();
+                await _syncService.FullSyncAsync(false);
                 return;
             }
 

--- a/src/App/Pages/Vault/GroupingsPage/GroupingsPageViewModel.cs
+++ b/src/App/Pages/Vault/GroupingsPage/GroupingsPageViewModel.cs
@@ -189,7 +189,7 @@ namespace Bit.App.Pages
             if (await _stateService.GetSyncOnRefreshAsync() && Refreshing && !SyncRefreshing)
             {
                 SyncRefreshing = true;
-                await _syncService.FullSyncAsync(false);
+                await _syncService.FullSyncAsync(true);
                 return;
             }
 

--- a/src/Core/Abstractions/ISyncService.cs
+++ b/src/Core/Abstractions/ISyncService.cs
@@ -14,5 +14,7 @@ namespace Bit.Core.Abstractions
         Task<bool> SyncDeleteFolderAsync(SyncFolderNotification notification);
         Task<bool> SyncUpsertCipherAsync(SyncCipherNotification notification, bool isEdit);
         Task<bool> SyncUpsertFolderAsync(SyncFolderNotification notification, bool isEdit);
+        // Passwordless code will be moved to an independent service in future techdept
+        Task SyncPasswordlessLoginRequestsAsync();
     }
 }

--- a/src/Core/Services/SyncService.cs
+++ b/src/Core/Services/SyncService.cs
@@ -111,7 +111,6 @@ namespace Bit.Core.Services
                 await SyncSettingsAsync(userId, response.Domains);
                 await SyncPoliciesAsync(response.Policies);
                 await SyncSendsAsync(userId, response.Sends);
-                await SyncPasswordlessLoginRequestsAsync(userId);
                 await SetLastSyncAsync(now);
                 return SyncCompleted(true);
             }
@@ -387,10 +386,11 @@ namespace Bit.Core.Services
             await _sendService.ReplaceAsync(sends);
         }
 
-        private async Task SyncPasswordlessLoginRequestsAsync(string userId)
+        public async Task SyncPasswordlessLoginRequestsAsync()
         {
             try
             {
+                var userId = await _stateService.GetActiveUserIdAsync();
                 // if the user has not enabled passwordless logins ignore requests
                 if (!await _stateService.GetApprovePasswordlessLoginsAsync(userId))
                 {


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Adding the possibility to manually get pending login requests. This will be always fetched even though the sync is not forced.

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->
Exposed the Sync Login Requests method to be called separately from the **FullSync**. This is a temporary solution. A tech dept ticket was created to move all Passwordless code to an independent service.

## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
