### PR TITLE
[SG-837] QA build crashing while attaching a file

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -132,6 +132,7 @@ Task("UpdateAndroidCodeFiles")
             Path.Combine(_slnPath, "src", "Android", "Receivers", "PackageReplacedReceiver.cs"),
             Path.Combine(_slnPath, "src", "Android", "Receivers", "RestrictionsChangedReceiver.cs"),
             Path.Combine(_slnPath, "src", "Android", "Services", "DeviceActionService.cs"),
+            Path.Combine(_slnPath, "src", "Android", "Services", "FileService.cs"),
             Path.Combine(_slnPath, "src", "Android", "Tiles", "AutofillTileService.cs"),
             Path.Combine(_slnPath, "src", "Android", "Tiles", "GeneratorTileService.cs"),
             Path.Combine(_slnPath, "src", "Android", "Tiles", "MyVaultTileService.cs"),


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

This fixes Android's QA apk crashing while trying to attach a file. A recently added file (`FileService.cs`) with a reference to the package name was missing from the script.



## Code changes
* **build.cake:** Script will now change the package name in Android's `FileService.cs`



## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
