### PR TITLE
[SG-601] Enhance experience when user denies camera access in Authenticator

### DIFF
--- a/src/App/Pages/Vault/CipherAddEditPage.xaml.cs
+++ b/src/App/Pages/Vault/CipherAddEditPage.xaml.cs
@@ -263,7 +263,6 @@ namespace Bit.App.Pages
         {
             if (DoOnce())
             {
-                var cameraPermission = await PermissionManager.CheckAndRequestPermissionAsync(new Permissions.Camera());
                 var page = new ScanPage(key =>
                 {
                     Device.BeginInvokeOnMainThread(async () =>
@@ -271,7 +270,7 @@ namespace Bit.App.Pages
                         await Navigation.PopModalAsync();
                         await _vm.UpdateTotpKeyAsync(key);
                     });
-                }, cameraPermission == PermissionStatus.Granted);
+                });
 
                 await Navigation.PushModalAsync(new Xamarin.Forms.NavigationPage(page));
             }

--- a/src/App/Pages/Vault/CipherAddEditPage.xaml.cs
+++ b/src/App/Pages/Vault/CipherAddEditPage.xaml.cs
@@ -264,11 +264,6 @@ namespace Bit.App.Pages
             if (DoOnce())
             {
                 var cameraPermission = await PermissionManager.CheckAndRequestPermissionAsync(new Permissions.Camera());
-                if (cameraPermission != PermissionStatus.Granted)
-                {
-                    return;
-                }
-
                 var page = new ScanPage(key =>
                 {
                     Device.BeginInvokeOnMainThread(async () =>
@@ -276,7 +271,8 @@ namespace Bit.App.Pages
                         await Navigation.PopModalAsync();
                         await _vm.UpdateTotpKeyAsync(key);
                     });
-                });
+                }, cameraPermission == PermissionStatus.Granted);
+
                 await Navigation.PushModalAsync(new Xamarin.Forms.NavigationPage(page));
             }
         }

--- a/src/App/Pages/Vault/ScanPage.xaml
+++ b/src/App/Pages/Vault/ScanPage.xaml
@@ -36,8 +36,6 @@
         </Grid.RowDefinitions>
         <ContentView 
             x:Name="_scannerContainer"
-            HorizontalOptions="FillAndExpand"
-            VerticalOptions="FillAndExpand"
             AutomationId="zxingScannerView"
             IsVisible="{Binding ShowScanner}"
             Grid.Column="0"

--- a/src/App/Pages/Vault/ScanPage.xaml
+++ b/src/App/Pages/Vault/ScanPage.xaml
@@ -34,16 +34,15 @@
             <RowDefinition Height="*" />
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
-        <zxing:ZXingScannerView
-            x:Name="_zxing"
+        <ContentView 
+            x:Name="_scannerContainer"
             HorizontalOptions="FillAndExpand"
             VerticalOptions="FillAndExpand"
             AutomationId="zxingScannerView"
             IsVisible="{Binding ShowScanner}"
             Grid.Column="0"
             Grid.Row="0"
-            Grid.RowSpan="3"
-            OnScanResult="OnScanResult"/>
+            Grid.RowSpan="3"/>
         <StackLayout
             VerticalOptions="Center"
             HorizontalOptions="FillAndExpand"

--- a/src/App/Pages/Vault/ScanPage.xaml.cs
+++ b/src/App/Pages/Vault/ScanPage.xaml.cs
@@ -31,7 +31,7 @@ namespace Bit.App.Pages
         private ZXingScannerView _zxing;
         private readonly LazyResolve<ILogger> _logger = new LazyResolve<ILogger>("logger");
 
-        public ScanPage(Action<string> callback, bool hasCameraPermission)
+        public ScanPage(Action<string> callback)
         {
             InitializeComponent();
             _callback = callback;

--- a/src/App/Pages/Vault/ScanPage.xaml.cs
+++ b/src/App/Pages/Vault/ScanPage.xaml.cs
@@ -47,7 +47,6 @@ namespace Bit.App.Pages
             _blueSKColor = ThemeManager.GetResourceColor("PrimaryColor").ToSKColor();
             _stopwatch = new Stopwatch();
             _qrcodeFound = false;
-            ViewModel.InitAsync().FireAndForget();
         }
 
         protected override void OnAppearing()

--- a/src/App/Pages/Vault/ScanPage.xaml.cs
+++ b/src/App/Pages/Vault/ScanPage.xaml.cs
@@ -55,7 +55,7 @@ namespace Bit.App.Pages
         protected override void OnAppearing()
         {
             base.OnAppearing();
-            if(_zxing != null)
+            if (_zxing != null)
             {
                 _zxing.IsScanning = true;
 

--- a/src/App/Pages/Vault/ScanPage.xaml.cs
+++ b/src/App/Pages/Vault/ScanPage.xaml.cs
@@ -79,7 +79,7 @@ namespace Bit.App.Pages
                     AutoRotate = false,
                     TryInverted = true,
                     DelayBetweenAnalyzingFrames = 5,
-                    DelayBetweenContinuousScans = 5 
+                    DelayBetweenContinuousScans = 5
                 };
                 _scannerContainer.Content = _zxing;
                 StartScanner();

--- a/src/App/Pages/Vault/ScanPage.xaml.cs
+++ b/src/App/Pages/Vault/ScanPage.xaml.cs
@@ -57,10 +57,11 @@ namespace Bit.App.Pages
 
         protected override void OnDisappearing()
         {
-            base.OnDisappearing();
             StopScanner();
+            base.OnDisappearing();
         }
 
+        // Fix known bug with DelayBetweenAnalyzingFrames & DelayBetweenContinuousScans: https://github.com/Redth/ZXing.Net.Mobile/issues/721
         private void InitScanner()
         {
             try
@@ -76,7 +77,9 @@ namespace Bit.App.Pages
                     UseNativeScanning = true,
                     PossibleFormats = new List<ZXing.BarcodeFormat> { ZXing.BarcodeFormat.QR_CODE },
                     AutoRotate = false,
-                    TryInverted = true
+                    TryInverted = true,
+                    DelayBetweenAnalyzingFrames = 5,
+                    DelayBetweenContinuousScans = 5 
                 };
                 _scannerContainer.Content = _zxing;
                 StartScanner();
@@ -94,6 +97,7 @@ namespace Bit.App.Pages
                 return;
             }
 
+            _zxing.OnScanResult -= OnScanResult;
             _zxing.OnScanResult += OnScanResult;
             _zxing.IsScanning = true;
 

--- a/src/App/Pages/Vault/ScanPage.xaml.cs
+++ b/src/App/Pages/Vault/ScanPage.xaml.cs
@@ -57,7 +57,7 @@ namespace Bit.App.Pages
 
         protected override void OnDisappearing()
         {
-            StopScanner();
+            StopScanner().FireAndForget();
             base.OnDisappearing();
         }
 
@@ -86,7 +86,7 @@ namespace Bit.App.Pages
             }
             catch (Exception ex)
             {
-                _logger?.Value.Exception(ex);
+                _logger.Value.Exception(ex);
             }
         }
 

--- a/src/App/Pages/Vault/ScanPageViewModel.cs
+++ b/src/App/Pages/Vault/ScanPageViewModel.cs
@@ -23,20 +23,24 @@ namespace Bit.App.Pages
 
         public ScanPageViewModel()
         {
-            ToggleScanModeCommand = new AsyncCommand(ToggleScanMode);
+            ToggleScanModeCommand = new AsyncCommand(ToggleScanMode, onException: HandleException);
             _platformUtilsService = ServiceContainer.Resolve<IPlatformUtilsService>("platformUtilsService");
             _deviceActionService = ServiceContainer.Resolve<IDeviceActionService>("deviceActionService");
             _logger = ServiceContainer.Resolve<ILogger>();
-            Device.InvokeOnMainThreadAsync(InitAsync);
+            InitAsync().FireAndForget();
         }
 
         public async Task InitAsync()
         {
             try
             {
-                var hasCameraPermission = await PermissionManager.CheckAndRequestPermissionAsync(new Permissions.Camera());
-                HasCameraPermission = hasCameraPermission == PermissionStatus.Granted;
-                ShowScanner = hasCameraPermission == PermissionStatus.Granted;
+                await Device.InvokeOnMainThreadAsync(async () =>
+                {
+                    var hasCameraPermission = await PermissionManager.CheckAndRequestPermissionAsync(new Permissions.Camera());
+                    HasCameraPermission = hasCameraPermission == PermissionStatus.Granted;
+                    ShowScanner = hasCameraPermission == PermissionStatus.Granted;
+                });
+
                 if (!HasCameraPermission)
                 {
                     return;

--- a/src/App/Pages/Vault/ScanPageViewModel.cs
+++ b/src/App/Pages/Vault/ScanPageViewModel.cs
@@ -26,6 +26,18 @@ namespace Bit.App.Pages
             _deviceActionService = ServiceContainer.Resolve<IDeviceActionService>("deviceActionService");
         }
 
+        public async Task InitAsync()
+        {
+            var hasCameraPermission = await PermissionManager.CheckAndRequestPermissionAsync(new Permissions.Camera());
+            HasCameraPermission = hasCameraPermission == PermissionStatus.Granted;
+            ShowScanner = hasCameraPermission == PermissionStatus.Granted;
+            if (!HasCameraPermission)
+            {
+                return;
+            }
+            InitScannerCommand.Execute(null);
+        }
+
         public ICommand ToggleScanModeCommand { get; set; }
         public ICommand InitScannerCommand { get; set; }
 
@@ -63,8 +75,8 @@ namespace Bit.App.Pages
                 if (openAppSettingsResult)
                 {
                     _deviceActionService.OpenAppSettings();
-                    return;
                 }
+                return;
             }
             ShowScanner = !ShowScanner;
             InitScannerCommand.Execute(null);

--- a/src/App/Pages/Vault/ScanPageViewModel.cs
+++ b/src/App/Pages/Vault/ScanPageViewModel.cs
@@ -59,7 +59,7 @@ namespace Bit.App.Pages
             HasCameraPermission = cameraPermission == PermissionStatus.Granted;
             if (!HasCameraPermission)
             {
-                var openAppSettingsResult = await _platformUtilsService.ShowDialogAsync(AppResources.EnableCamerPermissionsToUseTheScanner, title: string.Empty, confirmText: AppResources.Settings, cancelText: AppResources.NoThanks);
+                var openAppSettingsResult = await _platformUtilsService.ShowDialogAsync(AppResources.EnableCamerPermissionToUseTheScanner, title: string.Empty, confirmText: AppResources.Settings, cancelText: AppResources.NoThanks);
                 if (openAppSettingsResult)
                 {
                     _deviceActionService.OpenAppSettings();

--- a/src/App/Resources/AppResources.Designer.cs
+++ b/src/App/Resources/AppResources.Designer.cs
@@ -2129,6 +2129,15 @@ namespace Bit.App.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Enable camera permissions to use the scanner.
+        /// </summary>
+        public static string EnableCamerPermissionsToUseTheScanner {
+            get {
+                return ResourceManager.GetString("EnableCamerPermissionsToUseTheScanner", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Enabled.
         /// </summary>
         public static string Enabled {
@@ -3544,7 +3553,7 @@ namespace Bit.App.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Enterprise Single Sign-On.
+        ///   Looks up a localized string similar to Enterprise single sign-on.
         /// </summary>
         public static string LogInSso {
             get {
@@ -3589,7 +3598,7 @@ namespace Bit.App.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Log In with master password.
+        ///   Looks up a localized string similar to Log in with master password.
         /// </summary>
         public static string LogInWithMasterPassword {
             get {

--- a/src/App/Resources/AppResources.Designer.cs
+++ b/src/App/Resources/AppResources.Designer.cs
@@ -2129,11 +2129,11 @@ namespace Bit.App.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Enable camera permissions to use the scanner.
+        ///   Looks up a localized string similar to Enable camera permission to use the scanner.
         /// </summary>
-        public static string EnableCamerPermissionsToUseTheScanner {
+        public static string EnableCamerPermissionToUseTheScanner {
             get {
-                return ResourceManager.GetString("EnableCamerPermissionsToUseTheScanner", resourceCulture);
+                return ResourceManager.GetString("EnableCamerPermissionToUseTheScanner", resourceCulture);
             }
         }
         

--- a/src/App/Resources/AppResources.resx
+++ b/src/App/Resources/AppResources.resx
@@ -2512,7 +2512,7 @@ Do you want to switch to this account?</value>
   <data name="ThisRequestIsNoLongerValid" xml:space="preserve">
     <value>This request is no longer valid</value>
   </data>
-  <data name="EnableCamerPermissionsToUseTheScanner" xml:space="preserve">
-    <value>Enable camera permissions to use the scanner</value>
+  <data name="EnableCamerPermissionToUseTheScanner" xml:space="preserve">
+    <value>Enable camera permission to use the scanner</value>
   </data>
 </root>

--- a/src/App/Resources/AppResources.resx
+++ b/src/App/Resources/AppResources.resx
@@ -2512,4 +2512,7 @@ Do you want to switch to this account?</value>
   <data name="ThisRequestIsNoLongerValid" xml:space="preserve">
     <value>This request is no longer valid</value>
   </data>
+  <data name="EnableCamerPermissionsToUseTheScanner" xml:space="preserve">
+    <value>Enable camera permissions to use the scanner</value>
+  </data>
 </root>


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
When a user denies camera access for the QR code scan, they are neither prompted again nor are they given a modal that says ‘You must enable camera access…’ etc. when they tap the icon to add an authenticator code to an item that does not yet have one. This occurs in Prod as well; the camera icon/Set up TOTP buttons do not respond when selected if you have previously denied the setting.This poses an issue in the Authenticator UI because there is no way to manually add a new TOTP without accessing those screens, however, you can edit an existing one.

Expected behavior: When the user has camera permissions turned off, clicking the “add new TOTP” button launches the “Enter Key Manually” mode. If the user then clicks the “scan QR Code” link (attempting to switch to camera mode) we show the user the dialog requesting camera permissions.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->
**ScanPage.xaml**: Changed ScannerView to a container. The scanner is only added if the user has permissions to use the camera.
**ScanPage.xaml.cs**: Added couple of code protections agains a null scanner. Also added a command to init the scanner from the ViewModel.
**ScanViewModel.cs**: When executing the ToggleScanModeCommand it now checks if the user has camera permissions. If not it will prompt the user to go to settings and enable them. If it has permissions tries to init the scanner if needed and changes the UI.


## Screenshots
<!--Required for any UI changes. Delete if not applicable-->
https://user-images.githubusercontent.com/4648522/204020241-c9501aa7-6569-4f4a-b9d1-e9fb83684f60.mov



## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
