### PR TITLE
[SG-860] Add condition to execute notification tap code

### DIFF
--- a/src/App/Services/PushNotificationListenerService.cs
+++ b/src/App/Services/PushNotificationListenerService.cs
@@ -228,8 +228,9 @@ namespace Bit.App.Services
                 if (data is PasswordlessNotificationData passwordlessNotificationData)
                 {
                     var notificationUserId = await _stateService.Value.GetUserIdAsync(passwordlessNotificationData.UserEmail);
+                    var activeUserEmail = await _stateService.Value.GetActiveUserEmailAsync();
                     var notificationSaved = await _stateService.Value.GetPasswordlessLoginNotificationAsync();
-                    if (notificationUserId != null && notificationSaved != null)
+                    if (activeUserEmail != passwordlessNotificationData.UserEmail && notificationUserId != null && notificationSaved != null)
                     {
                         await _stateService.Value.SetActiveUserAsync(notificationUserId);
                         _messagingService.Value.Send(AccountsManagerMessageCommands.SWITCHED_ACCOUNT);


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Tapping the login request notification before the modal showed up, was launching a new window and the modal would never appear

## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
