### PR TITLE
[EC-759] Add avatar header Apple Watch MVP

### DIFF
--- a/src/watchOS/bitwarden/bitwarden WatchKit Extension/Controls/AvatarView.swift
+++ b/src/watchOS/bitwarden/bitwarden WatchKit Extension/Controls/AvatarView.swift
@@ -1,0 +1,85 @@
+import SwiftUI
+
+struct AvatarView: View {
+    var circleColor = Color.white
+    var textColor = Color.black
+    var initials = ""
+    
+    init(_ user: User?) {
+        let source = user?.name ?? user?.email
+        var upperCaseText: String? = nil
+        
+        if source == nil || source!.isEmpty {
+            initials = ".."
+        } else if source!.count > 1 {
+            upperCaseText = source!.uppercased()
+            initials = getFirstLetters(upperCaseText!, 2)
+        } else {
+            upperCaseText = source!.uppercased()
+            initials = upperCaseText!
+        }
+        
+        circleColor = stringToColor(str: user?.id ?? upperCaseText, fallbackColor: Color(hex: "#FFFFFF33")!)
+        textColor = textColorFromBgColor(circleColor)
+    }
+    
+    var body: some View {
+        ZStack {
+            Circle()
+                .foregroundColor(circleColor)
+                .frame(width: 30, height: 30)
+            Text(initials)
+                .font(.footnote)
+                .foregroundColor(textColor)
+        }
+    }
+    
+    func stringToColor(str: String?, fallbackColor: Color) -> Color {
+        guard let str = str else {
+            return fallbackColor
+        }
+        
+        var hash = 0
+        for char in str {
+            let uniSca = String(char).unicodeScalars
+            let intCharValue = Int(uniSca[uniSca.startIndex].value)
+
+            hash = intCharValue + ((hash << 5) &- hash)
+        }
+        var color = "#"
+        for i in 0..<3 {
+            let value = (hash >> (i * 8)) & 0xff
+            color += String(value, radix: 16).leftPadding(toLength: 2, withPad: "0")
+        }
+        return Color(hex: color) ?? fallbackColor
+    }
+    
+    func textColorFromBgColor(_ bgColor: Color, threshold: CGFloat = 0.65) -> Color {
+        let (r, g, b, _) = bgColor.components
+        let luminance = r * 0.299 + g * 0.587 + b * 0.114;
+        return luminance > threshold ? Color.black : Color.white;
+    }
+
+    func getFirstLetters(_ data: String, _ charCount: Int) -> String {
+        let sanitizedData = data.trimmingCharacters(in: CharacterSet.whitespaces)
+        let parts = sanitizedData.split(separator: " ")
+        
+        if parts.count > 1 && charCount <= 2 {
+            var text = "";
+            for i in 0..<charCount {
+                text += parts[i].prefix(1);
+            }
+            return text;
+        }
+        if sanitizedData.count > 2 {
+            return String(sanitizedData.prefix(2))
+        }
+        return sanitizedData;
+    }
+}
+
+struct AvatarView_Previews: PreviewProvider {
+    static var previews: some View {
+        AvatarView(User(id: "zxc", email: "asdfasdf@gmail.com", name: "John Snow"))
+    }
+}

--- a/src/watchOS/bitwarden/bitwarden WatchKit Extension/Utilities/ColorUtils.swift
+++ b/src/watchOS/bitwarden/bitwarden WatchKit Extension/Utilities/ColorUtils.swift
@@ -7,4 +7,53 @@ extension Color {
         let itemBackground = Color("ItemBackground")
         let darkTextMuted = Color("DarkTextMuted")
     }
+    
+    init?(hex: String) {
+        var hexSanitized = hex.trimmingCharacters(in: .whitespacesAndNewlines)
+        hexSanitized = hexSanitized.replacingOccurrences(of: "#", with: "")
+
+        var rgb: UInt64 = 0
+
+        var r: CGFloat = 0.0
+        var g: CGFloat = 0.0
+        var b: CGFloat = 0.0
+        var a: CGFloat = 1.0
+
+        guard Scanner(string: hexSanitized).scanHexInt64(&rgb) else{
+            return nil
+        }
+
+        switch hexSanitized.count {
+        case 3:
+            r = CGFloat((rgb >> 8) * 17) / 255.0
+            g = CGFloat((rgb >> 4 & 0xF) * 17) / 255.0
+            b = CGFloat((rgb & 0xF) * 17) / 255.0
+        case 6:
+            r = CGFloat((rgb & 0xFF0000) >> 16) / 255.0
+            g = CGFloat((rgb & 0x00FF00) >> 8) / 255.0
+            b = CGFloat(rgb & 0x0000FF) / 255.0
+        case 8:
+            r = CGFloat((rgb & 0xFF000000) >> 24) / 255.0
+            g = CGFloat((rgb & 0x00FF0000) >> 16) / 255.0
+            b = CGFloat((rgb & 0x0000FF00) >> 8) / 255.0
+            a = CGFloat(rgb & 0x000000FF) / 255.0
+        default:
+            return nil
+        }
+
+        self.init(red: r, green: g, blue: b, opacity: a)
+    }
+    
+    var components: (red: CGFloat, green: CGFloat, blue: CGFloat, opacity: CGFloat) {
+        var r: CGFloat = 0
+        var g: CGFloat = 0
+        var b: CGFloat = 0
+        var o: CGFloat = 0
+
+        guard UIColor(self).getRed(&r, green: &g, blue: &b, alpha: &o) else {
+            return (0, 0, 0, 0)
+        }
+
+        return (r, g, b, o)
+    }
 }

--- a/src/watchOS/bitwarden/bitwarden WatchKit Extension/Utilities/StringExtensions.swift
+++ b/src/watchOS/bitwarden/bitwarden WatchKit Extension/Utilities/StringExtensions.swift
@@ -16,4 +16,13 @@ extension String {
         
         return s.trimmingCharacters(in: .whitespaces).isEmpty
     }
+    
+    func leftPadding(toLength: Int, withPad character: Character) -> String {
+        let currentLength = self.count
+        if currentLength < toLength {
+            return String(repeatElement(character, count: toLength - currentLength)) + self
+        } else {
+            return String(self.suffix(toLength))
+        }
+    }
 }

--- a/src/watchOS/bitwarden/bitwarden WatchKit Extension/ViewModels/CipherListViewModel.swift
+++ b/src/watchOS/bitwarden/bitwarden WatchKit Extension/ViewModels/CipherListViewModel.swift
@@ -26,7 +26,7 @@ class CipherListViewModel : ObservableObject {
     func checkStateAndFetch(_ state: BWState? = nil) {
         user = StateService.shared.getUser()
         
-        guard let _ = user, !watchConnectivityManager.isSessionActivated else {
+        if user == nil && !watchConnectivityManager.isSessionActivated {
             currentState = .needSetup
             showingSheet = true
             return

--- a/src/watchOS/bitwarden/bitwarden WatchKit Extension/Views/CipherListView.swift
+++ b/src/watchOS/bitwarden/bitwarden WatchKit Extension/Views/CipherListView.swift
@@ -6,59 +6,67 @@ struct CipherListView: View {
     
     var body: some View {
         NavigationView {
-                VStack{
-                    GeometryReader { geometry in
-                        List {
-                            ForEach(viewModel.ciphers, id: \.id) { cipher in
-                                NavigationLink(destination: CipherDetailsView(cipher: cipher)){
-                                    VStack(alignment: .leading){
-                                        Text(cipher.name ?? "")
-                                            .font(.title3)
-                                            .fontWeight(.bold)
-                                            .lineLimit(1)
-                                            .truncationMode(.tail)
-                                            .frame(maxWidth: .infinity, alignment: .leading)
-                                        
-                                        if cipher.login.username != nil {
-                                            Text(cipher.login.username! )
-                                                .font(.body)
-                                                .lineLimit(1)
-                                                .truncationMode(.tail)
-                                                .foregroundColor(Color.ui.darkTextMuted)
-                                                .frame(maxWidth: .infinity, alignment: .leading)
-                                        }
-                                    }
-                                    .padding()
-                                    .background(
-                                        RoundedRectangle(cornerRadius: 5)
-                                            .foregroundColor(Color.ui.itemBackground)
-                                            .frame(width: geometry.size.width,
-                                                   alignment: .leading)
-                                    )
-                                    .frame(width: geometry.size.width,
-                                           alignment: .leading)
-                                }
-                                .listRowInsets(EdgeInsets())
-                                .listRowBackground(Color.clear)
-                                .padding(3)
+            GeometryReader { geometry in
+                List {
+                    if viewModel.user?.email != nil {
+                        Section() {
+                            HStack {
+                                AvatarView(viewModel.user)
+                                Text(viewModel.user!.email!)
+                                    .font(.headline)
+                                    .lineLimit(1)
+                                    .truncationMode(.tail)
                             }
                         }
-                        .emptyState(viewModel.ciphers.isEmpty, emptyContent: {
-                            VStack(alignment: .center) {
-                                Image("EmptyListPlaceholder")
-                                    .resizable()
-                                    .scaledToFit()
-                                    .padding(20)
-                                Text("ThereAreNoItemsToList")
-                                    .foregroundColor(Color.white)
-                                    .font(.headline)
-                                    .multilineTextAlignment(.center)
-                            }
-                            .frame(width: geometry.size.width, alignment: .center)
-                        })
                     }
-                     
+                    ForEach(viewModel.ciphers, id: \.id) { cipher in
+                        NavigationLink(destination: CipherDetailsView(cipher: cipher)){
+                            VStack(alignment: .leading){
+                                Text(cipher.name ?? "")
+                                    .font(.title3)
+                                    .fontWeight(.bold)
+                                    .lineLimit(1)
+                                    .truncationMode(.tail)
+                                    .frame(maxWidth: .infinity, alignment: .leading)
+                                
+                                if cipher.login.username != nil {
+                                    Text(cipher.login.username! )
+                                        .font(.body)
+                                        .lineLimit(1)
+                                        .truncationMode(.tail)
+                                        .foregroundColor(Color.ui.darkTextMuted)
+                                        .frame(maxWidth: .infinity, alignment: .leading)
+                                }
+                            }
+                            .padding()
+                            .background(
+                                RoundedRectangle(cornerRadius: 5)
+                                    .foregroundColor(Color.ui.itemBackground)
+                                    .frame(width: geometry.size.width,
+                                           alignment: .leading)
+                            )
+                            .frame(width: geometry.size.width,
+                                   alignment: .leading)
+                        }
+                        .listRowInsets(EdgeInsets())
+                        .listRowBackground(Color.clear)
+                        .padding(3)
+                    }
                 }
+                .emptyState(viewModel.ciphers.isEmpty, emptyContent: {
+                    VStack(alignment: .center) {
+                        Image("EmptyListPlaceholder")
+                            .resizable()
+                            .scaledToFit()
+                            .padding(20)
+                        Text("ThereAreNoItemsToList")
+                            .foregroundColor(Color.white)
+                            .font(.headline)
+                            .multilineTextAlignment(.center)
+                    }
+                    .frame(width: geometry.size.width, alignment: .center)
+                })
+            }
         }
         .onAppear {
             self.viewModel.checkStateAndFetch()
@@ -77,6 +85,7 @@ struct ContentView_Previews: PreviewProvider {
     static var previews: some View {
         var v = CipherListView()
         v.viewModel = CipherListViewModel(CipherServiceMock())
+        v.viewModel.user = User(id: "zxc", email: "testing@test.com", name: "Tester")
         return v
     }
 }

--- a/src/watchOS/bitwarden/bitwarden.xcodeproj/project.pbxproj
+++ b/src/watchOS/bitwarden/bitwarden.xcodeproj/project.pbxproj
@@ -34,6 +34,7 @@
 		1B59EC632901B1C100A8718D /* LoggerHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B59EC622901B1C100A8718D /* LoggerHelper.swift */; };
 		1B5AFF0329196C81004478F9 /* ColorUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B5AFF0229196C81004478F9 /* ColorUtils.swift */; };
 		1B5AFF0729197822004478F9 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 1B5AFF0929197822004478F9 /* Localizable.strings */; };
+		1B6BD10229364F020041982D /* AvatarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B6BD10129364F020041982D /* AvatarView.swift */; };
 		1B8453EC290C672E00F921E1 /* CipherEntity+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B8453EA290C672E00F921E1 /* CipherEntity+CoreDataClass.swift */; };
 		1B8453ED290C672E00F921E1 /* CipherEntity+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B8453EB290C672E00F921E1 /* CipherEntity+CoreDataProperties.swift */; };
 		1B8BF90429199BBB006F069E /* CipherDetailsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B8BF90329199BBB006F069E /* CipherDetailsView.swift */; };
@@ -137,6 +138,7 @@
 		1B59EC622901B1C100A8718D /* LoggerHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggerHelper.swift; sourceTree = "<group>"; };
 		1B5AFF0229196C81004478F9 /* ColorUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorUtils.swift; sourceTree = "<group>"; };
 		1B5AFF0829197822004478F9 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
+		1B6BD10129364F020041982D /* AvatarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AvatarView.swift; sourceTree = "<group>"; };
 		1B8453EA290C672E00F921E1 /* CipherEntity+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CipherEntity+CoreDataClass.swift"; sourceTree = "<group>"; };
 		1B8453EB290C672E00F921E1 /* CipherEntity+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CipherEntity+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		1B8BF90329199BBB006F069E /* CipherDetailsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CipherDetailsView.swift; sourceTree = "<group>"; };
@@ -344,6 +346,7 @@
 			children = (
 				1B8BF9082919A2CC006F069E /* CircularProgressView.swift */,
 				1BC1CD6D2922B92B006540DA /* ImageView.swift */,
+				1B6BD10129364F020041982D /* AvatarView.swift */,
 			);
 			path = Controls;
 			sourceTree = "<group>";
@@ -578,6 +581,7 @@
 				1BC1CD6529227F3C006540DA /* IconImageHelper.swift in Sources */,
 				1B59EC5C2900BB3400A8718D /* CryptoService.swift in Sources */,
 				1B15615428B7F3D800610B9B /* NotificationView.swift in Sources */,
+				1B6BD10229364F020041982D /* AvatarView.swift in Sources */,
 				1B8BF90B2919AF2A006F069E /* TotpService.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Add avatar header on Apple Watch


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **AvatarView:** Custom view to display the avatar icon (Circle with the letters inside)
* **ColorUtils:** Some utils to init a `Color` from a `hex` string and also to get its RGBA components
* **StringExtensions:** Added extension to add left padding on a string
* **CipherListViewModel:** Fix issue on the state check
* **CipherListView:** Removed outer `VStack` and added section for the user avatar header

### Additional notes

`AvatarView` is an adaptation from `AvatarImageSource` of the iPhone application. One caveat to take into consideration was when dealing with bitwise operations and overflow c# handles it internally by going to an `unchecked` context while in swift you need to mark the operation explicitly.
So what in C# is:
```c#
(hash << 5) - hash
```
In swift we need to explicitly say how the overflow needs to be handled (More [here](https://docs.swift.org/swift-book/LanguageGuide/AdvancedOperators.html) in Overflow Operators):
```swift
(hash << 5) &- hash
```

## Screenshots
<!--Required for any UI changes. Delete if not applicable-->
<img width="250" alt="Apple Watch Account Header" src="https://user-images.githubusercontent.com/15682323/205153956-10401177-4b1d-40b9-9f76-55ee949ec014.png">

## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
