### PR TITLE
[EC-786] Apple Watch MVP Sync fixes

### DIFF
--- a/src/App/Services/BaseWatchDeviceService.cs
+++ b/src/App/Services/BaseWatchDeviceService.cs
@@ -64,12 +64,12 @@ namespace Bit.App.Services
                 {
                     Base = _environmentService.BaseUrl,
                     Icons = _environmentService.IconsUrl
-                },
-                SettingsData = new WatchDTO.SettingsDataDto
-                {
-                    VaultTimeoutInMinutes = await _vaultTimeoutService.GetVaultTimeout(userData?.Id),
-                    VaultTimeoutAction = await _stateService.GetVaultTimeoutActionAsync(userData?.Id) ?? VaultTimeoutAction.Lock
                 }
+                //SettingsData = new WatchDTO.SettingsDataDto
+                //{
+                //    VaultTimeoutInMinutes = await _vaultTimeoutService.GetVaultTimeout(userData?.Id),
+                //    VaultTimeoutAction = await _stateService.GetVaultTimeoutActionAsync(userData?.Id) ?? VaultTimeoutAction.Lock
+                //}
             };
             await SendDataToWatchAsync(watchDto);
         }
@@ -81,11 +81,11 @@ namespace Bit.App.Services
                 return WatchState.NeedLogin;
             }
 
-            if (await _vaultTimeoutService.IsLockedAsync() ||
-                await _vaultTimeoutService.ShouldLockAsync())
-            {
-                return WatchState.NeedUnlock;
-            }
+            //if (await _vaultTimeoutService.IsLockedAsync() ||
+            //    await _vaultTimeoutService.ShouldLockAsync())
+            //{
+            //    return WatchState.NeedUnlock;
+            //}
 
             if (!await _stateService.CanAccessPremiumAsync(userId))
             {

--- a/src/Core/Enums/WatchState.cs
+++ b/src/Core/Enums/WatchState.cs
@@ -4,7 +4,7 @@
     {
         Valid = 0,
         NeedLogin,
-        NeedUnlock,
+        //NeedUnlock,
         NeedPremium,
         NeedSetup,
         Need2FAItem,

--- a/src/Core/Models/View/WatchDTO.cs
+++ b/src/Core/Models/View/WatchDTO.cs
@@ -19,7 +19,7 @@ namespace Bit.Core.Models
 
         public EnvironmentUrlDataDto EnvironmentData { get; set; }
 
-        public SettingsDataDto SettingsData { get; set; }
+        //public SettingsDataDto SettingsData { get; set; }
 
         public class UserDataDto
         {
@@ -34,11 +34,11 @@ namespace Bit.Core.Models
             public string Icons { get; set; }
         }
 
-        public class SettingsDataDto
-        {
-            public int? VaultTimeoutInMinutes { get; set; }
+        //public class SettingsDataDto
+        //{
+        //    public int? VaultTimeoutInMinutes { get; set; }
 
-            public VaultTimeoutAction VaultTimeoutAction { get; set; }
-        }
+        //    public VaultTimeoutAction VaultTimeoutAction { get; set; }
+        //}
     }
 }

--- a/src/iOS.Core/Services/WatchDeviceService.cs
+++ b/src/iOS.Core/Services/WatchDeviceService.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Bit.App.Services;
 using Bit.Core.Abstractions;
@@ -24,7 +25,13 @@ namespace Bit.iOS.Core.Services
         {
             var serializedData = JsonConvert.SerializeObject(watchDto);
 
-            WCSessionManager.SharedManager.SendBackgroundHighPriorityMessage(new Dictionary<string, object>() { { "watchDto", serializedData } });
+            // Add time to the key to make it change on every message sent so it's delivered faster.
+            // If we use the same key then the OS may defer the delivery of the message because of
+            // resources, reachability and other stuff
+            WCSessionManager.SharedManager.SendBackgroundHighPriorityMessage(new Dictionary<string, object>
+            {
+                [$"watchDto-{DateTime.UtcNow.ToLongTimeString()}"] = serializedData
+            });
 
             return Task.CompletedTask;
         }

--- a/src/watchOS/bitwarden/bitwarden WatchKit Extension/Models/VaultTimeoutAction.swift
+++ b/src/watchOS/bitwarden/bitwarden WatchKit Extension/Models/VaultTimeoutAction.swift
@@ -1,6 +1,6 @@
-import Foundation
-
-enum VaultTimeoutAction : Int, Codable {
-    case lock = 0
-    case logout = 1
-}
+//import Foundation
+//
+//enum VaultTimeoutAction : Int, Codable {
+//    case lock = 0
+//    case logout = 1
+//}

--- a/src/watchOS/bitwarden/bitwarden WatchKit Extension/Models/WatchDTO.swift
+++ b/src/watchOS/bitwarden/bitwarden WatchKit Extension/Models/WatchDTO.swift
@@ -5,7 +5,7 @@ struct WatchDTO : Codable{
     var ciphers: [Cipher]?
     var userData: User?
     var environmentData: EnvironmentUrlDataDto?
-    var settingsData: SettingsDataDto?
+//    var settingsData: SettingsDataDto?
     
     init(state: BWState) {
       self.state = state
@@ -20,7 +20,7 @@ struct EnvironmentUrlDataDto : Codable {
     var icons: String?
 }
 
-struct SettingsDataDto : Codable {
-    var vaultTimeoutInMinutes: Int?
-    var vaultTimeoutAction: VaultTimeoutAction
-}
+//struct SettingsDataDto : Codable {
+//    var vaultTimeoutInMinutes: Int?
+//    var vaultTimeoutAction: VaultTimeoutAction
+//}

--- a/src/watchOS/bitwarden/bitwarden WatchKit Extension/Services/StateService.swift
+++ b/src/watchOS/bitwarden/bitwarden WatchKit Extension/Services/StateService.swift
@@ -5,8 +5,8 @@ class StateService {
     
     let CURRENT_STATE_KEY = "current_state_key"
     let CURRENT_USER_KEY = "current_user_key"
-    let TIMEOUT_MINUTES_KEY = "timeout_minutes_key"
-    let TIMEOUT_ACTION_KEY = "timeout_action_key"
+//    let TIMEOUT_MINUTES_KEY = "timeout_minutes_key"
+//    let TIMEOUT_ACTION_KEY = "timeout_action_key"
     
     private init(){}
     
@@ -27,27 +27,6 @@ class StateService {
         }
     }
     
-    var vaultTimeoutInMinutes: Int? {
-        guard let timeoutData = KeychainHelper.standard.read(TIMEOUT_MINUTES_KEY),
-              let strData = String(data: timeoutData, encoding: .utf8),
-              let intVal = Int(strData) else {
-            return nil
-        }
-        
-        return intVal
-    }
-    
-    var vaultTimeoutAction: VaultTimeoutAction {
-        guard let timeoutActionData = KeychainHelper.standard.read(TIMEOUT_ACTION_KEY),
-              let strData = String(data: timeoutActionData, encoding: .utf8),
-              let intData = Int(strData),
-              let timeoutAction = VaultTimeoutAction(rawValue: intData) else {
-            return .lock
-        }
-        
-        return timeoutAction
-    }
-    
     func getUser() -> User? {
         return KeychainHelper.standard.read(CURRENT_USER_KEY, User.self)
     }
@@ -61,13 +40,34 @@ class StateService {
         KeychainHelper.standard.save(user, key: CURRENT_USER_KEY)
     }
     
-    func setVaultTimeout(_ timeoutInMinutes: Int?, _ action: VaultTimeoutAction) {
-        guard let timeoutInMinutes = timeoutInMinutes else {
-            KeychainHelper.standard.delete(TIMEOUT_MINUTES_KEY)
-            return
-        }
-        
-        KeychainHelper.standard.save(String(timeoutInMinutes).data(using: .utf8)!, TIMEOUT_MINUTES_KEY)
-        KeychainHelper.standard.save(String(action.rawValue).data(using: .utf8)!, TIMEOUT_ACTION_KEY)
-    }
+//    var vaultTimeoutInMinutes: Int? {
+//        guard let timeoutData = KeychainHelper.standard.read(TIMEOUT_MINUTES_KEY),
+//              let strData = String(data: timeoutData, encoding: .utf8),
+//              let intVal = Int(strData) else {
+//            return nil
+//        }
+//
+//        return intVal
+//    }
+    
+//    var vaultTimeoutAction: VaultTimeoutAction {
+//        guard let timeoutActionData = KeychainHelper.standard.read(TIMEOUT_ACTION_KEY),
+//              let strData = String(data: timeoutActionData, encoding: .utf8),
+//              let intData = Int(strData),
+//              let timeoutAction = VaultTimeoutAction(rawValue: intData) else {
+//            return .lock
+//        }
+//
+//        return timeoutAction
+//    }
+    
+//    func setVaultTimeout(_ timeoutInMinutes: Int?, _ action: VaultTimeoutAction) {
+//        guard let timeoutInMinutes = timeoutInMinutes else {
+//            KeychainHelper.standard.delete(TIMEOUT_MINUTES_KEY)
+//            return
+//        }
+//
+//        KeychainHelper.standard.save(String(timeoutInMinutes).data(using: .utf8)!, TIMEOUT_MINUTES_KEY)
+//        KeychainHelper.standard.save(String(action.rawValue).data(using: .utf8)!, TIMEOUT_ACTION_KEY)
+//    }
 }

--- a/src/watchOS/bitwarden/bitwarden WatchKit Extension/Utilities/BWState.swift
+++ b/src/watchOS/bitwarden/bitwarden WatchKit Extension/Utilities/BWState.swift
@@ -3,7 +3,7 @@ import Foundation
 enum BWState : Int, Codable {
     case valid = 0
     case needLogin = 1
-    case needUnlock = 2
+//    case needUnlock = 2
     case needPremium = 3
     case needSetup = 4
     case need2FAItem = 5

--- a/src/watchOS/bitwarden/bitwarden WatchKit Extension/ViewModels/BWStateViewModel.swift
+++ b/src/watchOS/bitwarden/bitwarden WatchKit Extension/ViewModels/BWStateViewModel.swift
@@ -8,8 +8,8 @@ class BWStateViewModel : ObservableObject{
         switch state {
         case .needLogin:
             text = "LogInToBitwardenOnYourIPhoneToViewVerificationCodes"
-        case .needUnlock:
-            text = "UnlockBitwardenOnYourIPhoneToViewVerificationCodes"
+//        case .needUnlock:
+//            text = "UnlockBitwardenOnYourIPhoneToViewVerificationCodes"
         case .needPremium:
             text = "ToViewVerificationCodesUpgradeToPremium"
         case .needSetup:

--- a/src/watchOS/bitwarden/bitwarden WatchKit Extension/WatchConnectivityManager.swift
+++ b/src/watchOS/bitwarden/bitwarden WatchKit Extension/WatchConnectivityManager.swift
@@ -61,7 +61,13 @@ extension WatchConnectivityManager: WCSessionDelegate {
     }
     
     func session(_ session: WCSession, didReceiveApplicationContext applicationContext: [String : Any]) {
-        guard let serializedDto = applicationContext[kCipherDataKey] as? String else {
+        // in order for the delivery to be faster the time is added to the key to make each application context update have a different key
+        // and update faster
+        let watchDtoKey = applicationContext.keys.first { k in
+            k.starts(with: kCipherDataKey)
+        }
+        
+        guard let dtoKey = watchDtoKey, let serializedDto = applicationContext[dtoKey] as? String else {
             return
         }
         
@@ -82,7 +88,7 @@ extension WatchConnectivityManager: WCSessionDelegate {
             
             StateService.shared.currentState = watchDTO.state
             StateService.shared.setUser(user: watchDTO.userData)
-            StateService.shared.setVaultTimeout(watchDTO.settingsData?.vaultTimeoutInMinutes, watchDTO.settingsData?.vaultTimeoutAction ?? .lock)
+//            StateService.shared.setVaultTimeout(watchDTO.settingsData?.vaultTimeoutInMinutes, watchDTO.settingsData?.vaultTimeoutAction ?? .lock)
             EnvironmentService.shared.baseUrl = watchDTO.environmentData?.base
             EnvironmentService.shared.setIconsUrl(url: watchDTO.environmentData?.icons)
             


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Removed (commented) things that are not going to be included on the MVP:
- Vault timeout sync
- Unlock state sync
Also fix issue on the `applicationContext` sent to have a key based on time to ensure faster delivery.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **WatchDeviceService:** Added time based suffix to key sent in `applicationContext` to have faster delivery of the message to the watch. If the same key is used on different syncs then the OS may defer the delivery of the message until a better time.
* **WatchConnectivityManager:** Now it needs to get the first key of the `applicationContext` dictionary that starts with the actual name of the key. We need to do this given that we don't know the full string of the key due to the added time-based-suffix
* **Other:** Commented out things not included on the MVP

## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
