### PR TITLE
[SG-870] Add null check on notification received

### DIFF
--- a/src/App/Services/PushNotificationListenerService.cs
+++ b/src/App/Services/PushNotificationListenerService.cs
@@ -141,7 +141,8 @@ namespace Bit.App.Services
                     }
 
                     // if there is a request modal opened ignore all incoming requests
-                    if (App.Current.MainPage.Navigation.ModalStack.Any(p => p is NavigationPage navPage && navPage.CurrentPage is LoginPasswordlessPage))
+                    // App.Current can be null if the app is killed
+                    if (App.Current != null && App.Current.MainPage.Navigation.ModalStack.Any(p => p is NavigationPage navPage && navPage.CurrentPage is LoginPasswordlessPage))
                     {
                         return;
                     }


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
If the user receives a passwordless login request and the application is not running on foreground or background the notification will not be shown.
This is due to an if condition to check if there is already a login request modal being presented to the user.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->
Added null check on `App.Current`. This is null when the app is killed.

## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
