### PR TITLE
[EC-830] Fix state checking when watch app had already been installed before

### DIFF
--- a/src/watchOS/bitwarden/bitwarden WatchKit Extension/Services/CryptoService.swift
+++ b/src/watchOS/bitwarden/bitwarden WatchKit Extension/Services/CryptoService.swift
@@ -70,6 +70,10 @@ public class CryptoService{
         }
         return data
     }
+    
+    static func clearKey() {
+        KeychainHelper.standard.delete(CryptoService.ENCRYPTION_KEY)
+    }
 }
 
 public extension Data {

--- a/src/watchOS/bitwarden/bitwarden WatchKit Extension/Services/EnvironmentService.swift
+++ b/src/watchOS/bitwarden/bitwarden WatchKit Extension/Services/EnvironmentService.swift
@@ -42,4 +42,9 @@ class EnvironmentService{
         }
         KeychainHelper.standard.save(url.data(using: .utf8)!, ICONS_URL_KEY)
     }
+    
+    func clear() {
+        baseUrl = nil
+        setIconsUrl(url: nil)
+    }
 }

--- a/src/watchOS/bitwarden/bitwarden WatchKit Extension/Services/StateService.swift
+++ b/src/watchOS/bitwarden/bitwarden WatchKit Extension/Services/StateService.swift
@@ -3,10 +3,13 @@ import Foundation
 class StateService {
     static let shared: StateService = StateService()
     
+    let HAS_RUN_BEFORE_KEY = "has_run_before_key"
     let CURRENT_STATE_KEY = "current_state_key"
     let CURRENT_USER_KEY = "current_user_key"
 //    let TIMEOUT_MINUTES_KEY = "timeout_minutes_key"
 //    let TIMEOUT_ACTION_KEY = "timeout_action_key"
+    
+    var hasRunBefore = false
     
     private init(){}
     
@@ -38,6 +41,29 @@ class StateService {
         }
         
         KeychainHelper.standard.save(user, key: CURRENT_USER_KEY)
+    }
+    
+    /// Checks the state integrity of the app. If the app has been reinstalled then there are some keychain things that need to be reset.
+    func checkIntegrity() {
+        if hasRunBefore {
+            return
+        }
+        
+        let userDefaults = UserDefaults.standard
+        hasRunBefore = userDefaults.bool(forKey: HAS_RUN_BEFORE_KEY)
+        
+        if !hasRunBefore {
+            clear()
+            EnvironmentService.shared.clear()
+            CryptoService.clearKey()
+            
+            userDefaults.set(true, forKey: HAS_RUN_BEFORE_KEY)
+        }
+    }
+    
+    func clear() {
+        currentState = .needSetup
+        setUser(user: nil)
     }
     
 //    var vaultTimeoutInMinutes: Int? {

--- a/src/watchOS/bitwarden/bitwarden WatchKit Extension/ViewModels/CipherListViewModel.swift
+++ b/src/watchOS/bitwarden/bitwarden WatchKit Extension/ViewModels/CipherListViewModel.swift
@@ -47,6 +47,8 @@ class CipherListViewModel : ObservableObject {
     }
     
     func checkStateAndFetch(_ state: BWState? = nil) {
+        StateService.shared.checkIntegrity()
+        
         user = StateService.shared.getUser()
         
         if user == nil && !watchConnectivityManager.isSessionActivated {


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Fix bug that the state was being held between app installations. So we need to clear the state (anything on the Keychain) on new installation.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **StateService:** Added `checkIntegrity()` method that will check if the app has already been run and if not will reset the state and the keychain related items. The `HAS_RUN_BEFORE_KEY` is saved on the `UserDefaults` so it's cleared when the app is uninstalled.
* **CipherListViewModel:** Added call to check the integrity of the state through the `StateService`
* **CryptoService:** Added method to clear the key
* **EnvironmentService:** Added clear method to clear keychain related items

## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
