### PR TITLE
[EC-833] Fix WatchDeviceService registration to be called appropiately

### DIFF
--- a/src/iOS.Autofill/CredentialProviderViewController.cs
+++ b/src/iOS.Autofill/CredentialProviderViewController.cs
@@ -404,6 +404,7 @@ namespace Bit.iOS.Autofill
             ServiceContainer.Init(deviceActionService.DeviceUserAgent, 
                 Bit.Core.Constants.iOSAutoFillClearCiphersCacheKey, Bit.Core.Constants.iOSAllClearCipherCacheKeys);
             iOSCoreHelpers.InitLogger();
+            iOSCoreHelpers.RegisterFinallyBeforeBootstrap();
             iOSCoreHelpers.Bootstrap();
             var appOptions = new AppOptions { IosExtension = true };
             var app = new App.App(appOptions);

--- a/src/iOS.Core/Utilities/iOSCoreHelpers.cs
+++ b/src/iOS.Core/Utilities/iOSCoreHelpers.cs
@@ -49,10 +49,7 @@ namespace Bit.iOS.Core.Utilities
                                   Bit.Core.Constants.iOSAllClearCipherCacheKeys);   
             InitLogger();
 
-            ServiceContainer.Register<IWatchDeviceService>(new WatchDeviceService(ServiceContainer.Resolve<ICipherService>(),
-                ServiceContainer.Resolve<IEnvironmentService>(),
-                ServiceContainer.Resolve<IStateService>(),
-                ServiceContainer.Resolve<IVaultTimeoutService>()));
+            RegisterFinallyBeforeBootstrap();
 
             Bootstrap();
 
@@ -137,6 +134,14 @@ namespace Bit.iOS.Core.Utilities
             ServiceContainer.Register<ICryptoService>("cryptoService", cryptoService);
             ServiceContainer.Register<IPasswordRepromptService>("passwordRepromptService", passwordRepromptService);
             ServiceContainer.Register<IAvatarImageSourcePool>("avatarImageSourcePool", new AvatarImageSourcePool());
+        }
+
+        public static void RegisterFinallyBeforeBootstrap()
+        {
+            ServiceContainer.Register<IWatchDeviceService>(new WatchDeviceService(ServiceContainer.Resolve<ICipherService>(),
+                ServiceContainer.Resolve<IEnvironmentService>(),
+                ServiceContainer.Resolve<IStateService>(),
+                ServiceContainer.Resolve<IVaultTimeoutService>()));
         }
 
         public static void Bootstrap(Func<Task> postBootstrapFunc = null)

--- a/src/iOS.Extension/LoadingViewController.cs
+++ b/src/iOS.Extension/LoadingViewController.cs
@@ -408,6 +408,7 @@ namespace Bit.iOS.Extension
             ServiceContainer.Init(deviceActionService.DeviceUserAgent, 
                 Bit.Core.Constants.iOSExtensionClearCiphersCacheKey, Bit.Core.Constants.iOSAllClearCipherCacheKeys);
             iOSCoreHelpers.InitLogger();
+            iOSCoreHelpers.RegisterFinallyBeforeBootstrap();
             iOSCoreHelpers.Bootstrap();
             var app = new App.App(new AppOptions { IosExtension = true });
             ThemeManager.SetTheme(app.Resources);

--- a/src/iOS/AppDelegate.cs
+++ b/src/iOS/AppDelegate.cs
@@ -306,11 +306,7 @@ namespace Bit.iOS
             ServiceContainer.Init(deviceActionService.DeviceUserAgent, Constants.ClearCiphersCacheKey, 
                 Constants.iOSAllClearCipherCacheKeys);
             iOSCoreHelpers.InitLogger();
-
-            ServiceContainer.Register<IWatchDeviceService>(new WatchDeviceService(ServiceContainer.Resolve<ICipherService>(),
-                ServiceContainer.Resolve<IEnvironmentService>(),
-                ServiceContainer.Resolve<IStateService>(),
-                ServiceContainer.Resolve<IVaultTimeoutService>()));
+            iOSCoreHelpers.RegisterFinallyBeforeBootstrap();
 
             _pushHandler = new iOSPushNotificationHandler(
                 ServiceContainer.Resolve<IPushNotificationListenerService>("pushNotificationListenerService"));


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Fix regression where the iOS autofill extension was not working due to services incorrectly registration.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **iOSCoreHelpers:** Moved the `IWatchDeviceService` registration here on the new method `RegisterFinallyBeforeBootstrap` intended to be used for stuff that need to be setup before bootstrap and after all the other registrations have been done.
* **AppDelegate:** Calls the new `RegisterFinallyBeforeBootstrap` to setup extra stuff before bootstrap. Moved the watch device  service registration there.
* **CredentialProviderViewController:** Calls the new `RegisterFinallyBeforeBootstrap` to setup extra stuff before bootstrap.
* **LoadingViewController:** Calls the new `RegisterFinallyBeforeBootstrap` to setup extra stuff before bootstrap.


## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
