### PR TITLE
[EC-844] Improve Apple Watch states

### DIFF
--- a/src/App/Services/BaseWatchDeviceService.cs
+++ b/src/App/Services/BaseWatchDeviceService.cs
@@ -91,14 +91,17 @@ namespace Bit.App.Services
 
         private async Task<WatchState> GetStateAsync(string userId, bool shouldConnectToWatch)
         {
+            if (await _stateService.GetLastUserShouldConnectToWatchAsync()
+                &&
+                (userId is null || !await _stateService.IsAuthenticatedAsync()))
+            {
+                // if the last user had "Connect to Watch" enabled and there's no user authenticated
+                return WatchState.NeedLogin;
+            }
+
             if (!shouldConnectToWatch)
             {
                 return WatchState.NeedSetup;
-            }
-
-            if (!await _stateService.IsAuthenticatedAsync() || userId is null)
-            {
-                return WatchState.NeedLogin;
             }
 
             //if (await _vaultTimeoutService.IsLockedAsync() ||

--- a/src/Core/Abstractions/IStateService.cs
+++ b/src/Core/Abstractions/IStateService.cs
@@ -162,5 +162,7 @@ namespace Bit.Core.Abstractions
         Task SetUsernameGenerationOptionsAsync(UsernameGenerationOptions value, string userId = null);
         Task<bool> GetShouldConnectToWatchAsync(string userId = null);
         Task SetShouldConnectToWatchAsync(bool shouldConnect, string userId = null);
+        Task<bool> GetLastUserShouldConnectToWatchAsync();
+        Task UpdateLastUserShouldConnectToWatchAsync(bool? shouldConnect = null);
     }
 }

--- a/src/Core/Constants.cs
+++ b/src/Core/Constants.cs
@@ -97,5 +97,10 @@
         public static string PushLastRegistrationDateKey(string userId) => $"pushLastRegistrationDate_{userId}";
         public static string PushCurrentTokenKey(string userId) => $"pushCurrentToken_{userId}";
         public static string ShouldConnectToWatchKey(string userId) => $"shouldConnectToWatch_{userId}";
+        /// <summary>
+        /// This key is used to store the value of "ShouldConnectToWatch" of the last user that had logged in
+        /// which is used to handle Apple Watch state logic
+        /// </summary>
+        public const string LastUserShouldConnectToWatchKey = "lastUserShouldConnectToWatch";
     }
 }

--- a/src/Core/Services/StateService.cs
+++ b/src/Core/Services/StateService.cs
@@ -84,6 +84,8 @@ namespace Bit.Core.Services
             // Update pre-auth settings based on now-active user
             await SetRememberedOrgIdentifierAsync(await GetRememberedOrgIdentifierAsync());
             await SetPreAuthEnvironmentUrlsAsync(await GetEnvironmentUrlsAsync());
+
+            await UpdateLastUserShouldConnectToWatchAsync();
         }
 
         public async Task CheckExtensionActiveUserAndSwitchIfNeededAsync()
@@ -1708,6 +1710,21 @@ namespace Bit.Core.Services
                 ReconcileOptions(new StorageOptions { UserId = userId }, await GetDefaultStorageOptionsAsync());
             var key = Constants.ShouldConnectToWatchKey(reconciledOptions.UserId);
             await SetValueAsync(key, shouldConnect, reconciledOptions);
+            await UpdateLastUserShouldConnectToWatchAsync(shouldConnect);
+        }
+
+        public async Task<bool> GetLastUserShouldConnectToWatchAsync()
+        {
+            var reconciledOptions = await GetDefaultStorageOptionsAsync();
+            var key = Constants.LastUserShouldConnectToWatchKey;
+            return await GetValueAsync<bool?>(key, reconciledOptions) ?? false;
+        }
+
+        public async Task UpdateLastUserShouldConnectToWatchAsync(bool? shouldConnect = null)
+        {
+            var reconciledOptions = await GetDefaultStorageOptionsAsync();
+            var key = Constants.LastUserShouldConnectToWatchKey;
+            await SetValueAsync(key, shouldConnect ?? await GetShouldConnectToWatchAsync(), reconciledOptions);
         }
     }
 }

--- a/src/watchOS/bitwarden/bitwarden WatchKit Extension/ViewModels/CipherListViewModel.swift
+++ b/src/watchOS/bitwarden/bitwarden WatchKit Extension/ViewModels/CipherListViewModel.swift
@@ -51,12 +51,6 @@ class CipherListViewModel : ObservableObject {
         
         user = StateService.shared.getUser()
         
-        if user == nil && !watchConnectivityManager.isSessionActivated {
-            currentState = .needSetup
-            showingSheet = true
-            return
-        }
-        
         currentState = state ?? StateService.shared.currentState
         showingSheet = currentState != .valid
         


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
On Apple Watch there's an overlap between the "Need Log in" / "Need set up" states, so this PR goal is to fix them so that:

- Need Set up => first time of the app until log in and "Connect to Watch" is turned on or if the last account has turned off "Connect to Watch"
- Need Log in => if the last logged out account had "Connect to Watch" still enabled when logging out


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **BaseWatchDeviceService:** Improved state logic to include the last active account value of "Connect to Watch" to determine whether to be in "Need Log in" state
* **StateService:** Added setting for `LastUserShouldConnectToWatch` which stands for the value of `ShouldConnectToWatch` of the last active user. Also, updates it accordingly when the active user changes and when the "Connect to Watch" value changes.
* **Watch -> CipherListViewModel:** Removed logic for `NeedSetup` when no user is found on the watch, given that it's not needed anymore with the additional logic on the iOS app.

## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
