### PR TITLE
[PS-1313] Android: Show toast on pre-13 devices when automatically copying TOTP from external autofill

### DIFF
--- a/src/Android/MainApplication.cs
+++ b/src/Android/MainApplication.cs
@@ -149,9 +149,10 @@ namespace Bit.Droid
             var clipboardService = new ClipboardService(stateService);
             var deviceActionService = new DeviceActionService(stateService, messagingService);
             var fileService = new FileService(stateService, broadcasterService);
-            var autofillHandler = new AutofillHandler(stateService, messagingService, clipboardService, new LazyResolve<IEventService>());
             var platformUtilsService = new MobilePlatformUtilsService(deviceActionService, clipboardService,
                 messagingService, broadcasterService);
+            var autofillHandler = new AutofillHandler(stateService, messagingService, clipboardService,
+                platformUtilsService, new LazyResolve<IEventService>());
             var biometricService = new BiometricService();
             var cryptoFunctionService = new PclCryptoFunctionService(cryptoPrimitiveService);
             var cryptoService = new CryptoService(stateService, cryptoFunctionService);

--- a/src/Android/Services/AutofillHandler.cs
+++ b/src/Android/Services/AutofillHandler.cs
@@ -6,6 +6,7 @@ using Android.Content;
 using Android.OS;
 using Android.Provider;
 using Android.Views.Autofill;
+using Bit.App.Resources;
 using Bit.Core.Abstractions;
 using Bit.Core.Enums;
 using Bit.Core.Models.View;
@@ -20,16 +21,19 @@ namespace Bit.Droid.Services
         private readonly IStateService _stateService;
         private readonly IMessagingService _messagingService;
         private readonly IClipboardService _clipboardService;
+        private readonly IPlatformUtilsService _platformUtilsService;
         private readonly LazyResolve<IEventService> _eventService;
 
         public AutofillHandler(IStateService stateService,
             IMessagingService messagingService,
             IClipboardService clipboardService,
+            IPlatformUtilsService platformUtilsService,
             LazyResolve<IEventService> eventService)
         {
             _stateService = stateService;
             _messagingService = messagingService;
             _clipboardService = clipboardService;
+            _platformUtilsService = platformUtilsService;
             _eventService = eventService;
         }
 
@@ -202,6 +206,7 @@ namespace Bit.Droid.Services
                     if (totp != null)
                     {
                         await _clipboardService.CopyTextAsync(totp);
+                        _platformUtilsService.ShowToastForCopiedValue(AppResources.VerificationCodeTotp);
                     }
                 }
             }

--- a/src/App/Resources/AppResources.resx
+++ b/src/App/Resources/AppResources.resx
@@ -376,7 +376,7 @@
   </data>
   <data name="ValueHasBeenCopied" xml:space="preserve">
     <value>{0} copied</value>
-    <comment>Confirmation message after suceessfully copying a value to the clipboard.</comment>
+    <comment>Confirmation message after successfully copying a value to the clipboard.</comment>
   </data>
   <data name="VerifyFingerprint" xml:space="preserve">
     <value>Verify fingerprint</value>


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Devices prior to Android 13 have no built-in indicator of contents being copied to the clipboard, so we're showing a toast when we automatically [copy the TOTP from external autofill](https://github.com/bitwarden/mobile/pull/2220).


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **AutofillHandler.cs:** Add call to `_platformUtilsService.ShowToastForCopiedValue` when TOTP is copied
* **MainApplication.cs:** Initialize `AutofillHandler` with `platformUtilsService`
* **AppResources.resx:** Fixed typo in comment

## Screenshots
<!--Required for any UI changes. Delete if not applicable-->

![toast](https://user-images.githubusercontent.com/59324545/208188147-09397bc6-4421-4fc2-a7ec-43875d2ff623.png)


## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
