### PR TITLE
[EC-835] Add kSecAttrAccessibleWhenPasscodeSetThisDeviceOnly on Watch Keychain

### DIFF
--- a/src/iOS.Core/Services/WatchDeviceService.cs
+++ b/src/iOS.Core/Services/WatchDeviceService.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Bit.App.Services;
 using Bit.Core.Abstractions;
 using Bit.Core.Models;
+using Bit.Core.Utilities;
 using Newtonsoft.Json;
 using WatchConnectivity;
 
@@ -11,12 +12,16 @@ namespace Bit.iOS.Core.Services
 {
     public class WatchDeviceService : BaseWatchDeviceService
     {
+        const string ACTION_MESSAGE_KEY = "actionMessage";
+        const string TRIGGER_SYNC_ACTION_KEY = "triggerSync";
+
         public WatchDeviceService(ICipherService cipherService,
             IEnvironmentService environmentService,
             IStateService stateService,
             IVaultTimeoutService vaultTimeoutService)
             : base(cipherService, environmentService, stateService, vaultTimeoutService)
         {
+            WCSessionManager.SharedManager.OnMessagedReceived += OnMessagedReceived;
         }
 
         public override bool IsConnected => WCSessionManager.SharedManager.IsSessionActivated;
@@ -43,6 +48,16 @@ namespace Bit.iOS.Core.Services
         protected override void ConnectToWatch()
         {
             WCSessionManager.SharedManager.StartSession();
+        }
+
+        private void OnMessagedReceived(WCSession session, Dictionary<string, object> data)
+        {
+            if (data?.TryGetValue(ACTION_MESSAGE_KEY, out var action) == true
+                &&
+                action as string == TRIGGER_SYNC_ACTION_KEY)
+            {
+                SyncDataToWatchAsync().FireAndForget();
+            }
         }
     }
 }

--- a/src/iOS.Core/Services/WatchDeviceService.cs
+++ b/src/iOS.Core/Services/WatchDeviceService.cs
@@ -52,7 +52,9 @@ namespace Bit.iOS.Core.Services
 
         private void OnMessagedReceived(WCSession session, Dictionary<string, object> data)
         {
-            if (data?.TryGetValue(ACTION_MESSAGE_KEY, out var action) == true
+            if (data != null
+                &&
+                data.TryGetValue(ACTION_MESSAGE_KEY, out var action)
                 &&
                 action as string == TRIGGER_SYNC_ACTION_KEY)
             {

--- a/src/iOS.Core/Utilities/DictionaryExtensions.cs
+++ b/src/iOS.Core/Utilities/DictionaryExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using Bit.Core.Models.Domain;
 using Foundation;
 using Newtonsoft.Json;
 
@@ -21,6 +22,25 @@ namespace Bit.iOS.Core.Utilities
             var NSKeys = dict.Keys.Select(x => keyConverter(x)).ToArray();
             return NSDictionary<KTo, VTo>.FromObjectsAndKeys(NSValues, NSKeys, NSKeys.Count());
         }
+
+        public static Dictionary<string, object> ToDictionary(this NSDictionary<NSString, NSObject> nsDict)
+        {
+            return nsDict.ToDictionary(v => v?.ToString() as object);
+        }
+
+        public static Dictionary<string, object> ToDictionary(this NSDictionary<NSString, NSObject> nsDict, Func<NSObject, object> valueTransformer)
+        {
+            return nsDict.ToDictionary(k => k.ToString(), v => valueTransformer(v));
+        }
+
+        public static Dictionary<KTo, VTo> ToDictionary<KFrom, VFrom, KTo, VTo>(this NSDictionary<KFrom, VFrom> nsDict, Func<KFrom, KTo> keyConverter, Func<VFrom, VTo> valueConverter)
+            where KFrom : NSObject
+            where VFrom : NSObject
+        {
+            var keys = nsDict.Keys.Select(k => keyConverter(k)).ToArray();
+            var values = nsDict.Values.Select(v => valueConverter(v)).ToArray();
+            return keys.Zip(values, (k, v) => new { Key = k, Value = v })
+                       .ToDictionary(x => x.Key, x => x.Value);
+        }
     }
 }
-

--- a/src/watchOS/bitwarden/bitwarden WatchKit Extension/Helpers/KeychainHelper.swift
+++ b/src/watchOS/bitwarden/bitwarden WatchKit Extension/Helpers/KeychainHelper.swift
@@ -1,4 +1,5 @@
 import Foundation
+import LocalAuthentication
 
 final class KeychainHelper {
     
@@ -6,6 +7,10 @@ final class KeychainHelper {
     let genericService = "com.8bit.bitwarden.watch.kc"
     
     private init() {}
+    
+    func hasDeviceOwnerAuth() -> Bool {
+        return LAContext().canEvaluatePolicy(LAPolicy.deviceOwnerAuthentication, error: nil)
+    }
     
     func read<T>(_ key: String, _ type: T.Type) -> T? where T : Codable {
         guard let data = read(key) else {
@@ -16,7 +21,7 @@ final class KeychainHelper {
             let item = try JSONDecoder().decode(type, from: data)
             return item
         } catch {
-            assertionFailure("Fail to decode item for keychain: \(error)")
+            Log.e("Fail to decode item for keychain: \(error)")
             return nil
         }
     }
@@ -28,7 +33,7 @@ final class KeychainHelper {
             save(data, key)
             
         } catch {
-            assertionFailure("Fail to encode item for keychain: \(error)")
+            Log.e("Fail to encode item for keychain: \(error)")
         }
     }
 
@@ -57,7 +62,7 @@ final class KeychainHelper {
             kSecClass: kSecClassGenericPassword,
             kSecAttrService: genericService,
             kSecAttrAccount: key,
-            kSecAttrAccessible: kSecAttrAccessibleAfterFirstUnlock
+            kSecAttrAccessible: kSecAttrAccessibleWhenPasscodeSetThisDeviceOnly
         ] as CFDictionary
         
         let status = SecItemAdd(query, nil)

--- a/src/watchOS/bitwarden/bitwarden WatchKit Extension/Localization/en.lproj/Localizable.strings
+++ b/src/watchOS/bitwarden/bitwarden WatchKit Extension/Localization/en.lproj/Localizable.strings
@@ -7,3 +7,4 @@
 "SetUpBitwardenToViewItemsContainingVerificationCodes"="Set up Bitwarden to view items containing verification codes";
 "Search"="Search";
 "NoItemsFound"="No items found";
+"SetUpAppleWatchPasscodeInOrderToUseBitwarden"="Set up Apple Watch passcode in order to use Bitwarden";

--- a/src/watchOS/bitwarden/bitwarden WatchKit Extension/Services/StateService.swift
+++ b/src/watchOS/bitwarden/bitwarden WatchKit Extension/Services/StateService.swift
@@ -6,6 +6,7 @@ class StateService {
     let HAS_RUN_BEFORE_KEY = "has_run_before_key"
     let CURRENT_STATE_KEY = "current_state_key"
     let CURRENT_USER_KEY = "current_user_key"
+    let LACKED_DEVICE_OWNER_AUTH_LAST_TIME_KEY = "lacked_device_owner_auth_last_time_key"
 //    let TIMEOUT_MINUTES_KEY = "timeout_minutes_key"
 //    let TIMEOUT_ACTION_KEY = "timeout_action_key"
     
@@ -64,6 +65,15 @@ class StateService {
     func clear() {
         currentState = .needSetup
         setUser(user: nil)
+    }
+    
+    var lackedDeviceOwnerAuthLastTime : Bool {
+        get {
+            return UserDefaults.standard.bool(forKey: LACKED_DEVICE_OWNER_AUTH_LAST_TIME_KEY)
+        }
+        set(newValue) {
+            UserDefaults.standard.set(newValue, forKey: LACKED_DEVICE_OWNER_AUTH_LAST_TIME_KEY)
+        }
     }
     
 //    var vaultTimeoutInMinutes: Int? {

--- a/src/watchOS/bitwarden/bitwarden WatchKit Extension/Utilities/BWState.swift
+++ b/src/watchOS/bitwarden/bitwarden WatchKit Extension/Utilities/BWState.swift
@@ -8,6 +8,7 @@ enum BWState : Int, Codable {
     case need2FAItem = 4
     case syncing = 5
     //    case needUnlock = 6
+    case needDeviceOwnerAuth = 7
     
     var isDestructive: Bool {
         return self == .needSetup || self == .needLogin || self == .needPremium || self == .need2FAItem

--- a/src/watchOS/bitwarden/bitwarden WatchKit Extension/Utilities/Queue.swift
+++ b/src/watchOS/bitwarden/bitwarden WatchKit Extension/Utilities/Queue.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+/// This is basic Queue implementation that uses an array internally.
+/// For the current use is enough, If intended to use with many items please improve it
+/// following https://nitinagam17.medium.com/data-structure-in-swift-queue-part-5-985601071606 Linked list or Two stacks approach
+struct ArrayQueue<T> : CustomStringConvertible {
+    private var elements: [T] = []
+    public init() {}
+    
+    var isEmpty: Bool {
+        elements.isEmpty
+    }
+    
+    var peek: T? {
+        elements.first
+    }
+    
+    var description: String {
+        if isEmpty {
+            return "Queue empty"
+        }
+        
+        return "---- Queue -----\n"
+            + elements.map({"\($0)"}).joined(separator: " -> ")
+            + "---- Queue end -----"
+    }
+    
+    mutating func enqueue(_ value: T) {
+        elements.append(value)
+    }
+    
+    mutating func dequeue() -> T? {
+        isEmpty ? nil : elements.removeFirst()
+    }
+}

--- a/src/watchOS/bitwarden/bitwarden WatchKit Extension/ViewModels/BWStateViewModel.swift
+++ b/src/watchOS/bitwarden/bitwarden WatchKit Extension/ViewModels/BWStateViewModel.swift
@@ -19,6 +19,8 @@ class BWStateViewModel : ObservableObject{
             isLoading = true
         case .need2FAItem:
             text = "Add2FactorAutenticationToAnItemToViewVerificationCodes"
+        case .needDeviceOwnerAuth:
+            text = "SetUpAppleWatchPasscodeInOrderToUseBitwarden"
         default:
             text = ""
         }

--- a/src/watchOS/bitwarden/bitwarden.xcodeproj/project.pbxproj
+++ b/src/watchOS/bitwarden/bitwarden.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		1B15615B28B7F3D900610B9B /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 1B15615A28B7F3D900610B9B /* Preview Assets.xcassets */; };
 		1B15616C28B81A2200610B9B /* Cipher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B15616B28B81A2200610B9B /* Cipher.swift */; };
 		1B15616E28B81A4300610B9B /* WatchConnectivityManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B15616D28B81A4300610B9B /* WatchConnectivityManager.swift */; };
+		1B5849A7294D1C020055286B /* Queue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B5849A6294D1C020055286B /* Queue.swift */; };
 		1B59EC5729007DEE00A8718D /* BitwardenDB.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 1B59EC5529007DEE00A8718D /* BitwardenDB.xcdatamodeld */; };
 		1B59EC592900801500A8718D /* StringEncryptionTransformer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B59EC582900801500A8718D /* StringEncryptionTransformer.swift */; };
 		1B59EC5C2900BB3400A8718D /* CryptoService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B59EC5B2900BB3400A8718D /* CryptoService.swift */; };
@@ -134,6 +135,7 @@
 		1B15615D28B7F3D900610B9B /* PushNotificationPayload.apns */ = {isa = PBXFileReference; lastKnownFileType = text; path = PushNotificationPayload.apns; sourceTree = "<group>"; };
 		1B15616B28B81A2200610B9B /* Cipher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Cipher.swift; sourceTree = "<group>"; };
 		1B15616D28B81A4300610B9B /* WatchConnectivityManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchConnectivityManager.swift; sourceTree = "<group>"; };
+		1B5849A6294D1C020055286B /* Queue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Queue.swift; sourceTree = "<group>"; };
 		1B59EC5629007DEE00A8718D /* BitwardenDB.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = BitwardenDB.xcdatamodel; sourceTree = "<group>"; };
 		1B59EC582900801500A8718D /* StringEncryptionTransformer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringEncryptionTransformer.swift; sourceTree = "<group>"; };
 		1B59EC5B2900BB3400A8718D /* CryptoService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CryptoService.swift; sourceTree = "<group>"; };
@@ -219,6 +221,7 @@
 				1BD291BE292D0E6F0004F33F /* JsonDecoderExtensions.swift */,
 				1BD291C0292E7E690004F33F /* ErrorExtensions.swift */,
 				1B5F5E39293F9D6F009B5FCC /* ViewExtensions.swift */,
+				1B5849A6294D1C020055286B /* Queue.swift */,
 			);
 			path = Utilities;
 			sourceTree = "<group>";
@@ -583,6 +586,7 @@
 				1BD291C1292E7E690004F33F /* ErrorExtensions.swift in Sources */,
 				1B14DF37291186D900EA43F1 /* EmptyStateViewModifier.swift in Sources */,
 				1BD291B52924047C0004F33F /* BWStateViewModel.swift in Sources */,
+				1B5849A7294D1C020055286B /* Queue.swift in Sources */,
 				1B15616E28B81A4300610B9B /* WatchConnectivityManager.swift in Sources */,
 				1B5AFF0329196C81004478F9 /* ColorUtils.swift in Sources */,
 				1B59EC612900C48E00A8718D /* KeychainHelper.swift in Sources */,

--- a/src/watchOS/bitwarden/bitwarden.xcodeproj/project.pbxproj
+++ b/src/watchOS/bitwarden/bitwarden.xcodeproj/project.pbxproj
@@ -28,8 +28,6 @@
 		1B15616C28B81A2200610B9B /* Cipher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B15616B28B81A2200610B9B /* Cipher.swift */; };
 		1B15616E28B81A4300610B9B /* WatchConnectivityManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B15616D28B81A4300610B9B /* WatchConnectivityManager.swift */; };
 		1B5849A7294D1C020055286B /* Queue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B5849A6294D1C020055286B /* Queue.swift */; };
-		1B5849AB2950CC430055286B /* LocalAuthentication.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1B5849A92950BC860055286B /* LocalAuthentication.framework */; };
-		1B5849AC2950CC430055286B /* LocalAuthentication.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 1B5849A92950BC860055286B /* LocalAuthentication.framework */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		1B59EC5729007DEE00A8718D /* BitwardenDB.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 1B59EC5529007DEE00A8718D /* BitwardenDB.xcdatamodeld */; };
 		1B59EC592900801500A8718D /* StringEncryptionTransformer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B59EC582900801500A8718D /* StringEncryptionTransformer.swift */; };
 		1B59EC5C2900BB3400A8718D /* CryptoService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B59EC5B2900BB3400A8718D /* CryptoService.swift */; };
@@ -109,17 +107,6 @@
 				1B15613E28B7F3D700610B9B /* Bitwarden.app in Embed Watch Content */,
 			);
 			name = "Embed Watch Content";
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		1B5849AD2950CC430055286B /* Embed Frameworks */ = {
-			isa = PBXCopyFilesBuildPhase;
-			buildActionMask = 2147483647;
-			dstPath = "";
-			dstSubfolderSpec = 10;
-			files = (
-				1B5849AC2950CC430055286B /* LocalAuthentication.framework in Embed Frameworks */,
-			);
-			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXCopyFilesBuildPhase section */
@@ -203,7 +190,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				1B5849AB2950CC430055286B /* LocalAuthentication.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -478,7 +464,6 @@
 				1B15614428B7F3D800610B9B /* Sources */,
 				1B15614528B7F3D800610B9B /* Frameworks */,
 				1B15614628B7F3D800610B9B /* Resources */,
-				1B5849AD2950CC430055286B /* Embed Frameworks */,
 			);
 			buildRules = (
 			);

--- a/src/watchOS/bitwarden/bitwarden.xcodeproj/project.pbxproj
+++ b/src/watchOS/bitwarden/bitwarden.xcodeproj/project.pbxproj
@@ -28,6 +28,8 @@
 		1B15616C28B81A2200610B9B /* Cipher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B15616B28B81A2200610B9B /* Cipher.swift */; };
 		1B15616E28B81A4300610B9B /* WatchConnectivityManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B15616D28B81A4300610B9B /* WatchConnectivityManager.swift */; };
 		1B5849A7294D1C020055286B /* Queue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B5849A6294D1C020055286B /* Queue.swift */; };
+		1B5849AB2950CC430055286B /* LocalAuthentication.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1B5849A92950BC860055286B /* LocalAuthentication.framework */; };
+		1B5849AC2950CC430055286B /* LocalAuthentication.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 1B5849A92950BC860055286B /* LocalAuthentication.framework */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		1B59EC5729007DEE00A8718D /* BitwardenDB.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 1B59EC5529007DEE00A8718D /* BitwardenDB.xcdatamodeld */; };
 		1B59EC592900801500A8718D /* StringEncryptionTransformer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B59EC582900801500A8718D /* StringEncryptionTransformer.swift */; };
 		1B59EC5C2900BB3400A8718D /* CryptoService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B59EC5B2900BB3400A8718D /* CryptoService.swift */; };
@@ -109,6 +111,17 @@
 			name = "Embed Watch Content";
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		1B5849AD2950CC430055286B /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				1B5849AC2950CC430055286B /* LocalAuthentication.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
@@ -136,6 +149,7 @@
 		1B15616B28B81A2200610B9B /* Cipher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Cipher.swift; sourceTree = "<group>"; };
 		1B15616D28B81A4300610B9B /* WatchConnectivityManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchConnectivityManager.swift; sourceTree = "<group>"; };
 		1B5849A6294D1C020055286B /* Queue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Queue.swift; sourceTree = "<group>"; };
+		1B5849A92950BC860055286B /* LocalAuthentication.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = LocalAuthentication.framework; path = Platforms/WatchOS.platform/Developer/SDKs/WatchOS9.1.sdk/System/Library/Frameworks/LocalAuthentication.framework; sourceTree = DEVELOPER_DIR; };
 		1B59EC5629007DEE00A8718D /* BitwardenDB.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = BitwardenDB.xcdatamodel; sourceTree = "<group>"; };
 		1B59EC582900801500A8718D /* StringEncryptionTransformer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringEncryptionTransformer.swift; sourceTree = "<group>"; };
 		1B59EC5B2900BB3400A8718D /* CryptoService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CryptoService.swift; sourceTree = "<group>"; };
@@ -189,6 +203,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				1B5849AB2950CC430055286B /* LocalAuthentication.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -233,6 +248,7 @@
 				1B15614128B7F3D700610B9B /* bitwarden WatchKit App */,
 				1B15614C28B7F3D800610B9B /* bitwarden WatchKit Extension */,
 				1B15613028B7F3D400610B9B /* Products */,
+				1B5849A82950BC860055286B /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -306,6 +322,14 @@
 				1B15615A28B7F3D900610B9B /* Preview Assets.xcassets */,
 			);
 			path = "Preview Content";
+			sourceTree = "<group>";
+		};
+		1B5849A82950BC860055286B /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				1B5849A92950BC860055286B /* LocalAuthentication.framework */,
+			);
+			name = Frameworks;
 			sourceTree = "<group>";
 		};
 		1B59EC5429007D7300A8718D /* Entities */ = {
@@ -454,6 +478,7 @@
 				1B15614428B7F3D800610B9B /* Sources */,
 				1B15614528B7F3D800610B9B /* Frameworks */,
 				1B15614628B7F3D800610B9B /* Resources */,
+				1B5849AD2950CC430055286B /* Embed Frameworks */,
 			);
 			buildRules = (
 			);

--- a/src/watchOS/bitwarden/bitwarden/WatchConnectivityManager.swift
+++ b/src/watchOS/bitwarden/bitwarden/WatchConnectivityManager.swift
@@ -10,8 +10,9 @@ final class WatchConnectivityManager: NSObject, ObservableObject {
     static let shared = WatchConnectivityManager()
     @Published var notificationMessage: NotificationMessage? = nil
     
-    private let kMessageKey = "message"
-    private let kCipherDataKey = "cipherData"
+    private let WATCH_DTO_APP_CONTEXT_KEY = "watchDto"
+    private let TRIGGER_SYNC_ACTION_KEY = "triggerSync"
+    private let ACTION_MESSAGE_KEY = "actionMessage"
     
     private override init() {
         super.init()
@@ -40,7 +41,7 @@ final class WatchConnectivityManager: NSObject, ObservableObject {
             return
         }
         
-        WCSession.default.sendMessage([kMessageKey : message], replyHandler: nil) { error in
+        WCSession.default.sendMessage([ACTION_MESSAGE_KEY : TRIGGER_SYNC_ACTION_KEY], replyHandler: nil) { error in
             print("Cannot send message: \(String(describing: error))")
         }
     }
@@ -52,7 +53,7 @@ extension WatchConnectivityManager: WCSessionDelegate {
             self?.notificationMessage = NotificationMessage(text: "testing this didReceiveMessage")
         }
         
-        if let notificationText = message[kMessageKey] as? String {
+        if let notificationText = message[ACTION_MESSAGE_KEY] as? String {
             DispatchQueue.main.async { [weak self] in
                 self?.notificationMessage = NotificationMessage(text: notificationText)
             }
@@ -96,7 +97,7 @@ extension WatchConnectivityManager: WCSessionDelegate {
         DispatchQueue.main.async { [weak self] in
             self?.notificationMessage = NotificationMessage(text: "testing this didReceiveApplicationContext")
         }
-        if let notificationText = applicationContext[kCipherDataKey] as? String {
+        if let notificationText = applicationContext[WATCH_DTO_APP_CONTEXT_KEY] as? String {
             
 //            let decoder = JSONDecoder()
 //            do {


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Add `kSecAttrAccessibleWhenPasscodeSetThisDeviceOnly` to the accessible on Keychain items.
Also, added state to show to the user when the Apple Watch Passcode is not set and also a check to see if that situation changed and if a passcode is set afterwards to signal the iPhone to trigger a sync.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

### iPhone app
* **WatchDeviceService:** Subscribed to `OnMessagedReceived` to trigger the sync when the action is the one intended
* **WCSessionManager:** Improved naming, changed `Console.WriteLine` to `Debug.WriteLine`, removed sending application context on main thread, added exception logging, and added method to get message with reply.

### Watch app
* **KeychainHelper:** Added `kSecAttrAccessibleWhenPasscodeSetThisDeviceOnly` accessible on save items and added `hasDeviceOwnerAuth` to check whether the user has a Passcode set 
* **StateService:** Added `lackedDeviceOwnerAuthLastTime` to track whether the last time the user entered the app the Passcode was on/off
* **BWState...:** Added new state handling
* **ArrayQueue:** Implemented basic queue array, it's not the best performant but we're not going to have many items (most of the times just one); so for now it's fine.
* **CipherListViewModel:** Added check for Passcode and signal to trigger sync if needed
* **WatchConnectivityManager:** Updated consts names, implemented triggering the sync (signaling the iPhone app to trigger the sync) by sending a message and if the session is not activated yet, the message will be queued and when the session gets activated the send method gets called again

## Screenshots
<!--Required for any UI changes. Delete if not applicable-->

<img width="314" alt="Apple Watch No Passcode State" src="https://user-images.githubusercontent.com/15682323/208194775-0a9a998c-1d97-4ce5-a60f-7fd45907de8b.PNG">

## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
