### PR TITLE
PS-1174 - Allowing to search items with diacritics

### DIFF
--- a/src/Core/Services/SearchService.cs
+++ b/src/Core/Services/SearchService.cs
@@ -86,7 +86,8 @@ namespace Bit.Core.Services
                 if (c.Name?.ToLower().Contains(query) ?? false)
                 {
                     matchedCiphers.Add(c);
-                }else if(RemoveDiacritics(c.Name)?.ToLower().Contains(query) ?? false)
+                }
+                else if (RemoveDiacritics(c.Name)?.ToLower().Contains(query) ?? false)
                 {
                     lowPriorityMatchedCiphers.Add(c);
                 }

--- a/src/Core/Services/SearchService.cs
+++ b/src/Core/Services/SearchService.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Bit.Core.Abstractions;
@@ -84,12 +86,19 @@ namespace Bit.Core.Services
                 if (c.Name?.ToLower().Contains(query) ?? false)
                 {
                     matchedCiphers.Add(c);
+                }else if(RemoveDiacritics(c.Name)?.ToLower().Contains(query) ?? false)
+                {
+                    lowPriorityMatchedCiphers.Add(c);
                 }
                 else if (query.Length >= 8 && c.Id.StartsWith(query))
                 {
                     lowPriorityMatchedCiphers.Add(c);
                 }
                 else if (c.SubTitle?.ToLower().Contains(query) ?? false)
+                {
+                    lowPriorityMatchedCiphers.Add(c);
+                }
+                else if (RemoveDiacritics(c.SubTitle)?.ToLower().Contains(query) ?? false)
                 {
                     lowPriorityMatchedCiphers.Add(c);
                 }
@@ -164,6 +173,28 @@ namespace Bit.Core.Services
             ct.ThrowIfCancellationRequested();
             matchedSends.AddRange(lowPriorityMatchSends);
             return matchedSends;
+        }
+
+        private string RemoveDiacritics(string text)
+        {
+            if (string.IsNullOrWhiteSpace(text))
+            {
+                return null;
+            }
+
+            string formD = text.Normalize(NormalizationForm.FormD);
+            StringBuilder sb = new StringBuilder();
+
+            foreach (char ch in formD)
+            {
+                UnicodeCategory uc = CharUnicodeInfo.GetUnicodeCategory(ch);
+                if (uc != UnicodeCategory.NonSpacingMark)
+                {
+                    sb.Append(ch);
+                }
+            }
+
+            return sb.ToString().Normalize(NormalizationForm.FormC);
         }
     }
 }


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
Items with diacritics should be returned on searches that match their name or subtitles without diacritics

## Code changes
Added a method to remove diacritics from a string and validated if the cipher item name and subtitle matches the search

* **SearchService.cs:** Added RemoveDiacritics method to normalize the strings without diacritics. Added new checks to the SearchCiphersBasic to validate if the item normalized name matches the search 

## Screenshots
**Android**
<img width="314" alt="Android search on name with diacritics" src="https://user-images.githubusercontent.com/109146700/209839515-0ae1d7f5-631f-4a1e-a3f3-065816376874.png">  <img width="314" alt="Android search on subtitle with diacritics" src="https://user-images.githubusercontent.com/109146700/209839520-921fb092-f60b-4254-b94b-5046459f4596.png">

**iOS**
<img width="314" alt="Android search on subtitle with diacritics" src="https://user-images.githubusercontent.com/109146700/209839524-5f8afa56-3aba-470c-a236-c2aba792e967.png">  <img width="314" alt="iOS search on name with diacritics" src="https://user-images.githubusercontent.com/109146700/209839522-9bf4aab4-0f9a-4453-b528-0b7c31bc9ec9.png">



## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
