### PR TITLE
[PS-2172] Fix repo url for F-Droid 1.15+

### DIFF
--- a/store/fdroid/config.py
+++ b/store/fdroid/config.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-repo_url = "https://mobileapp.bitwarden.com/fdroid"
+repo_url = "https://mobileapp.bitwarden.com/fdroid/repo"
 repo_name = "Bitwarden F-Droid Repo"
 repo_icon = "fdroid-icon.png"
 repo_description = """


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Recent changes to F-Droid have reduced tolerance for incorrect repo URLs.  I can confirm that the latest 1.15 client no longer experiences the reported issue, the upcoming 1.16 build maintains the strict requirement.  This will require re-publishing our F-Droid repo to get things moving again.  More info:

https://gitlab.com/fdroid/fdroidclient/-/issues/2390
https://gitlab.com/rfc2822/fdroid-firefox/-/merge_requests/54

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **config.py:** Added `/repo` to the end of the `repo_url`

## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
