### PR TITLE
[SG-978] Mobile - Settings page links are not launching browser

### DIFF
--- a/src/Android/Properties/AndroidManifest.xml
+++ b/src/Android/Properties/AndroidManifest.xml
@@ -40,4 +40,16 @@
 			</intent-filter>
 		</activity>
 	</application>
+	<!-- Support for Xamarin.Essentials.Browser.OpenAsync  (for Android > 11) -->
+	<!-- Related docs: https://learn.microsoft.com/en-us/xamarin/essentials/open-browser?tabs=android -->
+	<queries>
+		<intent>
+			<action android:name="android.intent.action.VIEW" />
+			<data android:scheme="http"/>
+		</intent>
+		<intent>
+			<action android:name="android.intent.action.VIEW" />
+			<data android:scheme="https"/>
+		</intent>
+	</queries>
 </manifest>


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Fix bug where browser urls are not launching.

Steps:
Launch App
Navigate to Settings
Tap on “Import Items” or “Change Master Password” or “Help and feedback”

Actual Results:
Settings page links are not launching browser

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->
After confirming in the documentation, when target API 30 or above, one needs to add extra info to the manifest.
https://learn.microsoft.com/en-us/xamarin/essentials/open-browser?tabs=android

## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
