### PR TITLE
[PS-2215] Implement scrypt key derivation function

### DIFF
--- a/src/Android/Services/CryptoPrimitiveService.cs
+++ b/src/Android/Services/CryptoPrimitiveService.cs
@@ -33,5 +33,10 @@ namespace Bit.Droid.Services
             generator.Init(password, salt, iterations);
             return ((KeyParameter)generator.GenerateDerivedMacParameters(keySize)).GetKey();
         }
+
+        public byte[] Scrypt(byte[] password, byte[] salt, int N, int r, int p, int dkLen)
+        {
+            return SCrypt.Generate(password, salt, N, r, p, dkLen);
+        }
     }
 }

--- a/src/Android/Services/CryptoPrimitiveService.cs
+++ b/src/Android/Services/CryptoPrimitiveService.cs
@@ -34,8 +34,11 @@ namespace Bit.Droid.Services
             return ((KeyParameter)generator.GenerateDerivedMacParameters(keySize)).GetKey();
         }
 
-        public byte[] Scrypt(byte[] password, byte[] salt, int N, int r, int p, int dkLen)
+        public byte[] Scrypt(byte[] password, byte[] salt, int N)
         {
+            const int r = 8;
+            const int p = 1;
+            const int dkLen = 32;
             return SCrypt.Generate(password, salt, N, r, p, dkLen);
         }
     }

--- a/src/Core/Abstractions/ICryptoFunctionService.cs
+++ b/src/Core/Abstractions/ICryptoFunctionService.cs
@@ -10,6 +10,10 @@ namespace Bit.Core.Abstractions
         Task<byte[]> Pbkdf2Async(byte[] password, string salt, CryptoHashAlgorithm algorithm, int iterations);
         Task<byte[]> Pbkdf2Async(string password, byte[] salt, CryptoHashAlgorithm algorithm, int iterations);
         Task<byte[]> Pbkdf2Async(byte[] password, byte[] salt, CryptoHashAlgorithm algorithm, int iterations);
+        Task<byte[]> ScryptAsync(string password, string salt, int N, int r, int p, int dkLen);
+        Task<byte[]> ScryptAsync(byte[] password, string salt, int N, int r, int p, int dkLen);
+        Task<byte[]> ScryptAsync(string password, byte[] salt, int N, int r, int p, int dkLen);
+        Task<byte[]> ScryptAsync(byte[] password, byte[] salt, int N, int r, int p, int dkLen);
         Task<byte[]> HkdfAsync(byte[] ikm, string salt, string info, int outputByteSize, HkdfAlgorithm algorithm);
         Task<byte[]> HkdfAsync(byte[] ikm, byte[] salt, string info, int outputByteSize, HkdfAlgorithm algorithm);
         Task<byte[]> HkdfAsync(byte[] ikm, string salt, byte[] info, int outputByteSize, HkdfAlgorithm algorithm);

--- a/src/Core/Abstractions/ICryptoFunctionService.cs
+++ b/src/Core/Abstractions/ICryptoFunctionService.cs
@@ -10,10 +10,10 @@ namespace Bit.Core.Abstractions
         Task<byte[]> Pbkdf2Async(byte[] password, string salt, CryptoHashAlgorithm algorithm, int iterations);
         Task<byte[]> Pbkdf2Async(string password, byte[] salt, CryptoHashAlgorithm algorithm, int iterations);
         Task<byte[]> Pbkdf2Async(byte[] password, byte[] salt, CryptoHashAlgorithm algorithm, int iterations);
-        Task<byte[]> ScryptAsync(string password, string salt, int N, int r, int p, int dkLen);
-        Task<byte[]> ScryptAsync(byte[] password, string salt, int N, int r, int p, int dkLen);
-        Task<byte[]> ScryptAsync(string password, byte[] salt, int N, int r, int p, int dkLen);
-        Task<byte[]> ScryptAsync(byte[] password, byte[] salt, int N, int r, int p, int dkLen);
+        Task<byte[]> ScryptAsync(string password, string salt, int N);
+        Task<byte[]> ScryptAsync(byte[] password, string salt, int N);
+        Task<byte[]> ScryptAsync(string password, byte[] salt, int N);
+        Task<byte[]> ScryptAsync(byte[] password, byte[] salt, int N);
         Task<byte[]> HkdfAsync(byte[] ikm, string salt, string info, int outputByteSize, HkdfAlgorithm algorithm);
         Task<byte[]> HkdfAsync(byte[] ikm, byte[] salt, string info, int outputByteSize, HkdfAlgorithm algorithm);
         Task<byte[]> HkdfAsync(byte[] ikm, string salt, byte[] info, int outputByteSize, HkdfAlgorithm algorithm);

--- a/src/Core/Abstractions/ICryptoPrimitiveService.cs
+++ b/src/Core/Abstractions/ICryptoPrimitiveService.cs
@@ -5,6 +5,6 @@ namespace Bit.Core.Abstractions
     public interface ICryptoPrimitiveService
     {
         byte[] Pbkdf2(byte[] password, byte[] salt, CryptoHashAlgorithm algorithm, int iterations);
-        byte[] Scrypt(byte[] password, byte[] salt, int N, int r, int p, int dkLen);
+        byte[] Scrypt(byte[] password, byte[] salt, int N);
     }
 }

--- a/src/Core/Abstractions/ICryptoPrimitiveService.cs
+++ b/src/Core/Abstractions/ICryptoPrimitiveService.cs
@@ -5,5 +5,6 @@ namespace Bit.Core.Abstractions
     public interface ICryptoPrimitiveService
     {
         byte[] Pbkdf2(byte[] password, byte[] salt, CryptoHashAlgorithm algorithm, int iterations);
+        byte[] Scrypt(byte[] password, byte[] salt, int N, int r, int p, int dkLen);
     }
 }

--- a/src/Core/Enums/KdfType.cs
+++ b/src/Core/Enums/KdfType.cs
@@ -2,6 +2,7 @@
 {
     public enum KdfType : byte
     {
-        PBKDF2_SHA256 = 0
+        PBKDF2_SHA256 = 0,
+        SCRYPT = 1
     }
 }

--- a/src/Core/Services/CryptoService.cs
+++ b/src/Core/Services/CryptoService.cs
@@ -412,18 +412,15 @@ namespace Bit.Core.Services
                 {
                     kdfIterations = 65536;
                 }
-                if (kdfIterations < 32768)
+                else if (kdfIterations < 32768)
                 {
                     throw new Exception("SCRYPT work factor minimum is 2^15.");
                 }
-
-                // parameters selected according to https://words.filippo.io/the-scrypt-parameters/
-                const int dkLen = 32; // output length in bytes, i.e 256 bits
-                const int p = 1; // parallelization factor leads to a tradeoff between memory and CPU
-                const int r = 8; // r is the block width, which scales linearly with memory usage
-                var n = kdfIterations.Value; // n is the CPU/memory cost parameter, it needs to be a power of two
-
-                key = await _cryptoFunctionService.ScryptAsync(password, salt, n, r, p, dkLen);
+                else if (kdfIterations > 4194304) {
+                    throw new Exception("SCRYPT work factor maximum is 2^22.");
+                }
+                var n = kdfIterations.Value;
+                key = await _cryptoFunctionService.ScryptAsync(password, salt, n);
             }
             else
             {

--- a/src/Core/Services/PclCryptoFunctionService.cs
+++ b/src/Core/Services/PclCryptoFunctionService.cs
@@ -44,26 +44,26 @@ namespace Bit.Core.Services
             return Task.FromResult(_cryptoPrimitiveService.Pbkdf2(password, salt, algorithm, iterations));
         }
 
-        public Task<byte[]> ScryptAsync(string password, string salt, int N, int r, int p, int dkLen)
+        public Task<byte[]> ScryptAsync(string password, string salt, int N)
         {
             password = NormalizePassword(password);
-            return ScryptAsync(Encoding.UTF8.GetBytes(password), Encoding.UTF8.GetBytes(salt), N, r, p, dkLen);
+            return ScryptAsync(Encoding.UTF8.GetBytes(password), Encoding.UTF8.GetBytes(salt), N);
         }
 
-        public Task<byte[]> ScryptAsync(byte[] password, string salt, int N, int r, int p, int dkLen)
+        public Task<byte[]> ScryptAsync(byte[] password, string salt, int N)
         {
-            return ScryptAsync(password, Encoding.UTF8.GetBytes(salt), N, r, p, dkLen);
+            return ScryptAsync(password, Encoding.UTF8.GetBytes(salt), N);
         }
 
-        public Task<byte[]> ScryptAsync(string password, byte[] salt, int N, int r, int p, int dkLen)
+        public Task<byte[]> ScryptAsync(string password, byte[] salt, int N)
         {
             password = NormalizePassword(password);
-            return ScryptAsync(Encoding.UTF8.GetBytes(password), salt, N, r, p, dkLen);
+            return ScryptAsync(Encoding.UTF8.GetBytes(password), salt, N);
         }
 
-        public Task<byte[]> ScryptAsync(byte[] password, byte[] salt, int N, int r, int p, int dkLen)
+        public Task<byte[]> ScryptAsync(byte[] password, byte[] salt, int N)
         {
-            return Task.FromResult(_cryptoPrimitiveService.Scrypt(password, salt, N, r, p, dkLen));
+            return Task.FromResult(_cryptoPrimitiveService.Scrypt(password, salt, N));
         }
 
         public async Task<byte[]> HkdfAsync(byte[] ikm, string salt, string info, int outputByteSize, HkdfAlgorithm algorithm) =>

--- a/src/Core/Services/PclCryptoFunctionService.cs
+++ b/src/Core/Services/PclCryptoFunctionService.cs
@@ -44,6 +44,28 @@ namespace Bit.Core.Services
             return Task.FromResult(_cryptoPrimitiveService.Pbkdf2(password, salt, algorithm, iterations));
         }
 
+        public Task<byte[]> ScryptAsync(string password, string salt, int N, int r, int p, int dkLen)
+        {
+            password = NormalizePassword(password);
+            return ScryptAsync(Encoding.UTF8.GetBytes(password), Encoding.UTF8.GetBytes(salt), N, r, p, dkLen);
+        }
+
+        public Task<byte[]> ScryptAsync(byte[] password, string salt, int N, int r, int p, int dkLen)
+        {
+            return ScryptAsync(password, Encoding.UTF8.GetBytes(salt), N, r, p, dkLen);
+        }
+
+        public Task<byte[]> ScryptAsync(string password, byte[] salt, int N, int r, int p, int dkLen)
+        {
+            password = NormalizePassword(password);
+            return ScryptAsync(Encoding.UTF8.GetBytes(password), salt, N, r, p, dkLen);
+        }
+
+        public Task<byte[]> ScryptAsync(byte[] password, byte[] salt, int N, int r, int p, int dkLen)
+        {
+            return Task.FromResult(_cryptoPrimitiveService.Scrypt(password, salt, N, r, p, dkLen));
+        }
+
         public async Task<byte[]> HkdfAsync(byte[] ikm, string salt, string info, int outputByteSize, HkdfAlgorithm algorithm) =>
             await HkdfAsync(ikm, Encoding.UTF8.GetBytes(salt), Encoding.UTF8.GetBytes(info), outputByteSize, algorithm);
 

--- a/src/iOS.Core/Services/CryptoPrimitiveService.cs
+++ b/src/iOS.Core/Services/CryptoPrimitiveService.cs
@@ -3,6 +3,7 @@ using Bit.Core.Enums;
 using Foundation;
 using System;
 using System.Runtime.InteropServices;
+using Org.BouncyCastle.Crypto.Generators;
 
 namespace Bit.iOS.Core.Services
 {
@@ -43,5 +44,10 @@ namespace Bit.iOS.Core.Services
         [DllImport(ObjCRuntime.Constants.libSystemLibrary, EntryPoint = "CCKeyDerivationPBKDF")]
         private extern static int CCKeyCerivationPBKDF(uint algorithm, IntPtr password, nuint passwordLen,
             IntPtr salt, nuint saltLen, uint prf, nuint rounds, IntPtr derivedKey, nuint derivedKeyLength);
+            
+        public byte[] Scrypt(byte[] password, byte[] salt, int N, int r, int p, int dkLen)
+        {
+            return SCrypt.Generate(password, salt, N, r, p, dkLen);
+        }
     }
 }

--- a/src/iOS.Core/Services/CryptoPrimitiveService.cs
+++ b/src/iOS.Core/Services/CryptoPrimitiveService.cs
@@ -45,8 +45,11 @@ namespace Bit.iOS.Core.Services
         private extern static int CCKeyCerivationPBKDF(uint algorithm, IntPtr password, nuint passwordLen,
             IntPtr salt, nuint saltLen, uint prf, nuint rounds, IntPtr derivedKey, nuint derivedKeyLength);
             
-        public byte[] Scrypt(byte[] password, byte[] salt, int N, int r, int p, int dkLen)
+        public byte[] Scrypt(byte[] password, byte[] salt, int N)
         {
+            const int r = 8;
+            const int p = 1;
+            const int dkLen = 32;
             return SCrypt.Generate(password, salt, N, r, p, dkLen);
         }
     }

--- a/src/iOS.Core/iOS.Core.csproj
+++ b/src/iOS.Core/iOS.Core.csproj
@@ -137,8 +137,6 @@
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Resources\" />
-    <Folder Include="Effects\" />
-    <Folder Include="Renderers\CollectionView\" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Constants.cs" />
@@ -224,6 +222,9 @@
   <ItemGroup>
     <PackageReference Include="NETStandard.Library">
       <Version>2.0.3</Version>
+    </PackageReference>
+    <PackageReference Include="Portable.BouncyCastle">
+      <Version>1.9.0</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
This pull request implements the scrypt kdf, as the second kdf next to pbkdf2.
The corresponding pull request on the clients repository is here: 

**Edit @djsmith85**: Community forum thread: https://community.bitwarden.com/t/scrypt-kdf-support/48148/1
## Code changes

There is also a pull request for the clients implementation here: bitwarden/clients/pull/4428

- CryptoPrimitiveService.cs (iOS, Android), ICryptoPrimitiveService.cs: Implement the basic scrypt call.
- KdfType.cs: Add the second KdfType
- PclCryptoFunctionService.cs, ICryptoFunctionService.cs: Add the Scrypt functions
- CryptoService: Add the scrypt case case for the kdf type. The default iterations are set to 2^16, and the minimum iterations are set to 2^15. (https://words.filippo.io/the-scrypt-parameters/ recommends 2^15 for interactive logins, but the article is from 2017 and it is arguable that bitwarden is closer to file encryption than interactive logins, so I'm open to debate here). The rest of the parameters are the same as recommended in the linked post.
- iOS.Core.csproj: Add the BouncyCastle library (which is already used on Android) to implement Scrypt

I will note that I only tested this on Android, as I do not have a working iOS testing setup. It is the same implementation, but if it still does not work, let me know and I'm happy to fix it :)