### PR TITLE
[SG-516] Additional forwarded email providers for username generator - mobile

### DIFF
--- a/src/App/Pages/Generator/GeneratorPage.xaml
+++ b/src/App/Pages/Generator/GeneratorPage.xaml
@@ -306,7 +306,7 @@
                                 Grid.Row="1"
                                 Grid.Column="1"/>
                         </Grid>
-                        <!--DUCKDUCKGO RELAY OPTIONS-->
+                        <!--DUCKDUCKGO OPTIONS-->
                         <Grid StyleClass="box-row, box-row-input"
                               IsVisible="{Binding ForwardedEmailServiceSelected, Converter={StaticResource enumToBool}, ConverterParameter={x:Static enums:ForwardedEmailServiceType.DuckDuckGo}}"
                               Grid.RowDefinitions="Auto,*"
@@ -323,6 +323,27 @@
                             <controls:IconButton
                                 StyleClass="box-row-button, box-row-button-platform"
                                 Text="{Binding ShowDuckDuckGoHiddenValueIcon}"
+                                Command="{Binding ToggleForwardedEmailHiddenValueCommand}"
+                                Grid.Row="1"
+                                Grid.Column="1"/>
+                        </Grid>
+                        <!--FASTMAIL OPTIONS-->
+                        <Grid StyleClass="box-row, box-row-input"
+                              IsVisible="{Binding ForwardedEmailServiceSelected, Converter={StaticResource enumToBool}, ConverterParameter={x:Static enums:ForwardedEmailServiceType.Fastmail}}"
+                              Grid.RowDefinitions="Auto,*"
+                              Grid.ColumnDefinitions="*,Auto">
+                            <Label
+                                Text="{u:I18n APIKeyRequiredParenthesis}"
+                                StyleClass="box-label"/>
+                            <Entry
+                                x:Name="_fastmailApiAccessTokenEntry"
+                                Text="{Binding FastmailApiKey}"
+                                StyleClass="box-value"
+                                Grid.Row="1"
+                                IsPassword="{Binding ShowFastmailApiKey, Converter={StaticResource inverseBool}}"/>
+                            <controls:IconButton
+                                StyleClass="box-row-button, box-row-button-platform"
+                                Text="{Binding ShowFastmailHiddenValueIcon}"
                                 Command="{Binding ToggleForwardedEmailHiddenValueCommand}"
                                 Grid.Row="1"
                                 Grid.Column="1"/>

--- a/src/App/Pages/Generator/GeneratorPage.xaml
+++ b/src/App/Pages/Generator/GeneratorPage.xaml
@@ -306,6 +306,27 @@
                                 Grid.Row="1"
                                 Grid.Column="1"/>
                         </Grid>
+                        <!--DUCKDUCKGO RELAY OPTIONS-->
+                        <Grid StyleClass="box-row, box-row-input"
+                              IsVisible="{Binding ForwardedEmailServiceSelected, Converter={StaticResource enumToBool}, ConverterParameter={x:Static enums:ForwardedEmailServiceType.DuckDuckGo}}"
+                              Grid.RowDefinitions="Auto,*"
+                              Grid.ColumnDefinitions="*,Auto">
+                            <Label
+                                Text="{u:I18n APIKeyRequiredParenthesis}"
+                                StyleClass="box-label"/>
+                            <Entry
+                                x:Name="_duckDuckGoApiAccessTokenEntry"
+                                Text="{Binding DuckDuckGoApiKey}"
+                                StyleClass="box-value"
+                                Grid.Row="1"
+                                IsPassword="{Binding ShowDuckDuckGoApiKey, Converter={StaticResource inverseBool}}"/>
+                            <controls:IconButton
+                                StyleClass="box-row-button, box-row-button-platform"
+                                Text="{Binding ShowDuckDuckGoHiddenValueIcon}"
+                                Command="{Binding ToggleForwardedEmailHiddenValueCommand}"
+                                Grid.Row="1"
+                                Grid.Column="1"/>
+                        </Grid>
                     </StackLayout>                    
                     <!--RANDOM WORD OPTIONS-->
                     <Grid IsVisible="{Binding UsernameTypeSelected, Converter={StaticResource enumToBool}, ConverterParameter={x:Static enums:UsernameType.RandomWord}}">

--- a/src/App/Pages/Generator/GeneratorPage.xaml
+++ b/src/App/Pages/Generator/GeneratorPage.xaml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8" ?>
+﻿<?xml version="1.0" encoding="utf-8" ?>
 <pages:BaseContentPage 
     xmlns="http://xamarin.com/schemas/2014/forms"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
@@ -20,6 +20,7 @@
         <ResourceDictionary>
             <u:InverseBoolConverter x:Key="inverseBool" />
             <u:LocalizableEnumConverter x:Key="localizableEnum" />
+            <u:IconGlyphConverter x:Key="iconGlyphConverter" />
             <xct:EnumToBoolConverter x:Key="enumToBool"/>
             <ToolbarItem Text="{u:I18n Cancel}" Command="{Binding CloseCommand}" Order="Primary" Priority="-1"
                          x:Name="_closeItem" x:Key="closeItem" />
@@ -251,7 +252,7 @@
                                 Grid.Row="1"/>
                             <controls:IconButton
                                 StyleClass="box-row-button, box-row-button-platform"
-                                Text="{Binding ShowAnonAddyHiddenValueIcon}"
+                                Text="{Binding ShowAnonAddyApiAccessToken, Converter={StaticResource inverseBool, iconGlyphConverter}, ConverterParameter={x:Static u:BooleanGlyphType.Eye}}"
                                 Command="{Binding ToggleForwardedEmailHiddenValueCommand}"
                                 Grid.Row="1"
                                 Grid.Column="1"/>
@@ -280,7 +281,7 @@
                                 IsPassword="{Binding ShowFirefoxRelayApiAccessToken, Converter={StaticResource inverseBool}}"/>
                             <controls:IconButton
                                 StyleClass="box-row-button, box-row-button-platform"
-                                Text="{Binding ShowFirefoxRelayHiddenValueIcon}"
+                                Text="{Binding ShowFirefoxRelayApiAccessToken, Converter={StaticResource inverseBool, iconGlyphConverter}, ConverterParameter={x:Static u:BooleanGlyphType.Eye}}"
                                 Command="{Binding ToggleForwardedEmailHiddenValueCommand}"
                                 Grid.Row="1"
                                 Grid.Column="1"/>
@@ -301,7 +302,7 @@
                                 IsPassword="{Binding ShowSimpleLoginApiKey, Converter={StaticResource inverseBool}}"/>
                             <controls:IconButton 
                                 StyleClass="box-row-button, box-row-button-platform"
-                                Text="{Binding ShowSimpleLoginHiddenValueIcon}"
+                                Text="{Binding ShowSimpleLoginApiKey, Converter={StaticResource inverseBool, iconGlyphConverter}, ConverterParameter={x:Static u:BooleanGlyphType.Eye}}"
                                 Command="{Binding ToggleForwardedEmailHiddenValueCommand}"
                                 Grid.Row="1"
                                 Grid.Column="1"/>
@@ -322,7 +323,7 @@
                                 IsPassword="{Binding ShowDuckDuckGoApiKey, Converter={StaticResource inverseBool}}"/>
                             <controls:IconButton
                                 StyleClass="box-row-button, box-row-button-platform"
-                                Text="{Binding ShowDuckDuckGoHiddenValueIcon}"
+                                Text="{Binding ShowDuckDuckGoApiKey, Converter={StaticResource inverseBool, iconGlyphConverter}, ConverterParameter={x:Static u:BooleanGlyphType.Eye}}"
                                 Command="{Binding ToggleForwardedEmailHiddenValueCommand}"
                                 Grid.Row="1"
                                 Grid.Column="1"/>
@@ -343,7 +344,7 @@
                                 IsPassword="{Binding ShowFastmailApiKey, Converter={StaticResource inverseBool}}"/>
                             <controls:IconButton
                                 StyleClass="box-row-button, box-row-button-platform"
-                                Text="{Binding ShowFastmailHiddenValueIcon}"
+                                Text="{Binding ShowFastmailApiKey, Converter={StaticResource iconGlyphConverter}, ConverterParameter={x:Static u:BooleanGlyphType.Eye}}"
                                 Command="{Binding ToggleForwardedEmailHiddenValueCommand}"
                                 Grid.Row="1"
                                 Grid.Column="1"/>

--- a/src/App/Pages/Generator/GeneratorPageViewModel.cs
+++ b/src/App/Pages/Generator/GeneratorPageViewModel.cs
@@ -81,10 +81,10 @@ namespace Bit.App.Pages
 
             ForwardedEmailServiceTypeOptions = new List<ForwardedEmailServiceType> {
                 ForwardedEmailServiceType.AnonAddy,
-                ForwardedEmailServiceType.FirefoxRelay,
-                ForwardedEmailServiceType.SimpleLogin,
+                ForwardedEmailServiceType.DuckDuckGo,
                 ForwardedEmailServiceType.Fastmail,
-                ForwardedEmailServiceType.DuckDuckGo
+                ForwardedEmailServiceType.FirefoxRelay,
+                ForwardedEmailServiceType.SimpleLogin
             };
 
             UsernameEmailTypeOptions = new List<UsernameEmailType>

--- a/src/App/Pages/Generator/GeneratorPageViewModel.cs
+++ b/src/App/Pages/Generator/GeneratorPageViewModel.cs
@@ -840,6 +840,8 @@ namespace Bit.App.Pages
             TriggerPropertyChanged(nameof(FirefoxRelayApiAccessToken));
             TriggerPropertyChanged(nameof(AnonAddyDomainName));
             TriggerPropertyChanged(nameof(AnonAddyApiAccessToken));
+            TriggerPropertyChanged(nameof(DuckDuckGoApiKey));
+            TriggerPropertyChanged(nameof(FastmailApiKey));
             TriggerPropertyChanged(nameof(CatchAllEmailDomain));
             TriggerPropertyChanged(nameof(ForwardedEmailServiceSelected));
             TriggerPropertyChanged(nameof(UsernameTypeSelected));

--- a/src/App/Pages/Generator/GeneratorPageViewModel.cs
+++ b/src/App/Pages/Generator/GeneratorPageViewModel.cs
@@ -52,6 +52,7 @@ namespace Bit.App.Pages
         private bool _showFirefoxRelayApiAccessToken;
         private bool _showAnonAddyApiAccessToken;
         private bool _showSimpleLoginApiKey;
+        private bool _showDuckDuckGoApiKey;
         private bool _editMode;
 
         public GeneratorPageViewModel()
@@ -80,7 +81,9 @@ namespace Bit.App.Pages
             ForwardedEmailServiceTypeOptions = new List<ForwardedEmailServiceType> {
                 ForwardedEmailServiceType.AnonAddy,
                 ForwardedEmailServiceType.FirefoxRelay,
-                ForwardedEmailServiceType.SimpleLogin
+                ForwardedEmailServiceType.SimpleLogin,
+                ForwardedEmailServiceType.FastMail,
+                ForwardedEmailServiceType.DuckDuckGo
             };
 
             UsernameEmailTypeOptions = new List<UsernameEmailType>
@@ -541,6 +544,35 @@ namespace Bit.App.Pages
         }
 
         public string ShowSimpleLoginHiddenValueIcon => _showSimpleLoginApiKey ? BitwardenIcons.EyeSlash : BitwardenIcons.Eye;
+
+        public string DuckDuckGoApiKey
+        {
+            get => _usernameOptions.DuckDuckGoApiKey;
+            set
+            {
+                if (_usernameOptions.DuckDuckGoApiKey != value)
+                {
+                    _usernameOptions.DuckDuckGoApiKey = value;
+                    TriggerPropertyChanged(nameof(DuckDuckGoApiKey));
+                    SaveUsernameOptionsAsync(false).FireAndForget();
+                }
+            }
+        }
+
+        public bool ShowDuckDuckGoApiKey
+        {
+            get
+            {
+                return _showDuckDuckGoApiKey;
+            }
+            set => SetProperty(ref _showDuckDuckGoApiKey, value,
+                additionalPropertyNames: new string[]
+                {
+                    nameof(ShowDuckDuckGoHiddenValueIcon)
+                });
+        }
+
+        public string ShowDuckDuckGoHiddenValueIcon => _showDuckDuckGoApiKey ? BitwardenIcons.EyeSlash : BitwardenIcons.Eye;
 
         public bool CapitalizeRandomWordUsername
         {

--- a/src/App/Pages/Generator/GeneratorPageViewModel.cs
+++ b/src/App/Pages/Generator/GeneratorPageViewModel.cs
@@ -53,6 +53,7 @@ namespace Bit.App.Pages
         private bool _showAnonAddyApiAccessToken;
         private bool _showSimpleLoginApiKey;
         private bool _showDuckDuckGoApiKey;
+        private bool _showFastmailApiKey;
         private bool _editMode;
 
         public GeneratorPageViewModel()
@@ -82,7 +83,7 @@ namespace Bit.App.Pages
                 ForwardedEmailServiceType.AnonAddy,
                 ForwardedEmailServiceType.FirefoxRelay,
                 ForwardedEmailServiceType.SimpleLogin,
-                ForwardedEmailServiceType.FastMail,
+                ForwardedEmailServiceType.Fastmail,
                 ForwardedEmailServiceType.DuckDuckGo
             };
 
@@ -574,6 +575,35 @@ namespace Bit.App.Pages
 
         public string ShowDuckDuckGoHiddenValueIcon => _showDuckDuckGoApiKey ? BitwardenIcons.EyeSlash : BitwardenIcons.Eye;
 
+        public string FastmailApiKey
+        {
+            get => _usernameOptions.FastMailApiKey;
+            set
+            {
+                if (_usernameOptions.FastMailApiKey != value)
+                {
+                    _usernameOptions.FastMailApiKey = value;
+                    TriggerPropertyChanged(nameof(FastmailApiKey));
+                    SaveUsernameOptionsAsync(false).FireAndForget();
+                }
+            }
+        }
+
+        public bool ShowFastmailApiKey
+        {
+            get
+            {
+                return _showFastmailApiKey;
+            }
+            set => SetProperty(ref _showFastmailApiKey, value,
+                additionalPropertyNames: new string[]
+                {
+                    nameof(ShowFastmailHiddenValueIcon)
+                });
+        }
+
+        public string ShowFastmailHiddenValueIcon => _showFastmailApiKey ? BitwardenIcons.EyeSlash : BitwardenIcons.Eye;
+
         public bool CapitalizeRandomWordUsername
         {
             get => _usernameOptions.CapitalizeRandomWordUsername;
@@ -880,6 +910,12 @@ namespace Bit.App.Pages
                     break;
                 case ForwardedEmailServiceType.SimpleLogin:
                     ShowSimpleLoginApiKey = !ShowSimpleLoginApiKey;
+                    break;
+                case ForwardedEmailServiceType.DuckDuckGo:
+                    ShowDuckDuckGoApiKey = !ShowDuckDuckGoApiKey;
+                    break;
+                case ForwardedEmailServiceType.Fastmail:
+                    ShowFastmailApiKey = !ShowFastmailApiKey;
                     break;
             }
         }

--- a/src/App/Pages/Generator/GeneratorPageViewModel.cs
+++ b/src/App/Pages/Generator/GeneratorPageViewModel.cs
@@ -465,14 +465,8 @@ namespace Bit.App.Pages
             {
                 return _showAnonAddyApiAccessToken;
             }
-            set => SetProperty(ref _showAnonAddyApiAccessToken, value,
-                additionalPropertyNames: new string[]
-                {
-                    nameof(ShowAnonAddyHiddenValueIcon)
-                });
+            set => SetProperty(ref _showAnonAddyApiAccessToken, value);
         }
-
-        public string ShowAnonAddyHiddenValueIcon => _showAnonAddyApiAccessToken ? BitwardenIcons.EyeSlash : BitwardenIcons.Eye;
 
         public string AnonAddyDomainName
         {
@@ -508,14 +502,8 @@ namespace Bit.App.Pages
             {
                 return _showFirefoxRelayApiAccessToken;
             }
-            set => SetProperty(ref _showFirefoxRelayApiAccessToken, value,
-                additionalPropertyNames: new string[]
-                {
-                    nameof(ShowFirefoxRelayHiddenValueIcon)
-                });
+            set => SetProperty(ref _showFirefoxRelayApiAccessToken, value);
         }
-
-        public string ShowFirefoxRelayHiddenValueIcon => _showFirefoxRelayApiAccessToken ? BitwardenIcons.EyeSlash : BitwardenIcons.Eye;
 
         public string SimpleLoginApiKey
         {
@@ -537,14 +525,8 @@ namespace Bit.App.Pages
             {
                 return _showSimpleLoginApiKey;
             }
-            set => SetProperty(ref _showSimpleLoginApiKey, value,
-                additionalPropertyNames: new string[]
-                {
-                    nameof(ShowSimpleLoginHiddenValueIcon)
-                });
+            set => SetProperty(ref _showSimpleLoginApiKey, value);
         }
-
-        public string ShowSimpleLoginHiddenValueIcon => _showSimpleLoginApiKey ? BitwardenIcons.EyeSlash : BitwardenIcons.Eye;
 
         public string DuckDuckGoApiKey
         {
@@ -566,14 +548,9 @@ namespace Bit.App.Pages
             {
                 return _showDuckDuckGoApiKey;
             }
-            set => SetProperty(ref _showDuckDuckGoApiKey, value,
-                additionalPropertyNames: new string[]
-                {
-                    nameof(ShowDuckDuckGoHiddenValueIcon)
-                });
+            set => SetProperty(ref _showDuckDuckGoApiKey, value);
         }
 
-        public string ShowDuckDuckGoHiddenValueIcon => _showDuckDuckGoApiKey ? BitwardenIcons.EyeSlash : BitwardenIcons.Eye;
 
         public string FastmailApiKey
         {
@@ -595,14 +572,8 @@ namespace Bit.App.Pages
             {
                 return _showFastmailApiKey;
             }
-            set => SetProperty(ref _showFastmailApiKey, value,
-                additionalPropertyNames: new string[]
-                {
-                    nameof(ShowFastmailHiddenValueIcon)
-                });
+            set => SetProperty(ref _showFastmailApiKey, value);
         }
-
-        public string ShowFastmailHiddenValueIcon => _showFastmailApiKey ? BitwardenIcons.EyeSlash : BitwardenIcons.Eye;
 
         public bool CapitalizeRandomWordUsername
         {

--- a/src/App/Resources/AppResources.Designer.cs
+++ b/src/App/Resources/AppResources.Designer.cs
@@ -2039,6 +2039,15 @@ namespace Bit.App.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to DuckDuckGo.
+        /// </summary>
+        public static string DuckDuckGo {
+            get {
+                return ResourceManager.GetString("DuckDuckGo", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Edit.
         /// </summary>
         public static string Edit {
@@ -2521,6 +2530,15 @@ namespace Bit.App.Resources {
         public static string FaceIDDirection {
             get {
                 return ResourceManager.GetString("FaceIDDirection", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to FastMail.
+        /// </summary>
+        public static string FastMail {
+            get {
+                return ResourceManager.GetString("FastMail", resourceCulture);
             }
         }
         

--- a/src/App/Resources/AppResources.Designer.cs
+++ b/src/App/Resources/AppResources.Designer.cs
@@ -2534,11 +2534,11 @@ namespace Bit.App.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to FastMail.
+        ///   Looks up a localized string similar to Fastmail.
         /// </summary>
-        public static string FastMail {
+        public static string Fastmail {
             get {
-                return ResourceManager.GetString("FastMail", resourceCulture);
+                return ResourceManager.GetString("Fastmail", resourceCulture);
             }
         }
         

--- a/src/App/Resources/AppResources.resx
+++ b/src/App/Resources/AppResources.resx
@@ -2424,9 +2424,9 @@ select Add TOTP to store the key safely</value>
     <value>DuckDuckGo</value>
     <comment>"DuckDuckGo" is the product name and should not be translated.</comment>
   </data>
-  <data name="FastMail" xml:space="preserve">
-    <value>FastMail</value>
-    <comment>"FastMail" is the product name and should not be translated.</comment>
+  <data name="Fastmail" xml:space="preserve">
+    <value>Fastmail</value>
+    <comment>"Fastmail" is the product name and should not be translated.</comment>
   </data>
   <data name="APIAccessToken" xml:space="preserve">
     <value>API access token</value>

--- a/src/App/Resources/AppResources.resx
+++ b/src/App/Resources/AppResources.resx
@@ -2420,6 +2420,14 @@ select Add TOTP to store the key safely</value>
     <value>SimpleLogin</value>
     <comment>"SimpleLogin" is the product name and should not be translated.</comment>
   </data>
+  <data name="DuckDuckGo" xml:space="preserve">
+    <value>DuckDuckGo</value>
+    <comment>"DuckDuckGo" is the product name and should not be translated.</comment>
+  </data>
+  <data name="FastMail" xml:space="preserve">
+    <value>FastMail</value>
+    <comment>"FastMail" is the product name and should not be translated.</comment>
+  </data>
   <data name="APIAccessToken" xml:space="preserve">
     <value>API access token</value>
   </data>

--- a/src/App/Utilities/IconGlyphExtensions.cs
+++ b/src/App/Utilities/IconGlyphExtensions.cs
@@ -54,7 +54,7 @@ namespace Bit.App.Utilities
                 case BooleanGlyphType.Checkbox:
                     return value ? BitwardenIcons.CheckSquare : BitwardenIcons.Square;
                 case BooleanGlyphType.Eye:
-                    return value ? BitwardenIcons.Eye : BitwardenIcons.EyeSlash;
+                    return value ? BitwardenIcons.EyeSlash : BitwardenIcons.Eye;
                 default:
                     return "";
             }

--- a/src/Core/Enums/ForwardedEmailServiceType.cs
+++ b/src/Core/Enums/ForwardedEmailServiceType.cs
@@ -10,5 +10,9 @@ namespace Bit.Core.Enums
         FirefoxRelay = 1,
         [LocalizableEnum("SimpleLogin")]
         SimpleLogin = 2,
+        [LocalizableEnum("FastMail")]
+        FastMail = 3,
+        [LocalizableEnum("DuckDuckGo")]
+        DuckDuckGo = 4,
     }
 }

--- a/src/Core/Enums/ForwardedEmailServiceType.cs
+++ b/src/Core/Enums/ForwardedEmailServiceType.cs
@@ -4,16 +4,16 @@ namespace Bit.Core.Enums
 {
     public enum ForwardedEmailServiceType
     {
-        None = 0,
+        None = -1,
         [LocalizableEnum("AnonAddy")]
-        AnonAddy = 1,
-        [LocalizableEnum("DuckDuckGo")]
-        DuckDuckGo = 2,
-        [LocalizableEnum("Fastmail")]
-        Fastmail = 3,
+        AnonAddy = 0,
         [LocalizableEnum("FirefoxRelay")]
-        FirefoxRelay = 4,
+        FirefoxRelay = 1,
         [LocalizableEnum("SimpleLogin")]
-        SimpleLogin = 5
+        SimpleLogin = 2,
+        [LocalizableEnum("DuckDuckGo")]
+        DuckDuckGo = 3,
+        [LocalizableEnum("Fastmail")]
+        Fastmail = 4,
     }
 }

--- a/src/Core/Enums/ForwardedEmailServiceType.cs
+++ b/src/Core/Enums/ForwardedEmailServiceType.cs
@@ -10,8 +10,8 @@ namespace Bit.Core.Enums
         FirefoxRelay = 1,
         [LocalizableEnum("SimpleLogin")]
         SimpleLogin = 2,
-        [LocalizableEnum("FastMail")]
-        FastMail = 3,
+        [LocalizableEnum("Fastmail")]
+        Fastmail = 3,
         [LocalizableEnum("DuckDuckGo")]
         DuckDuckGo = 4,
     }

--- a/src/Core/Enums/ForwardedEmailServiceType.cs
+++ b/src/Core/Enums/ForwardedEmailServiceType.cs
@@ -4,15 +4,16 @@ namespace Bit.Core.Enums
 {
     public enum ForwardedEmailServiceType
     {
+        None = 0,
         [LocalizableEnum("AnonAddy")]
-        AnonAddy = 0,
-        [LocalizableEnum("FirefoxRelay")]
-        FirefoxRelay = 1,
-        [LocalizableEnum("SimpleLogin")]
-        SimpleLogin = 2,
+        AnonAddy = 1,
+        [LocalizableEnum("DuckDuckGo")]
+        DuckDuckGo = 2,
         [LocalizableEnum("Fastmail")]
         Fastmail = 3,
-        [LocalizableEnum("DuckDuckGo")]
-        DuckDuckGo = 4,
+        [LocalizableEnum("FirefoxRelay")]
+        FirefoxRelay = 4,
+        [LocalizableEnum("SimpleLogin")]
+        SimpleLogin = 5
     }
 }

--- a/src/Core/Models/Domain/UsernameGenerationOptions.cs
+++ b/src/Core/Models/Domain/UsernameGenerationOptions.cs
@@ -17,6 +17,7 @@ namespace Bit.Core.Models.Domain
         public string FirefoxRelayApiAccessToken { get; set; }
         public string SimpleLoginApiKey { get; set; }
         public string DuckDuckGoApiKey { get; set; }
+        public string FastMailApiKey { get; set; }
         public string AnonAddyApiAccessToken { get; set; }
         public string AnonAddyDomainName { get; set; }
         public string EmailWebsite { get; set; }

--- a/src/Core/Models/Domain/UsernameGenerationOptions.cs
+++ b/src/Core/Models/Domain/UsernameGenerationOptions.cs
@@ -16,6 +16,7 @@ namespace Bit.Core.Models.Domain
         public string CatchAllEmailDomain { get; set; }
         public string FirefoxRelayApiAccessToken { get; set; }
         public string SimpleLoginApiKey { get; set; }
+        public string DuckDuckGoApiKey { get; set; }
         public string AnonAddyApiAccessToken { get; set; }
         public string AnonAddyDomainName { get; set; }
         public string EmailWebsite { get; set; }

--- a/src/Core/Models/Domain/UsernameGenerationOptions.cs
+++ b/src/Core/Models/Domain/UsernameGenerationOptions.cs
@@ -4,7 +4,10 @@ namespace Bit.Core.Models.Domain
 {
     public class UsernameGenerationOptions
     {
-        public UsernameGenerationOptions() { }
+        public UsernameGenerationOptions()
+        {
+            ServiceType = ForwardedEmailServiceType.None;
+        }
 
         public UsernameType Type { get; set; }
         public ForwardedEmailServiceType ServiceType { get; set; }

--- a/src/Core/Models/Domain/UsernameGeneratorConfig.cs
+++ b/src/Core/Models/Domain/UsernameGeneratorConfig.cs
@@ -5,5 +5,6 @@
         public string ApiToken { get; set; }
         public string Domain { get; set; }
         public string Url { get; set; }
+        public string AccountId { get; set; }
     }
 }

--- a/src/Core/Models/Domain/UsernameGeneratorConfig.cs
+++ b/src/Core/Models/Domain/UsernameGeneratorConfig.cs
@@ -5,6 +5,5 @@
         public string ApiToken { get; set; }
         public string Domain { get; set; }
         public string Url { get; set; }
-        public string AccountId { get; set; }
     }
 }

--- a/src/Core/Services/ApiService.cs
+++ b/src/Core/Services/ApiService.cs
@@ -889,9 +889,8 @@ namespace Bit.Core.Services
                 };
                 return requestJObj.ToString();
             }
-
-
         }
+
         private ErrorResponse HandleWebError(Exception e)
         {
             return new ErrorResponse

--- a/src/Core/Services/ApiService.cs
+++ b/src/Core/Services/ApiService.cs
@@ -760,6 +760,9 @@ namespace Bit.Core.Services
                     case ForwardedEmailServiceType.SimpleLogin:
                         requestMessage.Headers.Add("Authentication", config.ApiToken);
                         break;
+                    case ForwardedEmailServiceType.DuckDuckGo:
+                        requestMessage.Headers.Add("authorization", $"Bearer {config.ApiToken}");
+                        break;
                 }
 
                 HttpResponseMessage response;
@@ -790,6 +793,8 @@ namespace Bit.Core.Services
                         return result["full_address"]?.ToString();
                     case ForwardedEmailServiceType.SimpleLogin:
                         return result["alias"]?.ToString();
+                    case ForwardedEmailServiceType.DuckDuckGo:
+                        return $"{result["address"]?.ToString()}@duck.com";
                     default:
                         return string.Empty;
                 }

--- a/src/Core/Services/ApiService.cs
+++ b/src/Core/Services/ApiService.cs
@@ -761,7 +761,12 @@ namespace Bit.Core.Services
                         requestMessage.Headers.Add("Authentication", config.ApiToken);
                         break;
                     case ForwardedEmailServiceType.DuckDuckGo:
-                        requestMessage.Headers.Add("authorization", $"Bearer {config.ApiToken}");
+                        requestMessage.Headers.Add("Authorization", $"Bearer {config.ApiToken}");
+                        break;
+                    case ForwardedEmailServiceType.Fastmail:
+                        requestMessage.Headers.Add("Authorization", $"Bearer {config.ApiToken}");
+                        var requestJson = CreateFastmailRequest(await GetFastmailAccountId(config.ApiToken));
+                        requestMessage.Content = new StringContent(requestJson, Encoding.UTF8, "application/json");
                         break;
                 }
 
@@ -795,9 +800,89 @@ namespace Bit.Core.Services
                         return result["alias"]?.ToString();
                     case ForwardedEmailServiceType.DuckDuckGo:
                         return $"{result["address"]?.ToString()}@duck.com";
+                    case ForwardedEmailServiceType.Fastmail:
+                        if (result["methodResponses"] != null && result["methodResponses"].HasValues && result["methodResponses"][0].HasValues)
+                        {
+                            if (result["methodResponses"][0][0].ToString() == "MaskedEmail/set")
+                            {
+                                if (result["methodResponses"][0][1]?["created"]?["new-masked-email"] != null)
+                                {
+                                    return result["methodResponses"][0][1]?["created"]?["new-masked-email"]?["email"].ToString();
+                                }
+                                if (result["methodResponses"][0][1]?["notCreated"]?["new-masked-email"] != null)
+                                {
+                                    throw new Exception("Fastmail error: " +
+                                        result["methodResponses"][0][1]?["created"]?["new-masked-email"]?["description"].ToString());
+                                }
+                            }
+                            else if (result["methodResponses"][0][0].ToString() == "error")
+                            {
+                                throw new Exception("Fastmail error: " + result["methodResponses"][0][1]?["description"].ToString());
+                            }
+                        }
+                        throw new Exception("Fastmail error: could not parse response.");
                     default:
                         return string.Empty;
                 }
+            }
+        }
+
+        private string CreateFastmailRequest(string accountId)
+        {
+            var requestJObj = new JObject
+            {
+                new JProperty("using" , new JArray {
+                        "https://www.fastmail.com/dev/maskedemail",
+                        "urn:ietf:params:jmap:core"
+                    }),
+                new JProperty("methodCalls" , new JArray { new JArray{
+                    "MaskedEmail/set",
+                    new JObject
+                    {
+                        ["accountId"] = accountId,
+                        ["create"] = new JObject
+                        {
+                            ["new-masked-email"] = new JObject
+                            {
+                                ["state"] = "enabled",
+                                ["description"] = "",
+                                ["url"] = "",
+                                ["emailPrefix"] = ""
+                            }
+                        }
+                    },
+                    "0" } })
+            };
+            return requestJObj.ToString();
+        }
+
+        private async Task<string> GetFastmailAccountId(string apiKey)
+        {
+            using (var httpclient = new HttpClient())
+            {
+                    HttpResponseMessage response;
+                    try
+                    {
+                        httpclient.DefaultRequestHeaders.Add("Authorization", $"Bearer {apiKey}");
+                        httpclient.DefaultRequestHeaders.Add("Accept", "application/json");
+                        response = await httpclient.GetAsync(new Uri("https://api.fastmail.com/jmap/session"));
+                    }
+                    catch (Exception e)
+                    {
+                        throw new ApiException(HandleWebError(e));
+                    }
+                    if (!response.IsSuccessStatusCode)
+                    {
+                        throw new ApiException(new ErrorResponse
+                        {
+                            StatusCode = response.StatusCode,
+                            Message = $"Fastmail error: {(int)response.StatusCode} {response.ReasonPhrase}."
+                        });
+                    }
+                    var responseJsonString = await response.Content.ReadAsStringAsync();
+                    var result = JObject.Parse(responseJsonString);
+                    return result["primaryAccounts"]?["https://www.fastmail.com/dev/maskedemail"]?.ToString();
+                
             }
         }
 

--- a/src/Core/Services/UsernameGenerationService.cs
+++ b/src/Core/Services/UsernameGenerationService.cs
@@ -182,6 +182,18 @@ namespace Bit.Core.Services
                             ApiToken = options.DuckDuckGoApiKey,
                             Url = "https://quack.duckduckgo.com/api/email/addresses"
                         });
+                case ForwardedEmailServiceType.Fastmail:
+                    if (string.IsNullOrWhiteSpace(options.FastMailApiKey))
+                    {
+                        return Constants.DefaultUsernameGenerated;
+                    }
+
+                    return await _apiService.GetUsernameFromAsync(ForwardedEmailServiceType.Fastmail,
+                        new UsernameGeneratorConfig()
+                        {
+                            ApiToken = options.FastMailApiKey,
+                            Url = "https://api.fastmail.com/jmap/api/"
+                        });
                 default:
                     _logger.Value.Error($"Error UsernameGenerationService: ForwardedEmailServiceType {options.ServiceType} not implemented.");
                     return Constants.DefaultUsernameGenerated;

--- a/src/Core/Services/UsernameGenerationService.cs
+++ b/src/Core/Services/UsernameGenerationService.cs
@@ -171,6 +171,17 @@ namespace Bit.Core.Services
                             ApiToken = options.SimpleLoginApiKey,
                             Url = "https://app.simplelogin.io/api/alias/random/new"
                         });
+                case ForwardedEmailServiceType.DuckDuckGo:
+                    if (string.IsNullOrWhiteSpace(options.DuckDuckGoApiKey))
+                    {
+                        return Constants.DefaultUsernameGenerated;
+                    }
+                    return await _apiService.GetUsernameFromAsync(ForwardedEmailServiceType.DuckDuckGo,
+                        new UsernameGeneratorConfig()
+                        {
+                            ApiToken = options.DuckDuckGoApiKey,
+                            Url = "https://quack.duckduckgo.com/api/email/addresses"
+                        });
                 default:
                     _logger.Value.Error($"Error UsernameGenerationService: ForwardedEmailServiceType {options.ServiceType} not implemented.");
                     return Constants.DefaultUsernameGenerated;


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Add option to select Fastmail and Duck Duck Go as options in the forwarded email alias providers.
Default to none-selected if this is the first use of the screen. Otherwise default to the last selected.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->
[src/App/Pages/Generator/GeneratorPage.xaml](https://github.com/bitwarden/mobile/pull/2304/files#diff-6646362e986f583f0da02c8c01fad244607c0d4dd38e211dd22f7d7ac64664dd): 
New UI views to hold api keys for new services added. (This can be refactored in the future to avoid having multiple views)
[src/App/Pages/Generator/GeneratorPageViewModel.cs](https://github.com/bitwarden/mobile/pull/2304/files#diff-06d6f35a0e203bdae8fe03dade2ef549a73850f02dde233ac921a0fd7214dbc5):
Add new entries for Fastmail and Duck Duck Go to `ForwardedEmailServiceTypeOptions`.
Added properties to bind to the UI for Api Keys and Visibility.
[src/Core/Enums/ForwardedEmailServiceType.cs](https://github.com/bitwarden/mobile/pull/2304/files#diff-5c4fbe584a9869f63822190a1d2af12cad7f0f18caadb45a6da61cc65841b380):
Reorder the enum with added values. Added none to be defaulted the first the user sees the screen, after that it will always have a value saved.
[src/Core/Services/ApiService.cs](https://github.com/bitwarden/mobile/pull/2304/files#diff-5b9bd6e62fd23e1f8dbc2fd0b883357945eae927d73e88753478e3f7c2de2638): 
`HandleFastMailResponse` logic was copied from the other clients.
`CreateFastmailRequest` gets the necessary `accountId` value through a get call, after that builds a JSON object that will be used to perform the actual call to get a generated email.

## Screenshots
<!--Required for any UI changes. Delete if not applicable-->
First time on screen, default service to empty:

https://user-images.githubusercontent.com/4648522/213505609-ced1e223-9cb0-4a2b-b42d-7756f6d71f3b.mov

Subsequent screen landings, generate new emails from Fastmail and Duck Duck Go:

https://user-images.githubusercontent.com/4648522/213505852-1f347a6d-578c-4a61-9278-541369a07fe3.mov

## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
