### PR TITLE
[PS-2275] Update the default kdf iterations to 600k.

### DIFF
--- a/src/App/Pages/Accounts/RegisterPageViewModel.cs
+++ b/src/App/Pages/Accounts/RegisterPageViewModel.cs
@@ -139,8 +139,7 @@ namespace Bit.App.Pages
             Name = string.IsNullOrWhiteSpace(Name) ? null : Name;
             Email = Email.Trim().ToLower();
             var kdf = KdfType.PBKDF2_SHA256;
-            var kdfIterations = 100_000;
-            var key = await _cryptoService.MakeKeyAsync(MasterPassword, Email, kdf, kdfIterations);
+            var key = await _cryptoService.MakeKeyAsync(MasterPassword, Email, kdf, Constants.KdfIterations);
             var encKey = await _cryptoService.MakeEncKeyAsync(key);
             var hashedPassword = await _cryptoService.HashPasswordAsync(MasterPassword, key);
             var keys = await _cryptoService.MakeKeyPairAsync(encKey.Item1);
@@ -152,7 +151,7 @@ namespace Bit.App.Pages
                 MasterPasswordHint = Hint,
                 Key = encKey.Item2.EncryptedString,
                 Kdf = kdf,
-                KdfIterations = kdfIterations,
+                KdfIterations = Constants.KdfIterations,
                 Keys = new KeysRequest
                 {
                     PublicKey = keys.Item1,

--- a/src/App/Pages/Accounts/SetPasswordPageViewModel.cs
+++ b/src/App/Pages/Accounts/SetPasswordPageViewModel.cs
@@ -163,9 +163,8 @@ namespace Bit.App.Pages
             }
 
             var kdf = KdfType.PBKDF2_SHA256;
-            var kdfIterations = 100000;
             var email = await _stateService.GetEmailAsync();
-            var key = await _cryptoService.MakeKeyAsync(MasterPassword, email, kdf, kdfIterations);
+            var key = await _cryptoService.MakeKeyAsync(MasterPassword, email, kdf, Constants.KdfIterations);
             var masterPasswordHash = await _cryptoService.HashPasswordAsync(MasterPassword, key, HashPurpose.ServerAuthorization);
             var localMasterPasswordHash = await _cryptoService.HashPasswordAsync(MasterPassword, key, HashPurpose.LocalAuthorization);
 
@@ -187,7 +186,7 @@ namespace Bit.App.Pages
                 Key = encKey.Item2.EncryptedString,
                 MasterPasswordHint = Hint,
                 Kdf = kdf,
-                KdfIterations = kdfIterations,
+                KdfIterations = Constants.KdfIterations,
                 OrgIdentifier = OrgIdentifier,
                 Keys = new KeysRequest
                 {
@@ -202,7 +201,7 @@ namespace Bit.App.Pages
                 // Set Password and relevant information
                 await _apiService.SetPasswordAsync(request);
                 await _stateService.SetKdfTypeAsync(kdf);
-                await _stateService.SetKdfIterationsAsync(kdfIterations);
+                await _stateService.SetKdfIterationsAsync(Constants.KdfIterations);
                 await _cryptoService.SetKeyAsync(key);
                 await _cryptoService.SetKeyHashAsync(localMasterPasswordHash);
                 await _cryptoService.SetEncKeyAsync(encKey.Item2.EncryptedString);

--- a/src/Core/Constants.cs
+++ b/src/Core/Constants.cs
@@ -46,7 +46,7 @@
         public const int SaveFileRequestCode = 44;
         public const int TotpDefaultTimer = 30;
         public const int PasswordlessNotificationTimeoutInMinutes = 15;
-        public const int KdfIterations = 350000;
+        public const int KdfIterations = 600000;
         public const int MasterPasswordMinimumChars = 8;
 
         public static readonly string[] AndroidAllClearCipherCacheKeys =

--- a/src/Core/Constants.cs
+++ b/src/Core/Constants.cs
@@ -46,6 +46,7 @@
         public const int SaveFileRequestCode = 44;
         public const int TotpDefaultTimer = 30;
         public const int PasswordlessNotificationTimeoutInMinutes = 15;
+        public const int KdfIterations = 350000;
 
         public static readonly string[] AndroidAllClearCipherCacheKeys =
         {


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
Updating the KDF iterations to the same value as clients https://github.com/bitwarden/clients/pull/4482
Getting KdfIterations value from a global constant to be used by all the VMs that need it.


## Code changes
* **Constants.cs:** Added `KdfIterations` constant value with 600k
* **RegisterPageViewModel.cs, SetPasswordPageViewModel.cs:** Using the `KdfIterations` value from `Constants.cs`

## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
