### PR TITLE
Added Mir and RuPay card brands

### DIFF
--- a/src/App/Pages/Vault/CipherAddEditPageViewModel.cs
+++ b/src/App/Pages/Vault/CipherAddEditPageViewModel.cs
@@ -115,6 +115,8 @@ namespace Bit.App.Pages
                 new KeyValuePair<string, string>("JCB", "JCB"),
                 new KeyValuePair<string, string>("Maestro", "Maestro"),
                 new KeyValuePair<string, string>("UnionPay", "UnionPay"),
+                new KeyValuePair<string, string>("RuPay", "RuPay"),
+                new KeyValuePair<string, string>("Mir", "Mir"),
                 new KeyValuePair<string, string>(AppResources.Other, "Other")
             };
             CardExpMonthOptions = new List<KeyValuePair<string, string>>


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
Can't chose card brand types "Mir" or "RuPay" that available in web client.
Also when open edit existing card item with brand Mir or RuPay I see empty brand value.

In client it was added in this PRs:
https://github.com/bitwarden/clients/pull/3079
https://github.com/bitwarden/clients/pull/785

## Code changes
* **src/App/Pages/Vault/CipherAddEditPageViewModel.cs:** added missing items in list
