### PR TITLE
[PS-2342] Implement argon2 configuration options

### DIFF
--- a/src/App/Pages/Accounts/LockPageViewModel.cs
+++ b/src/App/Pages/Accounts/LockPageViewModel.cs
@@ -230,6 +230,8 @@ namespace Bit.App.Pages
             ShowPassword = false;
             var kdf = await _stateService.GetKdfTypeAsync();
             var kdfIterations = await _stateService.GetKdfIterationsAsync();
+            var kdfMemory = await _stateService.GetKdfMemoryAsync();
+            var kdfParallelism = await _stateService.GetKdfParallelismAsync();
 
             if (PinLock)
             {
@@ -240,6 +242,7 @@ namespace Bit.App.Pages
                     {
                         var key = await _cryptoService.MakeKeyFromPinAsync(Pin, _email,
                             kdf.GetValueOrDefault(KdfType.PBKDF2_SHA256), kdfIterations.GetValueOrDefault(5000),
+                            kdfMemory, kdfParallelism,
                             await _stateService.GetPinProtectedKeyAsync());
                         var encKey = await _cryptoService.GetEncKeyAsync(key);
                         var protectedPin = await _stateService.GetProtectedPinAsync();
@@ -255,7 +258,7 @@ namespace Bit.App.Pages
                     else
                     {
                         var key = await _cryptoService.MakeKeyFromPinAsync(Pin, _email,
-                            kdf.GetValueOrDefault(KdfType.PBKDF2_SHA256), kdfIterations.GetValueOrDefault(5000));
+                            kdf.GetValueOrDefault(KdfType.PBKDF2_SHA256), kdfIterations.GetValueOrDefault(5000), kdfMemory, kdfParallelism);
                         failed = false;
                         Pin = string.Empty;
                         await AppHelpers.ResetInvalidUnlockAttemptsAsync();
@@ -280,7 +283,7 @@ namespace Bit.App.Pages
             }
             else
             {
-                var key = await _cryptoService.MakeKeyAsync(MasterPassword, _email, kdf, kdfIterations);
+                var key = await _cryptoService.MakeKeyAsync(MasterPassword, _email, kdf, kdfIterations, kdfMemory, kdfParallelism);
                 var storedKeyHash = await _cryptoService.GetKeyHashAsync();
                 var passwordValid = false;
 
@@ -315,7 +318,7 @@ namespace Bit.App.Pages
                         var encKey = await _cryptoService.GetEncKeyAsync(key);
                         var decPin = await _cryptoService.DecryptToUtf8Async(new EncString(protectedPin), encKey);
                         var pinKey = await _cryptoService.MakePinKeyAysnc(decPin, _email,
-                            kdf.GetValueOrDefault(KdfType.PBKDF2_SHA256), kdfIterations.GetValueOrDefault(5000));
+                            kdf.GetValueOrDefault(KdfType.PBKDF2_SHA256), kdfIterations.GetValueOrDefault(5000), kdfMemory, kdfParallelism);
                         await _stateService.SetPinProtectedKeyAsync(await _cryptoService.EncryptAsync(key.Key, pinKey));
                     }
                     MasterPassword = string.Empty;

--- a/src/App/Pages/Accounts/RegisterPageViewModel.cs
+++ b/src/App/Pages/Accounts/RegisterPageViewModel.cs
@@ -177,7 +177,9 @@ namespace Bit.App.Pages
             Email = Email.Trim().ToLower();
             var kdf = KdfType.PBKDF2_SHA256;
             var kdfIterations = 100_000;
-            var key = await _cryptoService.MakeKeyAsync(MasterPassword, Email, kdf, kdfIterations);
+            int? kdfMemory = null;
+            int? kdfParallelism = null;
+            var key = await _cryptoService.MakeKeyAsync(MasterPassword, Email, kdf, kdfIterations, kdfMemory, kdfParallelism);
             var encKey = await _cryptoService.MakeEncKeyAsync(key);
             var hashedPassword = await _cryptoService.HashPasswordAsync(MasterPassword, key);
             var keys = await _cryptoService.MakeKeyPairAsync(encKey.Item1);

--- a/src/App/Pages/Accounts/SetPasswordPageViewModel.cs
+++ b/src/App/Pages/Accounts/SetPasswordPageViewModel.cs
@@ -165,8 +165,10 @@ namespace Bit.App.Pages
 
             var kdf = KdfType.PBKDF2_SHA256;
             var kdfIterations = 100000;
+            int? kdfMemory = null;
+            int? kdfParallelism = null;
             var email = await _stateService.GetEmailAsync();
-            var key = await _cryptoService.MakeKeyAsync(MasterPassword, email, kdf, kdfIterations);
+            var key = await _cryptoService.MakeKeyAsync(MasterPassword, email, kdf, kdfIterations, kdfMemory, kdfParallelism);
             var masterPasswordHash = await _cryptoService.HashPasswordAsync(MasterPassword, key, HashPurpose.ServerAuthorization);
             var localMasterPasswordHash = await _cryptoService.HashPasswordAsync(MasterPassword, key, HashPurpose.LocalAuthorization);
 

--- a/src/App/Pages/Accounts/UpdateTempPasswordPageViewModel.cs
+++ b/src/App/Pages/Accounts/UpdateTempPasswordPageViewModel.cs
@@ -45,10 +45,12 @@ namespace Bit.App.Pages
             // Retrieve details for key generation
             var kdf = await _stateService.GetKdfTypeAsync();
             var kdfIterations = await _stateService.GetKdfIterationsAsync();
+            var kdfMemory = await _stateService.GetKdfMemoryAsync();
+            var kdfParallelism = await _stateService.GetKdfParallelismAsync();
             var email = await _stateService.GetEmailAsync();
 
             // Create new key and hash new password
-            var key = await _cryptoService.MakeKeyAsync(MasterPassword, email, kdf, kdfIterations);
+            var key = await _cryptoService.MakeKeyAsync(MasterPassword, email, kdf, kdfIterations, kdfMemory, kdfParallelism);
             var masterPasswordHash = await _cryptoService.HashPasswordAsync(MasterPassword, key);
 
             // Create new encKey for the User

--- a/src/App/Pages/Settings/SettingsPage/SettingsPageViewModel.cs
+++ b/src/App/Pages/Settings/SettingsPage/SettingsPageViewModel.cs
@@ -424,10 +424,12 @@ namespace Bit.App.Pages
 
                     var kdf = await _stateService.GetKdfTypeAsync();
                     var kdfIterations = await _stateService.GetKdfIterationsAsync();
+                    var kdfMemory = await _stateService.GetKdfMemoryAsync();
+                    var kdfParallelism = await _stateService.GetKdfParallelismAsync();
                     var email = await _stateService.GetEmailAsync();
                     var pinKey = await _cryptoService.MakePinKeyAysnc(pin, email,
                         kdf.GetValueOrDefault(Core.Enums.KdfType.PBKDF2_SHA256),
-                        kdfIterations.GetValueOrDefault(5000));
+                        kdfIterations.GetValueOrDefault(5000), kdfMemory, kdfParallelism);
                     var key = await _cryptoService.GetKeyAsync();
                     var pinProtectedKey = await _cryptoService.EncryptAsync(key.Key, pinKey);
 

--- a/src/Core/Abstractions/ICryptoService.cs
+++ b/src/Core/Abstractions/ICryptoService.cs
@@ -36,11 +36,10 @@ namespace Bit.Core.Abstractions
         Task<string> HashPasswordAsync(string password, SymmetricCryptoKey key, HashPurpose hashPurpose = HashPurpose.ServerAuthorization);
         Task<bool> HasKeyAsync(string userId = null);
         Task<Tuple<SymmetricCryptoKey, EncString>> MakeEncKeyAsync(SymmetricCryptoKey key);
-        Task<SymmetricCryptoKey> MakeKeyAsync(string password, string salt, KdfType? kdf, int? kdfIterations);
-        Task<SymmetricCryptoKey> MakeKeyFromPinAsync(string pin, string salt, KdfType kdf, int kdfIterations,
-            EncString protectedKeyEs = null);
+        Task<SymmetricCryptoKey> MakeKeyAsync(string password, string salt, KdfType? kdf, int? kdfIterations, int? kdfMemory, int? kdfParallelism);
+        Task<SymmetricCryptoKey> MakeKeyFromPinAsync(string pin, string salt, KdfType kdf, int kdfIterations, int? kdfMemory, int? kdfParallelism, EncString protectedKeyEs = null);
         Task<Tuple<string, EncString>> MakeKeyPairAsync(SymmetricCryptoKey key = null);
-        Task<SymmetricCryptoKey> MakePinKeyAysnc(string pin, string salt, KdfType kdf, int kdfIterations);
+        Task<SymmetricCryptoKey> MakePinKeyAysnc(string pin, string salt, KdfType kdf, int kdfIterations, int? kdfMemory, int? kdfParallelism);
         Task<Tuple<EncString, SymmetricCryptoKey>> MakeShareKeyAsync();
         Task<SymmetricCryptoKey> MakeSendKeyAsync(byte[] keyMaterial);
         Task<int> RandomNumberAsync(int min, int max);

--- a/src/Core/Abstractions/IStateService.cs
+++ b/src/Core/Abstractions/IStateService.cs
@@ -41,6 +41,10 @@ namespace Bit.Core.Abstractions
         Task SetKdfTypeAsync(KdfType? value, string userId = null);
         Task<int?> GetKdfIterationsAsync(string userId = null);
         Task SetKdfIterationsAsync(int? value, string userId = null);
+        Task<int?> GetKdfMemoryAsync(string userId = null);
+        Task SetKdfMemoryAsync(int? value, string userId = null);
+        Task<int?> GetKdfParallelismAsync(string userId = null);
+        Task SetKdfParallelismAsync(int? value, string userId = null);
         Task<string> GetKeyEncryptedAsync(string userId = null);
         Task SetKeyEncryptedAsync(string value, string userId = null);
         Task<SymmetricCryptoKey> GetKeyDecryptedAsync(string userId = null);

--- a/src/Core/Models/Domain/Account.cs
+++ b/src/Core/Models/Domain/Account.cs
@@ -46,6 +46,8 @@ namespace Bit.Core.Models.Domain
                 OrgIdentifier = copy.OrgIdentifier;
                 KdfType = copy.KdfType;
                 KdfIterations = copy.KdfIterations;
+                KdfMemory = copy.KdfMemory;
+                KdfParallelism = copy.KdfParallelism;
                 EmailVerified = copy.EmailVerified;
                 HasPremiumPersonally = copy.HasPremiumPersonally;
                 AvatarColor = copy.AvatarColor;
@@ -59,6 +61,8 @@ namespace Bit.Core.Models.Domain
             public string AvatarColor;
             public KdfType? KdfType;
             public int? KdfIterations;
+            public int? KdfMemory;
+            public int? KdfParallelism;
             public bool? EmailVerified;
             public bool? HasPremiumPersonally;
         }

--- a/src/Core/Models/Request/RegisterRequest.cs
+++ b/src/Core/Models/Request/RegisterRequest.cs
@@ -15,6 +15,8 @@ namespace Bit.Core.Models.Request
         public Guid? OrganizationUserId { get; set; }
         public KdfType? Kdf { get; set; }
         public int? KdfIterations { get; set; }
+        public int? KdfMemory { get; set; }
+        public int? KdfParallelism { get; set; }
         public string CaptchaResponse { get; set; }
     }
 }

--- a/src/Core/Models/Request/SetKeyConnectorKeyRequest.cs
+++ b/src/Core/Models/Request/SetKeyConnectorKeyRequest.cs
@@ -9,15 +9,19 @@ namespace Bit.Core.Models.Request
         public KeysRequest Keys { get; set; }
         public KdfType Kdf { get; set; }
         public int? KdfIterations { get; set; }
+        public int? KdfMemory { get; set; }
+        public int? KdfParallelism { get; set; }
         public string OrgIdentifier { get; set; }
 
         public SetKeyConnectorKeyRequest(string key, KeysRequest keys,
-            KdfType kdf, int? kdfIterations, string orgIdentifier)
+            KdfType kdf, int? kdfIterations, int? kdfMemory, int? kdfParallelism, string orgIdentifier)
         {
             this.Key = key;
             this.Keys = keys;
             this.Kdf = kdf;
             this.KdfIterations = kdfIterations;
+            this.KdfMemory = kdfMemory;
+            this.KdfParallelism = kdfParallelism;
             this.OrgIdentifier = orgIdentifier;
         }
     }

--- a/src/Core/Models/Request/SetPasswordRequest.cs
+++ b/src/Core/Models/Request/SetPasswordRequest.cs
@@ -10,6 +10,8 @@ namespace Bit.Core.Models.Request
         public KeysRequest Keys { get; set; }
         public KdfType Kdf { get; set; }
         public int KdfIterations { get; set; }
+        public int KdfMemory { get; set; }
+        public int KdfParallelism { get; set; }
         public string OrgIdentifier { get; set; }
     }
 }

--- a/src/Core/Models/Response/IdentityTokenResponse.cs
+++ b/src/Core/Models/Response/IdentityTokenResponse.cs
@@ -20,6 +20,8 @@ namespace Bit.Core.Models.Response
         public string TwoFactorToken { get; set; }
         public KdfType Kdf { get; set; }
         public int? KdfIterations { get; set; }
+        public int? KdfMemory { get; set; }
+        public int? KdfParallelism { get; set; }
         public bool ForcePasswordReset { get; set; }
         public string KeyConnectorUrl { get; set; }
     }

--- a/src/Core/Models/Response/PreloginResponse.cs
+++ b/src/Core/Models/Response/PreloginResponse.cs
@@ -6,5 +6,7 @@ namespace Bit.Core.Models.Response
     {
         public KdfType Kdf { get; set; }
         public int KdfIterations { get; set; }
+        public int? KdfMemory { get; set; }
+        public int? KdfParallelism { get; set; }
     }
 }

--- a/src/Core/Services/PclCryptoFunctionService.cs
+++ b/src/Core/Services/PclCryptoFunctionService.cs
@@ -49,18 +49,15 @@ namespace Bit.Core.Services
             password = NormalizePassword(password);
             return Argon2Async(Encoding.UTF8.GetBytes(password), Encoding.UTF8.GetBytes(salt), iterations, memory, parallelism);
         }
-
         public Task<byte[]> Argon2Async(byte[] password, string salt, int iterations, int memory, int parallelism)
         {
             return Argon2Async(password, Encoding.UTF8.GetBytes(salt), iterations, memory, parallelism);
         }
-
         public Task<byte[]> Argon2Async(string password, byte[] salt, int iterations, int memory, int parallelism)
         {
             password = NormalizePassword(password);
             return Argon2Async(Encoding.UTF8.GetBytes(password), salt, iterations, memory, parallelism);
         }
-
         public Task<byte[]> Argon2Async(byte[] password, byte[] salt, int iterations, int memory, int parallelism)
         {
             return Task.FromResult(_cryptoPrimitiveService.Argon2id(password, salt, iterations, memory, parallelism));

--- a/src/Core/Services/StateMigrationService.cs
+++ b/src/Core/Services/StateMigrationService.cs
@@ -115,6 +115,8 @@ namespace Bit.Core.Services
             internal const string Keys_Stamp = "securityStamp";
             internal const string Keys_Kdf = "kdf";
             internal const string Keys_KdfIterations = "kdfIterations";
+            internal const string Keys_KdfMemory = "kdfMemory";
+            internal const string Keys_KdfParallelism = "kdfParallelis";
             internal const string Keys_EmailVerified = "emailVerified";
             internal const string Keys_ForcePasswordReset = "forcePasswordReset";
             internal const string Keys_AccessToken = "accessToken";
@@ -162,6 +164,8 @@ namespace Bit.Core.Services
 
             var kdfType = await GetValueAsync<int?>(Storage.LiteDb, V2Keys.Keys_Kdf);
             var kdfIterations = await GetValueAsync<int?>(Storage.LiteDb, V2Keys.Keys_KdfIterations);
+            var kdfMemory = await GetValueAsync<int?>(Storage.LiteDb, V2Keys.Keys_KdfMemory);
+            var kdfParallelism = await GetValueAsync<int?>(Storage.LiteDb, V2Keys.Keys_KdfParallelism);
             var stamp = await GetValueAsync<string>(Storage.LiteDb, V2Keys.Keys_Stamp);
             var emailVerified = await GetValueAsync<bool?>(Storage.LiteDb, V2Keys.Keys_EmailVerified);
             var refreshToken = await GetValueAsync<string>(Storage.LiteDb, V2Keys.Keys_RefreshToken);
@@ -174,6 +178,8 @@ namespace Bit.Core.Services
                     Stamp = stamp,
                     KdfType = (KdfType?)kdfType,
                     KdfIterations = kdfIterations,
+                    KdfMemory = kdfMemory,
+                    KdfParallelism = kdfParallelism,
                     EmailVerified = emailVerified,
                     HasPremiumPersonally = hasPremiumPersonally,
                 },
@@ -276,6 +282,8 @@ namespace Bit.Core.Services
             await RemoveValueAsync(Storage.LiteDb, V2Keys.Keys_RefreshToken);
             await RemoveValueAsync(Storage.LiteDb, V2Keys.Keys_Kdf);
             await RemoveValueAsync(Storage.LiteDb, V2Keys.Keys_KdfIterations);
+            await RemoveValueAsync(Storage.LiteDb, V2Keys.Keys_KdfMemory);
+            await RemoveValueAsync(Storage.LiteDb, V2Keys.Keys_KdfParallelism);
             await RemoveValueAsync(Storage.LiteDb, V2Keys.Keys_Stamp);
             await RemoveValueAsync(Storage.LiteDb, V2Keys.Keys_EmailVerified);
             await RemoveValueAsync(Storage.LiteDb, V2Keys.Keys_ForcePasswordReset);

--- a/src/Core/Services/StateService.cs
+++ b/src/Core/Services/StateService.cs
@@ -371,6 +371,38 @@ namespace Bit.Core.Services
             await SaveAccountAsync(account, reconciledOptions);
         }
 
+        public async Task SetKdfMemoryAsync(int? value, string userId = null)
+        {
+            var reconciledOptions = ReconcileOptions(new StorageOptions { UserId = userId },
+                await GetDefaultStorageOptionsAsync());
+            var account = await GetAccountAsync(reconciledOptions);
+            account.Profile.KdfMemory = value;
+            await SaveAccountAsync(account, reconciledOptions);
+        }
+
+        public async Task<int?> GetKdfMemoryAsync(string userId = null)
+        {
+            return (await GetAccountAsync(
+                ReconcileOptions(new StorageOptions { UserId = userId }, await GetDefaultStorageOptionsAsync())
+            ))?.Profile?.KdfMemory;
+        }
+
+        public async Task<int?> GetKdfParallelismAsync(string userId = null)
+        {
+            return (await GetAccountAsync(
+                ReconcileOptions(new StorageOptions { UserId = userId }, await GetDefaultStorageOptionsAsync())
+            ))?.Profile?.KdfParallelism;
+        }
+
+        public async Task SetKdfParallelismAsync(int? value, string userId = null)
+        {
+            var reconciledOptions = ReconcileOptions(new StorageOptions { UserId = userId },
+                await GetDefaultStorageOptionsAsync());
+            var account = await GetAccountAsync(reconciledOptions);
+            account.Profile.KdfParallelism = value;
+            await SaveAccountAsync(account, reconciledOptions);
+        }
+
         public async Task<string> GetKeyEncryptedAsync(string userId = null)
         {
             var reconciledOptions = ReconcileOptions(new StorageOptions { UserId = userId },

--- a/src/iOS.Core/Controllers/LockPasswordViewController.cs
+++ b/src/iOS.Core/Controllers/LockPasswordViewController.cs
@@ -212,6 +212,8 @@ namespace Bit.iOS.Core.Controllers
             var email = await _stateService.GetEmailAsync();
             var kdf = await _stateService.GetKdfTypeAsync();
             var kdfIterations = await _stateService.GetKdfIterationsAsync();
+            var kdfMemory = await _stateService.GetKdfMemoryAsync();
+            var kdfParallelism = await _stateService.GetKdfParallelismAsync();
             var inputtedValue = MasterPasswordCell.TextField.Text;
 
             if (_pinLock)
@@ -223,6 +225,7 @@ namespace Bit.iOS.Core.Controllers
                     {
                         var key = await _cryptoService.MakeKeyFromPinAsync(inputtedValue, email,
                             kdf.GetValueOrDefault(KdfType.PBKDF2_SHA256), kdfIterations.GetValueOrDefault(5000),
+                            kdfMemory, kdfParallelism,
                             await _stateService.GetPinProtectedKeyAsync());
                         var encKey = await _cryptoService.GetEncKeyAsync(key);
                         var protectedPin = await _stateService.GetProtectedPinAsync();
@@ -237,7 +240,7 @@ namespace Bit.iOS.Core.Controllers
                     else
                     {
                         var key2 = await _cryptoService.MakeKeyFromPinAsync(inputtedValue, email,
-                            kdf.GetValueOrDefault(KdfType.PBKDF2_SHA256), kdfIterations.GetValueOrDefault(5000));
+                            kdf.GetValueOrDefault(KdfType.PBKDF2_SHA256), kdfIterations.GetValueOrDefault(5000), kdfMemory, kdfParallelism);
                         failed = false;
                         await AppHelpers.ResetInvalidUnlockAttemptsAsync();
                         await SetKeyAndContinueAsync(key2);
@@ -260,7 +263,7 @@ namespace Bit.iOS.Core.Controllers
             }
             else
             {
-                var key2 = await _cryptoService.MakeKeyAsync(inputtedValue, email, kdf, kdfIterations);
+                var key2 = await _cryptoService.MakeKeyAsync(inputtedValue, email, kdf, kdfIterations, kdfMemory, kdfParallelism);
                 
                 var storedKeyHash = await _cryptoService.GetKeyHashAsync();
                 if (storedKeyHash == null)
@@ -282,7 +285,7 @@ namespace Bit.iOS.Core.Controllers
                         var encKey = await _cryptoService.GetEncKeyAsync(key2);
                         var decPin = await _cryptoService.DecryptToUtf8Async(new EncString(protectedPin), encKey);
                         var pinKey = await _cryptoService.MakePinKeyAysnc(decPin, email,
-                            kdf.GetValueOrDefault(KdfType.PBKDF2_SHA256), kdfIterations.GetValueOrDefault(5000));
+                            kdf.GetValueOrDefault(KdfType.PBKDF2_SHA256), kdfIterations.GetValueOrDefault(5000), kdfMemory, kdfParallelism);
                         await _stateService.SetPinProtectedKeyAsync(await _cryptoService.EncryptAsync(key2.Key, pinKey));
                     }
                     await AppHelpers.ResetInvalidUnlockAttemptsAsync();


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
This PR adds configuration option support for the argon2 kdf.


## Code changes
For all files: Basically anywhere where kdfIterations / kdfType is used (in requests, stateservice) we simply add the optional variables kdfMemory and kdfParalleism. The defaults are: 16 (MiB) for memory and 2 parallelism.

This is re-based to the latest argon2ios branch. I'll re-target this PR to master once https://github.com/bitwarden/mobile/pull/2309 is merged.