### PR TITLE
[PS-2358] Add kdf configuration options

### DIFF
--- a/src/App/Pages/Accounts/LockPageViewModel.cs
+++ b/src/App/Pages/Accounts/LockPageViewModel.cs
@@ -228,10 +228,7 @@ namespace Bit.App.Pages
             }
 
             ShowPassword = false;
-            var kdf = await _stateService.GetKdfTypeAsync();
-            var kdfIterations = await _stateService.GetKdfIterationsAsync();
-            var kdfMemory = await _stateService.GetKdfMemoryAsync();
-            var kdfParallelism = await _stateService.GetKdfParallelismAsync();
+            var kdfConfig = await _stateService.GetActiveUserCustomDataAsync(a => new KdfConfig(a?.Profile));
 
             if (PinLock)
             {
@@ -241,8 +238,7 @@ namespace Bit.App.Pages
                     if (_isPinProtected)
                     {
                         var key = await _cryptoService.MakeKeyFromPinAsync(Pin, _email,
-                            kdf.GetValueOrDefault(KdfType.PBKDF2_SHA256), kdfIterations.GetValueOrDefault(5000),
-                            kdfMemory, kdfParallelism,
+                            kdfConfig,
                             await _stateService.GetPinProtectedKeyAsync());
                         var encKey = await _cryptoService.GetEncKeyAsync(key);
                         var protectedPin = await _stateService.GetProtectedPinAsync();
@@ -257,8 +253,7 @@ namespace Bit.App.Pages
                     }
                     else
                     {
-                        var key = await _cryptoService.MakeKeyFromPinAsync(Pin, _email,
-                            kdf.GetValueOrDefault(KdfType.PBKDF2_SHA256), kdfIterations.GetValueOrDefault(5000), kdfMemory, kdfParallelism);
+                        var key = await _cryptoService.MakeKeyFromPinAsync(Pin, _email, kdfConfig);
                         failed = false;
                         Pin = string.Empty;
                         await AppHelpers.ResetInvalidUnlockAttemptsAsync();
@@ -283,7 +278,7 @@ namespace Bit.App.Pages
             }
             else
             {
-                var key = await _cryptoService.MakeKeyAsync(MasterPassword, _email, kdf, kdfIterations, kdfMemory, kdfParallelism);
+                var key = await _cryptoService.MakeKeyAsync(MasterPassword, _email, kdfConfig);
                 var storedKeyHash = await _cryptoService.GetKeyHashAsync();
                 var passwordValid = false;
 
@@ -317,8 +312,7 @@ namespace Bit.App.Pages
                         var protectedPin = await _stateService.GetProtectedPinAsync();
                         var encKey = await _cryptoService.GetEncKeyAsync(key);
                         var decPin = await _cryptoService.DecryptToUtf8Async(new EncString(protectedPin), encKey);
-                        var pinKey = await _cryptoService.MakePinKeyAysnc(decPin, _email,
-                            kdf.GetValueOrDefault(KdfType.PBKDF2_SHA256), kdfIterations.GetValueOrDefault(5000), kdfMemory, kdfParallelism);
+                        var pinKey = await _cryptoService.MakePinKeyAysnc(decPin, _email, kdfConfig);
                         await _stateService.SetPinProtectedKeyAsync(await _cryptoService.EncryptAsync(key.Key, pinKey));
                     }
                     MasterPassword = string.Empty;

--- a/src/App/Pages/Accounts/LockPageViewModel.cs
+++ b/src/App/Pages/Accounts/LockPageViewModel.cs
@@ -230,6 +230,8 @@ namespace Bit.App.Pages
             ShowPassword = false;
             var kdf = await _stateService.GetKdfTypeAsync();
             var kdfIterations = await _stateService.GetKdfIterationsAsync();
+            var kdfMemory = await _stateService.GetKdfMemoryAsync();
+            var kdfParallelism = await _stateService.GetKdfParallelismAsync();
 
             if (PinLock)
             {
@@ -240,6 +242,7 @@ namespace Bit.App.Pages
                     {
                         var key = await _cryptoService.MakeKeyFromPinAsync(Pin, _email,
                             kdf.GetValueOrDefault(KdfType.PBKDF2_SHA256), kdfIterations.GetValueOrDefault(5000),
+                            kdfMemory, kdfParallelism,
                             await _stateService.GetPinProtectedKeyAsync());
                         var encKey = await _cryptoService.GetEncKeyAsync(key);
                         var protectedPin = await _stateService.GetProtectedPinAsync();
@@ -255,7 +258,7 @@ namespace Bit.App.Pages
                     else
                     {
                         var key = await _cryptoService.MakeKeyFromPinAsync(Pin, _email,
-                            kdf.GetValueOrDefault(KdfType.PBKDF2_SHA256), kdfIterations.GetValueOrDefault(5000));
+                            kdf.GetValueOrDefault(KdfType.PBKDF2_SHA256), kdfIterations.GetValueOrDefault(5000), kdfMemory, kdfParallelism);
                         failed = false;
                         Pin = string.Empty;
                         await AppHelpers.ResetInvalidUnlockAttemptsAsync();
@@ -280,7 +283,7 @@ namespace Bit.App.Pages
             }
             else
             {
-                var key = await _cryptoService.MakeKeyAsync(MasterPassword, _email, kdf, kdfIterations);
+                var key = await _cryptoService.MakeKeyAsync(MasterPassword, _email, kdf, kdfIterations, kdfMemory, kdfParallelism);
                 var storedKeyHash = await _cryptoService.GetKeyHashAsync();
                 var passwordValid = false;
 
@@ -315,7 +318,7 @@ namespace Bit.App.Pages
                         var encKey = await _cryptoService.GetEncKeyAsync(key);
                         var decPin = await _cryptoService.DecryptToUtf8Async(new EncString(protectedPin), encKey);
                         var pinKey = await _cryptoService.MakePinKeyAysnc(decPin, _email,
-                            kdf.GetValueOrDefault(KdfType.PBKDF2_SHA256), kdfIterations.GetValueOrDefault(5000));
+                            kdf.GetValueOrDefault(KdfType.PBKDF2_SHA256), kdfIterations.GetValueOrDefault(5000), kdfMemory, kdfParallelism);
                         await _stateService.SetPinProtectedKeyAsync(await _cryptoService.EncryptAsync(key.Key, pinKey));
                     }
                     MasterPassword = string.Empty;

--- a/src/App/Pages/Accounts/RegisterPageViewModel.cs
+++ b/src/App/Pages/Accounts/RegisterPageViewModel.cs
@@ -175,8 +175,8 @@ namespace Bit.App.Pages
 
             Name = string.IsNullOrWhiteSpace(Name) ? null : Name;
             Email = Email.Trim().ToLower();
-            var kdf = KdfType.PBKDF2_SHA256;
-            var key = await _cryptoService.MakeKeyAsync(MasterPassword, Email, kdf, Constants.KdfIterations, null, null);
+            var kdfConfig = new KdfConfig(KdfType.PBKDF2_SHA256, Constants.KdfIterations, null, null);
+            var key = await _cryptoService.MakeKeyAsync(MasterPassword, Email, kdfConfig);
             var encKey = await _cryptoService.MakeEncKeyAsync(key);
             var hashedPassword = await _cryptoService.HashPasswordAsync(MasterPassword, key);
             var keys = await _cryptoService.MakeKeyPairAsync(encKey.Item1);
@@ -187,8 +187,10 @@ namespace Bit.App.Pages
                 MasterPasswordHash = hashedPassword,
                 MasterPasswordHint = Hint,
                 Key = encKey.Item2.EncryptedString,
-                Kdf = kdf,
-                KdfIterations = Constants.KdfIterations,
+                Kdf = kdfConfig.Type,
+                KdfIterations = kdfConfig.Iterations,
+                KdfMemory = kdfConfig.Memory,
+                KdfParallelism = kdfConfig.Parallelism,
                 Keys = new KeysRequest
                 {
                     PublicKey = keys.Item1,

--- a/src/App/Pages/Accounts/RegisterPageViewModel.cs
+++ b/src/App/Pages/Accounts/RegisterPageViewModel.cs
@@ -176,7 +176,7 @@ namespace Bit.App.Pages
             Name = string.IsNullOrWhiteSpace(Name) ? null : Name;
             Email = Email.Trim().ToLower();
             var kdf = KdfType.PBKDF2_SHA256;
-            var key = await _cryptoService.MakeKeyAsync(MasterPassword, Email, kdf, Constants.KdfIterations);
+            var key = await _cryptoService.MakeKeyAsync(MasterPassword, Email, kdf, Constants.KdfIterations, null, null);
             var encKey = await _cryptoService.MakeEncKeyAsync(key);
             var hashedPassword = await _cryptoService.HashPasswordAsync(MasterPassword, key);
             var keys = await _cryptoService.MakeKeyPairAsync(encKey.Item1);

--- a/src/App/Pages/Accounts/RegisterPageViewModel.cs
+++ b/src/App/Pages/Accounts/RegisterPageViewModel.cs
@@ -175,7 +175,7 @@ namespace Bit.App.Pages
 
             Name = string.IsNullOrWhiteSpace(Name) ? null : Name;
             Email = Email.Trim().ToLower();
-            var kdfConfig = new KdfConfig(KdfType.PBKDF2_SHA256, Constants.KdfIterations, null, null);
+            var kdfConfig = new KdfConfig(KdfType.PBKDF2_SHA256, Constants.Pbkdf2Iterations, null, null);
             var key = await _cryptoService.MakeKeyAsync(MasterPassword, Email, kdfConfig);
             var encKey = await _cryptoService.MakeEncKeyAsync(key);
             var hashedPassword = await _cryptoService.HashPasswordAsync(MasterPassword, key);

--- a/src/App/Pages/Accounts/SetPasswordPageViewModel.cs
+++ b/src/App/Pages/Accounts/SetPasswordPageViewModel.cs
@@ -163,9 +163,9 @@ namespace Bit.App.Pages
                 return;
             }
 
-            var kdf = KdfType.PBKDF2_SHA256;
+            var kdfConfig = new KdfConfig(KdfType.PBKDF2_SHA256, Constants.KdfIterations, null, null);
             var email = await _stateService.GetEmailAsync();
-            var key = await _cryptoService.MakeKeyAsync(MasterPassword, email, kdf, Constants.KdfIterations, null, null);
+            var key = await _cryptoService.MakeKeyAsync(MasterPassword, email, kdfConfig);
             var masterPasswordHash = await _cryptoService.HashPasswordAsync(MasterPassword, key, HashPurpose.ServerAuthorization);
             var localMasterPasswordHash = await _cryptoService.HashPasswordAsync(MasterPassword, key, HashPurpose.LocalAuthorization);
 
@@ -186,8 +186,10 @@ namespace Bit.App.Pages
                 MasterPasswordHash = masterPasswordHash,
                 Key = encKey.Item2.EncryptedString,
                 MasterPasswordHint = Hint,
-                Kdf = kdf,
-                KdfIterations = Constants.KdfIterations,
+                Kdf = kdfConfig.Type.GetValueOrDefault(KdfType.PBKDF2_SHA256),
+                KdfIterations = kdfConfig.Iterations.GetValueOrDefault(Constants.KdfIterations),
+                KdfMemory = kdfConfig.Memory,
+                KdfParallelism = kdfConfig.Parallelism,
                 OrgIdentifier = OrgIdentifier,
                 Keys = new KeysRequest
                 {
@@ -201,8 +203,7 @@ namespace Bit.App.Pages
                 await _deviceActionService.ShowLoadingAsync(AppResources.CreatingAccount);
                 // Set Password and relevant information
                 await _apiService.SetPasswordAsync(request);
-                await _stateService.SetKdfTypeAsync(kdf);
-                await _stateService.SetKdfIterationsAsync(Constants.KdfIterations);
+                await _stateService.SetKdfConfigurationAsync(kdfConfig);
                 await _cryptoService.SetKeyAsync(key);
                 await _cryptoService.SetKeyHashAsync(localMasterPasswordHash);
                 await _cryptoService.SetEncKeyAsync(encKey.Item2.EncryptedString);

--- a/src/App/Pages/Accounts/SetPasswordPageViewModel.cs
+++ b/src/App/Pages/Accounts/SetPasswordPageViewModel.cs
@@ -163,7 +163,7 @@ namespace Bit.App.Pages
                 return;
             }
 
-            var kdfConfig = new KdfConfig(KdfType.PBKDF2_SHA256, Constants.KdfIterations, null, null);
+            var kdfConfig = new KdfConfig(KdfType.PBKDF2_SHA256, Constants.Pbkdf2Iterations, null, null);
             var email = await _stateService.GetEmailAsync();
             var key = await _cryptoService.MakeKeyAsync(MasterPassword, email, kdfConfig);
             var masterPasswordHash = await _cryptoService.HashPasswordAsync(MasterPassword, key, HashPurpose.ServerAuthorization);
@@ -187,7 +187,7 @@ namespace Bit.App.Pages
                 Key = encKey.Item2.EncryptedString,
                 MasterPasswordHint = Hint,
                 Kdf = kdfConfig.Type.GetValueOrDefault(KdfType.PBKDF2_SHA256),
-                KdfIterations = kdfConfig.Iterations.GetValueOrDefault(Constants.KdfIterations),
+                KdfIterations = kdfConfig.Iterations.GetValueOrDefault(Constants.Pbkdf2Iterations),
                 KdfMemory = kdfConfig.Memory,
                 KdfParallelism = kdfConfig.Parallelism,
                 OrgIdentifier = OrgIdentifier,

--- a/src/App/Pages/Accounts/SetPasswordPageViewModel.cs
+++ b/src/App/Pages/Accounts/SetPasswordPageViewModel.cs
@@ -165,7 +165,7 @@ namespace Bit.App.Pages
 
             var kdf = KdfType.PBKDF2_SHA256;
             var email = await _stateService.GetEmailAsync();
-            var key = await _cryptoService.MakeKeyAsync(MasterPassword, email, kdf, Constants.KdfIterations);
+            var key = await _cryptoService.MakeKeyAsync(MasterPassword, email, kdf, Constants.KdfIterations, null, null);
             var masterPasswordHash = await _cryptoService.HashPasswordAsync(MasterPassword, key, HashPurpose.ServerAuthorization);
             var localMasterPasswordHash = await _cryptoService.HashPasswordAsync(MasterPassword, key, HashPurpose.LocalAuthorization);
 

--- a/src/App/Pages/Accounts/UpdateTempPasswordPageViewModel.cs
+++ b/src/App/Pages/Accounts/UpdateTempPasswordPageViewModel.cs
@@ -45,10 +45,12 @@ namespace Bit.App.Pages
             // Retrieve details for key generation
             var kdf = await _stateService.GetKdfTypeAsync();
             var kdfIterations = await _stateService.GetKdfIterationsAsync();
+            var kdfMemory = await _stateService.GetKdfMemoryAsync();
+            var kdfParallelism = await _stateService.GetKdfParallelismAsync();
             var email = await _stateService.GetEmailAsync();
 
             // Create new key and hash new password
-            var key = await _cryptoService.MakeKeyAsync(MasterPassword, email, kdf, kdfIterations);
+            var key = await _cryptoService.MakeKeyAsync(MasterPassword, email, kdf, kdfIterations, kdfMemory, kdfParallelism);
             var masterPasswordHash = await _cryptoService.HashPasswordAsync(MasterPassword, key);
 
             // Create new encKey for the User

--- a/src/App/Pages/Accounts/UpdateTempPasswordPageViewModel.cs
+++ b/src/App/Pages/Accounts/UpdateTempPasswordPageViewModel.cs
@@ -43,14 +43,11 @@ namespace Bit.App.Pages
             }
 
             // Retrieve details for key generation
-            var kdf = await _stateService.GetKdfTypeAsync();
-            var kdfIterations = await _stateService.GetKdfIterationsAsync();
-            var kdfMemory = await _stateService.GetKdfMemoryAsync();
-            var kdfParallelism = await _stateService.GetKdfParallelismAsync();
+            var kdfConfig = await _stateService.GetActiveUserCustomDataAsync(a => new KdfConfig(a?.Profile));
             var email = await _stateService.GetEmailAsync();
 
             // Create new key and hash new password
-            var key = await _cryptoService.MakeKeyAsync(MasterPassword, email, kdf, kdfIterations, kdfMemory, kdfParallelism);
+            var key = await _cryptoService.MakeKeyAsync(MasterPassword, email, kdfConfig);
             var masterPasswordHash = await _cryptoService.HashPasswordAsync(MasterPassword, key);
 
             // Create new encKey for the User

--- a/src/App/Pages/Settings/SettingsPage/SettingsPageViewModel.cs
+++ b/src/App/Pages/Settings/SettingsPage/SettingsPageViewModel.cs
@@ -422,14 +422,9 @@ namespace Bit.App.Pages
                             AppResources.Yes, AppResources.No);
                     }
 
-                    var kdf = await _stateService.GetKdfTypeAsync();
-                    var kdfIterations = await _stateService.GetKdfIterationsAsync();
-                    var kdfMemory = await _stateService.GetKdfMemoryAsync();
-                    var kdfParallelism = await _stateService.GetKdfParallelismAsync();
+                    var kdfConfig = await _stateService.GetActiveUserCustomDataAsync(a => new KdfConfig(a?.Profile));
                     var email = await _stateService.GetEmailAsync();
-                    var pinKey = await _cryptoService.MakePinKeyAysnc(pin, email,
-                        kdf.GetValueOrDefault(Core.Enums.KdfType.PBKDF2_SHA256),
-                        kdfIterations.GetValueOrDefault(5000), kdfMemory, kdfParallelism);
+                    var pinKey = await _cryptoService.MakePinKeyAysnc(pin, email, kdfConfig);
                     var key = await _cryptoService.GetKeyAsync();
                     var pinProtectedKey = await _cryptoService.EncryptAsync(key.Key, pinKey);
 

--- a/src/App/Pages/Settings/SettingsPage/SettingsPageViewModel.cs
+++ b/src/App/Pages/Settings/SettingsPage/SettingsPageViewModel.cs
@@ -424,10 +424,12 @@ namespace Bit.App.Pages
 
                     var kdf = await _stateService.GetKdfTypeAsync();
                     var kdfIterations = await _stateService.GetKdfIterationsAsync();
+                    var kdfMemory = await _stateService.GetKdfMemoryAsync();
+                    var kdfParallelism = await _stateService.GetKdfParallelismAsync();
                     var email = await _stateService.GetEmailAsync();
                     var pinKey = await _cryptoService.MakePinKeyAysnc(pin, email,
                         kdf.GetValueOrDefault(Core.Enums.KdfType.PBKDF2_SHA256),
-                        kdfIterations.GetValueOrDefault(5000));
+                        kdfIterations.GetValueOrDefault(5000), kdfMemory, kdfParallelism);
                     var key = await _cryptoService.GetKeyAsync();
                     var pinProtectedKey = await _cryptoService.EncryptAsync(key.Key, pinKey);
 

--- a/src/Core/Abstractions/ICryptoService.cs
+++ b/src/Core/Abstractions/ICryptoService.cs
@@ -36,10 +36,10 @@ namespace Bit.Core.Abstractions
         Task<string> HashPasswordAsync(string password, SymmetricCryptoKey key, HashPurpose hashPurpose = HashPurpose.ServerAuthorization);
         Task<bool> HasKeyAsync(string userId = null);
         Task<Tuple<SymmetricCryptoKey, EncString>> MakeEncKeyAsync(SymmetricCryptoKey key);
-        Task<SymmetricCryptoKey> MakeKeyAsync(string password, string salt, KdfType? kdf, int? kdfIterations, int? kdfMemory, int? kdfParallelism);
-        Task<SymmetricCryptoKey> MakeKeyFromPinAsync(string pin, string salt, KdfType kdf, int kdfIterations, int? kdfMemory, int? kdfParallelism, EncString protectedKeyEs = null);
+        Task<SymmetricCryptoKey> MakeKeyAsync(string password, string salt, KdfConfig config);
+        Task<SymmetricCryptoKey> MakeKeyFromPinAsync(string pin, string salt, KdfConfig config, EncString protectedKeyEs = null);
         Task<Tuple<string, EncString>> MakeKeyPairAsync(SymmetricCryptoKey key = null);
-        Task<SymmetricCryptoKey> MakePinKeyAysnc(string pin, string salt, KdfType kdf, int kdfIterations, int? kdfMemory, int? kdfParallelism);
+        Task<SymmetricCryptoKey> MakePinKeyAysnc(string pin, string salt, KdfConfig config);
         Task<Tuple<EncString, SymmetricCryptoKey>> MakeShareKeyAsync();
         Task<SymmetricCryptoKey> MakeSendKeyAsync(byte[] keyMaterial);
         Task<int> RandomNumberAsync(int min, int max);

--- a/src/Core/Abstractions/ICryptoService.cs
+++ b/src/Core/Abstractions/ICryptoService.cs
@@ -36,11 +36,10 @@ namespace Bit.Core.Abstractions
         Task<string> HashPasswordAsync(string password, SymmetricCryptoKey key, HashPurpose hashPurpose = HashPurpose.ServerAuthorization);
         Task<bool> HasKeyAsync(string userId = null);
         Task<Tuple<SymmetricCryptoKey, EncString>> MakeEncKeyAsync(SymmetricCryptoKey key);
-        Task<SymmetricCryptoKey> MakeKeyAsync(string password, string salt, KdfType? kdf, int? kdfIterations);
-        Task<SymmetricCryptoKey> MakeKeyFromPinAsync(string pin, string salt, KdfType kdf, int kdfIterations,
-            EncString protectedKeyEs = null);
+        Task<SymmetricCryptoKey> MakeKeyAsync(string password, string salt, KdfType? kdf, int? kdfIterations, int? kdfMemory, int? kdfParallelism);
+        Task<SymmetricCryptoKey> MakeKeyFromPinAsync(string pin, string salt, KdfType kdf, int kdfIterations, int? kdfMemory, int? kdfParallelism, EncString protectedKeyEs = null);
         Task<Tuple<string, EncString>> MakeKeyPairAsync(SymmetricCryptoKey key = null);
-        Task<SymmetricCryptoKey> MakePinKeyAysnc(string pin, string salt, KdfType kdf, int kdfIterations);
+        Task<SymmetricCryptoKey> MakePinKeyAysnc(string pin, string salt, KdfType kdf, int kdfIterations, int? kdfMemory, int? kdfParallelism);
         Task<Tuple<EncString, SymmetricCryptoKey>> MakeShareKeyAsync();
         Task<SymmetricCryptoKey> MakeSendKeyAsync(byte[] keyMaterial);
         Task<int> RandomNumberAsync(int min, int max);

--- a/src/Core/Abstractions/IStateService.cs
+++ b/src/Core/Abstractions/IStateService.cs
@@ -41,6 +41,10 @@ namespace Bit.Core.Abstractions
         Task SetKdfTypeAsync(KdfType? value, string userId = null);
         Task<int?> GetKdfIterationsAsync(string userId = null);
         Task SetKdfIterationsAsync(int? value, string userId = null);
+        Task<int?> GetKdfMemoryAsync(string userId = null);
+        Task SetKdfMemoryAsync(int? value, string userId = null);
+        Task<int?> GetKdfParallelismAsync(string userId = null);
+        Task SetKdfParallelismAsync(int? value, string userId = null);
         Task<string> GetKeyEncryptedAsync(string userId = null);
         Task SetKeyEncryptedAsync(string value, string userId = null);
         Task<SymmetricCryptoKey> GetKeyDecryptedAsync(string userId = null);

--- a/src/Core/Abstractions/IStateService.cs
+++ b/src/Core/Abstractions/IStateService.cs
@@ -37,14 +37,7 @@ namespace Bit.Core.Abstractions
         Task SetPinProtectedAsync(string value, string userId = null);
         Task<EncString> GetPinProtectedKeyAsync(string userId = null);
         Task SetPinProtectedKeyAsync(EncString value, string userId = null);
-        Task<KdfType?> GetKdfTypeAsync(string userId = null);
-        Task SetKdfTypeAsync(KdfType? value, string userId = null);
-        Task<int?> GetKdfIterationsAsync(string userId = null);
-        Task SetKdfIterationsAsync(int? value, string userId = null);
-        Task<int?> GetKdfMemoryAsync(string userId = null);
-        Task SetKdfMemoryAsync(int? value, string userId = null);
-        Task<int?> GetKdfParallelismAsync(string userId = null);
-        Task SetKdfParallelismAsync(int? value, string userId = null);
+        Task SetKdfConfigurationAsync(KdfConfig config, string userId = null);
         Task<string> GetKeyEncryptedAsync(string userId = null);
         Task SetKeyEncryptedAsync(string value, string userId = null);
         Task<SymmetricCryptoKey> GetKeyDecryptedAsync(string userId = null);

--- a/src/Core/Constants.cs
+++ b/src/Core/Constants.cs
@@ -47,6 +47,9 @@
         public const int TotpDefaultTimer = 30;
         public const int PasswordlessNotificationTimeoutInMinutes = 15;
         public const int KdfIterations = 600000;
+        public const int Argon2Iterations = 2;
+        public const int Argon2Memory = 19;
+        public const int Argon2Parallelism = 1;
         public const int MasterPasswordMinimumChars = 8;
 
         public static readonly string[] AndroidAllClearCipherCacheKeys =

--- a/src/Core/Constants.cs
+++ b/src/Core/Constants.cs
@@ -46,10 +46,10 @@
         public const int SaveFileRequestCode = 44;
         public const int TotpDefaultTimer = 30;
         public const int PasswordlessNotificationTimeoutInMinutes = 15;
-        public const int KdfIterations = 600000;
-        public const int Argon2Iterations = 2;
-        public const int Argon2Memory = 19;
-        public const int Argon2Parallelism = 1;
+        public const int Pbkdf2Iterations = 600000;
+        public const int Argon2Iterations = 3;
+        public const int Argon2MemoryInMB = 64;
+        public const int Argon2Parallelism = 4;
         public const int MasterPasswordMinimumChars = 8;
 
         public static readonly string[] AndroidAllClearCipherCacheKeys =

--- a/src/Core/Models/Domain/Account.cs
+++ b/src/Core/Models/Domain/Account.cs
@@ -46,6 +46,8 @@ namespace Bit.Core.Models.Domain
                 OrgIdentifier = copy.OrgIdentifier;
                 KdfType = copy.KdfType;
                 KdfIterations = copy.KdfIterations;
+                KdfMemory = copy.KdfMemory;
+                KdfParallelism = copy.KdfParallelism;
                 EmailVerified = copy.EmailVerified;
                 HasPremiumPersonally = copy.HasPremiumPersonally;
                 AvatarColor = copy.AvatarColor;
@@ -59,6 +61,8 @@ namespace Bit.Core.Models.Domain
             public string AvatarColor;
             public KdfType? KdfType;
             public int? KdfIterations;
+            public int? KdfMemory;
+            public int? KdfParallelism;
             public bool? EmailVerified;
             public bool? HasPremiumPersonally;
         }

--- a/src/Core/Models/Domain/KdfConfiguration.cs
+++ b/src/Core/Models/Domain/KdfConfiguration.cs
@@ -1,5 +1,6 @@
 ﻿using Bit.Core.Enums;
 using Bit.Core.Models.Domain;
+
 public struct KdfConfig
 {
     public KdfConfig(KdfType? type, int? iterations, int? memory, int? parallelism)

--- a/src/Core/Models/Domain/KdfConfiguration.cs
+++ b/src/Core/Models/Domain/KdfConfiguration.cs
@@ -1,0 +1,25 @@
+﻿using Bit.Core.Enums;
+using Bit.Core.Models.Domain;
+public struct KdfConfig
+{
+    public KdfConfig(KdfType? type, int? iterations, int? memory, int? parallelism)
+    {
+        Type = type;
+        Iterations = iterations;
+        Memory = memory;
+        Parallelism = parallelism;
+    }
+
+    public KdfConfig(Account.AccountProfile profile)
+    {
+        Type = profile.KdfType;
+        Iterations = profile.KdfIterations;
+        Memory = profile.KdfMemory;
+        Parallelism = profile.KdfParallelism;
+    }
+
+    public KdfType? Type { get; set; }
+    public int? Iterations { get; set; }
+    public int? Memory { get; set; }
+    public int? Parallelism { get; set; }
+}

--- a/src/Core/Models/Domain/KdfConfiguration.cs
+++ b/src/Core/Models/Domain/KdfConfiguration.cs
@@ -1,8 +1,9 @@
-﻿using Bit.Core.Enums;
+﻿using Bit.Core;
+using Bit.Core.Enums;
 using Bit.Core.Models.Domain;
-
 public struct KdfConfig
 {
+    public static KdfConfig Default = new KdfConfig(KdfType.PBKDF2_SHA256, 5000, null, null);
     public KdfConfig(KdfType? type, int? iterations, int? memory, int? parallelism)
     {
         Type = type;

--- a/src/Core/Models/Request/RegisterRequest.cs
+++ b/src/Core/Models/Request/RegisterRequest.cs
@@ -15,6 +15,8 @@ namespace Bit.Core.Models.Request
         public Guid? OrganizationUserId { get; set; }
         public KdfType? Kdf { get; set; }
         public int? KdfIterations { get; set; }
+        public int? KdfMemory { get; set; }
+        public int? KdfParallelism { get; set; }
         public string CaptchaResponse { get; set; }
     }
 }

--- a/src/Core/Models/Request/SetKeyConnectorKeyRequest.cs
+++ b/src/Core/Models/Request/SetKeyConnectorKeyRequest.cs
@@ -7,7 +7,7 @@ namespace Bit.Core.Models.Request
     {
         public string Key { get; set; }
         public KeysRequest Keys { get; set; }
-        public KdfType? Kdf { get; set; }
+        public KdfType Kdf { get; set; }
         public int? KdfIterations { get; set; }
         public int? KdfMemory { get; set; }
         public int? KdfParallelism { get; set; }
@@ -17,7 +17,7 @@ namespace Bit.Core.Models.Request
         {
             this.Key = key;
             this.Keys = keys;
-            this.Kdf = kdfConfig.Type;
+            this.Kdf = kdfConfig.Type.GetValueOrDefault(KdfType.PBKDF2_SHA256);
             this.KdfIterations = kdfConfig.Iterations;
             this.KdfMemory = kdfConfig.Memory;
             this.KdfParallelism = kdfConfig.Parallelism;

--- a/src/Core/Models/Request/SetKeyConnectorKeyRequest.cs
+++ b/src/Core/Models/Request/SetKeyConnectorKeyRequest.cs
@@ -7,7 +7,7 @@ namespace Bit.Core.Models.Request
     {
         public string Key { get; set; }
         public KeysRequest Keys { get; set; }
-        public KdfType Kdf { get; set; }
+        public KdfType? Kdf { get; set; }
         public int? KdfIterations { get; set; }
         public int? KdfMemory { get; set; }
         public int? KdfParallelism { get; set; }
@@ -17,7 +17,7 @@ namespace Bit.Core.Models.Request
         {
             this.Key = key;
             this.Keys = keys;
-            this.Kdf = kdfConfig.Type.GetValueOrDefault(KdfType.PBKDF2_SHA256);
+            this.Kdf = kdfConfig.Type;
             this.KdfIterations = kdfConfig.Iterations;
             this.KdfMemory = kdfConfig.Memory;
             this.KdfParallelism = kdfConfig.Parallelism;

--- a/src/Core/Models/Request/SetKeyConnectorKeyRequest.cs
+++ b/src/Core/Models/Request/SetKeyConnectorKeyRequest.cs
@@ -13,15 +13,14 @@ namespace Bit.Core.Models.Request
         public int? KdfParallelism { get; set; }
         public string OrgIdentifier { get; set; }
 
-        public SetKeyConnectorKeyRequest(string key, KeysRequest keys,
-            KdfType kdf, int? kdfIterations, int? kdfMemory, int? kdfParallelism, string orgIdentifier)
+        public SetKeyConnectorKeyRequest(string key, KeysRequest keys, KdfConfig kdfConfig, string orgIdentifier)
         {
             this.Key = key;
             this.Keys = keys;
-            this.Kdf = kdf;
-            this.KdfIterations = kdfIterations;
-            this.KdfMemory = kdfMemory;
-            this.KdfParallelism = kdfParallelism;
+            this.Kdf = kdfConfig.Type.GetValueOrDefault(KdfType.PBKDF2_SHA256);
+            this.KdfIterations = kdfConfig.Iterations;
+            this.KdfMemory = kdfConfig.Memory;
+            this.KdfParallelism = kdfConfig.Parallelism;
             this.OrgIdentifier = orgIdentifier;
         }
     }

--- a/src/Core/Models/Request/SetKeyConnectorKeyRequest.cs
+++ b/src/Core/Models/Request/SetKeyConnectorKeyRequest.cs
@@ -9,15 +9,19 @@ namespace Bit.Core.Models.Request
         public KeysRequest Keys { get; set; }
         public KdfType Kdf { get; set; }
         public int? KdfIterations { get; set; }
+        public int? KdfMemory { get; set; }
+        public int? KdfParallelism { get; set; }
         public string OrgIdentifier { get; set; }
 
         public SetKeyConnectorKeyRequest(string key, KeysRequest keys,
-            KdfType kdf, int? kdfIterations, string orgIdentifier)
+            KdfType kdf, int? kdfIterations, int? kdfMemory, int? kdfParallelism, string orgIdentifier)
         {
             this.Key = key;
             this.Keys = keys;
             this.Kdf = kdf;
             this.KdfIterations = kdfIterations;
+            this.KdfMemory = kdfMemory;
+            this.KdfParallelism = kdfParallelism;
             this.OrgIdentifier = orgIdentifier;
         }
     }

--- a/src/Core/Models/Request/SetPasswordRequest.cs
+++ b/src/Core/Models/Request/SetPasswordRequest.cs
@@ -10,6 +10,8 @@ namespace Bit.Core.Models.Request
         public KeysRequest Keys { get; set; }
         public KdfType Kdf { get; set; }
         public int KdfIterations { get; set; }
+        public int KdfMemory { get; set; }
+        public int KdfParallelism { get; set; }
         public string OrgIdentifier { get; set; }
     }
 }

--- a/src/Core/Models/Request/SetPasswordRequest.cs
+++ b/src/Core/Models/Request/SetPasswordRequest.cs
@@ -10,8 +10,8 @@ namespace Bit.Core.Models.Request
         public KeysRequest Keys { get; set; }
         public KdfType Kdf { get; set; }
         public int KdfIterations { get; set; }
-        public int KdfMemory { get; set; }
-        public int KdfParallelism { get; set; }
+        public int? KdfMemory { get; set; }
+        public int? KdfParallelism { get; set; }
         public string OrgIdentifier { get; set; }
     }
 }

--- a/src/Core/Models/Response/IdentityTokenResponse.cs
+++ b/src/Core/Models/Response/IdentityTokenResponse.cs
@@ -24,5 +24,7 @@ namespace Bit.Core.Models.Response
         public int? KdfParallelism { get; set; }
         public bool ForcePasswordReset { get; set; }
         public string KeyConnectorUrl { get; set; }
+        [JsonIgnore]
+        public KdfConfig KdfConfig => new KdfConfig(Kdf, KdfIterations, KdfMemory, KdfParallelism);
     }
 }

--- a/src/Core/Models/Response/IdentityTokenResponse.cs
+++ b/src/Core/Models/Response/IdentityTokenResponse.cs
@@ -20,6 +20,8 @@ namespace Bit.Core.Models.Response
         public string TwoFactorToken { get; set; }
         public KdfType Kdf { get; set; }
         public int? KdfIterations { get; set; }
+        public int? KdfMemory { get; set; }
+        public int? KdfParallelism { get; set; }
         public bool ForcePasswordReset { get; set; }
         public string KeyConnectorUrl { get; set; }
     }

--- a/src/Core/Models/Response/PreloginResponse.cs
+++ b/src/Core/Models/Response/PreloginResponse.cs
@@ -1,4 +1,5 @@
 ﻿using Bit.Core.Enums;
+using Newtonsoft.Json;
 
 namespace Bit.Core.Models.Response
 {
@@ -8,5 +9,7 @@ namespace Bit.Core.Models.Response
         public int KdfIterations { get; set; }
         public int? KdfMemory { get; set; }
         public int? KdfParallelism { get; set; }
+        [JsonIgnore]
+        public KdfConfig KdfConfig => new KdfConfig(Kdf, KdfIterations, KdfMemory, KdfParallelism);
     }
 }

--- a/src/Core/Models/Response/PreloginResponse.cs
+++ b/src/Core/Models/Response/PreloginResponse.cs
@@ -6,5 +6,7 @@ namespace Bit.Core.Models.Response
     {
         public KdfType Kdf { get; set; }
         public int KdfIterations { get; set; }
+        public int? KdfMemory { get; set; }
+        public int? KdfParallelism { get; set; }
     }
 }

--- a/src/Core/Services/AuthService.cs
+++ b/src/Core/Services/AuthService.cs
@@ -282,7 +282,7 @@ namespace Bit.Core.Services
                 var preloginResponse = await _apiService.PostPreloginAsync(new PreloginRequest { Email = email });
                 if (preloginResponse != null)
                 {
-                    kdfConfig = new KdfConfig(preloginResponse.Kdf, preloginResponse.KdfIterations, preloginResponse.KdfMemory, preloginResponse.KdfParallelism);
+                    kdfConfig = preloginResponse.KdfConfig;
                 }
             }
             catch (ApiException e)
@@ -440,8 +440,7 @@ namespace Bit.Core.Services
                 {
                     // SSO Key Connector Onboarding
                     var password = await _cryptoFunctionService.RandomBytesAsync(64);
-                    var kdfConfig = new KdfConfig(tokenResponse.Kdf, tokenResponse.KdfIterations, tokenResponse.KdfMemory, tokenResponse.KdfParallelism);
-                    var k = await _cryptoService.MakeKeyAsync(Convert.ToBase64String(password), _tokenService.GetEmail(), kdfConfig);
+                    var k = await _cryptoService.MakeKeyAsync(Convert.ToBase64String(password), _tokenService.GetEmail(), tokenResponse.KdfConfig);
                     var keyConnectorRequest = new KeyConnectorUserKeyRequest(k.EncKeyB64);
                     await _cryptoService.SetKeyAsync(k);
 
@@ -464,7 +463,7 @@ namespace Bit.Core.Services
                         EncryptedPrivateKey = keyPair.Item2.EncryptedString
                     };
                     var setPasswordRequest = new SetKeyConnectorKeyRequest(
-                        encKey.Item2.EncryptedString, keys, kdfConfig, orgId
+                        encKey.Item2.EncryptedString, keys, tokenResponse.KdfConfig, orgId
                     );
                     await _apiService.PostSetKeyConnectorKey(setPasswordRequest);
                 }

--- a/src/Core/Services/AuthService.cs
+++ b/src/Core/Services/AuthService.cs
@@ -276,7 +276,7 @@ namespace Bit.Core.Services
         private async Task<SymmetricCryptoKey> MakePreloginKeyAsync(string masterPassword, string email)
         {
             email = email.Trim().ToLower();
-            KdfConfig? kdfConfig = null;
+            KdfConfig kdfConfig = KdfConfig.Default;
             try
             {
                 var preloginResponse = await _apiService.PostPreloginAsync(new PreloginRequest { Email = email });
@@ -292,7 +292,7 @@ namespace Bit.Core.Services
                     throw;
                 }
             }
-            return await _cryptoService.MakeKeyAsync(masterPassword, email, kdfConfig.GetValueOrDefault(new KdfConfig(KdfType.PBKDF2_SHA256, 5000, null, null)));
+            return await _cryptoService.MakeKeyAsync(masterPassword, email, kdfConfig);
         }
 
         private async Task<AuthResult> LogInHelperAsync(string email, string hashedPassword, string localHashedPassword,

--- a/src/Core/Services/CryptoService.cs
+++ b/src/Core/Services/CryptoService.cs
@@ -394,16 +394,13 @@ namespace Bit.Core.Services
             byte[] key = null;
             if (kdfConfig.Type == null || kdfConfig.Type == KdfType.PBKDF2_SHA256)
             {
-                if (kdfConfig.Iterations == null)
-                {
-                    kdfConfig.Iterations = 5000;
-                }
-                if (kdfConfig.Iterations < 5000)
+                var iterations = kdfConfig.Iterations.GetValueOrDefault(5000);
+                if (iterations < 5000)
                 {
                     throw new Exception("PBKDF2 iteration minimum is 5000.");
                 }
                 key = await _cryptoFunctionService.Pbkdf2Async(password, salt,
-                    CryptoHashAlgorithm.Sha256, kdfConfig.Iterations.Value);
+                    CryptoHashAlgorithm.Sha256, iterations);
             }
             else if (kdfConfig.Type == KdfType.Argon2id)
             {
@@ -430,7 +427,8 @@ namespace Bit.Core.Services
                     throw new Exception("Argon2 parallelism minimum is 1");
                 }
 
-                key = await _cryptoFunctionService.Argon2Async(password, salt, iterations, memory, parallelism);
+                var saltHash = await _cryptoFunctionService.HashAsync(salt, CryptoHashAlgorithm.Sha256);
+                key = await _cryptoFunctionService.Argon2Async(password, saltHash, iterations, memory, parallelism);
             }
             else
             {

--- a/src/Core/Services/CryptoService.cs
+++ b/src/Core/Services/CryptoService.cs
@@ -407,39 +407,28 @@ namespace Bit.Core.Services
             }
             else if (kdfConfig.Type == KdfType.Argon2id)
             {
-                if (kdfConfig.Iterations == null)
-                {
-                    kdfConfig.Iterations = Constants.Argon2Iterations;
-                }
+                var iterations = kdfConfig.Iterations.GetValueOrDefault(Constants.Argon2Iterations);
+                var memory = kdfConfig.Memory.GetValueOrDefault(Constants.Argon2MemoryInMB) * 1024;
+                var parallelism = kdfConfig.Parallelism.GetValueOrDefault(Constants.Argon2Parallelism);
+
                 if (kdfConfig.Iterations < 2)
                 {
                     throw new Exception("Argon2 iterations minimum is 2");
                 }
 
-                if (kdfConfig.Memory == null)
-                {
-                    kdfConfig.Memory = Constants.Argon2MemoryInMB;
-                }
                 if (kdfConfig.Memory < 16)
                 {
                     throw new Exception("Argon2 memory minimum is 16 MB");
-                } else if (kdfConfig.Memory > 1024)
+                }
+                else if (kdfConfig.Memory > 1024)
                 {
                     throw new Exception("Argon2 memory maximum is 1024 MB");
                 }
 
-                if (kdfConfig.Parallelism == null)
-                {
-                    kdfConfig.Parallelism = Constants.Argon2Parallelism;
-                } 
-                else if (kdfConfig.Parallelism < 1)
+                if (kdfConfig.Parallelism < 1)
                 {
                     throw new Exception("Argon2 parallelism minimum is 1");
                 }
-
-                var iterations = kdfConfig.Iterations.GetValueOrDefault(Constants.Argon2Iterations);
-                var memory = kdfConfig.Memory.GetValueOrDefault(Constants.Argon2MemoryInMB) * 1024;
-                var parallelism = kdfConfig.Parallelism.GetValueOrDefault(Constants.Argon2Parallelism);
 
                 key = await _cryptoFunctionService.Argon2Async(password, salt, iterations, memory, parallelism);
             }

--- a/src/Core/Services/CryptoService.cs
+++ b/src/Core/Services/CryptoService.cs
@@ -9,7 +9,6 @@ using Bit.Core.Enums;
 using Bit.Core.Models.Domain;
 using Bit.Core.Models.Response;
 using Bit.Core.Utilities;
-using static System.Net.WebRequestMethods;
 
 namespace Bit.Core.Services
 {

--- a/src/Core/Services/CryptoService.cs
+++ b/src/Core/Services/CryptoService.cs
@@ -418,7 +418,7 @@ namespace Bit.Core.Services
 
                 if (kdfConfig.Memory == null)
                 {
-                    kdfConfig.Memory = Constants.Argon2Memory;
+                    kdfConfig.Memory = Constants.Argon2MemoryInMB;
                 }
                 if (kdfConfig.Memory < 16)
                 {
@@ -438,7 +438,7 @@ namespace Bit.Core.Services
                 }
 
                 var iterations = kdfConfig.Iterations.GetValueOrDefault(Constants.Argon2Iterations);
-                var memory = kdfConfig.Memory.GetValueOrDefault(Constants.Argon2Memory) * 1024;
+                var memory = kdfConfig.Memory.GetValueOrDefault(Constants.Argon2MemoryInMB) * 1024;
                 var parallelism = kdfConfig.Parallelism.GetValueOrDefault(Constants.Argon2Parallelism);
 
                 key = await _cryptoFunctionService.Argon2Async(password, salt, iterations, memory, parallelism);

--- a/src/Core/Services/CryptoService.cs
+++ b/src/Core/Services/CryptoService.cs
@@ -407,6 +407,36 @@ namespace Bit.Core.Services
             }
             else if (kdfConfig.Type == KdfType.Argon2id)
             {
+                if (kdfConfig.Iterations == null)
+                {
+                    kdfConfig.Iterations = Constants.Argon2Iterations;
+                }
+                if (kdfConfig.Iterations < 2)
+                {
+                    throw new Exception("Argon2 iterations minimum is 2");
+                }
+
+                if (kdfConfig.Memory == null)
+                {
+                    kdfConfig.Memory = Constants.Argon2Memory;
+                }
+                if (kdfConfig.Memory < 16)
+                {
+                    throw new Exception("Argon2 memory minimum is 16 MB");
+                } else if (kdfConfig.Memory > 1024)
+                {
+                    throw new Exception("Argon2 memory maximum is 1024 MB");
+                }
+
+                if (kdfConfig.Parallelism == null)
+                {
+                    kdfConfig.Parallelism = Constants.Argon2Parallelism;
+                } 
+                else if (kdfConfig.Parallelism < 1)
+                {
+                    throw new Exception("Argon2 parallelism minimum is 1");
+                }
+
                 var iterations = kdfConfig.Iterations.GetValueOrDefault(Constants.Argon2Iterations);
                 var memory = kdfConfig.Memory.GetValueOrDefault(Constants.Argon2Memory) * 1024;
                 var parallelism = kdfConfig.Parallelism.GetValueOrDefault(Constants.Argon2Parallelism);

--- a/src/Core/Services/PclCryptoFunctionService.cs
+++ b/src/Core/Services/PclCryptoFunctionService.cs
@@ -49,18 +49,15 @@ namespace Bit.Core.Services
             password = NormalizePassword(password);
             return Argon2Async(Encoding.UTF8.GetBytes(password), Encoding.UTF8.GetBytes(salt), iterations, memory, parallelism);
         }
-
         public Task<byte[]> Argon2Async(byte[] password, string salt, int iterations, int memory, int parallelism)
         {
             return Argon2Async(password, Encoding.UTF8.GetBytes(salt), iterations, memory, parallelism);
         }
-
         public Task<byte[]> Argon2Async(string password, byte[] salt, int iterations, int memory, int parallelism)
         {
             password = NormalizePassword(password);
             return Argon2Async(Encoding.UTF8.GetBytes(password), salt, iterations, memory, parallelism);
         }
-
         public Task<byte[]> Argon2Async(byte[] password, byte[] salt, int iterations, int memory, int parallelism)
         {
             return Task.FromResult(_cryptoPrimitiveService.Argon2id(password, salt, iterations, memory, parallelism));

--- a/src/Core/Services/PclCryptoFunctionService.cs
+++ b/src/Core/Services/PclCryptoFunctionService.cs
@@ -49,15 +49,18 @@ namespace Bit.Core.Services
             password = NormalizePassword(password);
             return Argon2Async(Encoding.UTF8.GetBytes(password), Encoding.UTF8.GetBytes(salt), iterations, memory, parallelism);
         }
+
         public Task<byte[]> Argon2Async(byte[] password, string salt, int iterations, int memory, int parallelism)
         {
             return Argon2Async(password, Encoding.UTF8.GetBytes(salt), iterations, memory, parallelism);
         }
+
         public Task<byte[]> Argon2Async(string password, byte[] salt, int iterations, int memory, int parallelism)
         {
             password = NormalizePassword(password);
             return Argon2Async(Encoding.UTF8.GetBytes(password), salt, iterations, memory, parallelism);
         }
+
         public Task<byte[]> Argon2Async(byte[] password, byte[] salt, int iterations, int memory, int parallelism)
         {
             return Task.FromResult(_cryptoPrimitiveService.Argon2id(password, salt, iterations, memory, parallelism));

--- a/src/Core/Services/StateMigrationService.cs
+++ b/src/Core/Services/StateMigrationService.cs
@@ -115,8 +115,6 @@ namespace Bit.Core.Services
             internal const string Keys_Stamp = "securityStamp";
             internal const string Keys_Kdf = "kdf";
             internal const string Keys_KdfIterations = "kdfIterations";
-            internal const string Keys_KdfMemory = "kdfMemory";
-            internal const string Keys_KdfParallelism = "kdfParallelis";
             internal const string Keys_EmailVerified = "emailVerified";
             internal const string Keys_ForcePasswordReset = "forcePasswordReset";
             internal const string Keys_AccessToken = "accessToken";

--- a/src/Core/Services/StateMigrationService.cs
+++ b/src/Core/Services/StateMigrationService.cs
@@ -162,8 +162,6 @@ namespace Bit.Core.Services
 
             var kdfType = await GetValueAsync<int?>(Storage.LiteDb, V2Keys.Keys_Kdf);
             var kdfIterations = await GetValueAsync<int?>(Storage.LiteDb, V2Keys.Keys_KdfIterations);
-            var kdfMemory = await GetValueAsync<int?>(Storage.LiteDb, V2Keys.Keys_KdfMemory);
-            var kdfParallelism = await GetValueAsync<int?>(Storage.LiteDb, V2Keys.Keys_KdfParallelism);
             var stamp = await GetValueAsync<string>(Storage.LiteDb, V2Keys.Keys_Stamp);
             var emailVerified = await GetValueAsync<bool?>(Storage.LiteDb, V2Keys.Keys_EmailVerified);
             var refreshToken = await GetValueAsync<string>(Storage.LiteDb, V2Keys.Keys_RefreshToken);
@@ -176,8 +174,6 @@ namespace Bit.Core.Services
                     Stamp = stamp,
                     KdfType = (KdfType?)kdfType,
                     KdfIterations = kdfIterations,
-                    KdfMemory = kdfMemory,
-                    KdfParallelism = kdfParallelism,
                     EmailVerified = emailVerified,
                     HasPremiumPersonally = hasPremiumPersonally,
                 },
@@ -280,8 +276,6 @@ namespace Bit.Core.Services
             await RemoveValueAsync(Storage.LiteDb, V2Keys.Keys_RefreshToken);
             await RemoveValueAsync(Storage.LiteDb, V2Keys.Keys_Kdf);
             await RemoveValueAsync(Storage.LiteDb, V2Keys.Keys_KdfIterations);
-            await RemoveValueAsync(Storage.LiteDb, V2Keys.Keys_KdfMemory);
-            await RemoveValueAsync(Storage.LiteDb, V2Keys.Keys_KdfParallelism);
             await RemoveValueAsync(Storage.LiteDb, V2Keys.Keys_Stamp);
             await RemoveValueAsync(Storage.LiteDb, V2Keys.Keys_EmailVerified);
             await RemoveValueAsync(Storage.LiteDb, V2Keys.Keys_ForcePasswordReset);

--- a/src/Core/Services/StateMigrationService.cs
+++ b/src/Core/Services/StateMigrationService.cs
@@ -115,6 +115,8 @@ namespace Bit.Core.Services
             internal const string Keys_Stamp = "securityStamp";
             internal const string Keys_Kdf = "kdf";
             internal const string Keys_KdfIterations = "kdfIterations";
+            internal const string Keys_KdfMemory = "kdfMemory";
+            internal const string Keys_KdfParallelism = "kdfParallelis";
             internal const string Keys_EmailVerified = "emailVerified";
             internal const string Keys_ForcePasswordReset = "forcePasswordReset";
             internal const string Keys_AccessToken = "accessToken";
@@ -162,6 +164,8 @@ namespace Bit.Core.Services
 
             var kdfType = await GetValueAsync<int?>(Storage.LiteDb, V2Keys.Keys_Kdf);
             var kdfIterations = await GetValueAsync<int?>(Storage.LiteDb, V2Keys.Keys_KdfIterations);
+            var kdfMemory = await GetValueAsync<int?>(Storage.LiteDb, V2Keys.Keys_KdfMemory);
+            var kdfParallelism = await GetValueAsync<int?>(Storage.LiteDb, V2Keys.Keys_KdfParallelism);
             var stamp = await GetValueAsync<string>(Storage.LiteDb, V2Keys.Keys_Stamp);
             var emailVerified = await GetValueAsync<bool?>(Storage.LiteDb, V2Keys.Keys_EmailVerified);
             var refreshToken = await GetValueAsync<string>(Storage.LiteDb, V2Keys.Keys_RefreshToken);
@@ -174,6 +178,8 @@ namespace Bit.Core.Services
                     Stamp = stamp,
                     KdfType = (KdfType?)kdfType,
                     KdfIterations = kdfIterations,
+                    KdfMemory = kdfMemory,
+                    KdfParallelism = kdfParallelism,
                     EmailVerified = emailVerified,
                     HasPremiumPersonally = hasPremiumPersonally,
                 },
@@ -276,6 +282,8 @@ namespace Bit.Core.Services
             await RemoveValueAsync(Storage.LiteDb, V2Keys.Keys_RefreshToken);
             await RemoveValueAsync(Storage.LiteDb, V2Keys.Keys_Kdf);
             await RemoveValueAsync(Storage.LiteDb, V2Keys.Keys_KdfIterations);
+            await RemoveValueAsync(Storage.LiteDb, V2Keys.Keys_KdfMemory);
+            await RemoveValueAsync(Storage.LiteDb, V2Keys.Keys_KdfParallelism);
             await RemoveValueAsync(Storage.LiteDb, V2Keys.Keys_Stamp);
             await RemoveValueAsync(Storage.LiteDb, V2Keys.Keys_EmailVerified);
             await RemoveValueAsync(Storage.LiteDb, V2Keys.Keys_ForcePasswordReset);

--- a/src/Core/Services/StateService.cs
+++ b/src/Core/Services/StateService.cs
@@ -371,6 +371,38 @@ namespace Bit.Core.Services
             await SaveAccountAsync(account, reconciledOptions);
         }
 
+        public async Task SetKdfMemoryAsync(int? value, string userId = null)
+        {
+            var reconciledOptions = ReconcileOptions(new StorageOptions { UserId = userId },
+                await GetDefaultStorageOptionsAsync());
+            var account = await GetAccountAsync(reconciledOptions);
+            account.Profile.KdfMemory = value;
+            await SaveAccountAsync(account, reconciledOptions);
+        }
+
+        public async Task<int?> GetKdfMemoryAsync(string userId = null)
+        {
+            return (await GetAccountAsync(
+                ReconcileOptions(new StorageOptions { UserId = userId }, await GetDefaultStorageOptionsAsync())
+            ))?.Profile?.KdfMemory;
+        }
+
+        public async Task<int?> GetKdfParallelismAsync(string userId = null)
+        {
+            return (await GetAccountAsync(
+                ReconcileOptions(new StorageOptions { UserId = userId }, await GetDefaultStorageOptionsAsync())
+            ))?.Profile?.KdfParallelism;
+        }
+
+        public async Task SetKdfParallelismAsync(int? value, string userId = null)
+        {
+            var reconciledOptions = ReconcileOptions(new StorageOptions { UserId = userId },
+                await GetDefaultStorageOptionsAsync());
+            var account = await GetAccountAsync(reconciledOptions);
+            account.Profile.KdfParallelism = value;
+            await SaveAccountAsync(account, reconciledOptions);
+        }
+
         public async Task<string> GetKeyEncryptedAsync(string userId = null)
         {
             var reconciledOptions = ReconcileOptions(new StorageOptions { UserId = userId },

--- a/src/Core/Services/StateService.cs
+++ b/src/Core/Services/StateService.cs
@@ -339,67 +339,15 @@ namespace Bit.Core.Services
             await SaveAccountAsync(account, reconciledOptions);
         }
 
-        public async Task<KdfType?> GetKdfTypeAsync(string userId = null)
-        {
-            return (await GetAccountAsync(
-                ReconcileOptions(new StorageOptions { UserId = userId }, await GetDefaultStorageOptionsAsync())
-            ))?.Profile?.KdfType;
-        }
-
-        public async Task SetKdfTypeAsync(KdfType? value, string userId = null)
+        public async Task SetKdfConfigurationAsync(KdfConfig config, string userId = null)
         {
             var reconciledOptions = ReconcileOptions(new StorageOptions { UserId = userId },
                 await GetDefaultStorageOptionsAsync());
             var account = await GetAccountAsync(reconciledOptions);
-            account.Profile.KdfType = value;
-            await SaveAccountAsync(account, reconciledOptions);
-        }
-
-        public async Task<int?> GetKdfIterationsAsync(string userId = null)
-        {
-            return (await GetAccountAsync(
-                ReconcileOptions(new StorageOptions { UserId = userId }, await GetDefaultStorageOptionsAsync())
-            ))?.Profile?.KdfIterations;
-        }
-
-        public async Task SetKdfIterationsAsync(int? value, string userId = null)
-        {
-            var reconciledOptions = ReconcileOptions(new StorageOptions { UserId = userId },
-                await GetDefaultStorageOptionsAsync());
-            var account = await GetAccountAsync(reconciledOptions);
-            account.Profile.KdfIterations = value;
-            await SaveAccountAsync(account, reconciledOptions);
-        }
-
-        public async Task SetKdfMemoryAsync(int? value, string userId = null)
-        {
-            var reconciledOptions = ReconcileOptions(new StorageOptions { UserId = userId },
-                await GetDefaultStorageOptionsAsync());
-            var account = await GetAccountAsync(reconciledOptions);
-            account.Profile.KdfMemory = value;
-            await SaveAccountAsync(account, reconciledOptions);
-        }
-
-        public async Task<int?> GetKdfMemoryAsync(string userId = null)
-        {
-            return (await GetAccountAsync(
-                ReconcileOptions(new StorageOptions { UserId = userId }, await GetDefaultStorageOptionsAsync())
-            ))?.Profile?.KdfMemory;
-        }
-
-        public async Task<int?> GetKdfParallelismAsync(string userId = null)
-        {
-            return (await GetAccountAsync(
-                ReconcileOptions(new StorageOptions { UserId = userId }, await GetDefaultStorageOptionsAsync())
-            ))?.Profile?.KdfParallelism;
-        }
-
-        public async Task SetKdfParallelismAsync(int? value, string userId = null)
-        {
-            var reconciledOptions = ReconcileOptions(new StorageOptions { UserId = userId },
-                await GetDefaultStorageOptionsAsync());
-            var account = await GetAccountAsync(reconciledOptions);
-            account.Profile.KdfParallelism = value;
+            account.Profile.KdfType = config.Type;
+            account.Profile.KdfIterations = config.Iterations;
+            account.Profile.KdfMemory = config.Memory;
+            account.Profile.KdfParallelism = config.Parallelism;
             await SaveAccountAsync(account, reconciledOptions);
         }
 

--- a/src/iOS.Core/Controllers/LockPasswordViewController.cs
+++ b/src/iOS.Core/Controllers/LockPasswordViewController.cs
@@ -210,10 +210,7 @@ namespace Bit.iOS.Core.Controllers
             }
 
             var email = await _stateService.GetEmailAsync();
-            var kdf = await _stateService.GetKdfTypeAsync();
-            var kdfIterations = await _stateService.GetKdfIterationsAsync();
-            var kdfMemory = await _stateService.GetKdfMemoryAsync();
-            var kdfParallelism = await _stateService.GetKdfParallelismAsync();
+            var kdfConfig = await _stateService.GetActiveUserCustomDataAsync(a => new KdfConfig(a?.Profile));
             var inputtedValue = MasterPasswordCell.TextField.Text;
 
             if (_pinLock)
@@ -224,8 +221,7 @@ namespace Bit.iOS.Core.Controllers
                     if (_isPinProtected)
                     {
                         var key = await _cryptoService.MakeKeyFromPinAsync(inputtedValue, email,
-                            kdf.GetValueOrDefault(KdfType.PBKDF2_SHA256), kdfIterations.GetValueOrDefault(5000),
-                            kdfMemory, kdfParallelism,
+                            kdfConfig,
                             await _stateService.GetPinProtectedKeyAsync());
                         var encKey = await _cryptoService.GetEncKeyAsync(key);
                         var protectedPin = await _stateService.GetProtectedPinAsync();
@@ -240,7 +236,7 @@ namespace Bit.iOS.Core.Controllers
                     else
                     {
                         var key2 = await _cryptoService.MakeKeyFromPinAsync(inputtedValue, email,
-                            kdf.GetValueOrDefault(KdfType.PBKDF2_SHA256), kdfIterations.GetValueOrDefault(5000), kdfMemory, kdfParallelism);
+                            kdfConfig);
                         failed = false;
                         await AppHelpers.ResetInvalidUnlockAttemptsAsync();
                         await SetKeyAndContinueAsync(key2);
@@ -263,7 +259,7 @@ namespace Bit.iOS.Core.Controllers
             }
             else
             {
-                var key2 = await _cryptoService.MakeKeyAsync(inputtedValue, email, kdf, kdfIterations, kdfMemory, kdfParallelism);
+                var key2 = await _cryptoService.MakeKeyAsync(inputtedValue, email, kdfConfig);
                 
                 var storedKeyHash = await _cryptoService.GetKeyHashAsync();
                 if (storedKeyHash == null)
@@ -285,7 +281,7 @@ namespace Bit.iOS.Core.Controllers
                         var encKey = await _cryptoService.GetEncKeyAsync(key2);
                         var decPin = await _cryptoService.DecryptToUtf8Async(new EncString(protectedPin), encKey);
                         var pinKey = await _cryptoService.MakePinKeyAysnc(decPin, email,
-                            kdf.GetValueOrDefault(KdfType.PBKDF2_SHA256), kdfIterations.GetValueOrDefault(5000), kdfMemory, kdfParallelism);
+                           kdfConfig);
                         await _stateService.SetPinProtectedKeyAsync(await _cryptoService.EncryptAsync(key2.Key, pinKey));
                     }
                     await AppHelpers.ResetInvalidUnlockAttemptsAsync();

--- a/src/iOS.Core/Controllers/LockPasswordViewController.cs
+++ b/src/iOS.Core/Controllers/LockPasswordViewController.cs
@@ -212,6 +212,8 @@ namespace Bit.iOS.Core.Controllers
             var email = await _stateService.GetEmailAsync();
             var kdf = await _stateService.GetKdfTypeAsync();
             var kdfIterations = await _stateService.GetKdfIterationsAsync();
+            var kdfMemory = await _stateService.GetKdfMemoryAsync();
+            var kdfParallelism = await _stateService.GetKdfParallelismAsync();
             var inputtedValue = MasterPasswordCell.TextField.Text;
 
             if (_pinLock)
@@ -223,6 +225,7 @@ namespace Bit.iOS.Core.Controllers
                     {
                         var key = await _cryptoService.MakeKeyFromPinAsync(inputtedValue, email,
                             kdf.GetValueOrDefault(KdfType.PBKDF2_SHA256), kdfIterations.GetValueOrDefault(5000),
+                            kdfMemory, kdfParallelism,
                             await _stateService.GetPinProtectedKeyAsync());
                         var encKey = await _cryptoService.GetEncKeyAsync(key);
                         var protectedPin = await _stateService.GetProtectedPinAsync();
@@ -237,7 +240,7 @@ namespace Bit.iOS.Core.Controllers
                     else
                     {
                         var key2 = await _cryptoService.MakeKeyFromPinAsync(inputtedValue, email,
-                            kdf.GetValueOrDefault(KdfType.PBKDF2_SHA256), kdfIterations.GetValueOrDefault(5000));
+                            kdf.GetValueOrDefault(KdfType.PBKDF2_SHA256), kdfIterations.GetValueOrDefault(5000), kdfMemory, kdfParallelism);
                         failed = false;
                         await AppHelpers.ResetInvalidUnlockAttemptsAsync();
                         await SetKeyAndContinueAsync(key2);
@@ -260,7 +263,7 @@ namespace Bit.iOS.Core.Controllers
             }
             else
             {
-                var key2 = await _cryptoService.MakeKeyAsync(inputtedValue, email, kdf, kdfIterations);
+                var key2 = await _cryptoService.MakeKeyAsync(inputtedValue, email, kdf, kdfIterations, kdfMemory, kdfParallelism);
                 
                 var storedKeyHash = await _cryptoService.GetKeyHashAsync();
                 if (storedKeyHash == null)
@@ -282,7 +285,7 @@ namespace Bit.iOS.Core.Controllers
                         var encKey = await _cryptoService.GetEncKeyAsync(key2);
                         var decPin = await _cryptoService.DecryptToUtf8Async(new EncString(protectedPin), encKey);
                         var pinKey = await _cryptoService.MakePinKeyAysnc(decPin, email,
-                            kdf.GetValueOrDefault(KdfType.PBKDF2_SHA256), kdfIterations.GetValueOrDefault(5000));
+                            kdf.GetValueOrDefault(KdfType.PBKDF2_SHA256), kdfIterations.GetValueOrDefault(5000), kdfMemory, kdfParallelism);
                         await _stateService.SetPinProtectedKeyAsync(await _cryptoService.EncryptAsync(key2.Key, pinKey));
                     }
                     await AppHelpers.ResetInvalidUnlockAttemptsAsync();


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
This PR adds configuration option support for the argon2 kdf.


## Code changes
For all files: Basically anywhere where kdfIterations / kdfType is used (in requests, stateservice) we simply add the optional variables kdfMemory and kdfParalleism. The defaults are: 64 (MiB) for memory and 4 parallelism.

This reopens mistakenly closed: https://github.com/bitwarden/mobile/pull/2322

I just applied the commit as a patch on the latest master, though there were 2 errors, which I can check in ~2 hours.