### PR TITLE
[PS-2330][PS-2329][PS-2332][PS-2333] Checking for username terms on Android Autofill

### DIFF
--- a/src/Android/Autofill/FieldCollection.cs
+++ b/src/Android/Autofill/FieldCollection.cs
@@ -12,6 +12,7 @@ namespace Bit.Droid.Autofill
         private List<Field> _passwordFields = null;
         private List<Field> _usernameFields = null;
         private HashSet<string> _ignoreSearchTerms = new HashSet<string> { "search", "find", "recipient", "edit" };
+        private HashSet<string> _usernameTerms = new HashSet<string> { "email", "phone", "username"};
         private HashSet<string> _passwordTerms = new HashSet<string> { "password", "pswd" };
 
         public List<AutofillId> AutofillIds { get; private set; } = new List<AutofillId>();
@@ -97,6 +98,11 @@ namespace Bit.Droid.Autofill
                         {
                             _usernameFields.Add(usernameField);
                         }
+                    }
+
+                    if (!_usernameFields.Any())
+                    {
+                        _usernameFields = Fields.Where(f => FieldHasUsernameTerms(f)).ToList();
                     }
                 }
                 return _usernameFields;
@@ -321,12 +327,17 @@ namespace Bit.Droid.Autofill
             }
 
             return inputTypePassword && !ValueContainsAnyTerms(f.IdEntry, _ignoreSearchTerms) &&
-                !ValueContainsAnyTerms(f.Hint, _ignoreSearchTerms);
+                !ValueContainsAnyTerms(f.Hint, _ignoreSearchTerms) && !FieldHasUsernameTerms(f);
         }
 
         private bool FieldHasPasswordTerms(Field f)
         {
             return ValueContainsAnyTerms(f.IdEntry, _passwordTerms) || ValueContainsAnyTerms(f.Hint, _passwordTerms);
+        }
+
+        private bool FieldHasUsernameTerms(Field f)
+        {
+            return ValueContainsAnyTerms(f.IdEntry, _usernameTerms) || ValueContainsAnyTerms(f.Hint, _usernameTerms);
         }
 
         private bool ValueContainsAnyTerms(string value, HashSet<string> terms)


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
Improving the way we recognize fields as Username and Password at the login autofill to avoid filling username fields with passwords or not detecting username fields as valid username fields


## Code changes

* **FieldCollection.cs:** Added common username terms 
On fields that identify as password we check if they don't have "Username terms" on hints to avoid filling passwords on usernames.
In cases we haven't found any Username Field, we will check if there is any Field with any hint or IdEntry that matches our "Username Terms"


## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
