### PR TITLE
[PS-2410] Remove unnecessary URI-pruning logic

### DIFF
--- a/src/App/Pages/Vault/CipherAddEditPageViewModel.cs
+++ b/src/App/Pages/Vault/CipherAddEditPageViewModel.cs
@@ -464,16 +464,6 @@ namespace Bit.App.Pages
 
             Cipher.Fields = Fields != null && Fields.Any() ?
                 Fields.Where(f => f != null).Select(f => f.Field).ToList() : null;
-            if (Cipher.Login != null)
-            {
-                Cipher.Login.Uris = Uris?.ToList();
-                if ((!EditMode || CloneMode) && Cipher.Type == CipherType.Login && Cipher.Login.Uris != null &&
-                   Cipher.Login.Uris.Count == 1 && string.IsNullOrWhiteSpace(Cipher.Login.Uris[0].Uri))
-                {
-                    Cipher.Login.Uris = null;
-                }
-            }
-
             if ((!EditMode || CloneMode) && Cipher.OrganizationId != null)
             {
                 if (Collections == null || !Collections.Any(c => c != null && c.Checked))


### PR DESCRIPTION
## Type of change

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc.)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Accompanies bitwarden/server#2661 whose goal is to remove unfilled URI entries on the user's behalf automatically.

## Code changes

- **CipherAddEditPageViewModel.cs:** removes redundant logic within the `submitAsync()` routine.

## Screenshots

N/A
