### PR TITLE
[PS-2413] set all kdf params on account profile

### DIFF
--- a/src/Core/Services/AuthService.cs
+++ b/src/Core/Services/AuthService.cs
@@ -388,6 +388,8 @@ namespace Bit.Core.Services
                         Name = _tokenService.GetName(),
                         KdfType = tokenResponse.Kdf,
                         KdfIterations = tokenResponse.KdfIterations,
+                        KdfMemory = tokenResponse.KdfMemory,
+                        KdfParallelism = tokenResponse.KdfParallelism,
                         HasPremiumPersonally = _tokenService.GetPremium(),
                     },
                     new Account.AccountTokens()


### PR DESCRIPTION
ref: https://bitwarden.atlassian.net/browse/PS-2413

## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
With the introduction of Argon2, KdfMemory and KdfParallelism need to be set to the account profile in state service. This spot was missed in the original work, resulting in null values for these fields.

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **AuthService.cs:** Add KdfMemory and KdfParallelism to the `AccountProfile` object saved after login.


## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
