### PR TITLE
[SG-1055] MP strength bar color is Blue for weakest password and should be red

### DIFF
--- a/src/App/Controls/PasswordStrengthProgressBar/PasswordStrengthProgressBar.xaml.cs
+++ b/src/App/Controls/PasswordStrengthProgressBar/PasswordStrengthProgressBar.xaml.cs
@@ -69,6 +69,7 @@ namespace Bit.App.Controls
         {
             InitializeComponent();
             SetBinding(PasswordStrengthProgressBar.PasswordStrengthLevelProperty, new Binding() { Path = nameof(PasswordStrengthViewModel.PasswordStrengthLevel) });
+            UpdateColors();
         }
 
         private static void OnControlPropertyChanged(BindableObject bindable, object oldValue, object newValue)


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
MP strength bar color is Blue for weakest password and should be red.

## Screenshots
<!--Required for any UI changes. Delete if not applicable-->


https://user-images.githubusercontent.com/4648522/217921416-140c6035-3298-4814-936c-adce1e138927.mov



## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
