### PR TITLE
[PS-2280] Retain app settings on logout

### DIFF
--- a/src/Android/Services/DeviceActionService.cs
+++ b/src/Android/Services/DeviceActionService.cs
@@ -502,11 +502,6 @@ namespace Bit.Droid.Services
 
         public async Task SetScreenCaptureAllowedAsync()
         {
-            if (CoreHelpers.ForceScreenCaptureEnabled())
-            {
-                return;
-            }
-
             var activity = CrossCurrentActivity.Current?.Activity;
             if (await _stateService.GetScreenCaptureAllowedAsync())
             {

--- a/src/App/Pages/Settings/SettingsPage/SettingsPageViewModel.cs
+++ b/src/App/Pages/Settings/SettingsPage/SettingsPageViewModel.cs
@@ -806,11 +806,6 @@ namespace Bit.App.Pages
 
         public async Task SetScreenCaptureAllowedAsync()
         {
-            if (CoreHelpers.ForceScreenCaptureEnabled())
-            {
-                return;
-            }
-
             try
             {
                 if (!_screenCaptureAllowed

--- a/src/Core/Abstractions/IStateService.cs
+++ b/src/Core/Abstractions/IStateService.cs
@@ -73,8 +73,8 @@ namespace Bit.Core.Abstractions
         Task SetInvalidUnlockAttemptsAsync(int? value, string userId = null);
         Task<string> GetLastBuildAsync();
         Task SetLastBuildAsync(string value);
-        Task<bool?> GetDisableFaviconAsync(string userId = null);
-        Task SetDisableFaviconAsync(bool? value, string userId = null);
+        Task<bool?> GetDisableFaviconAsync();
+        Task SetDisableFaviconAsync(bool? value);
         Task<bool?> GetDisableAutoTotpCopyAsync(string userId = null);
         Task SetDisableAutoTotpCopyAsync(bool? value, string userId = null);
         Task<bool?> GetInlineAutofillEnabledAsync(string userId = null);
@@ -109,10 +109,10 @@ namespace Bit.Core.Abstractions
         Task SetRememberedEmailAsync(string value);
         Task<string> GetRememberedOrgIdentifierAsync();
         Task SetRememberedOrgIdentifierAsync(string value);
-        Task<string> GetThemeAsync(string userId = null);
-        Task SetThemeAsync(string value, string userId = null);
-        Task<string> GetAutoDarkThemeAsync(string userId = null);
-        Task SetAutoDarkThemeAsync(string value, string userId = null);
+        Task<string> GetThemeAsync();
+        Task SetThemeAsync(string value);
+        Task<string> GetAutoDarkThemeAsync();
+        Task SetAutoDarkThemeAsync(string value);
         Task<bool?> GetAddSitePromptShownAsync(string userId = null);
         Task SetAddSitePromptShownAsync(bool? value, string userId = null);
         Task<bool?> GetPushInitialPromptShownAsync();

--- a/src/Core/Constants.cs
+++ b/src/Core/Constants.cs
@@ -29,6 +29,9 @@
         public static string RememberedEmailKey = "rememberedEmail";
         public static string RememberedOrgIdentifierKey = "rememberedOrgIdentifier";
         public static string PasswordlessLoginNotificationKey = "passwordlessLoginNotificationKey";
+        public const string ThemeKey = "theme";
+        public const string AutoDarkThemeKey = "autoDarkTheme";
+        public const string DisableFaviconKey = "disableFavicon";
         public const string PasswordlessNotificationId = "26072022";
         public const string AndroidNotificationChannelId = "general_notification_channel";
         public const string iOSNotificationCategoryId = "dismissableCategory";
@@ -65,6 +68,8 @@
             iOSShareExtensionClearCiphersCacheKey
         };
 
+        public static string VaultTimeoutKey(string userId) => $"vaultTimeout_{userId}";
+        public static string VaultTimeoutActionKey(string userId) => $"vaultTimeoutAction_{userId}";
         public static string CiphersKey(string userId) => $"ciphers_{userId}";
         public static string FoldersKey(string userId) => $"folders_{userId}";
         public static string CollectionsKey(string userId) => $"collections_{userId}";
@@ -89,10 +94,7 @@
         public static string AutofillBlacklistedUrisKey(string userId) => $"autofillBlacklistedUris_{userId}";
         public static string ClearClipboardKey(string userId) => $"clearClipboard_{userId}";
         public static string SyncOnRefreshKey(string userId) => $"syncOnRefresh_{userId}";
-        public static string DisableFaviconKey(string userId) => $"disableFavicon_{userId}";
         public static string DefaultUriMatchKey(string userId) => $"defaultUriMatch_{userId}";
-        public static string ThemeKey(string userId) => $"theme_{userId}";
-        public static string AutoDarkThemeKey(string userId) => $"autoDarkTheme_{userId}";
         public static string DisableAutoTotpCopyKey(string userId) => $"disableAutoTotpCopy_{userId}";
         public static string PreviousPageKey(string userId) => $"previousPage_{userId}";
         public static string PasswordRepromptAutofillKey(string userId) => $"passwordRepromptAutofillKey_{userId}";
@@ -107,5 +109,6 @@
         public static string PushLastRegistrationDateKey(string userId) => $"pushLastRegistrationDate_{userId}";
         public static string PushCurrentTokenKey(string userId) => $"pushCurrentToken_{userId}";
         public static string ShouldConnectToWatchKey(string userId) => $"shouldConnectToWatch_{userId}";
+        public static string ScreenCaptureAllowedKey(string userId) => $"screenCaptureAllowed_{userId}";
     }
 }

--- a/src/Core/Constants.cs
+++ b/src/Core/Constants.cs
@@ -3,6 +3,7 @@
     public static class Constants
     {
         public const int MaxAccounts = 5;
+        public const int VaultTimeoutDefault = 15;
         public const string AndroidAppProtocol = "androidapp://";
         public const string iOSAppProtocol = "iosapp://";
         public const string DefaultUsernameGenerated = "-";

--- a/src/Core/Models/Domain/Account.cs
+++ b/src/Core/Models/Domain/Account.cs
@@ -1,4 +1,5 @@
-﻿using Bit.Core.Enums;
+﻿using System;
+using Bit.Core.Enums;
 using Bit.Core.Models.Data;
 
 namespace Bit.Core.Models.Domain
@@ -104,9 +105,12 @@ namespace Bit.Core.Models.Domain
             }
 
             public EnvironmentUrlData EnvironmentUrls;
+            [Obsolete("Feb 10 2023: VaultTimeout has been deprecated in favor of stored prefs to retain value after logout. It remains here to allow for migration during app upgrade.")]
             public int? VaultTimeout;
+            [Obsolete("Feb 10 2023: VaultTimeoutAction has been deprecated in favor of stored prefs to retain value after logout. It remains here to allow for migration during app upgrade.")]
             public VaultTimeoutAction? VaultTimeoutAction;
-            public bool ScreenCaptureAllowed;
+            [Obsolete("Feb 10 2023: ScreenCaptureAllowed has been deprecated in favor of stored prefs to retain value after logout. It remains here to allow for migration during app upgrade.")]
+            public bool? ScreenCaptureAllowed;
         }
 
         public class AccountVolatileData

--- a/src/Core/Services/StateService.cs
+++ b/src/Core/Services/StateService.cs
@@ -542,7 +542,7 @@ namespace Bit.Core.Services
             var reconciledOptions = ReconcileOptions(new StorageOptions { UserId = userId },
                 await GetDefaultStorageOptionsAsync());
             var key = Constants.VaultTimeoutKey(reconciledOptions.UserId);
-            return await GetValueAsync<int?>(key, reconciledOptions) ?? 15;
+            return await GetValueAsync<int?>(key, reconciledOptions) ?? Constants.VaultTimeoutDefault;
         }
 
         public async Task SetVaultTimeoutAsync(int? value, string userId = null)

--- a/src/Core/Services/StateService.cs
+++ b/src/Core/Services/StateService.cs
@@ -539,55 +539,50 @@ namespace Bit.Core.Services
 
         public async Task<int?> GetVaultTimeoutAsync(string userId = null)
         {
-            return (await GetAccountAsync(
-                ReconcileOptions(new StorageOptions { UserId = userId }, await GetDefaultStorageOptionsAsync())
-            ))?.Settings?.VaultTimeout;
+            var reconciledOptions = ReconcileOptions(new StorageOptions { UserId = userId },
+                await GetDefaultStorageOptionsAsync());
+            var key = Constants.VaultTimeoutKey(reconciledOptions.UserId);
+            return await GetValueAsync<int?>(key, reconciledOptions) ?? 15;
         }
 
         public async Task SetVaultTimeoutAsync(int? value, string userId = null)
         {
             var reconciledOptions = ReconcileOptions(new StorageOptions { UserId = userId },
                 await GetDefaultStorageOptionsAsync());
-            var account = await GetAccountAsync(reconciledOptions);
-            account.Settings.VaultTimeout = value;
-            await SaveAccountAsync(account, reconciledOptions);
+            var key = Constants.VaultTimeoutKey(reconciledOptions.UserId);
+            await SetValueAsync(key, value, reconciledOptions);
         }
 
         public async Task<VaultTimeoutAction?> GetVaultTimeoutActionAsync(string userId = null)
         {
-            return (await GetAccountAsync(
-                ReconcileOptions(new StorageOptions { UserId = userId }, await GetDefaultStorageOptionsAsync())
-            ))?.Settings?.VaultTimeoutAction;
+            var reconciledOptions = ReconcileOptions(new StorageOptions { UserId = userId },
+                await GetDefaultStorageOptionsAsync());
+            var key = Constants.VaultTimeoutActionKey(reconciledOptions.UserId);
+            return await GetValueAsync<VaultTimeoutAction?>(key, reconciledOptions) ?? VaultTimeoutAction.Lock;
         }
 
         public async Task SetVaultTimeoutActionAsync(VaultTimeoutAction? value, string userId = null)
         {
             var reconciledOptions = ReconcileOptions(new StorageOptions { UserId = userId },
                 await GetDefaultStorageOptionsAsync());
-            var account = await GetAccountAsync(reconciledOptions);
-            account.Settings.VaultTimeoutAction = value;
-            await SaveAccountAsync(account, reconciledOptions);
+            var key = Constants.VaultTimeoutActionKey(reconciledOptions.UserId);
+            await SetValueAsync(key, value, reconciledOptions);
         }
 
         public async Task<bool> GetScreenCaptureAllowedAsync(string userId = null)
         {
-            if (CoreHelpers.ForceScreenCaptureEnabled())
-            {
-                return true;
-            }
-
-            return (await GetAccountAsync(
-                ReconcileOptions(new StorageOptions { UserId = userId }, await GetDefaultStorageOptionsAsync())
-            ))?.Settings?.ScreenCaptureAllowed ?? false;
+            var reconciledOptions = ReconcileOptions(new StorageOptions { UserId = userId },
+                await GetDefaultStorageOptionsAsync());
+            var key = Constants.ScreenCaptureAllowedKey(reconciledOptions.UserId);
+            return await GetValueAsync<bool?>(key, reconciledOptions) ?? CoreHelpers.InDebugMode();
         }
 
         public async Task SetScreenCaptureAllowedAsync(bool value, string userId = null)
         {
             var reconciledOptions = ReconcileOptions(new StorageOptions { UserId = userId },
                 await GetDefaultStorageOptionsAsync());
-            var account = await GetAccountAsync(reconciledOptions);
-            account.Settings.ScreenCaptureAllowed = value;
-            await SaveAccountAsync(account, reconciledOptions);
+            var key = Constants.ScreenCaptureAllowedKey(reconciledOptions.UserId);
+            await SetValueAsync(key, value, reconciledOptions);
         }
 
         public async Task<DateTime?> GetLastFileCacheClearAsync()
@@ -650,23 +645,18 @@ namespace Bit.Core.Services
             await SetValueAsync(key, value, options);
         }
 
-        public async Task<bool?> GetDisableFaviconAsync(string userId = null)
+        public async Task<bool?> GetDisableFaviconAsync()
         {
-            var reconciledOptions = ReconcileOptions(new StorageOptions { UserId = userId },
-                await GetDefaultStorageOptionsAsync());
-            var key = Constants.DisableFaviconKey(reconciledOptions.UserId);
-            return await GetValueAsync<bool?>(key, reconciledOptions);
+            var options = await GetDefaultStorageOptionsAsync();
+            var key = Constants.DisableFaviconKey;
+            return await GetValueAsync<bool?>(key, options);
         }
 
-        public async Task SetDisableFaviconAsync(bool? value, string userId = null)
+        public async Task SetDisableFaviconAsync(bool? value)
         {
-            var reconciledOptions = ReconcileOptions(new StorageOptions { UserId = userId },
-                await GetDefaultStorageOptionsAsync());
-            var key = Constants.DisableFaviconKey(reconciledOptions.UserId);
-            await SetValueAsync(key, value, reconciledOptions);
-
-            // TODO remove this to restore per-account DisableFavicon support
-            SetValueGloballyAsync(Constants.DisableFaviconKey, value, reconciledOptions).FireAndForget();
+            var options = await GetDefaultStorageOptionsAsync();
+            var key = Constants.DisableFaviconKey;
+            await SetValueAsync(key, value, options);
         }
 
         public async Task<bool?> GetDisableAutoTotpCopyAsync(string userId = null)
@@ -937,42 +927,32 @@ namespace Bit.Core.Services
             await SetValueAsync(key, value, options);
         }
 
-        public async Task<string> GetThemeAsync(string userId = null)
+        public async Task<string> GetThemeAsync()
         {
-            var reconciledOptions = ReconcileOptions(new StorageOptions { UserId = userId },
-                await GetDefaultStorageOptionsAsync());
-            var key = Constants.ThemeKey(reconciledOptions.UserId);
-            return await GetValueAsync<string>(key, reconciledOptions);
+            var options = await GetDefaultStorageOptionsAsync();
+            var key = Constants.ThemeKey;
+            return await GetValueAsync<string>(key, options);
         }
 
-        public async Task SetThemeAsync(string value, string userId = null)
+        public async Task SetThemeAsync(string value)
         {
-            var reconciledOptions = ReconcileOptions(new StorageOptions { UserId = userId },
-                await GetDefaultStorageOptionsAsync());
-            var key = Constants.ThemeKey(reconciledOptions.UserId);
-            await SetValueAsync(key, value, reconciledOptions);
-
-            // TODO remove this to restore per-account Theme support
-            SetValueGloballyAsync(Constants.ThemeKey, value, reconciledOptions).FireAndForget();
+            var options = await GetDefaultStorageOptionsAsync();
+            var key = Constants.ThemeKey;
+            await SetValueAsync(key, value, options);
         }
 
-        public async Task<string> GetAutoDarkThemeAsync(string userId = null)
+        public async Task<string> GetAutoDarkThemeAsync()
         {
-            var reconciledOptions = ReconcileOptions(new StorageOptions { UserId = userId },
-                await GetDefaultStorageOptionsAsync());
-            var key = Constants.AutoDarkThemeKey(reconciledOptions.UserId);
-            return await GetValueAsync<string>(key, reconciledOptions);
+            var options = await GetDefaultStorageOptionsAsync();
+            var key = Constants.AutoDarkThemeKey;
+            return await GetValueAsync<string>(key, options);
         }
 
-        public async Task SetAutoDarkThemeAsync(string value, string userId = null)
+        public async Task SetAutoDarkThemeAsync(string value)
         {
-            var reconciledOptions = ReconcileOptions(new StorageOptions { UserId = userId },
-                await GetDefaultStorageOptionsAsync());
-            var key = Constants.AutoDarkThemeKey(reconciledOptions.UserId);
-            await SetValueAsync(key, value, reconciledOptions);
-
-            // TODO remove this to restore per-account Theme support
-            SetValueGloballyAsync(Constants.AutoDarkThemeKey, value, reconciledOptions).FireAndForget();
+            var options = await GetDefaultStorageOptionsAsync();
+            var key = Constants.AutoDarkThemeKey;
+            await SetValueAsync(key, value, options);
         }
 
         public async Task<bool?> GetAddSitePromptShownAsync(string userId = null)
@@ -1333,30 +1313,6 @@ namespace Bit.Core.Services
             await GetStorageService(options).SaveAsync(key, value);
         }
 
-        private async Task SetValueGloballyAsync<T>(Func<string, string> keyPrefix, T value, StorageOptions options)
-        {
-            if (value == null)
-            {
-                // don't remove values globally
-                return;
-            }
-            await CheckStateAsync();
-            if (_state?.Accounts == null)
-            {
-                return;
-            }
-            // userId from options was already applied, skip those
-            var userIdToSkip = options.UserId;
-            foreach (var account in _state.Accounts)
-            {
-                var uid = account.Value?.Profile?.UserId;
-                if (uid != null && uid != userIdToSkip)
-                {
-                    await SetValueAsync(keyPrefix(uid), value, options);
-                }
-            }
-        }
-
         private IStorageService GetStorageService(StorageOptions options)
         {
             return options.UseSecureStorage.GetValueOrDefault(false) ? _secureStorageService : _storageService;
@@ -1489,7 +1445,6 @@ namespace Bit.Core.Services
             }
 
             // Non-state storage
-            await SetBiometricUnlockAsync(null, userId);
             await SetProtectedPinAsync(null, userId);
             await SetPinProtectedAsync(null, userId);
             await SetKeyEncryptedAsync(null, userId);
@@ -1511,37 +1466,11 @@ namespace Bit.Core.Services
             await SetEncryptedPasswordGenerationHistoryAsync(null, userId);
             await SetEncryptedSendsAsync(null, userId);
             await SetSettingsAsync(null, userId);
-            await SetApprovePasswordlessLoginsAsync(null, userId);
-
-            if (userInitiated)
-            {
-                // user initiated logout (not vault timeout or scaffolding new account) so remove remaining settings
-                await SetAutofillBlacklistedUrisAsync(null, userId);
-                await SetDisableFaviconAsync(null, userId);
-                await SetDisableAutoTotpCopyAsync(null, userId);
-                await SetInlineAutofillEnabledAsync(null, userId);
-                await SetAutofillDisableSavePromptAsync(null, userId);
-                await SetDefaultUriMatchAsync(null, userId);
-                await SetNeverDomainsAsync(null, userId);
-                await SetClearClipboardAsync(null, userId);
-                await SetPasswordRepromptAutofillAsync(null, userId);
-                await SetPasswordVerifiedAutofillAsync(null, userId);
-                await SetSyncOnRefreshAsync(null, userId);
-                await SetThemeAsync(null, userId);
-                await SetAutoDarkThemeAsync(null, userId);
-                await SetAddSitePromptShownAsync(null, userId);
-                await SetPasswordGenerationOptionsAsync(null, userId);
-                await SetApprovePasswordlessLoginsAsync(null, userId);
-                await SetUsernameGenerationOptionsAsync(null, userId);
-            }
         }
 
         private async Task ScaffoldNewAccountAsync(Account account)
         {
             await CheckStateAsync();
-            var currentTheme = await GetThemeAsync();
-            var currentAutoDarkTheme = await GetAutoDarkThemeAsync();
-            var currentDisableFavicons = await GetDisableFaviconAsync();
 
             account.Settings.EnvironmentUrls = await GetPreAuthEnvironmentUrlsAsync();
 
@@ -1551,28 +1480,6 @@ namespace Bit.Core.Services
             {
                 state.Accounts = new Dictionary<string, Account>();
             }
-            if (state.Accounts.ContainsKey(account.Profile.UserId))
-            {
-                // Run cleanup pass on existing account before proceeding
-                await RemoveAccountAsync(account.Profile.UserId, false);
-                var existingAccount = state.Accounts[account.Profile.UserId];
-                account.Settings.VaultTimeout = existingAccount.Settings.VaultTimeout;
-                account.Settings.VaultTimeoutAction = existingAccount.Settings.VaultTimeoutAction;
-                account.Settings.ScreenCaptureAllowed = existingAccount.Settings.ScreenCaptureAllowed;
-            }
-
-            // New account defaults
-            if (account.Settings.VaultTimeout == null)
-            {
-                account.Settings.VaultTimeout = 15;
-            }
-            if (account.Settings.VaultTimeoutAction == null)
-            {
-                account.Settings.VaultTimeoutAction = VaultTimeoutAction.Lock;
-            }
-            await SetThemeAsync(currentTheme, account.Profile.UserId);
-            await SetAutoDarkThemeAsync(currentAutoDarkTheme, account.Profile.UserId);
-            await SetDisableFaviconAsync(currentDisableFavicons, account.Profile.UserId);
 
             state.Accounts[account.Profile.UserId] = account;
             await SaveStateToStorageAsync(state);

--- a/src/Core/Utilities/CoreHelpers.cs
+++ b/src/Core/Utilities/CoreHelpers.cs
@@ -37,25 +37,6 @@ namespace Bit.Core.Utilities
 #endif
         }
 
-        /// <summary>
-        /// Returns whether to force enabling the screen capture.
-        /// On Debug it will allow screen capture by default but this method
-        /// makes it easier to test the change on enabling/disabling the feature
-        /// on debug.
-        /// </summary>
-        /// <remarks>
-        /// To test enabling/disabling in DEBUG, just return <c>false</c> in the #if condition
-        /// and that's it.
-        /// </remarks>
-        public static bool ForceScreenCaptureEnabled()
-        {
-#if DEBUG
-            return true;
-#else
-            return false;
-#endif
-        }
-
         public static string GetHostname(string uriString)
         {
             var uri = GetUri(uriString);


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
These changes allow the app to retain account-specific settings after a hard logout (previous would only retain on soft logout).  In order to accomplish this without re-architecting the way soft logout works with multiple users, some stored settings (`VaultTimeout`, `VaultTimeoutAction`, and `ScreenCaptureAllowed`) had to be relocated from the state object to normal local storage with an account-specific pref name (follows existing pattern).  This requires a new state migration, which resulted in a conflict with a previous migration with 3 values that were originally account-specific (`DisableFavicon`, `Theme`, and `AutoDarkTheme` but used trickery to apply globally to match other clients) requiring migrating those to true global values (remove the trickery).

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **StateService.cs:** 
   * Update getter/setter for `VaultTimeout`, `VaultTimeoutAction`, and `ScreenCaptureAllowed` to support account-specific storage key
   * Update getter/setter for `DisableFavicon`, `Theme`, and `AutoDarkTheme` to remove account-specific storage key
   * Remove account-to-global trickery method
   * Remove deletion of app settings in `RemoveAccountAsync`
   * Remove `DisableFavicon`, `Theme`, and `AutoDarkTheme` getting/setting trickery in `ScaffoldNewAccountAsync`
   * Remove setting defaults for `VaultTimeout`, `VaultTimeoutAction`, and `ScreenCaptureAllowed` (using established pattern of getter fallbacks since these are no longer in the state object)
   * Remove purging of any existing data when logging into account that was previously logged in (sensitive data is already removed on logout and we want the settings to remain)
* **StateMigrationService.cs:** Added new 3to4 migration block, details in Objective section above (realized I should not be referencing `Constants` for keys in 2to3 migration as those change over time and need to be self-contained in the service - will fix this in a subsequent PR since it adds a lot of noise)
* **CoreHelpers.cs:** Removed `ForceScreenCaptureEnabled` as it made debugging the toggle impossible, now simply defaults to allowing screenshots in debug builds but still allows toggling (returns `CoreHelpers.InDebugMode()` as fallback default in `StateService.GetScreenCaptureAllowedAsync(..)`
* **Account.cs:** Marked `VaultTimeout`, `VaultTimeoutAction`, and `ScreenCaptureAllowed` as `[Obsolete]` to allow older migrations to function, will eventually remove
* **Constants.cs:** Changed `VaultTimeout`, `VaultTimeoutAction`, and `ScreenCaptureAllowed` to account specific keys, and `DisableFavicon`, `Theme`, and `AutoDarkTheme` to global keys

## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
