### PR TITLE
[PS-2513] Capitalized Vault Menu Option

### DIFF
--- a/src/App/Resources/AppResources.resx
+++ b/src/App/Resources/AppResources.resx
@@ -296,7 +296,7 @@
     <comment>Text to define that there are more options things to see.</comment>
   </data>
   <data name="MyVault" xml:space="preserve">
-    <value>My vault</value>
+    <value>My Vault</value>
     <comment>The title for the vault page.</comment>
   </data>
   <data name="Authenticator" xml:space="preserve">


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [x] Other

## Objective
The Vault menu item was bothering me that it wasn't capitalized. 


## Code changes
A single character in `/src/App/Resources/AppResources.resx`

## Screenshots
![image](https://user-images.githubusercontent.com/60232273/219491959-32e60f61-f8c3-4bf1-acb0-b1cfc8a8021f.png)

