### PR TITLE
[PS-2520] Restore copy confirmation toast on Android 13+

### DIFF
--- a/src/Android/Services/ClipboardService.cs
+++ b/src/Android/Services/ClipboardService.cs
@@ -49,12 +49,6 @@ namespace Bit.Droid.Services
             }
         }
 
-        public bool IsCopyNotificationHandledByPlatform()
-        {
-            // Android 13+ provides built-in notification when text is copied to the clipboard
-            return (int)Build.VERSION.SdkInt >= 33;
-        }
-
         private void CopyToClipboard(string text, bool isSensitive = true)
         {
             var clipboardManager = Application.Context.GetSystemService(Context.ClipboardService) as ClipboardManager;

--- a/src/App/Services/MobilePlatformUtilsService.cs
+++ b/src/App/Services/MobilePlatformUtilsService.cs
@@ -134,7 +134,7 @@ namespace Bit.App.Services
 
         public void ShowToastForCopiedValue(string valueNameCopied)
         {
-            ShowToast("info", null,string.Format(AppResources.ValueHasBeenCopied, valueNameCopied));
+            ShowToast("info", null, string.Format(AppResources.ValueHasBeenCopied, valueNameCopied));
         }
 
         public bool SupportsFido2()

--- a/src/App/Services/MobilePlatformUtilsService.cs
+++ b/src/App/Services/MobilePlatformUtilsService.cs
@@ -134,11 +134,7 @@ namespace Bit.App.Services
 
         public void ShowToastForCopiedValue(string valueNameCopied)
         {
-            if (!_clipboardService.IsCopyNotificationHandledByPlatform())
-            {
-                ShowToast("info", null,
-                    string.Format(AppResources.ValueHasBeenCopied, valueNameCopied));
-            }
+            ShowToast("info", null,string.Format(AppResources.ValueHasBeenCopied, valueNameCopied));
         }
 
         public bool SupportsFido2()

--- a/src/Core/Abstractions/IClipboardService.cs
+++ b/src/Core/Abstractions/IClipboardService.cs
@@ -15,10 +15,5 @@ namespace Bit.Core.Abstractions
         /// <param name="expiresInMs">Expiration time in milliseconds of the copied text</param>
         /// <param name="isSensitive">Flag to mark copied text as sensitive</param>
         Task CopyTextAsync(string text, int expiresInMs = -1, bool isSensitive = true);
-
-        /// <summary>
-        /// Returns true if the platform provides its own notification when text is copied to the clipboard
-        /// </summary>
-        bool IsCopyNotificationHandledByPlatform();
     }
 }

--- a/src/iOS.Core/Services/ClipboardService.cs
+++ b/src/iOS.Core/Services/ClipboardService.cs
@@ -38,11 +38,5 @@ namespace Bit.iOS.Core.Services
                 ExpirationDate = clearSeconds > 0 ? NSDate.FromTimeIntervalSinceNow(clearSeconds) : null
             }));
         }
-
-        public bool IsCopyNotificationHandledByPlatform()
-        {
-            // return true for any future versions of iOS that notify the user when text is copied to the clipboard
-            return false;
-        }
     }
 }


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Copy confirmation toasts were originally removed on Android 13+ devices since the system provides its own notification now. However we’re seeing that functionality removed by some device makers, giving users the impression that copy isn’t working at all.  As there’s no official way to know if this is happening, we're restoring the toast across the board.  Better to have some overlap than no notification at all.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **ClipboardService.cs:** Removed `IsCopyNotificationHandledByPlatform` method
* **MobilePlatformUtilsService.cs:** Removed `_clipboardService.IsCopyNotificationHandledByPlatform` check before showing toast


## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
