### PR TITLE
[PM-1078] Login with Device - Change mobile to not get fingerprint from API

### DIFF
--- a/src/App/App.xaml.cs
+++ b/src/App/App.xaml.cs
@@ -201,7 +201,7 @@ namespace Bit.App
                 Id = loginRequestData.Id,
                 IpAddress = loginRequestData.RequestIpAddress,
                 Email = await _stateService.GetEmailAsync(),
-                FingerprintPhrase = loginRequestData.RequestFingerprint,
+                FingerprintPhrase = loginRequestData.FingerprintPhrase,
                 RequestDate = loginRequestData.CreationDate,
                 DeviceType = loginRequestData.RequestDeviceType,
                 Origin = loginRequestData.Origin

--- a/src/App/Pages/Accounts/LoginPasswordlessRequestViewModel.cs
+++ b/src/App/Pages/Accounts/LoginPasswordlessRequestViewModel.cs
@@ -171,7 +171,7 @@ namespace Bit.App.Pages
             var response = await _authService.PasswordlessCreateLoginRequestAsync(_email);
             if (response != null)
             {
-                FingerprintPhrase = response.RequestFingerprint;
+                FingerprintPhrase = response.FingerprintPhrase;
                 _requestId = response.Id;
                 _requestAccessCode = response.RequestAccessCode;
                 _requestKeyPair = response.RequestKeyPair;

--- a/src/App/Pages/Settings/LoginPasswordlessRequestsListPage.xaml
+++ b/src/App/Pages/Settings/LoginPasswordlessRequestsListPage.xaml
@@ -39,7 +39,7 @@
                             Padding="0, 10, 0 ,0"
                             FontAttributes="Bold"/>
                         <controls:MonoLabel
-                            FormattedText="{Binding RequestFingerprint}"
+                            FormattedText="{Binding FingerprintPhrase}"
                             Grid.Row="1"
                             Grid.ColumnSpan="2"
                             FontSize="Small"

--- a/src/App/Pages/Settings/LoginPasswordlessRequestsListViewModel.cs
+++ b/src/App/Pages/Settings/LoginPasswordlessRequestsListViewModel.cs
@@ -99,7 +99,7 @@ namespace Bit.App.Pages
                 Id = loginRequestData.Id,
                 IpAddress = loginRequestData.RequestIpAddress,
                 Email = await _stateService.GetEmailAsync(),
-                FingerprintPhrase = loginRequestData.RequestFingerprint,
+                FingerprintPhrase = loginRequestData.FingerprintPhrase,
                 RequestDate = loginRequestData.CreationDate,
                 DeviceType = loginRequestData.RequestDeviceType,
                 Origin = loginRequestData.Origin

--- a/src/Core/Models/Response/PasswordlessLoginResponse.cs
+++ b/src/Core/Models/Response/PasswordlessLoginResponse.cs
@@ -11,7 +11,7 @@ namespace Bit.Core.Models.Response
         public string PublicKey { get; set; }
         public string RequestDeviceType { get; set; }
         public string RequestIpAddress { get; set; }
-        public string RequestFingerprint { get; set; }
+        public string FingerprintPhrase { get; set; }
         public string Key { get; set; }
         public string MasterPasswordHash { get; set; }
         public DateTime CreationDate { get; set; }

--- a/src/Core/Services/AuthService.cs
+++ b/src/Core/Services/AuthService.cs
@@ -501,7 +501,7 @@ namespace Bit.Core.Services
         public async Task<List<PasswordlessLoginResponse>> GetActivePasswordlessLoginRequestsAsync()
         {
             var requests = await GetPasswordlessLoginRequestsAsync();
-            var activeRequests =  requests.Where(r => !r.IsAnswered && !r.IsExpired).OrderByDescending(r => r.CreationDate).ToList();
+            var activeRequests = requests.Where(r => !r.IsAnswered && !r.IsExpired).OrderByDescending(r => r.CreationDate).ToList();
             return await PopulateFingerprintPhrasesAsync(activeRequests);
         }
 


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
- Modify mobile client to generate the fingerprint phrase themselves, ignoring the one retrieved from the API
- Remove fingerprintPhrase from the AuthRequestResponse

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **src/Core/Models/Response/PasswordlessLoginResponse.cs:**
Renamed property containing the `FingerprintPhrase`, ignoring api value.

* **src/Core/Services/AuthService.cs:**
After fetching the data from the `ApiService`, `AuthService` will populate the values for the `FingerprintPhrase`.

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
