### PR TITLE
Create cipher submit redirects to new cipher page

### DIFF
--- a/src/App/Pages/Vault/CipherAddEditPageViewModel.cs
+++ b/src/App/Pages/Vault/CipherAddEditPageViewModel.cs
@@ -526,7 +526,9 @@ namespace Bit.App.Pages
                     // if the app is tombstoned then PopModalAsync would throw index out of bounds
                     if (Page.Navigation?.ModalStack?.Count > 0)
                     {
-                        await Page.Navigation.PopModalAsync();
+                        var previousPage = Page.Navigation.NavigationStack.LastOrDefault();
+                        await Page.Navigation.PushAsync(new NavigationPage(new CipherDetailsPage(this.Cipher.Id)));
+                        Page.Navigation.RemovePage(previousPage);
                     }
                 }
                 return true;


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
[Feature Request Link](https://community.bitwarden.com/t/enhance-the-experience-of-creating-a-new-cipher-using-the-mobile-app/51382?u=dblack)

When a user creates and saves a new cipher, they are navigated back to a previous page and usually have to search for the cipher they just created to copy details such as the password. This change set will navigate the user to the newly created cipher details page providing immediate access to the details they just saved and reducing friction.

#### What benefits will this feature bring?
* Enhances a user flow by enabling a user to access and copy details for a new cipher without needing to search for it.
* Reduces friction in the activity of creating a new login and copying the new username and password to paste into a signup form. 

## Code changes
* **CipherAddEditPageViewModel.cs** - changed navigation to navigate to newly created cipher page instead of back. 

