### PR TITLE
Ask for password reprompt (if enabled) in chipers page

### DIFF
--- a/src/App/Pages/Vault/CiphersPageViewModel.cs
+++ b/src/App/Pages/Vault/CiphersPageViewModel.cs
@@ -156,6 +156,12 @@ namespace Bit.App.Pages
                 selection = await Page.DisplayActionSheet(AppResources.AutofillOrView, AppResources.Cancel, null,
                     options.ToArray());
             }
+            
+            if (cipher.Reprompt != CipherRepromptType.None && !await _passwordRepromptService.ShowPasswordPromptAsync())
+            {
+                return;
+            }
+            
             if (selection == AppResources.View || string.IsNullOrWhiteSpace(AutofillUrl))
             {
                 var page = new CipherDetailsPage(cipher.Id);


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
This PR fixes the issue #1866. Now the app is asking for password reprompt (if enabled) on the autofill page.


## Code changes
The default autofill page [AutofillChipersPage](https://github.com/bitwarden/mobile/blob/master/src/App/Pages/Vault/AutofillCiphersPage.xaml.cs) is correctly checking and asking for password reprompt.

https://github.com/bitwarden/mobile/blob/3f86bb0cd7e33c29e7374c0caee402b9fd30386e/src/App/Pages/Vault/AutofillCiphersPageViewModel.cs#L189-L192

 This feature is missing when searching for other items in the vault using the [ChipersPage](https://github.com/bitwarden/mobile/blob/master/src/App/Pages/Vault/CiphersPage.xaml.cs). This commit adds this check before doing any action (view/autofill/autofill & save)


## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
