### PR TITLE
Add option to match URI by Origin

### DIFF
--- a/src/App/Pages/Settings/OptionsPageViewModel.cs
+++ b/src/App/Pages/Settings/OptionsPageViewModel.cs
@@ -74,6 +74,7 @@ namespace Bit.App.Pages
             {
                 new KeyValuePair<UriMatchType?, string>(UriMatchType.Domain, AppResources.BaseDomain),
                 new KeyValuePair<UriMatchType?, string>(UriMatchType.Host, AppResources.Host),
+                new KeyValuePair<UriMatchType?, string>(UriMatchType.Origin, AppResources.Origin),
                 new KeyValuePair<UriMatchType?, string>(UriMatchType.StartsWith, AppResources.StartsWith),
                 new KeyValuePair<UriMatchType?, string>(UriMatchType.RegularExpression, AppResources.RegEx),
                 new KeyValuePair<UriMatchType?, string>(UriMatchType.Exact, AppResources.Exact),

--- a/src/App/Pages/Vault/CipherAddEditPageViewModel.cs
+++ b/src/App/Pages/Vault/CipherAddEditPageViewModel.cs
@@ -62,6 +62,7 @@ namespace Bit.App.Pages
                 new KeyValuePair<UriMatchType?, string>(null, AppResources.Default),
                 new KeyValuePair<UriMatchType?, string>(UriMatchType.Domain, AppResources.BaseDomain),
                 new KeyValuePair<UriMatchType?, string>(UriMatchType.Host, AppResources.Host),
+                new KeyValuePair<UriMatchType?, string>(UriMatchType.Origin, AppResources.Origin),
                 new KeyValuePair<UriMatchType?, string>(UriMatchType.StartsWith, AppResources.StartsWith),
                 new KeyValuePair<UriMatchType?, string>(UriMatchType.RegularExpression, AppResources.RegEx),
                 new KeyValuePair<UriMatchType?, string>(UriMatchType.Exact, AppResources.Exact),

--- a/src/App/Resources/AppResources.Designer.cs
+++ b/src/App/Resources/AppResources.Designer.cs
@@ -3093,7 +3093,16 @@ namespace Bit.App.Resources {
                 return ResourceManager.GetString("Host", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Looks up a localized string similar to Origin.
+        /// </summary>
+        public static string Origin {
+            get {
+                return ResourceManager.GetString("Origin", resourceCulture);
+            }
+        }
+                
         /// <summary>
         ///   Looks up a localized string similar to Icons.
         /// </summary>

--- a/src/App/Resources/AppResources.resx
+++ b/src/App/Resources/AppResources.resx
@@ -1244,6 +1244,10 @@ Scanning will happen automatically.</value>
     <value>Host</value>
     <comment>A URL's host value. For example, the host of https://sub.domain.com:443 is 'sub.domain.com:443'.</comment>
   </data>
+  <data name="Origin" xml:space="preserve">
+    <value>Origin</value>
+    <comment>A URL's origin value. For example, the origin of https://sub.domain.com:443 is 'https://sub.domain.com:443'.</comment>
+  </data>
   <data name="RegEx" xml:space="preserve">
     <value>Regular expression</value>
     <comment>A programming term, also known as 'RegEx'.</comment>

--- a/src/Core/Enums/UriMatchType.cs
+++ b/src/Core/Enums/UriMatchType.cs
@@ -7,6 +7,7 @@
         StartsWith = 2,
         Exact = 3,
         RegularExpression = 4,
-        Never = 5
+        Never = 5,
+        Origin = 6
     }
 }

--- a/src/Core/Services/CipherService.cs
+++ b/src/Core/Services/CipherService.cs
@@ -410,6 +410,14 @@ namespace Bit.Core.Services
                                 AddMatchingLogin(cipher, matchingLogins, matchingFuzzyLogins);
                             }
                             break;
+                        case UriMatchType.Origin:
+                            var urlOrigin = CoreHelpers.GetOrigin(url);
+                            match = urlOrigin != null && urlOrigin == CoreHelpers.GetOrigin(u.Uri);
+                            if (match)
+                            {
+                                AddMatchingLogin(cipher, matchingLogins, matchingFuzzyLogins);
+                            }
+                            break;
                         case UriMatchType.Exact:
                             match = url == u.Uri;
                             if (match)

--- a/src/Core/Utilities/CoreHelpers.cs
+++ b/src/Core/Utilities/CoreHelpers.cs
@@ -60,6 +60,23 @@ namespace Bit.Core.Utilities
             return null;
         }
 
+        public static string GetOrigin(string uriString)
+        {
+            var uri = GetUri(uriString);
+            if (!string.IsNullOrEmpty(uri?.Scheme) && !string.IsNullOrEmpty(uri?.Host))
+            {
+                if (uri.IsDefaultPort)
+                {
+                    return string.Format("{0}://{1}", uri.Scheme, uri.Host);
+                }
+                else
+                {
+                    return string.Format("{0}://{1}:{2}", uri.Scheme, uri.Host, uri.Port);
+                }
+            }
+            return null;
+        }
+
         public static string GetDomain(string uriString)
         {
             var uri = GetUri(uriString);


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
The fundamental boundary of web security is the [Same Origin Policy (SOP)](https://developer.mozilla.org/en-US/docs/Glossary/Same-origin_policy), of which many additional security standards of the web platform are built on top of. For users familiar with SOP, being able to match vault URIs by origins makes it easier for them to reason about the security of a page they are attempting to autofill using vault login. However, users currently cannot restrict autofilling vault logins by matching the origin of the site they want to autofill a login with the origin of the URI saved to vault login they intend to autofill.

The current match detection options have security or usability flaws for achieving the same functionality as match by [Origin](https://developer.mozilla.org/en-US/docs/Glossary/Origin):

- `Base domain` match detection will exclude checking if the scheme and SLD of URIs match, which opens up the opportunity to fall for autofilling a login into a subdomain taken over by an attacker.

- `Host` match detection excludes the scheme of a URI, which may result in (1) the unlikely chance of falling for an HTTPS downgrade attack and autofilling, or (2) matching to any scheme in `CanLaunchWhitelist`

- `Exact` match detection will match the path of a URI. When saving a new vault login, Bitwarden takes the current URL on the page, strips the query parameters and saves that as the URI for the vault item. To replicate the functionality of match detection by origin, the user will often need to manually delete the path of URIs autosaved when creating a new vault login.

- `Starts with` suffers from the same problem as `Exact`, because of what Bitwarden does when saving a new vault item, except it's slightly more permissive as URIs with additional paths appended will autofill.

- `Regex` would allow for users to achieve the same functionality as match by origin, but it would (1) require writing a regex without making any mistakes, (2) would make matching by origin inaccessible for people not familiar with regex, and (3) require the user to copy over the regex pattern to each of their existing clients or new clients they use.

## Additional info
- [Other clients' implementation of this change](https://github.com/bitwarden/clients/pull/4937)
