### PR TITLE
[PM-1131] OTP Handling - Create cipher with OTP filled

### DIFF
--- a/src/App/Pages/Vault/AutofillCiphersPageViewModel.cs
+++ b/src/App/Pages/Vault/AutofillCiphersPageViewModel.cs
@@ -9,16 +9,21 @@ using Bit.Core.Enums;
 using Bit.Core.Exceptions;
 using Bit.Core.Models.View;
 using Bit.Core.Utilities;
+using Xamarin.Forms;
 
 namespace Bit.App.Pages
 {
     public class AutofillCiphersPageViewModel : CipherSelectionPageViewModel
     {
+        private CipherType? _fillType;
+
         public string Uri { get; set; }
 
         public override void Init(AppOptions appOptions)
         {
             Uri = appOptions?.Uri;
+            _fillType = appOptions.FillType;
+
             string name = null;
             if (Uri?.StartsWith(Constants.AndroidAppProtocol) ?? false)
             {
@@ -127,6 +132,20 @@ namespace Bit.App.Pages
             {
                 _autofillHandler.Autofill(cipher);
             }
+        }
+
+        protected override async Task AddCipherAsync()
+        {
+            if (_fillType.HasValue && _fillType != CipherType.Login)
+            {
+                var pageForOther = new CipherAddEditPage(type: _fillType, fromAutofill: true);
+                await Page.Navigation.PushModalAsync(new NavigationPage(pageForOther));
+                return;
+            }
+
+            var pageForLogin = new CipherAddEditPage(null, CipherType.Login, uri: Uri, name: Name,
+                fromAutofill: true);
+            await Page.Navigation.PushModalAsync(new NavigationPage(pageForLogin));
         }
     }
 }

--- a/src/App/Pages/Vault/CipherSelectionPage.xaml
+++ b/src/App/Pages/Vault/CipherSelectionPage.xaml
@@ -37,6 +37,12 @@
                 Clicked="CloseItem_Clicked"
                 Order="Primary"
                 Priority="-1" />
+            <ToolbarItem x:Name="_addItem" x:Key="addItem"
+                         IconImageSource="plus.png"
+                         Command="{Binding AddCipherCommand}"
+                         Order="Primary"
+                         AutomationProperties.IsInAccessibleTree="True"
+                         AutomationProperties.Name="{u:I18n AddItem}" />
 
             <DataTemplate x:Key="cipherTemplate"
                           x:DataType="pages:GroupingsPageListItem">
@@ -80,7 +86,7 @@
                         HorizontalTextAlignment="Center"></Label>
                     <Button
                         Text="{u:I18n AddAnItem}"
-                        Clicked="AddButton_Clicked"></Button>
+                        Command="{Binding AddCipherCommand}" />
                 </StackLayout>
 
                 <Frame
@@ -129,7 +135,7 @@
         <Button
             x:Name="_fab"
             ImageSource="plus.png"
-            Clicked="AddButton_Clicked"
+            Command="{Binding AddCipherCommand}"
             Style="{StaticResource btn-fab}"
             IsVisible="{OnPlatform iOS=false, Android=true}"
             AbsoluteLayout.LayoutFlags="PositionProportional"

--- a/src/App/Pages/Vault/CipherSelectionPage.xaml.cs
+++ b/src/App/Pages/Vault/CipherSelectionPage.xaml.cs
@@ -39,6 +39,7 @@ namespace Bit.App.Pages
             if (Device.RuntimePlatform == Device.iOS)
             {
                 ToolbarItems.Add(_closeItem);
+                ToolbarItems.Add(_addItem);
             }
 
             SetActivityIndicator(_mainContent);

--- a/src/App/Pages/Vault/CipherSelectionPageViewModel.cs
+++ b/src/App/Pages/Vault/CipherSelectionPageViewModel.cs
@@ -50,6 +50,9 @@ namespace Bit.App.Pages
             SelectCipherCommand = new AsyncCommand<IGroupingsPageListItem>(SelectCipherAsync,
                 onException: ex => HandleException(ex),
                 allowsMultipleExecutions: false);
+            AddCipherCommand = new AsyncCommand(AddCipherAsync,
+                onException: ex => HandleException(ex),
+                allowsMultipleExecutions: false);
 
             AccountSwitchingOverlayViewModel = new AccountSwitchingOverlayViewModel(_stateService, _messagingService, _logger)
             {
@@ -64,6 +67,7 @@ namespace Bit.App.Pages
 
         public ICommand CipherOptionsCommand { get; set; }
         public ICommand SelectCipherCommand { get; set; }
+        public ICommand AddCipherCommand { get; set; }
 
         public bool ShowNoData
         {
@@ -157,5 +161,7 @@ namespace Bit.App.Pages
         protected abstract Task<List<GroupingsPageListGroup>> LoadGroupedItemsAsync();
 
         protected abstract Task SelectCipherAsync(IGroupingsPageListItem item);
+
+        protected abstract Task AddCipherAsync();
     }
 }

--- a/src/App/Pages/Vault/OTPCipherSelectionPageViewModel.cs
+++ b/src/App/Pages/Vault/OTPCipherSelectionPageViewModel.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Bit.App.Resources;
@@ -65,6 +66,12 @@ namespace Bit.App.Pages
             var editCipherPage = new CipherAddEditPage(cipher.Id, appOptions: _appOptions);
             await Page.Navigation.PushModalAsync(new NavigationPage(editCipherPage));
             return;
+        }
+
+        protected override async Task AddCipherAsync()
+        {
+            var pageForLogin = new CipherAddEditPage(null, CipherType.Login, name: Name, appOptions: _appOptions);
+            await Page.Navigation.PushModalAsync(new NavigationPage(pageForLogin));
         }
     }
 }


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
On the OTP handler flow, add the possibility to create a new login cipher with the OTP key already filled in.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **CipherSelectionPage.xaml / ...xaml.cs:** Added "Add" toolbar item on iOS and changed click event handlers with commands on adding
* **CIpherSelectionPageViewModel:** Added `AddCommand` and template method to implement it
* **AutofillCiphersPageViewModel:** Moved add cipher implementation to this VM on the add command action
* **OTPCipherSelectionPageViewModel:** Implemented add cipher with the otp data

## Screenshots
<!--Required for any UI changes. Delete if not applicable-->

### Select cipher with add button
<img width="314" alt="Select cipher with add button" src="https://user-images.githubusercontent.com/15682323/223485607-e7755d8b-45d6-493a-b0d4-e59ecee173d3.PNG">

### Select cipher with add button (Dark)
<img width="314" alt="Select cipher with add button dark" src="https://user-images.githubusercontent.com/15682323/223485601-d7b0886d-8bd5-4a1a-b5a8-f502dda2f6d4.PNG">

### Add cipher from otp
<img width="314" alt="Add cipher from otp" src="https://user-images.githubusercontent.com/15682323/223485582-c854c2cb-a256-497e-bf99-e987c350444c.PNG">

### Add cipher from otp (Dark)
<img width="314" alt="Add cipher from otp dark" src="https://user-images.githubusercontent.com/15682323/223485594-ed413fa5-192d-472e-a6e2-3cddb53320b5.PNG">

## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
