### PR TITLE
[PM-1386] Fix OTP Data Issuer and Account name being set correctly

### DIFF
--- a/src/Core/Utilities/OtpData.cs
+++ b/src/Core/Utilities/OtpData.cs
@@ -32,8 +32,8 @@ namespace Bit.Core.Utilities
                 if (label.Contains(LABEL_SEPARATOR))
                 {
                     var parts = label.Split(LABEL_SEPARATOR);
-                    AccountName = parts[0].Trim();
-                    Issuer = parts[1].Trim();
+                    Issuer = parts[0].Trim();
+                    AccountName = parts[1].Trim();
                 }
                 else
                 {


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
The Issuer and Account name should be set correctly on the `OtpData` from the OTP uri


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **OTPData:** Fix set Issuer and Account name from the label. The correct order is first the `Issuer` and then the `AccountName`

## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
