### PR TITLE
[PM-1568] Support Mulch browser for autofill

### DIFF
--- a/src/Android/Accessibility/AccessibilityHelpers.cs
+++ b/src/Android/Accessibility/AccessibilityHelpers.cs
@@ -125,6 +125,7 @@ namespace Bit.Droid.Accessibility
             new Browser("org.ungoogled.chromium.extensions.stable", "url_bar"),
             new Browser("org.ungoogled.chromium.stable", "url_bar"),
             new Browser("us.spotco.fennec_dos", "mozac_browser_toolbar_url_view,url_bar_title"), // 2nd = Legacy
+            new Browser("us.spotco.mulch", "url_bar"),
 
             // [Section B] Entries only present here
             //

--- a/src/Android/Autofill/AutofillHelpers.cs
+++ b/src/Android/Autofill/AutofillHelpers.cs
@@ -141,6 +141,7 @@ namespace Bit.Droid.Autofill
             "org.ungoogled.chromium.extensions.stable",
             "org.ungoogled.chromium.stable",
             "us.spotco.fennec_dos",
+            "us.spotco.mulch",
         };
 
         // The URLs are blacklisted from autofilling

--- a/src/Android/Resources/xml/autofillservice.xml
+++ b/src/Android/Resources/xml/autofillservice.xml
@@ -278,4 +278,7 @@
   <compatibility-package
     android:name="us.spotco.fennec_dos"
     android:maxLongVersionCode="10000000000"/>
+  <compatibility-package
+    android:name="us.spotco.mulch"
+    android:maxLongVersionCode="10000000000"/>
 </autofill-service>


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [X] Other

## Objective
This PR adds the Mulch to the autofill whitelist.

## Code changes

* src/Android/Accessibility/AccessibilityHelpers.cs
* src/Android/Autofill/AutofillHelpers.cs
* src/Android/Resources/xml/autofillservice.xml

All to add Mulch support.