### PR TITLE
[PM-1576] Fix Race condition AccountsManager registration

### DIFF
--- a/src/Android/MainApplication.cs
+++ b/src/Android/MainApplication.cs
@@ -81,7 +81,8 @@ namespace Bit.Droid
                     ServiceContainer.Resolve<IAuthService>("authService"),
                     ServiceContainer.Resolve<ILogger>("logger"),
                     ServiceContainer.Resolve<IMessagingService>("messagingService"),
-                    ServiceContainer.Resolve<IWatchDeviceService>());
+                    ServiceContainer.Resolve<IWatchDeviceService>(),
+                    ServiceContainer.Resolve<IConditionedAwaiterManager>());
                 ServiceContainer.Register<IAccountsManager>("accountsManager", accountsManager);
             }
 #if !FDROID

--- a/src/App/Utilities/AccountManagement/AccountsManager.cs
+++ b/src/App/Utilities/AccountManagement/AccountsManager.cs
@@ -140,7 +140,7 @@ namespace Bit.App.Utilities.AccountManagement
             try
             {
                 await _conditionedAwaiterManager.GetAwaiterForPrecondition(AwaiterPrecondition.EnvironmentUrlsInited);
-                
+
                 switch (message.Command)
                 {
                     case AccountsManagerMessageCommands.LOCKED:

--- a/src/Core/Abstractions/IConditionedAwaiterManager.cs
+++ b/src/Core/Abstractions/IConditionedAwaiterManager.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Threading.Tasks;
+
+namespace Bit.Core.Abstractions
+{
+    public enum AwaiterPrecondition
+    {
+        EnvironmentUrlsInited
+    }
+
+    public interface IConditionedAwaiterManager
+    {
+        Task GetAwaiterForPrecondition(AwaiterPrecondition awaiterPrecondition);
+        void SetAsCompleted(AwaiterPrecondition awaiterPrecondition);
+        void SetException(AwaiterPrecondition awaiterPrecondition, Exception ex);
+    }
+}

--- a/src/Core/Services/ConditionedAwaiterManager.cs
+++ b/src/Core/Services/ConditionedAwaiterManager.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using Bit.Core.Abstractions;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Bit.Core.Services
+{
+    public class ConditionedAwaiterManager : IConditionedAwaiterManager
+    {
+        private readonly ConcurrentDictionary<AwaiterPrecondition, TaskCompletionSource<bool>> _preconditionsTasks = new ConcurrentDictionary<AwaiterPrecondition, TaskCompletionSource<bool>>
+        {
+            [AwaiterPrecondition.EnvironmentUrlsInited] = new TaskCompletionSource<bool>()
+        };
+
+        public Task GetAwaiterForPrecondition(AwaiterPrecondition awaiterPrecondition)
+        {
+            if (_preconditionsTasks.TryGetValue(awaiterPrecondition, out var tcs))
+            {
+                return tcs.Task;
+            }
+
+            return Task.CompletedTask;
+        }
+
+        public void SetAsCompleted(AwaiterPrecondition awaiterPrecondition)
+        {
+            if (_preconditionsTasks.TryGetValue(awaiterPrecondition, out var tcs))
+            {
+                tcs.TrySetResult(true);
+            }
+        }
+
+        public void SetException(AwaiterPrecondition awaiterPrecondition, Exception ex)
+        {
+            if (_preconditionsTasks.TryGetValue(awaiterPrecondition, out var tcs))
+            {
+                tcs.TrySetException(ex);
+            }
+        }
+    }
+}

--- a/src/Core/Services/ConditionedAwaiterManager.cs
+++ b/src/Core/Services/ConditionedAwaiterManager.cs
@@ -1,8 +1,8 @@
 ﻿using System;
-using Bit.Core.Abstractions;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Bit.Core.Abstractions;
 
 namespace Bit.Core.Services
 {

--- a/src/Core/Services/EnvironmentService.cs
+++ b/src/Core/Services/EnvironmentService.cs
@@ -93,7 +93,7 @@ namespace Bit.Core.Services
                 _conditionedAwaiterManager.SetException(AwaiterPrecondition.EnvironmentUrlsInited, ex);
                 throw ex;
             }
-            
+
         }
 
         public async Task<EnvironmentUrlData> SetUrlsAsync(EnvironmentUrlData urls)

--- a/src/Core/Services/EnvironmentService.cs
+++ b/src/Core/Services/EnvironmentService.cs
@@ -91,7 +91,7 @@ namespace Bit.Core.Services
             catch (System.Exception ex)
             {
                 _conditionedAwaiterManager.SetException(AwaiterPrecondition.EnvironmentUrlsInited, ex);
-                throw ex;
+                throw;
             }
 
         }

--- a/src/Core/Utilities/ServiceContainer.cs
+++ b/src/Core/Utilities/ServiceContainer.cs
@@ -33,6 +33,7 @@ namespace Bit.Core.Utilities
 
             SearchService searchService = null;
 
+            var conditionedRunner = new ConditionedAwaiterManager();
             var tokenService = new TokenService(stateService);
             var apiService = new ApiService(tokenService, platformUtilsService, (extras) =>
             {
@@ -82,12 +83,13 @@ namespace Bit.Core.Utilities
                 keyConnectorService, passwordGenerationService);
             var exportService = new ExportService(folderService, cipherService, cryptoService);
             var auditService = new AuditService(cryptoFunctionService, apiService);
-            var environmentService = new EnvironmentService(apiService, stateService);
+            var environmentService = new EnvironmentService(apiService, stateService, conditionedRunner);
             var eventService = new EventService(apiService, stateService, organizationService, cipherService);
             var userVerificationService = new UserVerificationService(apiService, platformUtilsService, i18nService,
                 cryptoService);
             var usernameGenerationService = new UsernameGenerationService(cryptoService, apiService, stateService);
 
+            Register<IConditionedAwaiterManager>(conditionedRunner);
             Register<ITokenService>("tokenService", tokenService);
             Register<IApiService>("apiService", apiService);
             Register<IAppIdService>("appIdService", appIdService);

--- a/src/iOS.Core/Utilities/iOSCoreHelpers.cs
+++ b/src/iOS.Core/Utilities/iOSCoreHelpers.cs
@@ -156,6 +156,20 @@ namespace Bit.iOS.Core.Utilities
             ServiceContainer.Resolve<IAuthService>("authService").Init();
             (ServiceContainer.
                 Resolve<IPlatformUtilsService>("platformUtilsService") as MobilePlatformUtilsService).Init();
+
+            var accountsManager = new AccountsManager(
+                ServiceContainer.Resolve<IBroadcasterService>("broadcasterService"),
+                ServiceContainer.Resolve<IVaultTimeoutService>("vaultTimeoutService"),
+                ServiceContainer.Resolve<IStorageService>("secureStorageService"),
+                ServiceContainer.Resolve<IStateService>("stateService"),
+                ServiceContainer.Resolve<IPlatformUtilsService>("platformUtilsService"),
+                ServiceContainer.Resolve<IAuthService>("authService"),
+                ServiceContainer.Resolve<ILogger>("logger"),
+                ServiceContainer.Resolve<IMessagingService>("messagingService"),
+                ServiceContainer.Resolve<IWatchDeviceService>(),
+                ServiceContainer.Resolve<IConditionedAwaiterManager>());
+            ServiceContainer.Register<IAccountsManager>("accountsManager", accountsManager);
+
             // Note: This is not awaited
             var bootstrapTask = BootstrapAsync(postBootstrapFunc);
         }
@@ -234,18 +248,6 @@ namespace Bit.iOS.Core.Utilities
                 ServiceContainer.Resolve<IPasswordRepromptService>("passwordRepromptService"),
                 ServiceContainer.Resolve<ICryptoService>("cryptoService"));
             ServiceContainer.Register<IVerificationActionsFlowHelper>("verificationActionsFlowHelper", verificationActionsFlowHelper);
-
-            var accountsManager = new AccountsManager(
-                ServiceContainer.Resolve<IBroadcasterService>("broadcasterService"),
-                ServiceContainer.Resolve<IVaultTimeoutService>("vaultTimeoutService"),
-                ServiceContainer.Resolve<IStorageService>("secureStorageService"),
-                ServiceContainer.Resolve<IStateService>("stateService"),
-                ServiceContainer.Resolve<IPlatformUtilsService>("platformUtilsService"),
-                ServiceContainer.Resolve<IAuthService>("authService"),
-                ServiceContainer.Resolve<ILogger>("logger"),
-                ServiceContainer.Resolve<IMessagingService>("messagingService"),
-                ServiceContainer.Resolve<IWatchDeviceService>());
-            ServiceContainer.Register<IAccountsManager>("accountsManager", accountsManager);
 
             if (postBootstrapFunc != null)
             {


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
There are some cases where a race-condition happens on `AccountsManager` registration and it ends up crashing the iOS app.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **ConditionedAwaiterManager:** Added this class as a helper to have a condition task that can be awaited and can be completed/faulted from other services without needing any dependencies. This uses the `AwaiterPrecondition` to handle the proper task depending on the condition.
* **AccountsManager:** It now awaits for the precondition `EnvironmentUrlsInited` in order to perform any calls which is why before was being registered too late and now it can be registered before the App.App constructor is called.
* **EnvironmentService:** Change to update the `ConditionedAwaiterManager` -> `EnvironmentUrlsInited` precondition accordingly depending if it succeeds or fails.
* **ServiceContainer:** Moved the registration of the `AccountsManager` to be in a sooner place so that race-condition don't happen with the start of the application

## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
