### PR TITLE
[PM-1646] Add thread safety to migration process

### DIFF
--- a/src/Core/Abstractions/IStateMigrationService.cs
+++ b/src/Core/Abstractions/IStateMigrationService.cs
@@ -4,7 +4,6 @@ namespace Bit.Core.Abstractions
 {
     public interface IStateMigrationService
     {
-        Task<bool> NeedsMigration();
-        Task Migrate();
+        Task MigrateIfNeeded();
     }
 }

--- a/src/Core/Abstractions/IStateMigrationService.cs
+++ b/src/Core/Abstractions/IStateMigrationService.cs
@@ -4,6 +4,6 @@ namespace Bit.Core.Abstractions
 {
     public interface IStateMigrationService
     {
-        Task MigrateIfNeeded();
+        Task MigrateIfNeededAsync();
     }
 }

--- a/src/Core/Services/StateMigrationService.cs
+++ b/src/Core/Services/StateMigrationService.cs
@@ -18,8 +18,7 @@ namespace Bit.Core.Services
         private readonly IStorageService _preferencesStorageService;
         private readonly IStorageService _liteDbStorageService;
         private readonly IStorageService _secureStorageService;
-
-        private static SemaphoreSlim _semaphore;
+        private readonly SemaphoreSlim _semaphore;
 
         private enum Storage
         {
@@ -38,7 +37,7 @@ namespace Bit.Core.Services
             _semaphore = new SemaphoreSlim(1);
         }
 
-        public async Task MigrateIfNeeded()
+        public async Task MigrateIfNeededAsync()
         {
             await _semaphore.WaitAsync();
             try

--- a/src/Core/Services/StateService.cs
+++ b/src/Core/Services/StateService.cs
@@ -1537,8 +1537,8 @@ namespace Bit.Core.Services
         {
             if (!_migrationChecked)
             {
-                var migrationService = ServiceContainer.Resolve<IStateMigrationService>("stateMigrationService");
-                await migrationService.MigrateIfNeeded();
+                var migrationService = ServiceContainer.Resolve<IStateMigrationService>();
+                await migrationService.MigrateIfNeededAsync();
                 _migrationChecked = true;
             }
 

--- a/src/Core/Services/StateService.cs
+++ b/src/Core/Services/StateService.cs
@@ -1538,10 +1538,7 @@ namespace Bit.Core.Services
             if (!_migrationChecked)
             {
                 var migrationService = ServiceContainer.Resolve<IStateMigrationService>("stateMigrationService");
-                if (await migrationService.NeedsMigration())
-                {
-                    await migrationService.Migrate();
-                }
+                await migrationService.MigrateIfNeeded();
                 _migrationChecked = true;
             }
 


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
This makes the storage migration process thread safe to cover for cases where migration is inadvertently called more than once during app initialization.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **StateMigrationService.cs:** Combine checking for and performing migration into a single step behind a `SemaphoreSlim` to make sure migration will complete before executing a subsequent check.
* **StateService.cs:** Replace `NeedsMigration()` and `Migrate()` with `MigrateIfNeeded()`


## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
