### PR TITLE
[PM-1615] Fix cipher options not working in lists due to binding failing

### DIFF
--- a/src/App/Controls/CipherViewCell/CipherViewCell.xaml.cs
+++ b/src/App/Controls/CipherViewCell/CipherViewCell.xaml.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Windows.Input;
 using Bit.App.Abstractions;
 using Bit.Core.Models.View;
 using Bit.Core.Utilities;
@@ -18,7 +19,7 @@ namespace Bit.App.Controls
             nameof(WebsiteIconsEnabled), typeof(bool?), typeof(CipherViewCell));
 
         public static readonly BindableProperty ButtonCommandProperty = BindableProperty.Create(
-            nameof(ButtonCommand), typeof(Command<CipherView>), typeof(CipherViewCell));
+            nameof(ButtonCommand), typeof(ICommand), typeof(CipherViewCell));
 
         public CipherViewCell()
         {
@@ -42,9 +43,9 @@ namespace Bit.App.Controls
             set => SetValue(CipherProperty, value);
         }
 
-        public Command<CipherView> ButtonCommand
+        public ICommand ButtonCommand
         {
-            get => GetValue(ButtonCommandProperty) as Command<CipherView>;
+            get => GetValue(ButtonCommandProperty) as ICommand;
             set => SetValue(ButtonCommandProperty, value);
         }
 

--- a/src/App/Pages/Vault/GroupingsPage/GroupingsPageViewModel.cs
+++ b/src/App/Pages/Vault/GroupingsPage/GroupingsPageViewModel.cs
@@ -78,7 +78,9 @@ namespace Bit.App.Pages
                 Refreshing = true;
                 await LoadAsync();
             });
-            CipherOptionsCommand = new Command<CipherView>(CipherOptionsAsync);
+            CipherOptionsCommand = new AsyncCommand<CipherView>(cipher => AppHelpers.CipherListOptions(Page, cipher, _passwordRepromptService),
+                onException: ex => _logger.Exception(ex),
+                allowsMultipleExecutions: false);
             VaultFilterCommand = new AsyncCommand(VaultFilterOptionsAsync,
                 onException: ex => _logger.Exception(ex),
                 allowsMultipleExecutions: false);
@@ -168,7 +170,7 @@ namespace Bit.App.Pages
         public AccountSwitchingOverlayViewModel AccountSwitchingOverlayViewModel { get; }
         public ObservableRangeCollection<IGroupingsPageListItem> GroupedItems { get; set; }
         public Command RefreshCommand { get; set; }
-        public Command<CipherView> CipherOptionsCommand { get; set; }
+        public ICommand CipherOptionsCommand { get; }
         public bool LoadedOnce { get; set; }
 
         public async Task LoadAsync()
@@ -708,14 +710,6 @@ namespace Bit.App.Pages
         {
             var folders = decFolders.Where(f => _allCiphers.Any(c => c.FolderId == f.Id)).ToList();
             return folders.Any() ? folders : null;
-        }
-
-        private async void CipherOptionsAsync(CipherView cipher)
-        {
-            if ((Page as BaseContentPage).DoOnce())
-            {
-                await AppHelpers.CipherListOptions(Page, cipher, _passwordRepromptService);
-            }
         }
     }
 }


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Fix cipher options not working on lists due to binding failing.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **CipherViewCell:** Changed type of the `ButtonCommand` from `Command<CipherView>` to `ICommand` to make it more generic and easy to bind to any type of command in the ViewModel. This was causing the issue due to the change on the ViewModel to an `AsyncCommand<...>`
* **GroupingsPageViewModel:** Updated to use the `AsyncCommand<...>` as in the other places.

## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
