### PR TITLE
[PM-1690] Added minimum server version restriction to cipher key encryption

### DIFF
--- a/src/Core/Constants.cs
+++ b/src/Core/Constants.cs
@@ -60,6 +60,7 @@
         public const int Argon2Parallelism = 4;
         public const int MasterPasswordMinimumChars = 12;
         public const int CipherKeyRandomBytesLength = 64;
+        public const string CipherKeyEncryptionMinServerVersion = "2023.4.0";
 
         public static readonly string[] AndroidAllClearCipherCacheKeys =
         {

--- a/src/Core/Utilities/VersionHelpers.cs
+++ b/src/Core/Utilities/VersionHelpers.cs
@@ -1,0 +1,34 @@
+﻿using System;
+
+namespace Bit.Core.Utilities
+{
+    public static class VersionHelpers
+    {
+        private const char HOTFIX_SEPARATOR = '-';
+
+        /// <summary>
+        /// Compares two server versions and gets whether the <paramref name="targetVersion"/>
+        /// is greater than or equal to <paramref name="compareToVersion"/>.
+        /// WARNING: This doesn't take into account hotfix suffix.
+        /// </summary>
+        /// <param name="targetVersion">Version to compare</param>
+        /// <param name="compareToVersion">Version to compare against</param>
+        /// <returns>
+        /// <c>True</c> if <paramref name="targetVersion"/> is greater than or equal to <paramref name="compareToVersion"/>; <c>False</c> otherwise.
+        /// </returns>
+        public static bool IsServerVersionGreaterThanOrEqualTo(string targetVersion, string compareToVersion)
+        {
+            return GetServerVersionWithoutHotfix(targetVersion).CompareTo(GetServerVersionWithoutHotfix(compareToVersion)) >= 0;
+        }
+
+        public static Version GetServerVersionWithoutHotfix(string version)
+        {
+            if (string.IsNullOrWhiteSpace(version))
+            {
+                throw new ArgumentNullException(nameof(version));
+            }
+
+            return new Version(version.Split(HOTFIX_SEPARATOR)[0]);
+        }
+    }
+}


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Add minimum server version restriction to cipher key encryption usage and set force cipher key rotation to `false` after rotation happens.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **file.ext:** Description of what was changed and why


## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
