### PR TITLE
[PM-1731] Using UIDocumentPickerViewController when saving files on iOS

### DIFF
--- a/src/iOS.Core/Services/FileService.cs
+++ b/src/iOS.Core/Services/FileService.cs
@@ -5,7 +5,6 @@ using System.Threading.Tasks;
 using Bit.App.Resources;
 using Bit.Core.Abstractions;
 using Bit.iOS.Core.Utilities;
-using CoreGraphics;
 using Foundation;
 using MobileCoreServices;
 using Photos;
@@ -29,11 +28,20 @@ namespace Bit.iOS.Core.Services
             var filePath = Path.Combine(GetTempPath(), fileName);
             File.WriteAllBytes(filePath, fileData);
             var url = NSUrl.FromFilename(filePath);
-            var viewer = UIDocumentInteractionController.FromUrl(url);
             var controller = UIViewControllerExtensions.GetVisibleViewController();
-            var rect = UIDevice.CurrentDevice.UserInterfaceIdiom == UIUserInterfaceIdiom.Pad ?
-                new CGRect(100, 5, 320, 320) : controller.View.Frame;
-            return viewer.PresentOpenInMenu(rect, controller.View, true);
+
+            try
+            {
+                UIView presentingView = UIApplication.SharedApplication.KeyWindow.RootViewController.View;
+                var documentController = new UIDocumentPickerViewController(url, UIDocumentPickerMode.ExportToService);
+                controller.PresentViewController(documentController, true, null);
+
+                return true;
+            }
+            catch
+            {
+                return false;
+            }
         }
 
         public bool CanOpenFile(string fileName)


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
Some users are experiencing difficulties when trying to download attachments or exports. After selecting "Save in files" it should show the file system so that the user could select where to save it. Although sometimes it doesn't appear.


## Code changes

* **FileService.cs:** Changed `UIDocumentInteractionController` with `UIDocumentPickerViewController`. This way it opens immediately the "file system" and works consistently.

## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
