### PR TITLE
[PM-1906] Fix syncing issue with new policies method to update Vault Timeout

### DIFF
--- a/src/Core/Services/PolicyService.cs
+++ b/src/Core/Services/PolicyService.cs
@@ -63,7 +63,7 @@ namespace Bit.Core.Services
             _policyCache = null;
 
             var vaultTimeoutPolicy = policies.FirstOrDefault(p => p.Value.Type == PolicyType.MaximumVaultTimeout);
-            if (!vaultTimeoutPolicy.Equals(default))
+            if (vaultTimeoutPolicy.Value != null)
             {
                 await UpdateVaultTimeoutFromPolicyAsync(new Policy(vaultTimeoutPolicy.Value));
             }


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
We are now updating the vault timeout information from new policies that come in from a sync. During this, I checked the existence of a `MaximumVaultTimeout` policy using `.Equals(default)`, but this didn't seem to actually check the values for null. 

I have now changed it to check the Value of the `KeyValuePair` for null instead.

Will need to be cherry-picked to `rc`

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **file.ext:** Description of what was changed and why

## Screenshots
<!--Required for any UI changes. Delete if not applicable-->



## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
