### PR TITLE
[PM-1817] Expand biometric integrity checks to the account level

### DIFF
--- a/src/Android/MainApplication.cs
+++ b/src/Android/MainApplication.cs
@@ -155,7 +155,7 @@ namespace Bit.Droid
                 messagingService, broadcasterService);
             var autofillHandler = new AutofillHandler(stateService, messagingService, clipboardService,
                 platformUtilsService, new LazyResolve<IEventService>());
-            var biometricService = new BiometricService();
+            var biometricService = new BiometricService(stateService);
             var cryptoFunctionService = new PclCryptoFunctionService(cryptoPrimitiveService);
             var cryptoService = new CryptoService(stateService, cryptoFunctionService);
             var passwordRepromptService = new MobilePasswordRepromptService(platformUtilsService, cryptoService);

--- a/src/Android/MainApplication.cs
+++ b/src/Android/MainApplication.cs
@@ -21,6 +21,7 @@ using Bit.App.Utilities;
 using Bit.App.Pages;
 using Bit.App.Utilities.AccountManagement;
 using Bit.App.Controls;
+using Bit.Core.Enums;
 #if !FDROID
 using Android.Gms.Security;
 #endif
@@ -147,7 +148,7 @@ namespace Bit.Droid
             var storageMediatorService = new StorageMediatorService(mobileStorageService, secureStorageService, preferencesStorage);
             var stateService = new StateService(mobileStorageService, secureStorageService, storageMediatorService, messagingService);
             var stateMigrationService =
-                new StateMigrationService(liteDbStorage, preferencesStorage, secureStorageService);
+                new StateMigrationService(DeviceType.Android, liteDbStorage, preferencesStorage, secureStorageService);
             var clipboardService = new ClipboardService(stateService);
             var deviceActionService = new DeviceActionService(stateService, messagingService);
             var fileService = new FileService(stateService, broadcasterService);

--- a/src/App/Pages/Accounts/LockPage.xaml
+++ b/src/App/Pages/Accounts/LockPage.xaml
@@ -137,7 +137,7 @@
                     </StackLayout>
                     <StackLayout Padding="10, 0">
                         <Label
-                            Text="{u:I18n BiometricInvalidated}"
+                            Text="{u:I18n AccountBiometricInvalidated}"
                             StyleClass="box-footer-label,text-danger,text-bold"
                             IsVisible="{Binding BiometricIntegrityValid, Converter={StaticResource inverseBool}}" />
                         <Button Text="{Binding BiometricButtonText}" Clicked="Biometric_Clicked"

--- a/src/App/Pages/Accounts/LockPageViewModel.cs
+++ b/src/App/Pages/Accounts/LockPageViewModel.cs
@@ -209,7 +209,7 @@ namespace Bit.App.Pages
 
             if (BiometricLock)
             {
-                BiometricIntegrityValid = await _biometricService.ValidateIntegrityAsync();
+                BiometricIntegrityValid = await _platformUtilsService.IsBiometricIntegrityValidAsync();
                 if (!_biometricIntegrityValid)
                 {
                     BiometricButtonVisible = false;
@@ -431,7 +431,8 @@ namespace Bit.App.Pages
 
         public async Task PromptBiometricAsync()
         {
-            BiometricIntegrityValid = await _biometricService.ValidateIntegrityAsync();
+            BiometricIntegrityValid = await _platformUtilsService.IsBiometricIntegrityValidAsync();
+            BiometricButtonVisible = BiometricIntegrityValid;
             if (!BiometricLock || !BiometricIntegrityValid)
             {
                 return;

--- a/src/App/Resources/AppResources.Designer.cs
+++ b/src/App/Resources/AppResources.Designer.cs
@@ -970,18 +970,18 @@ namespace Bit.App.Resources {
         /// <summary>
         ///   Looks up a localized string similar to Biometric unlock disabled pending verification of master password..
         /// </summary>
-        public static string BiometricInvalidated {
+        public static string AccountBiometricInvalidated {
             get {
-                return ResourceManager.GetString("BiometricInvalidated", resourceCulture);
+                return ResourceManager.GetString("AccountBiometricInvalidated", resourceCulture);
             }
         }
         
         /// <summary>
         ///   Looks up a localized string similar to Biometric unlock for autofill disabled pending verification of master password..
         /// </summary>
-        public static string BiometricInvalidatedExtension {
+        public static string AccountBiometricInvalidatedExtension {
             get {
-                return ResourceManager.GetString("BiometricInvalidatedExtension", resourceCulture);
+                return ResourceManager.GetString("AccountBiometricInvalidatedExtension", resourceCulture);
             }
         }
         

--- a/src/App/Resources/AppResources.resx
+++ b/src/App/Resources/AppResources.resx
@@ -1752,11 +1752,11 @@ Scanning will happen automatically.</value>
     <value>Do you really want to send to the trash?</value>
     <comment>Confirmation alert message when soft-deleting a cipher.</comment>
   </data>
-  <data name="BiometricInvalidated" xml:space="preserve">
-    <value>Biometric unlock disabled pending verification of master password.</value>
+  <data name="AccountBiometricInvalidated" xml:space="preserve">
+    <value>Biometric unlock for this account is disabled pending verification of master password.</value>
   </data>
-  <data name="BiometricInvalidatedExtension" xml:space="preserve">
-    <value>Biometric unlock for autofill disabled pending verification of master password.</value>
+  <data name="AccountBiometricInvalidatedExtension" xml:space="preserve">
+    <value>Autofill biometric unlock for this account is disabled pending verification of master password.</value>
   </data>
   <data name="EnableSyncOnRefresh" xml:space="preserve">
     <value>Allow sync on refresh</value>

--- a/src/App/Services/MobilePlatformUtilsService.cs
+++ b/src/App/Services/MobilePlatformUtilsService.cs
@@ -6,6 +6,7 @@ using Bit.App.Models;
 using Bit.App.Resources;
 using Bit.Core.Abstractions;
 using Bit.Core.Enums;
+using Bit.Core.Utilities;
 using Plugin.Fingerprint;
 using Plugin.Fingerprint.Abstractions;
 using Xamarin.Essentials;
@@ -224,6 +225,20 @@ namespace Bit.App.Services
             {
                 return false;
             }
+        }
+
+        public async Task<bool> IsBiometricIntegrityValidAsync(string bioIntegritySrcKey = null)
+        {
+            bioIntegritySrcKey ??= Core.Constants.BiometricIntegritySourceKey;
+
+            var biometricService = ServiceContainer.Resolve<IBiometricService>();
+            if (!await biometricService.IsSystemBiometricIntegrityValidAsync(bioIntegritySrcKey))
+            {
+                return false;
+            }
+
+            var stateService = ServiceContainer.Resolve<IStateService>();
+            return await stateService.IsAccountBiometricIntegrityValidAsync(bioIntegritySrcKey);
         }
 
         public async Task<bool> AuthenticateBiometricAsync(string text = null, string fallbackText = null,

--- a/src/App/Services/MobileStorageService.cs
+++ b/src/App/Services/MobileStorageService.cs
@@ -22,14 +22,14 @@ namespace Bit.App.Services
             Constants.PushRegisteredTokenKey,
             Constants.LastBuildKey,
             Constants.ClearCiphersCacheKey,
-            Constants.BiometricIntegrityKey,
+            Constants.BiometricIntegritySourceKey,
             Constants.iOSExtensionActiveUserIdKey,
             Constants.iOSAutoFillClearCiphersCacheKey,
-            Constants.iOSAutoFillBiometricIntegrityKey,
+            Constants.iOSAutoFillBiometricIntegritySourceKey,
             Constants.iOSExtensionClearCiphersCacheKey,
-            Constants.iOSExtensionBiometricIntegrityKey,
+            Constants.iOSExtensionBiometricIntegritySourceKey,
             Constants.iOSShareExtensionClearCiphersCacheKey,
-            Constants.iOSShareExtensionBiometricIntegrityKey,
+            Constants.iOSShareExtensionBiometricIntegritySourceKey,
             Constants.RememberedEmailKey,
             Constants.RememberedOrgIdentifierKey
         };

--- a/src/Core/Abstractions/IBiometricService.cs
+++ b/src/Core/Abstractions/IBiometricService.cs
@@ -4,7 +4,7 @@ namespace Bit.Core.Abstractions
 {
     public interface IBiometricService
     {
-        Task<bool> SetupBiometricAsync(string bioIntegrityKey = null);
-        Task<bool> ValidateIntegrityAsync(string bioIntegrityKey = null);
+        Task<bool> SetupBiometricAsync(string bioIntegritySrcKey = null);
+        Task<bool> IsSystemBiometricIntegrityValidAsync(string bioIntegritySrcKey = null);
     }
 }

--- a/src/Core/Abstractions/IPlatformUtilsService.cs
+++ b/src/Core/Abstractions/IPlatformUtilsService.cs
@@ -28,6 +28,7 @@ namespace Bit.Core.Abstractions
         bool SupportsFido2();
         bool SupportsDuo();
         Task<bool> SupportsBiometricAsync();
+        Task<bool> IsBiometricIntegrityValidAsync(string bioIntegritySrcKey = null);
         Task<bool> AuthenticateBiometricAsync(string text = null, string fallbackText = null, Action fallback = null);
         long GetActiveTime();
     }

--- a/src/Core/Abstractions/IStateService.cs
+++ b/src/Core/Abstractions/IStateService.cs
@@ -31,6 +31,10 @@ namespace Bit.Core.Abstractions
         Task SetBiometricUnlockAsync(bool? value, string userId = null);
         Task<bool> GetBiometricLockedAsync(string userId = null);
         Task SetBiometricLockedAsync(bool value, string userId = null);
+        Task<string> GetSystemBiometricIntegrityState(string bioIntegritySrcKey);
+        Task SetSystemBiometricIntegrityState(string bioIntegritySrcKey, string systemBioIntegrityState);
+        Task<bool> IsAccountBiometricIntegrityValidAsync(string bioIntegritySrcKey, string userId = null);
+        Task SetAccountBiometricIntegrityValidAsync(string bioIntegritySrcKey, string userId = null);
         Task<bool> CanAccessPremiumAsync(string userId = null);
         Task SetPersonalPremiumAsync(bool value, string userId = null);
         Task<string> GetProtectedPinAsync(string userId = null);

--- a/src/Core/Constants.cs
+++ b/src/Core/Constants.cs
@@ -18,13 +18,13 @@
         public const string LastBuildKey = "lastBuild";
         public const string AddSitePromptShownKey = "addSitePromptShown";
         public const string ClearCiphersCacheKey = "clearCiphersCache";
-        public const string BiometricIntegritySourceKey = "biometricIntegrityState";
+        public const string BiometricIntegritySourceKey = "biometricIntegritySource";
         public const string iOSAutoFillClearCiphersCacheKey = "iOSAutoFillClearCiphersCache";
-        public const string iOSAutoFillBiometricIntegritySourceKey = "iOSAutoFillBiometricIntegrityState";
+        public const string iOSAutoFillBiometricIntegritySourceKey = "iOSAutoFillBiometricIntegritySource";
         public const string iOSExtensionClearCiphersCacheKey = "iOSExtensionClearCiphersCache";
-        public const string iOSExtensionBiometricIntegritySourceKey = "iOSExtensionBiometricIntegrityState";
+        public const string iOSExtensionBiometricIntegritySourceKey = "iOSExtensionBiometricIntegritySource";
         public const string iOSShareExtensionClearCiphersCacheKey = "iOSShareExtensionClearCiphersCache";
-        public const string iOSShareExtensionBiometricIntegritySourceKey = "iOSShareExtensionBiometricIntegrityState";
+        public const string iOSShareExtensionBiometricIntegritySourceKey = "iOSShareExtensionBiometricIntegritySource";
         public const string iOSExtensionActiveUserIdKey = "iOSExtensionActiveUserId";
         public const string EventCollectionKey = "eventCollection";
         public const string RememberedEmailKey = "rememberedEmail";

--- a/src/Core/Constants.cs
+++ b/src/Core/Constants.cs
@@ -18,13 +18,13 @@
         public const string LastBuildKey = "lastBuild";
         public const string AddSitePromptShownKey = "addSitePromptShown";
         public const string ClearCiphersCacheKey = "clearCiphersCache";
-        public const string BiometricIntegrityKey = "biometricIntegrityState";
+        public const string BiometricIntegritySourceKey = "biometricIntegrityState";
         public const string iOSAutoFillClearCiphersCacheKey = "iOSAutoFillClearCiphersCache";
-        public const string iOSAutoFillBiometricIntegrityKey = "iOSAutoFillBiometricIntegrityState";
+        public const string iOSAutoFillBiometricIntegritySourceKey = "iOSAutoFillBiometricIntegrityState";
         public const string iOSExtensionClearCiphersCacheKey = "iOSExtensionClearCiphersCache";
-        public const string iOSExtensionBiometricIntegrityKey = "iOSExtensionBiometricIntegrityState";
+        public const string iOSExtensionBiometricIntegritySourceKey = "iOSExtensionBiometricIntegrityState";
         public const string iOSShareExtensionClearCiphersCacheKey = "iOSShareExtensionClearCiphersCache";
-        public const string iOSShareExtensionBiometricIntegrityKey = "iOSShareExtensionBiometricIntegrityState";
+        public const string iOSShareExtensionBiometricIntegritySourceKey = "iOSShareExtensionBiometricIntegrityState";
         public const string iOSExtensionActiveUserIdKey = "iOSExtensionActiveUserId";
         public const string EventCollectionKey = "eventCollection";
         public const string RememberedEmailKey = "rememberedEmail";
@@ -110,6 +110,8 @@
         public static string ProtectedPinKey(string userId) => $"protectedPin_{userId}";
         public static string LastSyncKey(string userId) => $"lastSync_{userId}";
         public static string BiometricUnlockKey(string userId) => $"biometricUnlock_{userId}";
+        public static string AccountBiometricIntegrityValidKey(string userId, string systemBioIntegrityState) =>
+            $"accountBiometricIntegrityValid_{userId}_{systemBioIntegrityState}";
         public static string ApprovePasswordlessLoginsKey(string userId) => $"approvePasswordlessLogins_{userId}";
         public static string UsernameGenOptionsKey(string userId) => $"usernameGenerationOptions_{userId}";
         public static string PushLastRegistrationDateKey(string userId) => $"pushLastRegistrationDate_{userId}";

--- a/src/Core/Services/StateMigrationService.cs
+++ b/src/Core/Services/StateMigrationService.cs
@@ -13,8 +13,9 @@ namespace Bit.Core.Services
 {
     public class StateMigrationService : IStateMigrationService
     {
-        private const int StateVersion = 4;
+        private const int StateVersion = 5;
 
+        private readonly DeviceType _deviceType;
         private readonly IStorageService _preferencesStorageService;
         private readonly IStorageService _liteDbStorageService;
         private readonly IStorageService _secureStorageService;
@@ -27,9 +28,10 @@ namespace Bit.Core.Services
             Secure,
         }
 
-        public StateMigrationService(IStorageService liteDbStorageService, IStorageService preferenceStorageService,
-            IStorageService secureStorageService)
+        public StateMigrationService(DeviceType deviceType, IStorageService liteDbStorageService,
+            IStorageService preferenceStorageService, IStorageService secureStorageService)
         {
+            _deviceType = deviceType;
             _liteDbStorageService = liteDbStorageService;
             _preferencesStorageService = preferenceStorageService;
             _secureStorageService = secureStorageService;
@@ -78,6 +80,9 @@ namespace Bit.Core.Services
                     goto case 3;
                 case 3:
                     await MigrateFrom3To4Async();
+                    break;
+                case 4:
+                    await MigrateFrom4To5Async();
                     break;
             }
         }
@@ -442,6 +447,10 @@ namespace Bit.Core.Services
             // Removal of old state data will happen organically as state is rebuilt in app
         }
 
+        #endregion
+
+        #region v4 to v5 Migration
+
         private class V4Keys
         {
             internal static string VaultTimeoutKey(string userId) => $"vaultTimeout_{userId}";
@@ -450,6 +459,87 @@ namespace Bit.Core.Services
             internal const string ThemeKey = "theme";
             internal const string AutoDarkThemeKey = "autoDarkTheme";
             internal const string DisableFaviconKey = "disableFavicon";
+            internal const string BiometricIntegrityKey = "biometricIntegrityState";
+            internal const string iOSAutoFillBiometricIntegrityKey = "iOSAutoFillBiometricIntegrityState";
+            internal const string iOSExtensionBiometricIntegrityKey = "iOSExtensionBiometricIntegrityState";
+            internal const string iOSShareExtensionBiometricIntegrityKey = "iOSShareExtensionBiometricIntegrityState";
+        }
+
+        private async Task MigrateFrom4To5Async()
+        {
+            var bioIntegrityState = await GetValueAsync<string>(Storage.Prefs, V4Keys.BiometricIntegrityKey);
+            var iOSAutofillBioIntegrityState =
+                await GetValueAsync<string>(Storage.Prefs, V4Keys.iOSAutoFillBiometricIntegrityKey);
+            var iOSExtensionBioIntegrityState =
+                await GetValueAsync<string>(Storage.Prefs, V4Keys.iOSExtensionBiometricIntegrityKey);
+            var iOSShareExtensionBioIntegrityState =
+                await GetValueAsync<string>(Storage.Prefs, V4Keys.iOSShareExtensionBiometricIntegrityKey);
+
+            if (_deviceType == DeviceType.Android && string.IsNullOrWhiteSpace(bioIntegrityState))
+            {
+                bioIntegrityState = Guid.NewGuid().ToString();
+            }
+
+            await SetValueAsync(Storage.Prefs, V5Keys.BiometricIntegritySourceKey, bioIntegrityState);
+
+            if (_deviceType == DeviceType.iOS)
+            {
+                await SetValueAsync(Storage.Prefs, V5Keys.iOSAutoFillBiometricIntegritySourceKey,
+                    iOSAutofillBioIntegrityState);
+                await SetValueAsync(Storage.Prefs, V5Keys.iOSExtensionBiometricIntegritySourceKey,
+                    iOSExtensionBioIntegrityState);
+                await SetValueAsync(Storage.Prefs, V5Keys.iOSShareExtensionBiometricIntegritySourceKey,
+                    iOSShareExtensionBioIntegrityState);
+            }
+
+            var state = await GetValueAsync<State>(Storage.LiteDb, Constants.StateKey);
+            if (state?.Accounts is null)
+            {
+                // Nobody logged in, update stored version and exit
+                await SetLastStateVersionAsync(5);
+                return;
+            }
+
+            // build integrity keys for existing users
+            foreach (var account in state.Accounts.Where(a => a.Value?.Profile?.UserId != null))
+            {
+                var userId = account.Value.Profile.UserId;
+
+                await SetValueAsync(Storage.Prefs,
+                    V5Keys.AccountBiometricIntegrityValidKey(userId, bioIntegrityState), true);
+
+                if (_deviceType == DeviceType.iOS)
+                {
+                    await SetValueAsync(Storage.Prefs,
+                        V5Keys.AccountBiometricIntegrityValidKey(userId, iOSAutofillBioIntegrityState), true);
+                    await SetValueAsync(Storage.Prefs,
+                        V5Keys.AccountBiometricIntegrityValidKey(userId, iOSExtensionBioIntegrityState), true);
+                    await SetValueAsync(Storage.Prefs,
+                        V5Keys.AccountBiometricIntegrityValidKey(userId, iOSShareExtensionBioIntegrityState), true);
+                }
+            }
+
+            // Update stored version
+            await SetLastStateVersionAsync(5);
+
+            // Remove old data
+            await RemoveValueAsync(Storage.Prefs, V4Keys.BiometricIntegrityKey);
+            await RemoveValueAsync(Storage.Prefs, V4Keys.iOSAutoFillBiometricIntegrityKey);
+            await RemoveValueAsync(Storage.Prefs, V4Keys.iOSExtensionBiometricIntegrityKey);
+            await RemoveValueAsync(Storage.Prefs, V4Keys.iOSShareExtensionBiometricIntegrityKey);
+        }
+
+        private class V5Keys
+        {
+            internal const string BiometricIntegritySourceKey = "biometricIntegritySource";
+            internal const string iOSAutoFillBiometricIntegritySourceKey = "iOSAutoFillBiometricIntegritySource";
+            internal const string iOSExtensionBiometricIntegritySourceKey = "iOSExtensionBiometricIntegritySource";
+
+            internal const string iOSShareExtensionBiometricIntegritySourceKey =
+                "iOSShareExtensionBiometricIntegritySource";
+
+            internal static string AccountBiometricIntegrityValidKey(string userId, string systemBioIntegrityState) =>
+                $"accountBiometricIntegrityValid_{userId}_{systemBioIntegrityState}";
         }
 
         #endregion

--- a/src/Core/Services/StateMigrationService.cs
+++ b/src/Core/Services/StateMigrationService.cs
@@ -495,7 +495,7 @@ namespace Bit.Core.Services
             var state = await GetValueAsync<State>(Storage.LiteDb, Constants.StateKey);
             if (state?.Accounts is null)
             {
-                // Nobody logged in, update stored version and exit
+                // No accounts available, update stored version and exit
                 await SetLastStateVersionAsync(5);
                 return;
             }

--- a/src/Core/Services/StateMigrationService.cs
+++ b/src/Core/Services/StateMigrationService.cs
@@ -505,16 +505,16 @@ namespace Bit.Core.Services
             {
                 var userId = account.Value.Profile.UserId;
 
-                await SetValueAsync(Storage.Prefs,
+                await SetValueAsync(Storage.LiteDb,
                     V5Keys.AccountBiometricIntegrityValidKey(userId, bioIntegrityState), true);
 
                 if (_deviceType == DeviceType.iOS)
                 {
-                    await SetValueAsync(Storage.Prefs,
+                    await SetValueAsync(Storage.LiteDb,
                         V5Keys.AccountBiometricIntegrityValidKey(userId, iOSAutofillBioIntegrityState), true);
-                    await SetValueAsync(Storage.Prefs,
+                    await SetValueAsync(Storage.LiteDb,
                         V5Keys.AccountBiometricIntegrityValidKey(userId, iOSExtensionBioIntegrityState), true);
-                    await SetValueAsync(Storage.Prefs,
+                    await SetValueAsync(Storage.LiteDb,
                         V5Keys.AccountBiometricIntegrityValidKey(userId, iOSShareExtensionBioIntegrityState), true);
                 }
             }

--- a/src/Core/Services/StateService.cs
+++ b/src/Core/Services/StateService.cs
@@ -272,6 +272,36 @@ namespace Bit.Core.Services
             await SaveAccountAsync(account, reconciledOptions);
         }
 
+        public async Task<string> GetSystemBiometricIntegrityState(string bioIntegritySrcKey)
+        {
+            return await GetValueAsync<string>(bioIntegritySrcKey, await GetDefaultStorageOptionsAsync());
+        }
+
+        public async Task SetSystemBiometricIntegrityState(string bioIntegritySrcKey, string systemBioIntegrityState)
+        {
+            await SetValueAsync(bioIntegritySrcKey, systemBioIntegrityState, await GetDefaultStorageOptionsAsync());
+        }
+
+        public async Task<bool> IsAccountBiometricIntegrityValidAsync(string bioIntegritySrcKey, string userId = null)
+        {
+            var systemBioIntegrityState = await GetSystemBiometricIntegrityState(bioIntegritySrcKey);
+            var reconciledOptions = ReconcileOptions(new StorageOptions { UserId = userId },
+                await GetDefaultStorageOptionsAsync());
+            return await GetValueAsync<bool?>(
+                Constants.AccountBiometricIntegrityValidKey(reconciledOptions.UserId, systemBioIntegrityState),
+                reconciledOptions) ?? false;
+        }
+
+        public async Task SetAccountBiometricIntegrityValidAsync(string bioIntegritySrcKey, string userId = null)
+        {
+            var systemBioIntegrityState = await GetSystemBiometricIntegrityState(bioIntegritySrcKey);
+            var reconciledOptions = ReconcileOptions(new StorageOptions { UserId = userId },
+                await GetDefaultStorageOptionsAsync());
+            await SetValueAsync(
+                Constants.AccountBiometricIntegrityValidKey(reconciledOptions.UserId, systemBioIntegrityState),
+                true, reconciledOptions);
+        }
+
         public async Task<bool> CanAccessPremiumAsync(string userId = null)
         {
             if (userId == null)

--- a/src/iOS.Autofill/LockPasswordViewController.cs
+++ b/src/iOS.Autofill/LockPasswordViewController.cs
@@ -15,7 +15,7 @@ namespace Bit.iOS.Autofill
         public LockPasswordViewController(IntPtr handle)
             : base(handle)
         {
-            BiometricIntegrityKey = Bit.Core.Constants.iOSAutoFillBiometricIntegrityKey;
+            BiometricIntegritySourceKey = Bit.Core.Constants.iOSAutoFillBiometricIntegritySourceKey;
             DismissModalAction = Cancel;
             autofillExtension = true;
         }

--- a/src/iOS.Core/Controllers/BaseLockPasswordViewController.cs
+++ b/src/iOS.Core/Controllers/BaseLockPasswordViewController.cs
@@ -56,7 +56,7 @@ namespace Bit.iOS.Core.Controllers
         public FormEntryTableViewCell MasterPasswordCell { get; set; } = new FormEntryTableViewCell(
             AppResources.MasterPassword, buttonsConfig: FormEntryTableViewCell.ButtonsConfig.One);
 
-        public string BiometricIntegrityKey { get; set; }
+        public string BiometricIntegritySourceKey { get; set; }
 
         public UITableViewCell BiometricCell
         {
@@ -77,7 +77,7 @@ namespace Bit.iOS.Core.Controllers
                     cell.TextLabel.Font = ThemeHelpers.GetDangerFont();
                     cell.TextLabel.Lines = 0;
                     cell.TextLabel.LineBreakMode = UILineBreakMode.WordWrap;
-                    cell.TextLabel.Text = AppResources.BiometricInvalidatedExtension;
+                    cell.TextLabel.Text = AppResources.AccountBiometricInvalidatedExtension;
                 }
                 return cell;
             }
@@ -114,7 +114,8 @@ namespace Bit.iOS.Core.Controllers
                            _isPinProtectedWithKey;
                 _biometricLock = await _vaultTimeoutService.IsBiometricLockSetAsync() &&
                                  await _cryptoService.HasKeyAsync();
-                _biometricIntegrityValid = await _biometricService.ValidateIntegrityAsync(BiometricIntegrityKey);
+                _biometricIntegrityValid =
+                    await _platformUtilsService.IsBiometricIntegrityValidAsync(BiometricIntegritySourceKey);
                 _usesKeyConnector = await _keyConnectorService.GetUsesKeyConnector();
                 _biometricUnlockOnly = _usesKeyConnector && _biometricLock && !_pinLock;
             }
@@ -371,7 +372,7 @@ namespace Bit.iOS.Core.Controllers
             // Re-enable biometrics if initial use
             if (_biometricLock & !_biometricIntegrityValid)
             {
-                await _biometricService.SetupBiometricAsync(BiometricIntegrityKey);
+                await _biometricService.SetupBiometricAsync(BiometricIntegritySourceKey);
             }
         }
 

--- a/src/iOS.Core/Controllers/LockPasswordViewController.cs
+++ b/src/iOS.Core/Controllers/LockPasswordViewController.cs
@@ -53,7 +53,7 @@ namespace Bit.iOS.Core.Controllers
         public FormEntryTableViewCell MasterPasswordCell { get; set; } = new FormEntryTableViewCell(
             AppResources.MasterPassword, buttonsConfig: FormEntryTableViewCell.ButtonsConfig.One);
 
-        public string BiometricIntegrityKey { get; set; }
+        public string BiometricIntegritySourceKey { get; set; }
 
         public UITableViewCell BiometricCell
         {
@@ -74,7 +74,7 @@ namespace Bit.iOS.Core.Controllers
                     cell.TextLabel.Font = ThemeHelpers.GetDangerFont();
                     cell.TextLabel.Lines = 0;
                     cell.TextLabel.LineBreakMode = UILineBreakMode.WordWrap;
-                    cell.TextLabel.Text = AppResources.BiometricInvalidatedExtension;
+                    cell.TextLabel.Text = AppResources.AccountBiometricInvalidatedExtension;
                 }
                 return cell;
             }
@@ -108,7 +108,8 @@ namespace Bit.iOS.Core.Controllers
                            _isPinProtectedWithKey;
                 _biometricLock = await _vaultTimeoutService.IsBiometricLockSetAsync() &&
                                  await _cryptoService.HasKeyAsync();
-                _biometricIntegrityValid = await _biometricService.ValidateIntegrityAsync(BiometricIntegrityKey);
+                _biometricIntegrityValid =
+                    await _platformUtilsService.IsBiometricIntegrityValidAsync(BiometricIntegritySourceKey);
                 _usesKeyConnector = await _keyConnectorService.GetUsesKeyConnector();
                 _biometricUnlockOnly = _usesKeyConnector && _biometricLock && !_pinLock;
             }
@@ -361,7 +362,7 @@ namespace Bit.iOS.Core.Controllers
             // Re-enable biometrics if initial use
             if (_biometricLock & !_biometricIntegrityValid)
             {
-                await _biometricService.SetupBiometricAsync(BiometricIntegrityKey);
+                await _biometricService.SetupBiometricAsync(BiometricIntegritySourceKey);
             }
         }
 

--- a/src/iOS.Core/Utilities/AccountSwitchingOverlayHelper.cs
+++ b/src/iOS.Core/Utilities/AccountSwitchingOverlayHelper.cs
@@ -34,7 +34,8 @@ namespace Bit.iOS.Core.Utilities
                 }
 
                 var avatarImageSource = new AvatarImageSource(await _stateService.GetActiveUserIdAsync(),
-                    await _stateService.GetNameAsync(), await _stateService.GetEmailAsync());
+                    await _stateService.GetNameAsync(), await _stateService.GetEmailAsync(),
+                    await _stateService.GetAvatarColorAsync());
                 using (var avatarUIImage = await avatarImageSource.GetNativeImageAsync())
                 {
                     return avatarUIImage?.ImageWithRenderingMode(UIImageRenderingMode.AlwaysOriginal) ?? UIImage.GetSystemImage(DEFAULT_SYSTEM_AVATAR_IMAGE);

--- a/src/iOS.Core/Utilities/iOSCoreHelpers.cs
+++ b/src/iOS.Core/Utilities/iOSCoreHelpers.cs
@@ -10,6 +10,7 @@ using Bit.App.Services;
 using Bit.App.Utilities;
 using Bit.App.Utilities.AccountManagement;
 using Bit.Core.Abstractions;
+using Bit.Core.Enums;
 using Bit.Core.Services;
 using Bit.Core.Utilities;
 using Bit.iOS.Core.Services;
@@ -105,7 +106,7 @@ namespace Bit.iOS.Core.Utilities
             var storageMediatorService = new StorageMediatorService(mobileStorageService, secureStorageService, preferencesStorage);
             var stateService = new StateService(mobileStorageService, secureStorageService, storageMediatorService, messagingService);
             var stateMigrationService =
-                new StateMigrationService(liteDbStorage, preferencesStorage, secureStorageService);
+                new StateMigrationService(DeviceType.iOS, liteDbStorage, preferencesStorage, secureStorageService);
             var deviceActionService = new DeviceActionService();
             var fileService = new FileService(stateService, messagingService);
             var clipboardService = new ClipboardService(stateService);

--- a/src/iOS.Core/Utilities/iOSCoreHelpers.cs
+++ b/src/iOS.Core/Utilities/iOSCoreHelpers.cs
@@ -111,7 +111,7 @@ namespace Bit.iOS.Core.Utilities
             var clipboardService = new ClipboardService(stateService);
             var platformUtilsService = new MobilePlatformUtilsService(deviceActionService, clipboardService,
                 messagingService, broadcasterService);
-            var biometricService = new BiometricService(mobileStorageService);
+            var biometricService = new BiometricService(stateService);
             var cryptoFunctionService = new PclCryptoFunctionService(cryptoPrimitiveService);
             var cryptoService = new CryptoService(stateService, cryptoFunctionService);
             var passwordRepromptService = new MobilePasswordRepromptService(platformUtilsService, cryptoService);

--- a/src/iOS.Extension/LockPasswordViewController.cs
+++ b/src/iOS.Extension/LockPasswordViewController.cs
@@ -9,7 +9,7 @@ namespace Bit.iOS.Extension
         public LockPasswordViewController(IntPtr handle)
             : base(handle)
         {
-            BiometricIntegrityKey = Bit.Core.Constants.iOSExtensionBiometricIntegrityKey;
+            BiometricIntegritySourceKey = Bit.Core.Constants.iOSExtensionBiometricIntegritySourceKey;
             DismissModalAction = Cancel;
         }
 

--- a/src/iOS.ShareExtension/LockPasswordViewController.cs
+++ b/src/iOS.ShareExtension/LockPasswordViewController.cs
@@ -13,14 +13,14 @@ namespace Bit.iOS.ShareExtension
 
         public LockPasswordViewController()
         {
-            BiometricIntegrityKey = Bit.Core.Constants.iOSShareExtensionBiometricIntegrityKey;
+            BiometricIntegritySourceKey = Bit.Core.Constants.iOSShareExtensionBiometricIntegritySourceKey;
             DismissModalAction = Cancel;
         }
 
         public LockPasswordViewController(IntPtr handle)
             : base(handle)
         {
-            BiometricIntegrityKey = Bit.Core.Constants.iOSShareExtensionBiometricIntegrityKey;
+            BiometricIntegritySourceKey = Bit.Core.Constants.iOSShareExtensionBiometricIntegritySourceKey;
             DismissModalAction = Cancel;
         }
 


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
This modification tracks system-level biometric invalidation (new fingerprint/face added, etc.) at the account level by storing 'approval flags' with the user ID & representations of the current 'state' of biometrics in the following format:

     accountBiometricIntegrityValid_{userId}_{systemBioIntegrityState}

The presence of this key indicates to the app that this particular user is clear to use biometrics in the state provided.  Once the state changes and the key is no longer valid, the user must re-enter their password to save a new key with the updated state for their user ID.

_Android notes:_

Our Android implementation never stored any kind of system biometric state because validation relies on key functions throwing specific exceptions.  For this to work a state was added in the form of a GUID which is generated on biometric initialization if one doesn't already exist, and removed when invalidation occurs (to be re-generated on re-initialization).  This follows the pattern already established by our iOS implementation.

_iOS notes:_

As state is process-specific, additional validation keys are used for iOS extensions so password re-entry is still required for each extension separate from the main app (same as now).  I have a few thoughts on how to improve this experience but that's for later.

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

_Main changes:_

* **BiometricService.cs:** Init with `StateService` to give main app access to state and validation keys, utilize source key name in key generation, removed old migration as it should no longer be needed (iOS)
* **Mobile/PlatformUtilsService:** Added `IsBiometricIntegrityValidAsync` to perform both system and account-level validation in a single method
* **StateService:** Added getter/setter for system bio state and account bio key validation
* **StateMigrationService:** Generate new bio state (android), migrate existing bio integrity to any existing accounts
* **AppResources:** Add "for this account" phrasing to biometric invalidation prompt

_Other:_

* **LockPageViewModel:** Apply `BiometricButtonVisible` after checking `BiometricIntegrityValid` to dynamically remove button if app is resumed (vs cold start) after bio state changes
* **AccountSwitchingOverlayHelper:** Make use of custom avatar color in iOS extensions
* **Other:** Lots of var renaming to discern between system and account level biometric validation as well as validation source vs key value


## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
