### PR TITLE
[PM-1352] Fix Avatar toolbar icon on OTP cipher selection

### DIFF
--- a/src/App/Pages/Vault/CipherSelectionPage.xaml
+++ b/src/App/Pages/Vault/CipherSelectionPage.xaml
@@ -16,7 +16,7 @@
             IconImageSource="{Binding AvatarImageSource}"
             Command="{Binding Source={x:Reference _accountListOverlay}, Path=ToggleVisibililtyCommand}"
             Order="Primary"
-            Priority="-2"
+            Priority="-1"
             UseOriginalImage="True"
             AutomationProperties.IsInAccessibleTree="True"
             AutomationProperties.Name="{u:I18n Account}" />

--- a/src/App/Pages/Vault/CipherSelectionPage.xaml.cs
+++ b/src/App/Pages/Vault/CipherSelectionPage.xaml.cs
@@ -69,13 +69,15 @@ namespace Bit.App.Pages
                 return;
             }
 
-            // TODO: There's currently an issue on iOS where the toolbar item is not getting updated
-            // as the others somehow. Removing this so at least we get the circle with ".." instead
-            // of a white circle
-            if (Device.RuntimePlatform != Device.iOS)
+            try
             {
+                // don't crash the app if the avatar can't be loaded, just log the ex
                 _accountAvatar?.OnAppearing();
                 _vm.AvatarImageSource = await GetAvatarImageSourceAsync();
+            }
+            catch (Exception ex)
+            {
+                LoggerHelper.LogEvenIfCantBeResolved(ex);
             }
 
             _broadcasterService.Subscribe(nameof(CipherSelectionPage), async (message) =>


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
🐛 Fix the toolbar icon for the avatar switch on OTP cipher selection that wasn't being loaded.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **CipherSelectionPage.xaml:** Changed toolbar item priority to "-1" which seems to fix the bug and not the icon loads and updates in the UI correctly
* **CipherSelectionPage.xaml.cs:** Enabled back the account toolbar icon loading and surrounded it in a try...catch so that the app doesn't crash if the icon can't be loaded somehow.

## Screenshots
<!--Required for any UI changes. Delete if not applicable-->

<img width="314" alt="OTP cipher selection account toolbar icon" src="https://user-images.githubusercontent.com/15682323/236491502-a591a45b-f293-4a2b-87db-e966a13df05a.jpeg">



## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
