### PR TITLE
[PM-1748] Fix Watch TOTP details on Always On Display

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,7 +1,3 @@
-watchOS:
-- 'src/watchOS/*'
-- 'src/watchOS/bitwarden/bitwarden WatchKit Extension/*'
-
 android:
 - src/App/*
 - src/Core/*
@@ -17,3 +13,7 @@ iOS:
 - 'src/iOS.Extension/*'
 - 'src/iOS.ShareExtension/*'
 - 'src/iOS.Widget/*'
+- src/watchOS/*
+
+watchOS:
+- src/watchOS/*

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,3 +1,7 @@
+watchOS:
+- 'src/watchOS/*'
+- 'src/watchOS/bitwarden/bitwarden WatchKit Extension/*'
+
 android:
 - src/App/*
 - src/Core/*
@@ -13,7 +17,3 @@ iOS:
 - 'src/iOS.Extension/*'
 - 'src/iOS.ShareExtension/*'
 - 'src/iOS.Widget/*'
-- src/watchOS/*
-
-watchOS:
-- src/watchOS/*

--- a/src/watchOS/bitwarden/bitwarden WatchKit Extension/Models/Mocks/CipherMock.swift
+++ b/src/watchOS/bitwarden/bitwarden WatchKit Extension/Models/Mocks/CipherMock.swift
@@ -2,7 +2,7 @@ import Foundation
 
 struct CipherMock {
     static let ciphers:[Cipher] = [
-        Cipher(id: "0", name: "1933", userId: "123123", login: Login(username: "thisisatest@testing.com", totp: "otpauth://account?period=10&secret=LLLLLLLLLLLLLLLL", uris: cipherLoginUris)),
+        Cipher(id: "0", name: "MySite", userId: "123123", login: Login(username: "test@testing.com", totp: "otpauth://account?period=10&secret=LLLLLLLLLLLLLLLL", uris: cipherLoginUris)),
         Cipher(id: "1", name: "GitHub", userId: "123123", login: Login(username: "thisisatest@testing.com", totp: "LLLLLLLLLLLLLLLL", uris: cipherLoginUris)),
         Cipher(id: "2", name: "No user", userId: "123123", login: Login(username: nil, totp: "otpauth://account?period=10&digits=8&algorithm=sha256&secret=LLLLLLLLLLLLLLLL", uris: cipherLoginUris)),
         Cipher(id: "3", name: "Site 2", userId: "123123", login: Login(username: "longtestemail000000@fastmailasdfasdf.com", totp: "otpauth://account?period=10&digits=7&algorithm=sha512&secret=LLLLLLLLLLLLLLLL", uris: cipherLoginUris)),

--- a/src/watchOS/bitwarden/bitwarden WatchKit Extension/ViewModels/CipherDetailsViewModel.swift
+++ b/src/watchOS/bitwarden/bitwarden WatchKit Extension/ViewModels/CipherDetailsViewModel.swift
@@ -34,30 +34,34 @@ class CipherDetailsViewModel: ObservableObject{
                 self.counter = self.period - mod
                 self.progress = Double(self.counter) / Double(self.period)
             }
+            
             if mod == 0 || self.totpFormatted == "" {
                 do {
-                    var totpF = try TotpService.shared.GetCodeAsync(key: self.key) ?? ""
-                    if totpF.count > 4 {
-                        let halfIndex = totpF.index(totpF.startIndex, offsetBy: totpF.count / 2)
-                        totpF = "\(totpF[totpF.startIndex..<halfIndex]) \(totpF[halfIndex..<totpF.endIndex])"
-                    }
-                    DispatchQueue.main.async {
-                        self.totpFormatted = totpF
-                    }
+                    try self.regenerateTotp()
                 } catch {
                     DispatchQueue.main.async {
                         self.totpFormatted = "error"
                         t.invalidate()
                     }
                 }
-                
             }
         })
         RunLoop.current.add(timer!, forMode: .common)
         timer?.fire()
     }
     
-    func stopGeneration(){
+    func stopGeneration() {
         self.timer?.invalidate()
+    }
+    
+    func regenerateTotp() throws {
+        var totpF = try TotpService.shared.GetCodeAsync(key: self.key) ?? ""
+        if totpF.count > 4 {
+            let halfIndex = totpF.index(totpF.startIndex, offsetBy: totpF.count / 2)
+            totpF = "\(totpF[totpF.startIndex..<halfIndex]) \(totpF[halfIndex..<totpF.endIndex])"
+        }
+        DispatchQueue.main.async {
+            self.totpFormatted = totpF
+        }
     }
 }

--- a/src/watchOS/bitwarden/bitwarden WatchKit Extension/Views/CipherDetailsView.swift
+++ b/src/watchOS/bitwarden/bitwarden WatchKit Extension/Views/CipherDetailsView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct CipherDetailsView: View {
     @ObservedObject var cipherDetailsViewModel: CipherDetailsViewModel
+    @Environment(\.scenePhase) var scenePhase
     
     let iconSize: CGSize = CGSize(width: 30, height: 30)
     
@@ -61,6 +62,7 @@ struct CipherDetailsView: View {
                         .minimumScaleFactor(0.01)
                         .lineLimit(1)
                         .id(cipherDetailsViewModel.totpFormatted)
+                        .privacySensitive()
                         .transition(transition)
                         .animation(.default.speed(0.7), value: cipherDetailsViewModel.totpFormatted)
                     Spacer()
@@ -70,6 +72,7 @@ struct CipherDetailsView: View {
                         Text("\(cipherDetailsViewModel.counter)")
                             .font(.title3)
                             .fontWeight(.semibold)
+                            .privacySensitive()
                     }
                 }
                 .padding(.top, 20)
@@ -82,6 +85,11 @@ struct CipherDetailsView: View {
         }
         .onDisappear{
             self.cipherDetailsViewModel.stopGeneration()
+        }
+        .onChange(of: scenePhase) { newPhase in
+            if newPhase == .active {
+                try? self.cipherDetailsViewModel.regenerateTotp()
+            }
         }
     }
     

--- a/src/watchOS/bitwarden/bitwarden WatchKit Extension/Views/CipherDetailsView.swift
+++ b/src/watchOS/bitwarden/bitwarden WatchKit Extension/Views/CipherDetailsView.swift
@@ -50,6 +50,7 @@ struct CipherDetailsView: View {
                     .fontWeight(.bold)
                     .lineLimit(1)
                     .truncationMode(.tail)
+                    .privacySensitive()
             }
             if cipherDetailsViewModel.totpFormatted == "" {
                 ProgressView()

--- a/src/watchOS/bitwarden/bitwarden WatchKit Extension/Views/CipherItemView.swift
+++ b/src/watchOS/bitwarden/bitwarden WatchKit Extension/Views/CipherItemView.swift
@@ -36,6 +36,7 @@ struct CipherItemView: View {
                     .truncationMode(.tail)
                     .foregroundColor(Color.ui.darkTextMuted)
                     .frame(maxWidth: .infinity, alignment: .leading)
+                    .privacySensitive()
             }
         }
         .padding()

--- a/src/watchOS/bitwarden/bitwarden WatchKit Extension/Views/CipherListView.swift
+++ b/src/watchOS/bitwarden/bitwarden WatchKit Extension/Views/CipherListView.swift
@@ -87,6 +87,7 @@ struct CipherListView: View {
                 .font(.headline)
                 .lineLimit(1)
                 .truncationMode(.tail)
+                .privacySensitive()
         }
     }
     


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Fix TOTP code regeneration after Always On Display. Also, blur username, TOTP code and timer when entering in Always On Display.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **CipherDetailsViewModel:** Extracted the generation of the code to a specific method so that it can be reused.
* **CipherDetailsView:** Regenerates the code when the view becomes active (after coming from background/always on display) and also marked the username, TOTP code and timer value as sensitive so they are blurred when entering into Always On Display.
* **CipherListView:** Blur username on Always On Display
* **CipherItemView:** Blur username on Always On Display

## Screenshots
<!--Required for any UI changes. Delete if not applicable-->

<img width="258" alt="TOTP List Always On Display" src="https://github.com/bitwarden/mobile/assets/15682323/1681baa6-b976-42f8-9a04-6e46883e1d14">


<img width="273" alt="TOTP Details Always On Display" src="https://github.com/bitwarden/mobile/assets/15682323/5187e965-3ae5-43e9-a6c4-77a08892c277">




## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
