### PR TITLE
[PM-2219] Dependency Updates

### DIFF
--- a/src/Android/Android.csproj
+++ b/src/Android/Android.csproj
@@ -78,21 +78,20 @@
       <Version>1.9.0</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.AndroidX.AppCompat" Version="1.5.1.1" />
-    <PackageReference Include="Xamarin.AndroidX.AutoFill" Version="1.1.0.14" />
-    <PackageReference Include="Xamarin.AndroidX.CardView" Version="1.0.0.17" />
-    <PackageReference Include="Xamarin.AndroidX.Core" Version="1.9.0.1" />
-    <PackageReference Include="Xamarin.AndroidX.Legacy.Support.V4" Version="1.0.0.15" />
+    <PackageReference Include="Xamarin.AndroidX.AutoFill" Version="1.1.0.16" />
+    <PackageReference Include="Xamarin.AndroidX.CardView" Version="1.0.0.19" />
+    <PackageReference Include="Xamarin.AndroidX.Core" Version="1.10.0" />
     <PackageReference Include="Xamarin.AndroidX.MediaRouter" Version="1.3.1.1" />
     <PackageReference Include="Xamarin.Essentials">
-      <Version>1.7.3</Version>
+      <Version>1.7.5</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Firebase.Messaging">
-      <Version>123.0.8</Version>
+      <Version>123.1.1.1</Version>
     </PackageReference>
-    <PackageReference Include="Xamarin.Google.Android.Material" Version="1.6.1.1" />
-    <PackageReference Include="Xamarin.Google.Dagger" Version="2.41.0.2" />
+    <PackageReference Include="Xamarin.Google.Android.Material" Version="1.8.0" />
+    <PackageReference Include="Xamarin.Google.Dagger" Version="2.44.2.1" />
     <PackageReference Include="Xamarin.GooglePlayServices.SafetyNet">
-      <Version>118.0.1.2</Version>
+      <Version>118.0.1.3</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/App/App.csproj
+++ b/src/App/App.csproj
@@ -14,11 +14,11 @@
 
   <ItemGroup>
     <PackageReference Include="Plugin.Fingerprint" Version="2.1.5" />
-    <PackageReference Include="SkiaSharp.Views.Forms" Version="2.88.2" />
-    <PackageReference Include="Xamarin.CommunityToolkit" Version="2.0.5" />
-    <PackageReference Include="Xamarin.Essentials" Version="1.7.3" />
+    <PackageReference Include="SkiaSharp.Views.Forms" Version="2.88.3" />
+    <PackageReference Include="Xamarin.CommunityToolkit" Version="2.0.6" />
+    <PackageReference Include="Xamarin.Essentials" Version="1.7.5" />
     <PackageReference Include="Xamarin.FFImageLoading.Forms" Version="2.4.11.982" />
-    <PackageReference Include="Xamarin.Forms" Version="5.0.0.2515" />
+    <PackageReference Include="Xamarin.Forms" Version="5.0.0.2578" />
     <PackageReference Include="ZXing.Net.Mobile" Version="2.4.1" />
     <PackageReference Include="ZXing.Net.Mobile.Forms" Version="2.4.1" />
     <PackageReference Include="MessagePack" Version="2.4.59" />

--- a/src/Core/Core.csproj
+++ b/src/Core/Core.csproj
@@ -28,12 +28,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="CsvHelper" Version="28.0.1" />
-    <PackageReference Include="LiteDB" Version="5.0.12" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="CsvHelper" Version="30.0.1" />
+    <PackageReference Include="LiteDB" Version="5.0.16" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="PCLCrypto" Version="2.0.147" />
     <PackageReference Include="zxcvbn-core" Version="7.0.92" />
-    <PackageReference Include="Microsoft.AppCenter.Crashes" Version="4.5.3" />
+    <PackageReference Include="Microsoft.AppCenter.Crashes" Version="5.0.1" />
     <PackageReference Include="MessagePack" Version="2.4.59" />
     <PackageReference Include="MessagePack.MSBuild.Tasks" Version="2.4.59">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/iOS.Autofill/iOS.Autofill.csproj
+++ b/src/iOS.Autofill/iOS.Autofill.csproj
@@ -266,7 +266,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AppCenter.Crashes">
-      <Version>4.5.3</Version>
+      <Version>5.0.1</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/iOS.Extension/Info.plist
+++ b/src/iOS.Extension/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>MinimumOSVersion</key>
-	<string>10.0</string>
+	<string>11.0</string>
 	<key>CFBundleDisplayName</key>
 	<string>Bitwarden</string>
 	<key>CFBundleName</key>

--- a/src/iOS.Extension/iOS.Extension.csproj
+++ b/src/iOS.Extension/iOS.Extension.csproj
@@ -242,7 +242,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AppCenter.Crashes">
-      <Version>4.5.3</Version>
+      <Version>5.0.1</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.AppExtension.CSharp.targets" />

--- a/src/iOS.ShareExtension/Info.plist
+++ b/src/iOS.ShareExtension/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>MinimumOSVersion</key>
-	<string>10.0</string>
+	<string>11.0</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionMainStoryboard</key>

--- a/src/iOS.ShareExtension/iOS.ShareExtension.csproj
+++ b/src/iOS.ShareExtension/iOS.ShareExtension.csproj
@@ -167,7 +167,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AppCenter.Crashes">
-      <Version>4.5.3</Version>
+      <Version>5.0.1</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/iOS/Info.plist
+++ b/src/iOS/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>MinimumOSVersion</key>
-	<string>10.0</string>
+	<string>11.0</string>
 	<key>CFBundleDisplayName</key>
 	<string>Bitwarden</string>
 	<key>CFBundleName</key>

--- a/src/iOS/iOS.csproj
+++ b/src/iOS/iOS.csproj
@@ -195,7 +195,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Xamarin.Essentials">
-      <Version>1.7.3</Version>
+      <Version>1.7.5</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />

--- a/test/Common/Common.csproj
+++ b/test/Common/Common.csproj
@@ -7,15 +7,15 @@
   </PropertyGroup>
 
     <ItemGroup>
-    <PackageReference Include="NSubstitute" Version="4.4.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="NSubstitute" Version="5.0.0" />
+    <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="AutoFixture.Xunit2" Version="4.17.0" />
-    <PackageReference Include="AutoFixture.AutoNSubstitute" Version="4.17.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
+    <PackageReference Include="AutoFixture.Xunit2" Version="4.18.0" />
+    <PackageReference Include="AutoFixture.AutoNSubstitute" Version="4.18.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
   </ItemGroup>
 
 </Project>

--- a/test/Core.Test/Core.Test.csproj
+++ b/test/Core.Test/Core.Test.csproj
@@ -7,15 +7,15 @@
   </PropertyGroup>
 
     <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
-    <PackageReference Include="NSubstitute" Version="4.4.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+    <PackageReference Include="NSubstitute" Version="5.0.0" />
+    <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="AutoFixture.Xunit2" Version="4.17.0" />
-    <PackageReference Include="AutoFixture.AutoNSubstitute" Version="4.17.0" />
+    <PackageReference Include="AutoFixture.Xunit2" Version="4.18.0" />
+    <PackageReference Include="AutoFixture.AutoNSubstitute" Version="4.18.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Core.Test/Models/Request/SendRequestTests.cs
+++ b/test/Core.Test/Models/Request/SendRequestTests.cs
@@ -14,7 +14,7 @@ namespace Bit.Core.Test.Models.Request
     {
         [Theory]
         [InlineCustomAutoData(new[] { typeof(TextSendCustomization) }, null)]
-        [InlineCustomAutoData(new[] { typeof(FileSendCustomization) }, 100)]
+        [InlineCustomAutoData(new[] { typeof(FileSendCustomization) }, 100L)]
         public void SendRequest_FromSend_Success(long? fileLength, Send send)
         {
             var request = new SendRequest(send, fileLength);


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [ ] New feature development
- [X] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Dependency updates galore.

**_Note 1:_** Some Android libs (`AndroidX.AppCompat`, `AndroidX.MediaRouter`, and `Google.Material.Android`) could not be updated to their latest versions due to being compiled at a higher build target than the current public `Xamarin.Forms` (fixed in an upcoming XF release - I tested against `5.0.0.8491` and everything seemed happy).

**_Note 2:_** Updating `MessagePack*` breaks the Android build with the following error:

```
Xamarin.Android.Legacy.targets(317, 5): [XA2002] Can not resolve reference: `Microsoft.NET.StringTools`, referenced by `MessagePack`. Please add a NuGet package or assembly reference for `Microsoft.NET.StringTools`, or remove the reference to `MessagePack`.
```
I'm not sure of the correct path forward here so I'll need input from @fedemkr & @vvolkgang . Note that iOS continues to build fine with this update so /shrug

**_Note 3:_** Saving `Google.Apis.AndroidPublisher.v3` updates for another day to prevent breaking the Github publishing automation (it's a big version jump so the likelihood of it bursting into flames is high)

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* ***.csproj:** Dependency version bumps
* **info.plist:** Change iOS minimum supported version to 11 to support MS AppCenter 5.x
* **SendRequestTests.cs:** Declare param as long to support fixed strict input in `xunit 2.4.2`

## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
