### PR TITLE
[PM-2347] Refresh feature flags when environment urls change

### DIFF
--- a/src/App/Pages/Accounts/HomePageViewModel.cs
+++ b/src/App/Pages/Accounts/HomePageViewModel.cs
@@ -165,6 +165,7 @@ namespace Bit.App.Pages
 
         public async Task ShowEnvironmentPickerAsync()
         {
+            _displayEuEnvironment = await _configService.GetFeatureFlagBoolAsync(Constants.DisplayEuEnvironmentFlag);
             var options = _displayEuEnvironment
                     ? new string[] { AppResources.US, AppResources.EU, AppResources.SelfHosted }
                     : new string[] { AppResources.US, AppResources.SelfHosted };
@@ -185,6 +186,7 @@ namespace Bit.App.Pages
                 }
 
                 await _environmentService.SetUrlsAsync(result == AppResources.EU ? EnvironmentUrlData.DefaultEU : EnvironmentUrlData.DefaultUS);
+                await _configService.GetAsync(true);
                 SelectedEnvironmentName = result;
             });
         }
@@ -210,6 +212,7 @@ namespace Bit.App.Pages
             }
             else
             {
+                await _configService.GetAsync(true);
                 SelectedEnvironmentName = AppResources.SelfHosted;
             }
         }


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
When environments change we need to fetch the feature flags for that environment.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->
Added force refresh on picker selection and environment update.

## Screenshots
<!--Required for any UI changes. Delete if not applicable-->

https://github.com/bitwarden/mobile/assets/4648522/30b8c41a-f6a1-429f-8a23-edba1d50e6f0




## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
