### PR TITLE
[PM-724] reset lock delay when returning from activity result

### DIFF
--- a/src/Android/MainActivity.cs
+++ b/src/Android/MainActivity.cs
@@ -44,6 +44,7 @@ namespace Bit.Droid
         private IAppIdService _appIdService;
         private IEventService _eventService;
         private IPushNotificationListenerService _pushNotificationListenerService;
+        private IVaultTimeoutService _vaultTimeoutService;
         private ILogger _logger;
         private PendingIntent _eventUploadPendingIntent;
         private AppOptions _appOptions;
@@ -68,6 +69,7 @@ namespace Bit.Droid
             _appIdService = ServiceContainer.Resolve<IAppIdService>("appIdService");
             _eventService = ServiceContainer.Resolve<IEventService>("eventService");
             _pushNotificationListenerService = ServiceContainer.Resolve<IPushNotificationListenerService>();
+            _vaultTimeoutService = ServiceContainer.Resolve<IVaultTimeoutService>();
             _logger = ServiceContainer.Resolve<ILogger>("logger");
 
             TabLayoutResource = Resource.Layout.Tabbar;
@@ -232,6 +234,7 @@ namespace Bit.Droid
 
         protected override void OnActivityResult(int requestCode, Result resultCode, Intent data)
         {
+            _vaultTimeoutService.ResetTimeoutDelay = true;
             if (resultCode == Result.Ok &&
                (requestCode == Core.Constants.SelectFileRequestCode || requestCode == Core.Constants.SaveFileRequestCode))
             {

--- a/src/App/App.xaml.cs
+++ b/src/App/App.xaml.cs
@@ -297,7 +297,7 @@ namespace Bit.App
             {
                 await _vaultTimeoutService.CheckVaultTimeoutAsync();
                 // Reset delay on every start
-                _vaultTimeoutService.DelayLockAndLogoutMs = null;
+                _vaultTimeoutService.DelayTimeoutMs = null;
             }
 
             await _configService.GetAsync();

--- a/src/App/Pages/Vault/AttachmentsPageViewModel.cs
+++ b/src/App/Pages/Vault/AttachmentsPageViewModel.cs
@@ -156,7 +156,7 @@ namespace Bit.App.Pages
             // Prevent Android from locking if vault timeout set to "immediate"
             if (Device.RuntimePlatform == Device.Android)
             {
-                _vaultTimeoutService.DelayLockAndLogoutMs = 60000;
+                _vaultTimeoutService.DelayTimeoutMs = 60000;
             }
             await _fileService.SelectFileAsync();
         }

--- a/src/Core/Abstractions/IVaultTimeoutService.cs
+++ b/src/Core/Abstractions/IVaultTimeoutService.cs
@@ -6,7 +6,8 @@ namespace Bit.Core.Abstractions
 {
     public interface IVaultTimeoutService
     {
-        long? DelayLockAndLogoutMs { get; set; }
+        long? DelayTimeoutMs { get; set; }
+        bool ResetTimeoutDelay { get; set; }
 
         Task CheckVaultTimeoutAsync();
         Task<bool> ShouldTimeoutAsync(string userId = null);

--- a/src/Core/Services/VaultTimeoutService.cs
+++ b/src/Core/Services/VaultTimeoutService.cs
@@ -50,7 +50,8 @@ namespace Bit.Core.Services
             _loggedOutCallback = loggedOutCallback;
         }
 
-        public long? DelayLockAndLogoutMs { get; set; }
+        public long? DelayTimeoutMs { get; set; }
+        public bool ResetTimeoutDelay { get; set; }
 
         public async Task<bool> IsLockedAsync(string userId = null)
         {
@@ -117,7 +118,7 @@ namespace Bit.Core.Services
             {
                 return false;
             }
-            if (vaultTimeoutMinutes == 0 && !DelayLockAndLogoutMs.HasValue)
+            if (vaultTimeoutMinutes == 0 && !DelayTimeoutMs.HasValue)
             {
                 return true;
             }
@@ -127,8 +128,13 @@ namespace Bit.Core.Services
                 return false;
             }
             var diffMs = _platformUtilsService.GetActiveTime() - lastActiveTime;
-            if (DelayLockAndLogoutMs.HasValue && diffMs < DelayLockAndLogoutMs)
+            if (DelayTimeoutMs.HasValue && diffMs < DelayTimeoutMs)
             {
+                if (ResetTimeoutDelay)
+                {
+                    DelayTimeoutMs = null;
+                    ResetTimeoutDelay = false;
+                }
                 return false;
             }
             var vaultTimeoutMs = vaultTimeoutMinutes * 60000;


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
To smooth out the process of using external functions (file selection, camera, etc.) in Android while also using `immediate` for vault timeout, a delay in locking [was introduced](https://github.com/bitwarden/mobile/pull/1626) to give users 60 seconds to perform the task outside of the Bitwarden app.  Upon returning to the app however, the delay remained active so if the user backgrounded-then-foregrounded the app within the 60-second window, the immediate lock failed to fire (locking worked normally again once the delay time expired).  This PR sets a flag to notify the app when the task connected to activity result is complete, so the delay can be reset immediately upon return.

Note that we're introducing a second value (the bool) instead of adjusting the delay directly in `OnActivityResult` to act as a second factor against intent forgery.  The flag is meaningless unless the delay is set which can only happen when file selection is requested by a human (outside of any intent receivers).

Closes #2255

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **VaultTimeoutService:** Added `ResetTimeoutDelay` bool and reset logic inside `ShouldTimeoutAsync` method (also renamed `DelayLockAndLogoutMs` to `DelayTimeoutMs` for consistency)
* **MainActivity.cs:** Enable `ResetTimeoutDelay` in `OnActivityResult`
* **Other:** Renamed `DelayLockAndLogoutMs` to `DelayTimeoutMs`

## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
