### PR TITLE
[PM-1798] Improve ScreenReader when adding a cipher

### DIFF
--- a/src/App/Lists/ItemLayouts/CustomFields/HiddenCustomFieldItemLayout.xaml
+++ b/src/App/Lists/ItemLayouts/CustomFields/HiddenCustomFieldItemLayout.xaml
@@ -54,7 +54,9 @@
             IsPassword="{Binding ShowHiddenValue, Converter={StaticResource inverseBool}}"
             IsEnabled="{Binding ShowViewHidden}"
             IsSpellCheckEnabled="False"
-            IsTextPredictionEnabled="False">
+            IsTextPredictionEnabled="False"
+            AutomationProperties.IsInAccessibleTree="True"
+            AutomationProperties.Name="{Binding Field.Name}">
             <Entry.Keyboard>
                 <Keyboard x:FactoryMethod="Create">
                     <x:Arguments>

--- a/src/App/Lists/ItemLayouts/CustomFields/TextCustomFieldItemLayout.xaml
+++ b/src/App/Lists/ItemLayouts/CustomFields/TextCustomFieldItemLayout.xaml
@@ -41,7 +41,9 @@
             StyleClass="box-value"
             Grid.Row="1"
             Grid.Column="0"
-            IsVisible="{Binding IsEditing}" />
+            IsVisible="{Binding IsEditing}"
+            AutomationProperties.IsInAccessibleTree="True"
+            AutomationProperties.Name="{Binding Field.Name}" />
         <controls:IconButton
             StyleClass="box-row-button, box-row-button-platform"
             Text="{Binding Source={x:Static core:BitwardenIcons.Clone}}"

--- a/src/App/Pages/Vault/CipherAddEditPage.xaml
+++ b/src/App/Pages/Vault/CipherAddEditPage.xaml
@@ -125,7 +125,9 @@
                     <Entry
                         x:Name="_nameEntry"
                         Text="{Binding Cipher.Name}"
-                        StyleClass="box-value" />
+                        StyleClass="box-value"
+                        AutomationProperties.IsInAccessibleTree="True"
+                        AutomationProperties.Name="{u:I18n Name}" />
                 </StackLayout>
                 <StackLayout IsVisible="{Binding IsLogin}" Spacing="0" Padding="0">
                     <Grid StyleClass="box-row, box-row-input"
@@ -138,7 +140,9 @@
                             x:Name="_loginUsernameEntry"
                             Text="{Binding Cipher.Login.Username}"
                             StyleClass="box-value" 
-                            Grid.Row="1"/>
+                            Grid.Row="1"
+                            AutomationProperties.IsInAccessibleTree="True"
+                            AutomationProperties.Name="{u:I18n Username}"/>
                         <controls:IconButton 
                             StyleClass="box-row-button, box-row-button-platform"
                             Text="{Binding Source={x:Static core:BitwardenIcons.Generate}}"
@@ -174,7 +178,9 @@
                             IsPassword="{Binding ShowPassword, Converter={StaticResource inverseBool}}"
                             IsSpellCheckEnabled="False"
                             IsTextPredictionEnabled="False"
-                            IsEnabled="{Binding Cipher.ViewPassword}"/>
+                            IsEnabled="{Binding Cipher.ViewPassword}"
+                            AutomationProperties.IsInAccessibleTree="True"
+                            AutomationProperties.Name="{u:I18n Password}"/>
                         <controls:IconButton 
                             StyleClass="box-row-button, box-row-button-platform"
                             Text="{Binding Source={x:Static core:BitwardenIcons.CheckCircle}}"
@@ -254,7 +260,9 @@
                             StyleClass="box-value"
                             Grid.Row="1"
                             Grid.Column="0"
-                            Grid.ColumnSpan="{Binding TotpColumnSpan}" />
+                            Grid.ColumnSpan="{Binding TotpColumnSpan}"
+                            AutomationProperties.IsInAccessibleTree="True"
+                            AutomationProperties.Name="{u:I18n AuthenticatorKey}" />
                         <controls:IconButton 
                             StyleClass="box-row-button, box-row-button-platform"
                             Text="{Binding Source={x:Static core:BitwardenIcons.Clone}}"
@@ -262,7 +270,9 @@
                             IsVisible="{Binding HasTotpValue}"
                             Grid.Row="0"
                             Grid.Column="1"
-                            Grid.RowSpan="2" />
+                            Grid.RowSpan="2"
+                            AutomationProperties.IsInAccessibleTree="True"
+                            AutomationProperties.Name="{u:I18n CopyTotp}" />
                         <controls:IconButton 
                             StyleClass="box-row-button, box-row-button-platform"
                             Text="{Binding Source={x:Static core:BitwardenIcons.Camera}}"
@@ -307,7 +317,9 @@
                             Grid.Column="0"
                             IsPassword="{Binding ShowCardNumber, Converter={StaticResource inverseBool}}"
                             IsSpellCheckEnabled="False"
-                            IsTextPredictionEnabled="False" />
+                            IsTextPredictionEnabled="False"
+                            AutomationProperties.IsInAccessibleTree="True"
+                            AutomationProperties.Name="{u:I18n Number}" />
                         <controls:IconButton 
                             StyleClass="box-row-button, box-row-button-platform"
                             Text="{Binding ShowCardNumberIcon}"
@@ -346,7 +358,9 @@
                             x:Name="_cardExpYearEntry"
                             Text="{Binding Cipher.Card.ExpYear}"
                             StyleClass="box-value"
-                            Keyboard="Numeric" />
+                            Keyboard="Numeric"
+                            AutomationProperties.IsInAccessibleTree="True"
+                            AutomationProperties.Name="{u:I18n ExpirationYear}" />
                     </StackLayout>
                     <Grid StyleClass="box-row, box-row-input">
                         <Grid.RowDefinitions>
@@ -371,7 +385,9 @@
                             Keyboard="Numeric"
                             IsPassword="{Binding ShowCardCode, Converter={StaticResource inverseBool}}"
                             IsSpellCheckEnabled="False"
-                            IsTextPredictionEnabled="False" />
+                            IsTextPredictionEnabled="False"
+                            AutomationProperties.IsInAccessibleTree="True"
+                            AutomationProperties.Name="{u:I18n SecurityCode}" />
                         <controls:IconButton 
                             StyleClass="box-row-button, box-row-button-platform"
                             Text="{Binding ShowCardCodeIcon}"
@@ -401,7 +417,9 @@
                         <Entry
                             x:Name="_identityFirstNameEntry"
                             Text="{Binding Cipher.Identity.FirstName}"
-                            StyleClass="box-value,capitalize-word-input"/>
+                            StyleClass="box-value,capitalize-word-input"
+                            AutomationProperties.IsInAccessibleTree="True"
+                            AutomationProperties.Name="{u:I18n FirstName}"/>
                     </StackLayout>
                     <StackLayout StyleClass="box-row, box-row-input">
                         <Label
@@ -410,7 +428,9 @@
                         <Entry
                             x:Name="_identityMiddleNameEntry"
                             Text="{Binding Cipher.Identity.MiddleName}"
-                            StyleClass="box-value,capitalize-word-input" />
+                            StyleClass="box-value,capitalize-word-input"
+                            AutomationProperties.IsInAccessibleTree="True"
+                            AutomationProperties.Name="{u:I18n MiddleName}" />
                     </StackLayout>
                     <StackLayout StyleClass="box-row, box-row-input">
                         <Label
@@ -419,7 +439,9 @@
                         <Entry
                             x:Name="_identityLastNameEntry"
                             Text="{Binding Cipher.Identity.LastName}"
-                            StyleClass="box-value,capitalize-word-input" />
+                            StyleClass="box-value,capitalize-word-input"
+                            AutomationProperties.IsInAccessibleTree="True"
+                            AutomationProperties.Name="{u:I18n LastName}" />
                     </StackLayout>
                     <StackLayout StyleClass="box-row, box-row-input">
                         <Label
@@ -428,7 +450,9 @@
                         <Entry
                             x:Name="_identityUsernameEntry"
                             Text="{Binding Cipher.Identity.Username}"
-                            StyleClass="box-value" />
+                            StyleClass="box-value"
+                            AutomationProperties.IsInAccessibleTree="True"
+                            AutomationProperties.Name="{u:I18n Username}" />
                     </StackLayout>
                     <StackLayout StyleClass="box-row, box-row-input">
                         <Label
@@ -437,7 +461,9 @@
                         <Entry
                             x:Name="_identityCompanyEntry"
                             Text="{Binding Cipher.Identity.Company}"
-                            StyleClass="box-value" />
+                            StyleClass="box-value" 
+                            AutomationProperties.IsInAccessibleTree="True"
+                            AutomationProperties.Name="{u:I18n Company}"/>
                     </StackLayout>
                     <StackLayout StyleClass="box-row, box-row-input">
                         <Label
@@ -446,7 +472,9 @@
                         <Entry
                             x:Name="_identitySsnEntry"
                             Text="{Binding Cipher.Identity.SSN}"
-                            StyleClass="box-value" />
+                            StyleClass="box-value" 
+                            AutomationProperties.IsInAccessibleTree="True"
+                            AutomationProperties.Name="{u:I18n SSN}"/>
                     </StackLayout>
                     <StackLayout StyleClass="box-row, box-row-input">
                         <Label
@@ -455,7 +483,9 @@
                         <Entry
                             x:Name="_identityPassportNumberEntry"
                             Text="{Binding Cipher.Identity.PassportNumber}"
-                            StyleClass="box-value" />
+                            StyleClass="box-value" 
+                            AutomationProperties.IsInAccessibleTree="True"
+                            AutomationProperties.Name="{u:I18n PassportNumber}"/>
                     </StackLayout>
                     <StackLayout StyleClass="box-row, box-row-input">
                         <Label
@@ -464,7 +494,9 @@
                         <Entry
                             x:Name="_identityLicenseNumberEntry"
                             Text="{Binding Cipher.Identity.LicenseNumber}"
-                            StyleClass="box-value" />
+                            StyleClass="box-value"
+                            AutomationProperties.IsInAccessibleTree="True"
+                            AutomationProperties.Name="{u:I18n LicenseNumber}" />
                     </StackLayout>
                     <StackLayout StyleClass="box-row, box-row-input">
                         <Label
@@ -474,7 +506,9 @@
                             x:Name="_identityEmailEntry"
                             Keyboard="Email"
                             Text="{Binding Cipher.Identity.Email}"
-                            StyleClass="box-value" />
+                            StyleClass="box-value" 
+                            AutomationProperties.IsInAccessibleTree="True"
+                            AutomationProperties.Name="{u:I18n Email}"/>
                     </StackLayout>
                     <StackLayout StyleClass="box-row, box-row-input">
                         <Label
@@ -484,7 +518,9 @@
                             x:Name="_identityPhoneEntry"
                             Text="{Binding Cipher.Identity.Phone}"
                             Keyboard="Telephone"
-                            StyleClass="box-value" />
+                            StyleClass="box-value"
+                            AutomationProperties.IsInAccessibleTree="True"
+                            AutomationProperties.Name="{u:I18n Phone}" />
                     </StackLayout>
                     <StackLayout StyleClass="box-row, box-row-input">
                         <Label
@@ -493,7 +529,9 @@
                         <Entry
                             x:Name="_identityAddress1Entry"
                             Text="{Binding Cipher.Identity.Address1}"
-                            StyleClass="box-value" />
+                            StyleClass="box-value" 
+                            AutomationProperties.IsInAccessibleTree="True"
+                            AutomationProperties.Name="{u:I18n Address1}"/>
                     </StackLayout>
                     <StackLayout StyleClass="box-row, box-row-input">
                         <Label
@@ -502,7 +540,9 @@
                         <Entry
                             x:Name="_identityAddress2Entry"
                             Text="{Binding Cipher.Identity.Address2}"
-                            StyleClass="box-value" />
+                            StyleClass="box-value"
+                            AutomationProperties.IsInAccessibleTree="True"
+                            AutomationProperties.Name="{u:I18n Address2}" />
                     </StackLayout>
                     <StackLayout StyleClass="box-row, box-row-input">
                         <Label
@@ -511,7 +551,9 @@
                         <Entry
                             x:Name="_identityAddress3Entry"
                             Text="{Binding Cipher.Identity.Address3}"
-                            StyleClass="box-value" />
+                            StyleClass="box-value"
+                            AutomationProperties.IsInAccessibleTree="True"
+                            AutomationProperties.Name="{u:I18n Address3}" />
                     </StackLayout>
                     <StackLayout StyleClass="box-row, box-row-input">
                         <Label
@@ -520,7 +562,9 @@
                         <Entry
                             x:Name="_identityCityEntry"
                             Text="{Binding Cipher.Identity.City}"
-                            StyleClass="box-value,capitalize-sentence-input" />
+                            StyleClass="box-value,capitalize-sentence-input"
+                            AutomationProperties.IsInAccessibleTree="True"
+                            AutomationProperties.Name="{u:I18n CityTown}" />
                     </StackLayout>
                     <StackLayout StyleClass="box-row, box-row-input">
                         <Label
@@ -529,7 +573,9 @@
                         <Entry
                             x:Name="_identityStateEntry"
                             Text="{Binding Cipher.Identity.State}"
-                            StyleClass="box-value,capitalize-sentence-input" />
+                            StyleClass="box-value,capitalize-sentence-input"
+                            AutomationProperties.IsInAccessibleTree="True"
+                            AutomationProperties.Name="{u:I18n StateProvince}" />
                     </StackLayout>
                     <StackLayout StyleClass="box-row, box-row-input">
                         <Label
@@ -538,7 +584,9 @@
                         <Entry
                             x:Name="_identityPostalCodeEntry"
                             Text="{Binding Cipher.Identity.PostalCode}"
-                            StyleClass="box-value" />
+                            StyleClass="box-value"
+                            AutomationProperties.IsInAccessibleTree="True"
+                            AutomationProperties.Name="{u:I18n ZipPostalCode}" />
                     </StackLayout>
                     <StackLayout StyleClass="box-row, box-row-input">
                         <Label
@@ -547,7 +595,9 @@
                         <Entry
                             x:Name="_identityCountryEntry"
                             Text="{Binding Cipher.Identity.Country}"
-                            StyleClass="box-value,capitalize-sentence-input" />
+                            StyleClass="box-value,capitalize-sentence-input"
+                            AutomationProperties.IsInAccessibleTree="True"
+                            AutomationProperties.Name="{u:I18n Country}" />
                     </StackLayout>
                 </StackLayout>
             </StackLayout>
@@ -578,7 +628,9 @@
                                     Keyboard="Url"
                                     StyleClass="box-value"
                                     Grid.Row="1"
-                                    Grid.Column="0" />
+                                    Grid.Column="0"
+                                    AutomationProperties.IsInAccessibleTree="True"
+                                    AutomationProperties.Name="{u:I18n URI}" />
                                 <controls:IconButton
                                     StyleClass="box-row-button, box-row-button-platform"
                                     Text="{Binding Source={x:Static core:BitwardenIcons.Cog}}"
@@ -631,7 +683,7 @@
                         Command="{Binding PasswordPromptHelpCommand}"
                         TextColor="{DynamicResource MutedColor}"
                         AutomationProperties.IsInAccessibleTree="True"
-                        AutomationProperties.Name="{u:I18n ToggleVisibility}"
+                        AutomationProperties.Name="{u:I18n MasterPasswordRePromptHelp}"
                         HorizontalOptions="StartAndExpand" />
                     <Switch
                         IsToggled="{Binding PasswordPrompt}"
@@ -652,7 +704,9 @@
                         AutoSize="TextChanges"
                         StyleClass="box-value"
                         effects:ScrollEnabledEffect.IsScrollEnabled="false"
-                        Text="{Binding Cipher.Notes}">
+                        Text="{Binding Cipher.Notes}"
+                        AutomationProperties.IsInAccessibleTree="True"
+                        AutomationProperties.Name="{u:I18n Notes}" >
                         <Editor.Behaviors>
                             <behaviors:EditorPreventAutoBottomScrollingOnFocusedBehavior ParentScrollView="{x:Reference _scrollView}" />
                         </Editor.Behaviors>
@@ -717,7 +771,7 @@
                                     <Switch
                                         IsToggled="{Binding Checked}"
                                         StyleClass="box-value"
-                                        HorizontalOptions="End" />
+                                        HorizontalOptions="End"/>
                                 </StackLayout>
                                 <BoxView StyleClass="box-row-separator" />
                             </StackLayout>

--- a/src/App/Resources/AppResources.Designer.cs
+++ b/src/App/Resources/AppResources.Designer.cs
@@ -203,6 +203,24 @@ namespace Bit.App.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Biometric unlock for this account is disabled pending verification of master password..
+        /// </summary>
+        public static string AccountBiometricInvalidated {
+            get {
+                return ResourceManager.GetString("AccountBiometricInvalidated", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Autofill biometric unlock for this account is disabled pending verification of master password..
+        /// </summary>
+        public static string AccountBiometricInvalidatedExtension {
+            get {
+                return ResourceManager.GetString("AccountBiometricInvalidatedExtension", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Your new account has been created! You may now log in..
         /// </summary>
         public static string AccountCreated {
@@ -964,24 +982,6 @@ namespace Bit.App.Resources {
         public static string BaseDomain {
             get {
                 return ResourceManager.GetString("BaseDomain", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Biometric unlock disabled pending verification of master password..
-        /// </summary>
-        public static string AccountBiometricInvalidated {
-            get {
-                return ResourceManager.GetString("AccountBiometricInvalidated", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Biometric unlock for autofill disabled pending verification of master password..
-        /// </summary>
-        public static string AccountBiometricInvalidatedExtension {
-            get {
-                return ResourceManager.GetString("AccountBiometricInvalidatedExtension", resourceCulture);
             }
         }
         
@@ -3891,6 +3891,15 @@ namespace Bit.App.Resources {
         public static string MasterPasswordPolicyValidationTitle {
             get {
                 return ResourceManager.GetString("MasterPasswordPolicyValidationTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Master password re-prompt help.
+        /// </summary>
+        public static string MasterPasswordRePromptHelp {
+            get {
+                return ResourceManager.GetString("MasterPasswordRePromptHelp", resourceCulture);
             }
         }
         

--- a/src/App/Resources/AppResources.resx
+++ b/src/App/Resources/AppResources.resx
@@ -2631,4 +2631,7 @@ Do you want to switch to this account?</value>
   <data name="CurrentMasterPassword" xml:space="preserve">
     <value>Current master password</value>
   </data>
+  <data name="MasterPasswordRePromptHelp" xml:space="preserve">
+    <value>Master password re-prompt help</value>
+  </data>
 </root>


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
The entries when adding a cipher should have a name assigned for screen reader.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **All files:** Added the entires to the accessible tree and set their accessible name. I couldn't use `LabeledBy` feature of Xamarin Forms because it doesn't work on iOS as stated in the [docs](https://learn.microsoft.com/en-us/xamarin/xamarin-forms/app-fundamentals/accessibility/automation-properties#automationpropertieslabeledby).


## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
