### PR TITLE
[PM-1076] Added warning on unlocking iOS extensions for argon2id memory

### DIFF
--- a/src/App/Resources/AppResources.Designer.cs
+++ b/src/App/Resources/AppResources.Designer.cs
@@ -6435,6 +6435,15 @@ namespace Bit.App.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Unlocking may fail due to insufficient memory. Decrease your KDF memory settings to resolve.
+        /// </summary>
+        public static string UnlockingMayFailDueToInsufficientMemoryDecreaseYourKDFMemorySettingsToResolve {
+            get {
+                return ResourceManager.GetString("UnlockingMayFailDueToInsufficientMemoryDecreaseYourKDFMemorySettingsToResolve", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Unlock vault.
         /// </summary>
         public static string UnlockVault {

--- a/src/App/Resources/AppResources.resx
+++ b/src/App/Resources/AppResources.resx
@@ -2634,4 +2634,7 @@ Do you want to switch to this account?</value>
   <data name="MasterPasswordRePromptHelp" xml:space="preserve">
     <value>Master password re-prompt help</value>
   </data>
+  <data name="UnlockingMayFailDueToInsufficientMemoryDecreaseYourKDFMemorySettingsToResolve" xml:space="preserve">
+    <value>Unlocking may fail due to insufficient memory. Decrease your KDF memory settings to resolve</value>
+  </data>
 </root>

--- a/src/iOS.Core/Constants.cs
+++ b/src/iOS.Core/Constants.cs
@@ -32,5 +32,6 @@
         public const string UTTypeAppExtensionImage = "public.image";
 
         public const string AutofillNeedsIdentityReplacementKey = "autofillNeedsIdentityReplacement";
+        public const int MaximumArgon2IdMemoryBeforeExtensionCrashing = 48;
     }
 }


### PR DESCRIPTION
…s argon2id and the memory is higher than 48MB, to let the user know that unlocking might crash the extension

## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Add warning to the user when unlocking iOS extensions when using Argon2Id when the memory is higher than what the extension could handle, which causes the extension to crash.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **BaseLockPasswordViewController:** Added warning for argon2id when memory configured may crash the extension

## Screenshots
<!--Required for any UI changes. Delete if not applicable-->

<img width="314" alt="iOS Extensions argon2id memory warning" src="https://github.com/bitwarden/mobile/assets/15682323/51d47f1d-5e09-4ab4-979d-27ba2f728ab0">



## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
