### PR TITLE
[PM-2392] Enhancement to login field detection for Android autofill

### DIFF
--- a/src/Android/Autofill/FieldCollection.cs
+++ b/src/Android/Autofill/FieldCollection.cs
@@ -12,7 +12,7 @@ namespace Bit.Droid.Autofill
         private List<Field> _passwordFields = null;
         private List<Field> _usernameFields = null;
         private HashSet<string> _ignoreSearchTerms = new HashSet<string> { "search", "find", "recipient", "edit" };
-        private HashSet<string> _usernameTerms = new HashSet<string> { "email", "phone", "username"};
+        private HashSet<string> _usernameTerms = new HashSet<string> { "email", "phone", "username" };
         private HashSet<string> _passwordTerms = new HashSet<string> { "password", "pswd" };
 
         public List<AutofillId> AutofillIds { get; private set; } = new List<AutofillId>();
@@ -54,15 +54,14 @@ namespace Bit.Droid.Autofill
                     if (HintToFieldsMap.ContainsKey(View.AutofillHintPassword))
                     {
                         _passwordFields.AddRange(HintToFieldsMap[View.AutofillHintPassword]);
+                        return _passwordFields;
                     }
                 }
-                else
+
+                _passwordFields = Fields.Where(f => FieldIsPassword(f)).ToList();
+                if (!_passwordFields.Any())
                 {
-                    _passwordFields = Fields.Where(f => FieldIsPassword(f)).ToList();
-                    if (!_passwordFields.Any())
-                    {
-                        _passwordFields = Fields.Where(f => FieldHasPasswordTerms(f)).ToList();
-                    }
+                    _passwordFields = Fields.Where(f => FieldHasPasswordTerms(f)).ToList();
                 }
                 return _passwordFields;
             }
@@ -87,23 +86,25 @@ namespace Bit.Droid.Autofill
                     {
                         _usernameFields.AddRange(HintToFieldsMap[View.AutofillHintUsername]);
                     }
+                    if (_usernameFields.Any())
+                    {
+                        return _usernameFields;
+                    }
                 }
-                else
-                {
-                    foreach (var passwordField in PasswordFields)
-                    {
-                        var usernameField = Fields.TakeWhile(f => f.AutofillId != passwordField.AutofillId)
-                            .LastOrDefault();
-                        if (usernameField != null)
-                        {
-                            _usernameFields.Add(usernameField);
-                        }
-                    }
 
-                    if (!_usernameFields.Any())
+                foreach (var passwordField in PasswordFields)
+                {
+                    var usernameField = Fields.TakeWhile(f => f.AutofillId != passwordField.AutofillId)
+                        .LastOrDefault();
+                    if (usernameField != null)
                     {
-                        _usernameFields = Fields.Where(f => FieldIsUsername(f)).ToList();
+                        _usernameFields.Add(usernameField);
                     }
+                }
+
+                if (!_usernameFields.Any())
+                {
+                    _usernameFields = Fields.Where(f => FieldIsUsername(f)).ToList();
                 }
                 return _usernameFields;
             }


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
This PR allows user/pass field detection to utilize fallback code on both fields if hints are only available for one (previously a single hint would prevent fallback detection from executing resulting in only the username or password field being filled).


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **FieldCollection.cs:** Only return if matching hint found, otherwise execute fallback detection in `PasswordFields` & `UsernameFields`

## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
