### PR TITLE
[PM-2544] Adding AutomationIDs for CipherAddEditViewPage elements

### DIFF
--- a/src/App/Lists/ItemLayouts/CustomFields/BooleanCustomFieldItemLayout.xaml
+++ b/src/App/Lists/ItemLayouts/CustomFields/BooleanCustomFieldItemLayout.xaml
@@ -34,7 +34,7 @@
             Grid.Row="0"
             Grid.Column="0"
             IsVisible="{Binding IsEditing, Mode=OneWay, Converter={StaticResource inverseBool}}"
-            AutomationId="BooleanCustomFieldNameLabel"/>
+            AutomationId="BooleanCustomFieldNameLabel" />
         <Label
             Text="{Binding Field.Name, Mode=OneWay}"
             IsVisible="{Binding IsEditing}"
@@ -51,14 +51,14 @@
             Grid.Column="0"
             Margin="0, 5, 0, 0"
             IsVisible="{Binding IsEditing, Mode=OneWay, Converter={StaticResource inverseBool}}"
-            AutomationId="BooleanCustomFieldValueLabel"/>
+            AutomationId="BooleanCustomFieldValueLabel" />
         <Switch
             IsToggled="{Binding BooleanValue}"
             IsVisible="{Binding IsEditing}"
             Grid.Row="0"
             Grid.Column="1"
             Grid.RowSpan="2"
-            AutomationId="BooleanCustomFieldValueToggle"/>
+            AutomationId="BooleanCustomFieldValueToggle" />
         <controls:IconButton 
             StyleClass="box-row-button, box-row-button-platform"
             Text="{Binding Source={x:Static core:BitwardenIcons.Cog}}"

--- a/src/App/Lists/ItemLayouts/CustomFields/BooleanCustomFieldItemLayout.xaml
+++ b/src/App/Lists/ItemLayouts/CustomFields/BooleanCustomFieldItemLayout.xaml
@@ -33,7 +33,8 @@
             StyleClass="box-label"
             Grid.Row="0"
             Grid.Column="0"
-            IsVisible="{Binding IsEditing, Mode=OneWay, Converter={StaticResource inverseBool}}" />
+            IsVisible="{Binding IsEditing, Mode=OneWay, Converter={StaticResource inverseBool}}"
+            AutomationId="BooleanCustomFieldNameLabel"/>
         <Label
             Text="{Binding Field.Name, Mode=OneWay}"
             IsVisible="{Binding IsEditing}"
@@ -49,13 +50,15 @@
             Grid.Row="1"
             Grid.Column="0"
             Margin="0, 5, 0, 0"
-            IsVisible="{Binding IsEditing, Mode=OneWay, Converter={StaticResource inverseBool}}"  />
+            IsVisible="{Binding IsEditing, Mode=OneWay, Converter={StaticResource inverseBool}}"
+            AutomationId="BooleanCustomFieldValueLabel"/>
         <Switch
             IsToggled="{Binding BooleanValue}"
             IsVisible="{Binding IsEditing}"
             Grid.Row="0"
             Grid.Column="1"
-            Grid.RowSpan="2" />
+            Grid.RowSpan="2"
+            AutomationId="BooleanCustomFieldValueToggle"/>
         <controls:IconButton 
             StyleClass="box-row-button, box-row-button-platform"
             Text="{Binding Source={x:Static core:BitwardenIcons.Cog}}"

--- a/src/App/Lists/ItemLayouts/CustomFields/HiddenCustomFieldItemLayout.xaml
+++ b/src/App/Lists/ItemLayouts/CustomFields/HiddenCustomFieldItemLayout.xaml
@@ -31,7 +31,8 @@
             Text="{Binding Field.Name, Mode=OneWay}"
             StyleClass="box-label"
             Grid.Row="0"
-            Grid.Column="0" />
+            Grid.Column="0"
+            AutomationId="HiddenCustomFieldNameLabel"/>
         <StackLayout
             Grid.Row="1"
             Grid.Column="0"
@@ -39,7 +40,8 @@
             <controls:MonoLabel
                 Text="{Binding ValueText, Mode=OneWay}"
                 StyleClass="box-value"
-                IsVisible="{Binding ShowHiddenValue}" />
+                IsVisible="{Binding ShowHiddenValue}"
+                AutomationId="HiddenCustomFieldValueLabel"/>
             <controls:MonoLabel
                 Text="{Binding Field.MaskedValue, Mode=OneWay}"
                 StyleClass="box-value"
@@ -56,7 +58,8 @@
             IsSpellCheckEnabled="False"
             IsTextPredictionEnabled="False"
             AutomationProperties.IsInAccessibleTree="True"
-            AutomationProperties.Name="{Binding Field.Name}">
+            AutomationProperties.Name="{Binding Field.Name}"
+            AutomationId="HiddenCustomFieldValueEntry">
             <Entry.Keyboard>
                 <Keyboard x:FactoryMethod="Create">
                     <x:Arguments>
@@ -74,7 +77,8 @@
             Grid.Column="1"
             Grid.RowSpan="2"
             AutomationProperties.IsInAccessibleTree="True"
-            AutomationProperties.Name="{u:I18n ToggleVisibility}" />
+            AutomationProperties.Name="{u:I18n ToggleVisibility}"
+            AutomationId="HiddenCustomFieldShowValueButton"/>
         <controls:IconButton
             StyleClass="box-row-button, box-row-button-platform"
             Text="{Binding Source={x:Static core:BitwardenIcons.Clone}}"

--- a/src/App/Lists/ItemLayouts/CustomFields/HiddenCustomFieldItemLayout.xaml
+++ b/src/App/Lists/ItemLayouts/CustomFields/HiddenCustomFieldItemLayout.xaml
@@ -32,7 +32,7 @@
             StyleClass="box-label"
             Grid.Row="0"
             Grid.Column="0"
-            AutomationId="HiddenCustomFieldNameLabel"/>
+            AutomationId="HiddenCustomFieldNameLabel" />
         <StackLayout
             Grid.Row="1"
             Grid.Column="0"
@@ -59,7 +59,7 @@
             IsTextPredictionEnabled="False"
             AutomationProperties.IsInAccessibleTree="True"
             AutomationProperties.Name="{Binding Field.Name}"
-            AutomationId="HiddenCustomFieldValueEntry" >
+            AutomationId="HiddenCustomFieldValueEntry">
             <Entry.Keyboard>
                 <Keyboard x:FactoryMethod="Create">
                     <x:Arguments>

--- a/src/App/Lists/ItemLayouts/CustomFields/HiddenCustomFieldItemLayout.xaml
+++ b/src/App/Lists/ItemLayouts/CustomFields/HiddenCustomFieldItemLayout.xaml
@@ -41,7 +41,7 @@
                 Text="{Binding ValueText, Mode=OneWay}"
                 StyleClass="box-value"
                 IsVisible="{Binding ShowHiddenValue}"
-                AutomationId="HiddenCustomFieldValueLabel"/>
+                AutomationId="HiddenCustomFieldValueLabel" />
             <controls:MonoLabel
                 Text="{Binding Field.MaskedValue, Mode=OneWay}"
                 StyleClass="box-value"
@@ -59,7 +59,7 @@
             IsTextPredictionEnabled="False"
             AutomationProperties.IsInAccessibleTree="True"
             AutomationProperties.Name="{Binding Field.Name}"
-            AutomationId="HiddenCustomFieldValueEntry">
+            AutomationId="HiddenCustomFieldValueEntry" >
             <Entry.Keyboard>
                 <Keyboard x:FactoryMethod="Create">
                     <x:Arguments>
@@ -78,7 +78,7 @@
             Grid.RowSpan="2"
             AutomationProperties.IsInAccessibleTree="True"
             AutomationProperties.Name="{u:I18n ToggleVisibility}"
-            AutomationId="HiddenCustomFieldShowValueButton"/>
+            AutomationId="HiddenCustomFieldShowValueButton" />
         <controls:IconButton
             StyleClass="box-row-button, box-row-button-platform"
             Text="{Binding Source={x:Static core:BitwardenIcons.Clone}}"

--- a/src/App/Lists/ItemLayouts/CustomFields/LinkedCustomFieldItemLayout.xaml
+++ b/src/App/Lists/ItemLayouts/CustomFields/LinkedCustomFieldItemLayout.xaml
@@ -29,13 +29,15 @@
             Text="{Binding Field.Name, Mode=OneWay}"
             StyleClass="box-label"
             Grid.Row="0"
-            Grid.Column="0" />
+            Grid.Column="0"
+            AutomationId="LinkedCustomFieldNameLabel"/>
         <controls:IconLabel
             Text="{Binding ValueText, Mode=OneWay}"
             StyleClass="box-value"
             Grid.Row="1"
             Grid.Column="0"
-            IsVisible="{Binding IsEditing, Mode=OneWay, Converter={StaticResource inverseBool}}" />
+            IsVisible="{Binding IsEditing, Mode=OneWay, Converter={StaticResource inverseBool}}"
+            AutomationId="LinkedCustomFieldValueLabel"/>
         <StackLayout
             StyleClass="box-row, box-row-input"
             IsVisible="{Binding IsEditing}">
@@ -44,7 +46,8 @@
                 ItemsSource="{Binding LinkedFieldOptions, Mode=OneTime}"
                 SelectedIndex="{Binding LinkedFieldOptionSelectedIndex}"
                 ItemDisplayBinding="{Binding Key}"
-                StyleClass="box-value" />
+                StyleClass="box-value"
+                AutomationId="LinkedCustomFieldValuePicker"/>
         </StackLayout>
         <controls:IconButton 
             StyleClass="box-row-button, box-row-button-platform"
@@ -55,7 +58,8 @@
             Grid.Column="1"
             Grid.RowSpan="2"
             AutomationProperties.IsInAccessibleTree="True"
-            AutomationProperties.Name="{u:I18n Options}" />
+            AutomationProperties.Name="{u:I18n Options}"
+            AutomationId="LinkedCustomFieldOptionsButton"/>
     </Grid>
     <BoxView StyleClass="box-row-separator" IsVisible="{Binding IsEditing, Mode=OneWay, Converter={StaticResource inverseBool}}" />
 </StackLayout>

--- a/src/App/Lists/ItemLayouts/CustomFields/LinkedCustomFieldItemLayout.xaml
+++ b/src/App/Lists/ItemLayouts/CustomFields/LinkedCustomFieldItemLayout.xaml
@@ -30,14 +30,14 @@
             StyleClass="box-label"
             Grid.Row="0"
             Grid.Column="0"
-            AutomationId="LinkedCustomFieldNameLabel"/>
+            AutomationId="LinkedCustomFieldNameLabel" />
         <controls:IconLabel
             Text="{Binding ValueText, Mode=OneWay}"
             StyleClass="box-value"
             Grid.Row="1"
             Grid.Column="0"
             IsVisible="{Binding IsEditing, Mode=OneWay, Converter={StaticResource inverseBool}}"
-            AutomationId="LinkedCustomFieldValueLabel"/>
+            AutomationId="LinkedCustomFieldValueLabel" />
         <StackLayout
             StyleClass="box-row, box-row-input"
             IsVisible="{Binding IsEditing}">
@@ -47,7 +47,7 @@
                 SelectedIndex="{Binding LinkedFieldOptionSelectedIndex}"
                 ItemDisplayBinding="{Binding Key}"
                 StyleClass="box-value"
-                AutomationId="LinkedCustomFieldValuePicker"/>
+                AutomationId="LinkedCustomFieldValuePicker" />
         </StackLayout>
         <controls:IconButton 
             StyleClass="box-row-button, box-row-button-platform"
@@ -59,7 +59,7 @@
             Grid.RowSpan="2"
             AutomationProperties.IsInAccessibleTree="True"
             AutomationProperties.Name="{u:I18n Options}"
-            AutomationId="LinkedCustomFieldOptionsButton"/>
+            AutomationId="LinkedCustomFieldOptionsButton" />
     </Grid>
     <BoxView StyleClass="box-row-separator" IsVisible="{Binding IsEditing, Mode=OneWay, Converter={StaticResource inverseBool}}" />
 </StackLayout>

--- a/src/App/Lists/ItemLayouts/CustomFields/TextCustomFieldItemLayout.xaml
+++ b/src/App/Lists/ItemLayouts/CustomFields/TextCustomFieldItemLayout.xaml
@@ -30,14 +30,14 @@
             StyleClass="box-label"
             Grid.Row="0"
             Grid.Column="0"
-            AutomationId="TextCustomFieldNameLabel"/>
+            AutomationId="TextCustomFieldNameLabel" />
         <Label
             Text="{Binding ValueText, Mode=OneWay}"
             StyleClass="box-value"
             Grid.Row="1"
             Grid.Column="0"
             IsVisible="{Binding IsEditing, Mode=OneWay, Converter={StaticResource inverseBool}}"
-            AutomationId="TextCustomFieldValueLabel"/>
+            AutomationId="TextCustomFieldValueLabel" />
         <Entry
             Text="{Binding Field.Value}"
             StyleClass="box-value"
@@ -46,7 +46,7 @@
             IsVisible="{Binding IsEditing}"
             AutomationProperties.IsInAccessibleTree="True"
             AutomationProperties.Name="{Binding Field.Name}"
-            AutomationId="TextCustomFieldValueEntry"/>
+            AutomationId="TextCustomFieldValueEntry" />
         <controls:IconButton
             StyleClass="box-row-button, box-row-button-platform"
             Text="{Binding Source={x:Static core:BitwardenIcons.Clone}}"
@@ -57,7 +57,7 @@
             Grid.RowSpan="2"
             AutomationProperties.IsInAccessibleTree="True"
             AutomationProperties.Name="{u:I18n Copy}"
-            AutomationId="TextCustomFieldCopyValue"/>
+            AutomationId="TextCustomFieldCopyValue" />
         <controls:IconButton 
             StyleClass="box-row-button, box-row-button-platform"
             Text="{Binding Source={x:Static core:BitwardenIcons.Cog}}"
@@ -68,7 +68,7 @@
             Grid.RowSpan="2"
             AutomationProperties.IsInAccessibleTree="True"
             AutomationProperties.Name="{u:I18n Options}"
-            AutomationId="TextCustomFieldOptionsButton"/>
+            AutomationId="TextCustomFieldOptionsButton" />
     </Grid>
     <BoxView StyleClass="box-row-separator" IsVisible="{Binding IsEditing, Mode=OneWay, Converter={StaticResource inverseBool}}" />
 </StackLayout>

--- a/src/App/Lists/ItemLayouts/CustomFields/TextCustomFieldItemLayout.xaml
+++ b/src/App/Lists/ItemLayouts/CustomFields/TextCustomFieldItemLayout.xaml
@@ -29,13 +29,15 @@
             Text="{Binding Field.Name, Mode=OneWay}"
             StyleClass="box-label"
             Grid.Row="0"
-            Grid.Column="0" />
+            Grid.Column="0"
+            AutomationId="TextCustomFieldNameLabel"/>
         <Label
             Text="{Binding ValueText, Mode=OneWay}"
             StyleClass="box-value"
             Grid.Row="1"
             Grid.Column="0"
-            IsVisible="{Binding IsEditing, Mode=OneWay, Converter={StaticResource inverseBool}}" />
+            IsVisible="{Binding IsEditing, Mode=OneWay, Converter={StaticResource inverseBool}}"
+            AutomationId="TextCustomFieldValueLabel"/>
         <Entry
             Text="{Binding Field.Value}"
             StyleClass="box-value"
@@ -43,7 +45,8 @@
             Grid.Column="0"
             IsVisible="{Binding IsEditing}"
             AutomationProperties.IsInAccessibleTree="True"
-            AutomationProperties.Name="{Binding Field.Name}" />
+            AutomationProperties.Name="{Binding Field.Name}"
+            AutomationId="TextCustomFieldValueEntry"/>
         <controls:IconButton
             StyleClass="box-row-button, box-row-button-platform"
             Text="{Binding Source={x:Static core:BitwardenIcons.Clone}}"
@@ -53,7 +56,8 @@
             Grid.Column="1"
             Grid.RowSpan="2"
             AutomationProperties.IsInAccessibleTree="True"
-            AutomationProperties.Name="{u:I18n Copy}" />
+            AutomationProperties.Name="{u:I18n Copy}"
+            AutomationId="TextCustomFieldCopyValue"/>
         <controls:IconButton 
             StyleClass="box-row-button, box-row-button-platform"
             Text="{Binding Source={x:Static core:BitwardenIcons.Cog}}"
@@ -63,7 +67,8 @@
             Grid.Column="1"
             Grid.RowSpan="2"
             AutomationProperties.IsInAccessibleTree="True"
-            AutomationProperties.Name="{u:I18n Options}" />
+            AutomationProperties.Name="{u:I18n Options}"
+            AutomationId="TextCustomFieldOptionsButton"/>
     </Grid>
     <BoxView StyleClass="box-row-separator" IsVisible="{Binding IsEditing, Mode=OneWay, Converter={StaticResource inverseBool}}" />
 </StackLayout>

--- a/src/App/Pages/Vault/CipherAddEditPage.xaml
+++ b/src/App/Pages/Vault/CipherAddEditPage.xaml
@@ -57,16 +57,16 @@
                          x:Key="deleteItem" />
             
             <DataTemplate x:Key="TextCustomFieldDataTemplate">
-                <il:TextCustomFieldItemLayout />
+                <il:TextCustomFieldItemLayout AutomationId="TextCustomFieldItem"/>
             </DataTemplate>
             <DataTemplate x:Key="BooleanCustomFieldDataTemplate">
-                <il:BooleanCustomFieldItemLayout />
+                <il:BooleanCustomFieldItemLayout AutomationId="BooleanCustomFieldItem"/>
             </DataTemplate>
             <DataTemplate x:Key="HiddenCustomFieldDataTemplate">
-                <il:HiddenCustomFieldItemLayout />
+                <il:HiddenCustomFieldItemLayout AutomationId="HiddenCustomFieldItem"/>
             </DataTemplate>
             <DataTemplate x:Key="LinkedCustomFieldDataTemplate">
-                <il:LinkedCustomFieldItemLayout />
+                <il:LinkedCustomFieldItemLayout AutomationId="LinkedCustomFieldItem"/>
             </DataTemplate>
 
             <dts:CustomFieldItemTemplateSelector x:Key="CustomFieldItemTemplateSelector"
@@ -100,7 +100,8 @@
                         <Label
                             Text="{u:I18n PersonalOwnershipPolicyInEffect}"
                             StyleClass="text-muted, text-sm, text-bold"
-                            HorizontalTextAlignment="Center" />
+                            HorizontalTextAlignment="Center"
+                            AutomationId="PersonalOwnershipPolicyLabel"/>
                     </Frame>
                 </Grid>
                 <StackLayout StyleClass="box-row-header">
@@ -116,7 +117,8 @@
                         x:Name="_typePicker"
                         ItemsSource="{Binding TypeOptions, Mode=OneTime}"
                         SelectedIndex="{Binding TypeSelectedIndex}"
-                        StyleClass="box-value" />
+                        StyleClass="box-value"
+                        AutomationId="ItemTypePicker"/>
                 </StackLayout>
                 <StackLayout StyleClass="box-row, box-row-input">
                     <Label
@@ -127,7 +129,8 @@
                         Text="{Binding Cipher.Name}"
                         StyleClass="box-value"
                         AutomationProperties.IsInAccessibleTree="True"
-                        AutomationProperties.Name="{u:I18n Name}" />
+                        AutomationProperties.Name="{u:I18n Name}"
+                        AutomationId="ItemNameEntry"/>
                 </StackLayout>
                 <StackLayout IsVisible="{Binding IsLogin}" Spacing="0" Padding="0">
                     <Grid StyleClass="box-row, box-row-input"
@@ -142,7 +145,8 @@
                             StyleClass="box-value" 
                             Grid.Row="1"
                             AutomationProperties.IsInAccessibleTree="True"
-                            AutomationProperties.Name="{u:I18n Username}"/>
+                            AutomationProperties.Name="{u:I18n Username}"
+                            AutomationId="LoginUsernameEntry"/>
                         <controls:IconButton 
                             StyleClass="box-row-button, box-row-button-platform"
                             Text="{Binding Source={x:Static core:BitwardenIcons.Generate}}"
@@ -150,7 +154,8 @@
                             Grid.Column="1"
                             Grid.RowSpan="2"
                             AutomationProperties.IsInAccessibleTree="True"
-                            AutomationProperties.Name="{u:I18n GenerateUsername}" />
+                            AutomationProperties.Name="{u:I18n GenerateUsername}"
+                            AutomationId="GenerateUsernameButton"/>
                     </Grid>
                     <Grid StyleClass="box-row, box-row-input">
                         <Grid.RowDefinitions>
@@ -180,7 +185,8 @@
                             IsTextPredictionEnabled="False"
                             IsEnabled="{Binding Cipher.ViewPassword}"
                             AutomationProperties.IsInAccessibleTree="True"
-                            AutomationProperties.Name="{u:I18n Password}"/>
+                            AutomationProperties.Name="{u:I18n Password}"
+                            AutomationId="LoginPasswordEntry"/>
                         <controls:IconButton 
                             StyleClass="box-row-button, box-row-button-platform"
                             Text="{Binding Source={x:Static core:BitwardenIcons.CheckCircle}}"
@@ -190,7 +196,9 @@
                             Grid.RowSpan="2"
                             AutomationProperties.IsInAccessibleTree="True"
                             AutomationProperties.Name="{u:I18n CheckPassword}"
-                            IsVisible="{Binding Cipher.ViewPassword}" />
+                            IsVisible="{Binding Cipher.ViewPassword}"
+                            AutomationId="CheckPasswordButton"
+                            />
                         <controls:IconButton 
                             StyleClass="box-row-button, box-row-button-platform"
                             Text="{Binding ShowPasswordIcon}"
@@ -201,7 +209,8 @@
                             AutomationProperties.IsInAccessibleTree="True"
                             AutomationProperties.Name="{u:I18n ToggleVisibility}"
                             AutomationProperties.HelpText="{Binding PasswordVisibilityAccessibilityText}"
-                            IsVisible="{Binding Cipher.ViewPassword}" />
+                            IsVisible="{Binding Cipher.ViewPassword}"
+                            AutomationId="ViewPasswordButton"/>
                         <controls:IconButton 
                             StyleClass="box-row-button, box-row-button-platform"
                             Text="{Binding Source={x:Static core:BitwardenIcons.Generate}}"
@@ -211,7 +220,8 @@
                             Grid.RowSpan="2"
                             AutomationProperties.IsInAccessibleTree="True"
                             AutomationProperties.Name="{u:I18n GeneratePassword}"
-                            IsVisible="{Binding Cipher.ViewPassword}" />
+                            IsVisible="{Binding Cipher.ViewPassword}"
+                            AutomationId="RegeneratePasswordButton"/>
                     </Grid>
 
                     <Grid StyleClass="box-row, box-row-input">
@@ -247,7 +257,8 @@
                                 Padding="0,15"
                                 HorizontalOptions="Center"
                                 VerticalOptions="FillAndExpand"
-                                VerticalTextAlignment="Center" />
+                                VerticalTextAlignment="Center"
+                                AutomationId="SetupTotpButton"/>
                         </Frame>
                         <controls:MonoEntry
                             x:Name="_loginTotpEntry"
@@ -262,7 +273,8 @@
                             Grid.Column="0"
                             Grid.ColumnSpan="{Binding TotpColumnSpan}"
                             AutomationProperties.IsInAccessibleTree="True"
-                            AutomationProperties.Name="{u:I18n AuthenticatorKey}" />
+                            AutomationProperties.Name="{u:I18n AuthenticatorKey}"
+                            AutomationId="LoginTotpEntry"/>
                         <controls:IconButton 
                             StyleClass="box-row-button, box-row-button-platform"
                             Text="{Binding Source={x:Static core:BitwardenIcons.Clone}}"
@@ -272,7 +284,8 @@
                             Grid.Column="1"
                             Grid.RowSpan="2"
                             AutomationProperties.IsInAccessibleTree="True"
-                            AutomationProperties.Name="{u:I18n CopyTotp}" />
+                            AutomationProperties.Name="{u:I18n CopyTotp}"
+                            AutomationId="CopyTotpValueButton"/>
                         <controls:IconButton 
                             StyleClass="box-row-button, box-row-button-platform"
                             Text="{Binding Source={x:Static core:BitwardenIcons.Camera}}"
@@ -282,7 +295,8 @@
                             Grid.RowSpan="2"
                             IsVisible="{Binding HasTotpValue}"
                             AutomationProperties.IsInAccessibleTree="True"
-                            AutomationProperties.Name="{u:I18n ScanQrTitle}" />
+                            AutomationProperties.Name="{u:I18n ScanQrTitle}"
+                            />
                     </Grid>
                 </StackLayout>
                 <StackLayout IsVisible="{Binding IsCard}" Spacing="0" Padding="0">
@@ -293,7 +307,8 @@
                         <Entry
                             x:Name="_cardholderNameEntry"
                             Text="{Binding Cipher.Card.CardholderName}"
-                            StyleClass="box-value" />
+                            StyleClass="box-value"
+                            AutomationId="CardholderNameEntry"/>
                     </StackLayout>
                     <Grid StyleClass="box-row, box-row-input">
                         <Grid.RowDefinitions>
@@ -319,7 +334,8 @@
                             IsSpellCheckEnabled="False"
                             IsTextPredictionEnabled="False"
                             AutomationProperties.IsInAccessibleTree="True"
-                            AutomationProperties.Name="{u:I18n Number}" />
+                            AutomationProperties.Name="{u:I18n Number}"
+                            AutomationId="CardNumberEntry"/>
                         <controls:IconButton 
                             StyleClass="box-row-button, box-row-button-platform"
                             Text="{Binding ShowCardNumberIcon}"
@@ -328,7 +344,8 @@
                             Grid.Column="1"
                             Grid.RowSpan="2"
                             AutomationProperties.IsInAccessibleTree="True"
-                            AutomationProperties.Name="{u:I18n ToggleVisibility}" />
+                            AutomationProperties.Name="{u:I18n ToggleVisibility}"
+                            AutomationId="ShowCardNumberButton"/>
                     </Grid>
                     <StackLayout StyleClass="box-row, box-row-input">
                         <Label
@@ -338,7 +355,8 @@
                             x:Name="_cardBrandPicker"
                             ItemsSource="{Binding CardBrandOptions, Mode=OneTime}"
                             SelectedIndex="{Binding CardBrandSelectedIndex}"
-                            StyleClass="box-value" />
+                            StyleClass="box-value"
+                            AutomationId="CardBrandPicker"/>
                     </StackLayout>
                     <StackLayout StyleClass="box-row, box-row-input">
                         <Label
@@ -348,7 +366,8 @@
                             x:Name="_cardExpMonthPicker"
                             ItemsSource="{Binding CardExpMonthOptions, Mode=OneTime}"
                             SelectedIndex="{Binding CardExpMonthSelectedIndex}"
-                            StyleClass="box-value" />
+                            StyleClass="box-value"
+                            AutomationId="CardExpirationMonthPicker"/>
                     </StackLayout>
                     <StackLayout StyleClass="box-row, box-row-input">
                         <Label
@@ -360,7 +379,8 @@
                             StyleClass="box-value"
                             Keyboard="Numeric"
                             AutomationProperties.IsInAccessibleTree="True"
-                            AutomationProperties.Name="{u:I18n ExpirationYear}" />
+                            AutomationProperties.Name="{u:I18n ExpirationYear}"
+                            AutomationId="CardExpirationYearEntry"/>
                     </StackLayout>
                     <Grid StyleClass="box-row, box-row-input">
                         <Grid.RowDefinitions>
@@ -387,7 +407,8 @@
                             IsSpellCheckEnabled="False"
                             IsTextPredictionEnabled="False"
                             AutomationProperties.IsInAccessibleTree="True"
-                            AutomationProperties.Name="{u:I18n SecurityCode}" />
+                            AutomationProperties.Name="{u:I18n SecurityCode}"
+                            AutomationId="CardSecurityCodeEntry"/>
                         <controls:IconButton 
                             StyleClass="box-row-button, box-row-button-platform"
                             Text="{Binding ShowCardCodeIcon}"
@@ -396,7 +417,8 @@
                             Grid.Column="1"
                             Grid.RowSpan="2"
                             AutomationProperties.IsInAccessibleTree="True"
-                            AutomationProperties.Name="{u:I18n ToggleVisibility}" />
+                            AutomationProperties.Name="{u:I18n ToggleVisibility}"
+                            AutomationId="CardShowSecurityCodeButton"/>
                     </Grid>
                 </StackLayout>
                 <StackLayout IsVisible="{Binding IsIdentity}" Spacing="0" Padding="0">
@@ -408,7 +430,8 @@
                             x:Name="_identityTitlePicker"
                             ItemsSource="{Binding IdentityTitleOptions, Mode=OneTime}"
                             SelectedIndex="{Binding IdentityTitleSelectedIndex}"
-                            StyleClass="box-value" />
+                            StyleClass="box-value"
+                            AutomationId="IdentityTitlePicker"/>
                     </StackLayout>
                     <StackLayout StyleClass="box-row, box-row-input">
                         <Label
@@ -419,7 +442,8 @@
                             Text="{Binding Cipher.Identity.FirstName}"
                             StyleClass="box-value,capitalize-word-input"
                             AutomationProperties.IsInAccessibleTree="True"
-                            AutomationProperties.Name="{u:I18n FirstName}"/>
+                            AutomationProperties.Name="{u:I18n FirstName}"
+                            AutomationId="IdentityFirstNameEntry"/>
                     </StackLayout>
                     <StackLayout StyleClass="box-row, box-row-input">
                         <Label
@@ -430,7 +454,8 @@
                             Text="{Binding Cipher.Identity.MiddleName}"
                             StyleClass="box-value,capitalize-word-input"
                             AutomationProperties.IsInAccessibleTree="True"
-                            AutomationProperties.Name="{u:I18n MiddleName}" />
+                            AutomationProperties.Name="{u:I18n MiddleName}"
+                            AutomationId="IdentityMiddleNameEntry"/>
                     </StackLayout>
                     <StackLayout StyleClass="box-row, box-row-input">
                         <Label
@@ -441,7 +466,8 @@
                             Text="{Binding Cipher.Identity.LastName}"
                             StyleClass="box-value,capitalize-word-input"
                             AutomationProperties.IsInAccessibleTree="True"
-                            AutomationProperties.Name="{u:I18n LastName}" />
+                            AutomationProperties.Name="{u:I18n LastName}"
+                            AutomationId="IdentityLastNameEntry"/>
                     </StackLayout>
                     <StackLayout StyleClass="box-row, box-row-input">
                         <Label
@@ -452,7 +478,8 @@
                             Text="{Binding Cipher.Identity.Username}"
                             StyleClass="box-value"
                             AutomationProperties.IsInAccessibleTree="True"
-                            AutomationProperties.Name="{u:I18n Username}" />
+                            AutomationProperties.Name="{u:I18n Username}"
+                            AutomationId="IdentityUsernameEntry"/>
                     </StackLayout>
                     <StackLayout StyleClass="box-row, box-row-input">
                         <Label
@@ -463,7 +490,8 @@
                             Text="{Binding Cipher.Identity.Company}"
                             StyleClass="box-value" 
                             AutomationProperties.IsInAccessibleTree="True"
-                            AutomationProperties.Name="{u:I18n Company}"/>
+                            AutomationProperties.Name="{u:I18n Company}"
+                            AutomationId="IdentityCompanyEntry"/>
                     </StackLayout>
                     <StackLayout StyleClass="box-row, box-row-input">
                         <Label
@@ -474,7 +502,8 @@
                             Text="{Binding Cipher.Identity.SSN}"
                             StyleClass="box-value" 
                             AutomationProperties.IsInAccessibleTree="True"
-                            AutomationProperties.Name="{u:I18n SSN}"/>
+                            AutomationProperties.Name="{u:I18n SSN}"
+                            AutomationId="IdentitySsnEntry"/>
                     </StackLayout>
                     <StackLayout StyleClass="box-row, box-row-input">
                         <Label
@@ -485,7 +514,8 @@
                             Text="{Binding Cipher.Identity.PassportNumber}"
                             StyleClass="box-value" 
                             AutomationProperties.IsInAccessibleTree="True"
-                            AutomationProperties.Name="{u:I18n PassportNumber}"/>
+                            AutomationProperties.Name="{u:I18n PassportNumber}"
+                            AutomationId="IdentityPassportNumberEntry"/>
                     </StackLayout>
                     <StackLayout StyleClass="box-row, box-row-input">
                         <Label
@@ -496,7 +526,8 @@
                             Text="{Binding Cipher.Identity.LicenseNumber}"
                             StyleClass="box-value"
                             AutomationProperties.IsInAccessibleTree="True"
-                            AutomationProperties.Name="{u:I18n LicenseNumber}" />
+                            AutomationProperties.Name="{u:I18n LicenseNumber}"
+                            AutomationId="IdentityLicenseNumberEntry"/>
                     </StackLayout>
                     <StackLayout StyleClass="box-row, box-row-input">
                         <Label
@@ -508,7 +539,8 @@
                             Text="{Binding Cipher.Identity.Email}"
                             StyleClass="box-value" 
                             AutomationProperties.IsInAccessibleTree="True"
-                            AutomationProperties.Name="{u:I18n Email}"/>
+                            AutomationProperties.Name="{u:I18n Email}"
+                            AutomationId="IdentityEmailEntry"/>
                     </StackLayout>
                     <StackLayout StyleClass="box-row, box-row-input">
                         <Label
@@ -520,7 +552,8 @@
                             Keyboard="Telephone"
                             StyleClass="box-value"
                             AutomationProperties.IsInAccessibleTree="True"
-                            AutomationProperties.Name="{u:I18n Phone}" />
+                            AutomationProperties.Name="{u:I18n Phone}"
+                            AutomationId="IdentityPhoneEntry"/>
                     </StackLayout>
                     <StackLayout StyleClass="box-row, box-row-input">
                         <Label
@@ -531,7 +564,8 @@
                             Text="{Binding Cipher.Identity.Address1}"
                             StyleClass="box-value" 
                             AutomationProperties.IsInAccessibleTree="True"
-                            AutomationProperties.Name="{u:I18n Address1}"/>
+                            AutomationProperties.Name="{u:I18n Address1}"
+                            AutomationId="IdentityAddressOneEntry"/>
                     </StackLayout>
                     <StackLayout StyleClass="box-row, box-row-input">
                         <Label
@@ -542,7 +576,8 @@
                             Text="{Binding Cipher.Identity.Address2}"
                             StyleClass="box-value"
                             AutomationProperties.IsInAccessibleTree="True"
-                            AutomationProperties.Name="{u:I18n Address2}" />
+                            AutomationProperties.Name="{u:I18n Address2}"
+                            AutomationId="IdentityAddressTwoEntry"/>
                     </StackLayout>
                     <StackLayout StyleClass="box-row, box-row-input">
                         <Label
@@ -553,7 +588,8 @@
                             Text="{Binding Cipher.Identity.Address3}"
                             StyleClass="box-value"
                             AutomationProperties.IsInAccessibleTree="True"
-                            AutomationProperties.Name="{u:I18n Address3}" />
+                            AutomationProperties.Name="{u:I18n Address3}"
+                            AutomationId="IdentityAddressThreeEntry"/>
                     </StackLayout>
                     <StackLayout StyleClass="box-row, box-row-input">
                         <Label
@@ -564,7 +600,8 @@
                             Text="{Binding Cipher.Identity.City}"
                             StyleClass="box-value,capitalize-sentence-input"
                             AutomationProperties.IsInAccessibleTree="True"
-                            AutomationProperties.Name="{u:I18n CityTown}" />
+                            AutomationProperties.Name="{u:I18n CityTown}"
+                            AutomationId="IdentityCityEntry"/>
                     </StackLayout>
                     <StackLayout StyleClass="box-row, box-row-input">
                         <Label
@@ -575,7 +612,8 @@
                             Text="{Binding Cipher.Identity.State}"
                             StyleClass="box-value,capitalize-sentence-input"
                             AutomationProperties.IsInAccessibleTree="True"
-                            AutomationProperties.Name="{u:I18n StateProvince}" />
+                            AutomationProperties.Name="{u:I18n StateProvince}"
+                            AutomationId="IdentityStateEntry"/>
                     </StackLayout>
                     <StackLayout StyleClass="box-row, box-row-input">
                         <Label
@@ -586,7 +624,8 @@
                             Text="{Binding Cipher.Identity.PostalCode}"
                             StyleClass="box-value"
                             AutomationProperties.IsInAccessibleTree="True"
-                            AutomationProperties.Name="{u:I18n ZipPostalCode}" />
+                            AutomationProperties.Name="{u:I18n ZipPostalCode}"
+                            AutomationId="IdentityPostalCodeEntry"/>
                     </StackLayout>
                     <StackLayout StyleClass="box-row, box-row-input">
                         <Label
@@ -597,7 +636,8 @@
                             Text="{Binding Cipher.Identity.Country}"
                             StyleClass="box-value,capitalize-sentence-input"
                             AutomationProperties.IsInAccessibleTree="True"
-                            AutomationProperties.Name="{u:I18n Country}" />
+                            AutomationProperties.Name="{u:I18n Country}"
+                            AutomationId="IdentityCountryEntry"/>
                     </StackLayout>
                 </StackLayout>
             </StackLayout>
@@ -609,7 +649,7 @@
                 <controls:RepeaterView ItemsSource="{Binding Uris}">
                     <controls:RepeaterView.ItemTemplate>
                         <DataTemplate x:DataType="views:LoginUriView">
-                            <Grid StyleClass="box-row, box-row-input">
+                            <Grid StyleClass="box-row, box-row-input" AutomationId="UriListGrid">
                                 <Grid.RowDefinitions>
                                     <RowDefinition Height="Auto" />
                                     <RowDefinition Height="*" />
@@ -630,7 +670,8 @@
                                     Grid.Row="1"
                                     Grid.Column="0"
                                     AutomationProperties.IsInAccessibleTree="True"
-                                    AutomationProperties.Name="{u:I18n URI}" />
+                                    AutomationProperties.Name="{u:I18n URI}"
+                                    AutomationId="LoginUriEntry"/>
                                 <controls:IconButton
                                     StyleClass="box-row-button, box-row-button-platform"
                                     Text="{Binding Source={x:Static core:BitwardenIcons.Cog}}"
@@ -640,13 +681,15 @@
                                     Grid.Column="1"
                                     Grid.RowSpan="2"
                                     AutomationProperties.IsInAccessibleTree="True"
-                                    AutomationProperties.Name="{u:I18n Options}" />
+                                    AutomationProperties.Name="{u:I18n Options}"
+                                    AutomationId="LoginUriOptionsButton"/>
                             </Grid>
                         </DataTemplate>
                     </controls:RepeaterView.ItemTemplate>
                 </controls:RepeaterView>
                 <Button Text="{u:I18n NewUri}" StyleClass="box-button-row"
-                        Clicked="NewUri_Clicked"></Button>
+                        Clicked="NewUri_Clicked"
+                        AutomationId="LoginAddNewUriButton"></Button>
             </StackLayout>
             <StackLayout StyleClass="box">
                 <StackLayout StyleClass="box-row-header">
@@ -661,7 +704,8 @@
                         x:Name="_folderPicker"
                         ItemsSource="{Binding FolderOptions, Mode=OneTime}"
                         SelectedIndex="{Binding FolderSelectedIndex}"
-                        StyleClass="box-value" />
+                        StyleClass="box-value"
+                        AutomationId="FolderPicker"/>
                 </StackLayout>
                 <StackLayout StyleClass="box-row, box-row-switch">
                     <Label
@@ -671,7 +715,8 @@
                     <Switch
                         IsToggled="{Binding Cipher.Favorite}"
                         StyleClass="box-value"
-                        HorizontalOptions="End" />
+                        HorizontalOptions="End"
+                        AutomationId="ItemFavoriteToggle"/>
                 </StackLayout>
                 <StackLayout x:Name="_passwordPrompt" StyleClass="box-row, box-row-switch">
                     <Label
@@ -689,7 +734,8 @@
                         IsToggled="{Binding PasswordPrompt}"
                         Toggled="PasswordPrompt_Toggled"
                         StyleClass="box-value"
-                        HorizontalOptions="End" />
+                        HorizontalOptions="End"
+                        AutomationId="MasterPasswordRepromptToggle"/>
                 </StackLayout>
                 <BoxView StyleClass="box-row-separator" />
             </StackLayout>
@@ -706,7 +752,8 @@
                         effects:ScrollEnabledEffect.IsScrollEnabled="false"
                         Text="{Binding Cipher.Notes}"
                         AutomationProperties.IsInAccessibleTree="True"
-                        AutomationProperties.Name="{u:I18n Notes}" >
+                        AutomationProperties.Name="{u:I18n Notes}"
+                        AutomationId="ItemNotesEntry">
                         <Editor.Behaviors>
                             <behaviors:EditorPreventAutoBottomScrollingOnFocusedBehavior ParentScrollView="{x:Reference _scrollView}" />
                         </Editor.Behaviors>
@@ -725,9 +772,11 @@
                 <StackLayout
                     Spacing="0"
                     BindableLayout.ItemsSource="{Binding Fields}"
-                    BindableLayout.ItemTemplateSelector="{StaticResource CustomFieldItemTemplateSelector}" />
+                    BindableLayout.ItemTemplateSelector="{StaticResource CustomFieldItemTemplateSelector}"
+                    AutomationId="CustomFieldsList"/>
                 <Button Text="{u:I18n NewCustomField}" StyleClass="box-button-row"
-                        Clicked="NewField_Clicked"></Button>
+                        Clicked="NewField_Clicked"
+                        AutomationId="NewCustomFieldButton"></Button>
             </StackLayout>
             <StackLayout StyleClass="box" IsVisible="{Binding ShowOwnershipOptions}">
                 <StackLayout StyleClass="box-row-header">
@@ -742,7 +791,8 @@
                         x:Name="_ownershipPicker"
                         ItemsSource="{Binding OwnershipOptions, Mode=OneTime}"
                         SelectedIndex="{Binding OwnershipSelectedIndex}"
-                        StyleClass="box-value" />
+                        StyleClass="box-value"
+                        AutomationId="ItemOwnershipPicker"/>
                 </StackLayout>
             </StackLayout>
             <StackLayout StyleClass="box" IsVisible="{Binding ShowCollections}">
@@ -753,7 +803,8 @@
                 <StackLayout Spacing="0" Padding="0"
                                 IsVisible="{Binding HasCollections, Converter={StaticResource inverseBool}}">
                     <StackLayout StyleClass="box-row, box-row-switch">
-                        <Label Text="{u:I18n NoCollectionsToList}" />
+                        <Label Text="{u:I18n NoCollectionsToList}"
+                               AutomationId="NoCollectionsToListLabel"/>
                     </StackLayout>
                     <BoxView StyleClass="box-row-separator" />
                 </StackLayout>
@@ -763,15 +814,17 @@
                     <controls:RepeaterView.ItemTemplate>
                         <DataTemplate x:DataType="pages:CollectionViewModel">
                             <StackLayout Spacing="0" Padding="0">
-                                <StackLayout StyleClass="box-row, box-row-switch">
+                                <StackLayout StyleClass="box-row, box-row-switch" AutomationId="CollectionItemCell">
                                     <Label
                                         Text="{Binding Collection.Name}"
                                         StyleClass="box-label-regular"
-                                        HorizontalOptions="StartAndExpand" />
+                                        HorizontalOptions="StartAndExpand"
+                                        AutomationId="CollectionItemNameLabel"/>
                                     <Switch
                                         IsToggled="{Binding Checked}"
                                         StyleClass="box-value"
-                                        HorizontalOptions="End"/>
+                                        HorizontalOptions="End"
+                                        AutomationId="CollectionItemSwitch"/>
                                 </StackLayout>
                                 <BoxView StyleClass="box-row-separator" />
                             </StackLayout>
@@ -781,5 +834,4 @@
             </StackLayout>
         </StackLayout>
     </ScrollView>
-
 </pages:BaseContentPage>

--- a/src/App/Pages/Vault/CipherAddEditPage.xaml
+++ b/src/App/Pages/Vault/CipherAddEditPage.xaml
@@ -118,7 +118,7 @@
                         ItemsSource="{Binding TypeOptions, Mode=OneTime}"
                         SelectedIndex="{Binding TypeSelectedIndex}"
                         StyleClass="box-value"
-                        AutomationId="ItemTypePicker"/>
+                        AutomationId="ItemTypePicker" />
                 </StackLayout>
                 <StackLayout StyleClass="box-row, box-row-input">
                     <Label
@@ -130,7 +130,7 @@
                         StyleClass="box-value"
                         AutomationProperties.IsInAccessibleTree="True"
                         AutomationProperties.Name="{u:I18n Name}"
-                        AutomationId="ItemNameEntry"/>
+                        AutomationId="ItemNameEntry" />
                 </StackLayout>
                 <StackLayout IsVisible="{Binding IsLogin}" Spacing="0" Padding="0">
                     <Grid StyleClass="box-row, box-row-input"
@@ -146,7 +146,7 @@
                             Grid.Row="1"
                             AutomationProperties.IsInAccessibleTree="True"
                             AutomationProperties.Name="{u:I18n Username}"
-                            AutomationId="LoginUsernameEntry"/>
+                            AutomationId="LoginUsernameEntry" />
                         <controls:IconButton 
                             StyleClass="box-row-button, box-row-button-platform"
                             Text="{Binding Source={x:Static core:BitwardenIcons.Generate}}"
@@ -155,7 +155,7 @@
                             Grid.RowSpan="2"
                             AutomationProperties.IsInAccessibleTree="True"
                             AutomationProperties.Name="{u:I18n GenerateUsername}"
-                            AutomationId="GenerateUsernameButton"/>
+                            AutomationId="GenerateUsernameButton" />
                     </Grid>
                     <Grid StyleClass="box-row, box-row-input">
                         <Grid.RowDefinitions>
@@ -186,7 +186,7 @@
                             IsEnabled="{Binding Cipher.ViewPassword}"
                             AutomationProperties.IsInAccessibleTree="True"
                             AutomationProperties.Name="{u:I18n Password}"
-                            AutomationId="LoginPasswordEntry"/>
+                            AutomationId="LoginPasswordEntry" />
                         <controls:IconButton 
                             StyleClass="box-row-button, box-row-button-platform"
                             Text="{Binding Source={x:Static core:BitwardenIcons.CheckCircle}}"
@@ -197,8 +197,7 @@
                             AutomationProperties.IsInAccessibleTree="True"
                             AutomationProperties.Name="{u:I18n CheckPassword}"
                             IsVisible="{Binding Cipher.ViewPassword}"
-                            AutomationId="CheckPasswordButton"
-                            />
+                            AutomationId="CheckPasswordButton" />
                         <controls:IconButton 
                             StyleClass="box-row-button, box-row-button-platform"
                             Text="{Binding ShowPasswordIcon}"
@@ -210,7 +209,7 @@
                             AutomationProperties.Name="{u:I18n ToggleVisibility}"
                             AutomationProperties.HelpText="{Binding PasswordVisibilityAccessibilityText}"
                             IsVisible="{Binding Cipher.ViewPassword}"
-                            AutomationId="ViewPasswordButton"/>
+                            AutomationId="ViewPasswordButton" />
                         <controls:IconButton 
                             StyleClass="box-row-button, box-row-button-platform"
                             Text="{Binding Source={x:Static core:BitwardenIcons.Generate}}"
@@ -221,7 +220,7 @@
                             AutomationProperties.IsInAccessibleTree="True"
                             AutomationProperties.Name="{u:I18n GeneratePassword}"
                             IsVisible="{Binding Cipher.ViewPassword}"
-                            AutomationId="RegeneratePasswordButton"/>
+                            AutomationId="RegeneratePasswordButton" />
                     </Grid>
 
                     <Grid StyleClass="box-row, box-row-input">
@@ -258,7 +257,7 @@
                                 HorizontalOptions="Center"
                                 VerticalOptions="FillAndExpand"
                                 VerticalTextAlignment="Center"
-                                AutomationId="SetupTotpButton"/>
+                                AutomationId="SetupTotpButton" />
                         </Frame>
                         <controls:MonoEntry
                             x:Name="_loginTotpEntry"
@@ -274,7 +273,7 @@
                             Grid.ColumnSpan="{Binding TotpColumnSpan}"
                             AutomationProperties.IsInAccessibleTree="True"
                             AutomationProperties.Name="{u:I18n AuthenticatorKey}"
-                            AutomationId="LoginTotpEntry"/>
+                            AutomationId="LoginTotpEntry" />
                         <controls:IconButton 
                             StyleClass="box-row-button, box-row-button-platform"
                             Text="{Binding Source={x:Static core:BitwardenIcons.Clone}}"
@@ -285,7 +284,7 @@
                             Grid.RowSpan="2"
                             AutomationProperties.IsInAccessibleTree="True"
                             AutomationProperties.Name="{u:I18n CopyTotp}"
-                            AutomationId="CopyTotpValueButton"/>
+                            AutomationId="CopyTotpValueButton" />
                         <controls:IconButton 
                             StyleClass="box-row-button, box-row-button-platform"
                             Text="{Binding Source={x:Static core:BitwardenIcons.Camera}}"
@@ -308,7 +307,7 @@
                             x:Name="_cardholderNameEntry"
                             Text="{Binding Cipher.Card.CardholderName}"
                             StyleClass="box-value"
-                            AutomationId="CardholderNameEntry"/>
+                            AutomationId="CardholderNameEntry" />
                     </StackLayout>
                     <Grid StyleClass="box-row, box-row-input">
                         <Grid.RowDefinitions>
@@ -335,7 +334,7 @@
                             IsTextPredictionEnabled="False"
                             AutomationProperties.IsInAccessibleTree="True"
                             AutomationProperties.Name="{u:I18n Number}"
-                            AutomationId="CardNumberEntry"/>
+                            AutomationId="CardNumberEntry" />
                         <controls:IconButton 
                             StyleClass="box-row-button, box-row-button-platform"
                             Text="{Binding ShowCardNumberIcon}"
@@ -345,7 +344,7 @@
                             Grid.RowSpan="2"
                             AutomationProperties.IsInAccessibleTree="True"
                             AutomationProperties.Name="{u:I18n ToggleVisibility}"
-                            AutomationId="ShowCardNumberButton"/>
+                            AutomationId="ShowCardNumberButton" />
                     </Grid>
                     <StackLayout StyleClass="box-row, box-row-input">
                         <Label
@@ -356,7 +355,7 @@
                             ItemsSource="{Binding CardBrandOptions, Mode=OneTime}"
                             SelectedIndex="{Binding CardBrandSelectedIndex}"
                             StyleClass="box-value"
-                            AutomationId="CardBrandPicker"/>
+                            AutomationId="CardBrandPicker" />
                     </StackLayout>
                     <StackLayout StyleClass="box-row, box-row-input">
                         <Label
@@ -367,7 +366,7 @@
                             ItemsSource="{Binding CardExpMonthOptions, Mode=OneTime}"
                             SelectedIndex="{Binding CardExpMonthSelectedIndex}"
                             StyleClass="box-value"
-                            AutomationId="CardExpirationMonthPicker"/>
+                            AutomationId="CardExpirationMonthPicker" />
                     </StackLayout>
                     <StackLayout StyleClass="box-row, box-row-input">
                         <Label
@@ -380,7 +379,7 @@
                             Keyboard="Numeric"
                             AutomationProperties.IsInAccessibleTree="True"
                             AutomationProperties.Name="{u:I18n ExpirationYear}"
-                            AutomationId="CardExpirationYearEntry"/>
+                            AutomationId="CardExpirationYearEntry" />
                     </StackLayout>
                     <Grid StyleClass="box-row, box-row-input">
                         <Grid.RowDefinitions>
@@ -408,7 +407,7 @@
                             IsTextPredictionEnabled="False"
                             AutomationProperties.IsInAccessibleTree="True"
                             AutomationProperties.Name="{u:I18n SecurityCode}"
-                            AutomationId="CardSecurityCodeEntry"/>
+                            AutomationId="CardSecurityCodeEntry" />
                         <controls:IconButton 
                             StyleClass="box-row-button, box-row-button-platform"
                             Text="{Binding ShowCardCodeIcon}"
@@ -418,7 +417,7 @@
                             Grid.RowSpan="2"
                             AutomationProperties.IsInAccessibleTree="True"
                             AutomationProperties.Name="{u:I18n ToggleVisibility}"
-                            AutomationId="CardShowSecurityCodeButton"/>
+                            AutomationId="CardShowSecurityCodeButton" />
                     </Grid>
                 </StackLayout>
                 <StackLayout IsVisible="{Binding IsIdentity}" Spacing="0" Padding="0">
@@ -431,7 +430,7 @@
                             ItemsSource="{Binding IdentityTitleOptions, Mode=OneTime}"
                             SelectedIndex="{Binding IdentityTitleSelectedIndex}"
                             StyleClass="box-value"
-                            AutomationId="IdentityTitlePicker"/>
+                            AutomationId="IdentityTitlePicker" />
                     </StackLayout>
                     <StackLayout StyleClass="box-row, box-row-input">
                         <Label
@@ -443,7 +442,7 @@
                             StyleClass="box-value,capitalize-word-input"
                             AutomationProperties.IsInAccessibleTree="True"
                             AutomationProperties.Name="{u:I18n FirstName}"
-                            AutomationId="IdentityFirstNameEntry"/>
+                            AutomationId="IdentityFirstNameEntry" />
                     </StackLayout>
                     <StackLayout StyleClass="box-row, box-row-input">
                         <Label
@@ -455,7 +454,7 @@
                             StyleClass="box-value,capitalize-word-input"
                             AutomationProperties.IsInAccessibleTree="True"
                             AutomationProperties.Name="{u:I18n MiddleName}"
-                            AutomationId="IdentityMiddleNameEntry"/>
+                            AutomationId="IdentityMiddleNameEntry" />
                     </StackLayout>
                     <StackLayout StyleClass="box-row, box-row-input">
                         <Label
@@ -467,7 +466,7 @@
                             StyleClass="box-value,capitalize-word-input"
                             AutomationProperties.IsInAccessibleTree="True"
                             AutomationProperties.Name="{u:I18n LastName}"
-                            AutomationId="IdentityLastNameEntry"/>
+                            AutomationId="IdentityLastNameEntry" />
                     </StackLayout>
                     <StackLayout StyleClass="box-row, box-row-input">
                         <Label
@@ -479,7 +478,7 @@
                             StyleClass="box-value"
                             AutomationProperties.IsInAccessibleTree="True"
                             AutomationProperties.Name="{u:I18n Username}"
-                            AutomationId="IdentityUsernameEntry"/>
+                            AutomationId="IdentityUsernameEntry" />
                     </StackLayout>
                     <StackLayout StyleClass="box-row, box-row-input">
                         <Label
@@ -491,7 +490,7 @@
                             StyleClass="box-value" 
                             AutomationProperties.IsInAccessibleTree="True"
                             AutomationProperties.Name="{u:I18n Company}"
-                            AutomationId="IdentityCompanyEntry"/>
+                            AutomationId="IdentityCompanyEntry" />
                     </StackLayout>
                     <StackLayout StyleClass="box-row, box-row-input">
                         <Label
@@ -503,7 +502,7 @@
                             StyleClass="box-value" 
                             AutomationProperties.IsInAccessibleTree="True"
                             AutomationProperties.Name="{u:I18n SSN}"
-                            AutomationId="IdentitySsnEntry"/>
+                            AutomationId="IdentitySsnEntry" />
                     </StackLayout>
                     <StackLayout StyleClass="box-row, box-row-input">
                         <Label
@@ -515,7 +514,7 @@
                             StyleClass="box-value" 
                             AutomationProperties.IsInAccessibleTree="True"
                             AutomationProperties.Name="{u:I18n PassportNumber}"
-                            AutomationId="IdentityPassportNumberEntry"/>
+                            AutomationId="IdentityPassportNumberEntry" />
                     </StackLayout>
                     <StackLayout StyleClass="box-row, box-row-input">
                         <Label
@@ -527,7 +526,7 @@
                             StyleClass="box-value"
                             AutomationProperties.IsInAccessibleTree="True"
                             AutomationProperties.Name="{u:I18n LicenseNumber}"
-                            AutomationId="IdentityLicenseNumberEntry"/>
+                            AutomationId="IdentityLicenseNumberEntry" />
                     </StackLayout>
                     <StackLayout StyleClass="box-row, box-row-input">
                         <Label
@@ -540,7 +539,7 @@
                             StyleClass="box-value" 
                             AutomationProperties.IsInAccessibleTree="True"
                             AutomationProperties.Name="{u:I18n Email}"
-                            AutomationId="IdentityEmailEntry"/>
+                            AutomationId="IdentityEmailEntry" />
                     </StackLayout>
                     <StackLayout StyleClass="box-row, box-row-input">
                         <Label
@@ -553,7 +552,7 @@
                             StyleClass="box-value"
                             AutomationProperties.IsInAccessibleTree="True"
                             AutomationProperties.Name="{u:I18n Phone}"
-                            AutomationId="IdentityPhoneEntry"/>
+                            AutomationId="IdentityPhoneEntry" />
                     </StackLayout>
                     <StackLayout StyleClass="box-row, box-row-input">
                         <Label
@@ -565,7 +564,7 @@
                             StyleClass="box-value" 
                             AutomationProperties.IsInAccessibleTree="True"
                             AutomationProperties.Name="{u:I18n Address1}"
-                            AutomationId="IdentityAddressOneEntry"/>
+                            AutomationId="IdentityAddressOneEntry" />
                     </StackLayout>
                     <StackLayout StyleClass="box-row, box-row-input">
                         <Label
@@ -577,7 +576,7 @@
                             StyleClass="box-value"
                             AutomationProperties.IsInAccessibleTree="True"
                             AutomationProperties.Name="{u:I18n Address2}"
-                            AutomationId="IdentityAddressTwoEntry"/>
+                            AutomationId="IdentityAddressTwoEntry" />
                     </StackLayout>
                     <StackLayout StyleClass="box-row, box-row-input">
                         <Label
@@ -589,7 +588,7 @@
                             StyleClass="box-value"
                             AutomationProperties.IsInAccessibleTree="True"
                             AutomationProperties.Name="{u:I18n Address3}"
-                            AutomationId="IdentityAddressThreeEntry"/>
+                            AutomationId="IdentityAddressThreeEntry" />
                     </StackLayout>
                     <StackLayout StyleClass="box-row, box-row-input">
                         <Label
@@ -601,7 +600,7 @@
                             StyleClass="box-value,capitalize-sentence-input"
                             AutomationProperties.IsInAccessibleTree="True"
                             AutomationProperties.Name="{u:I18n CityTown}"
-                            AutomationId="IdentityCityEntry"/>
+                            AutomationId="IdentityCityEntry" />
                     </StackLayout>
                     <StackLayout StyleClass="box-row, box-row-input">
                         <Label
@@ -613,7 +612,7 @@
                             StyleClass="box-value,capitalize-sentence-input"
                             AutomationProperties.IsInAccessibleTree="True"
                             AutomationProperties.Name="{u:I18n StateProvince}"
-                            AutomationId="IdentityStateEntry"/>
+                            AutomationId="IdentityStateEntry" />
                     </StackLayout>
                     <StackLayout StyleClass="box-row, box-row-input">
                         <Label
@@ -625,7 +624,7 @@
                             StyleClass="box-value"
                             AutomationProperties.IsInAccessibleTree="True"
                             AutomationProperties.Name="{u:I18n ZipPostalCode}"
-                            AutomationId="IdentityPostalCodeEntry"/>
+                            AutomationId="IdentityPostalCodeEntry" />
                     </StackLayout>
                     <StackLayout StyleClass="box-row, box-row-input">
                         <Label
@@ -637,7 +636,7 @@
                             StyleClass="box-value,capitalize-sentence-input"
                             AutomationProperties.IsInAccessibleTree="True"
                             AutomationProperties.Name="{u:I18n Country}"
-                            AutomationId="IdentityCountryEntry"/>
+                            AutomationId="IdentityCountryEntry" />
                     </StackLayout>
                 </StackLayout>
             </StackLayout>
@@ -649,7 +648,7 @@
                 <controls:RepeaterView ItemsSource="{Binding Uris}">
                     <controls:RepeaterView.ItemTemplate>
                         <DataTemplate x:DataType="views:LoginUriView">
-                            <Grid StyleClass="box-row, box-row-input" AutomationId="UriListGrid">
+                            <Grid StyleClass="box-row, box-row-input" AutomationId="UriListGrid" >
                                 <Grid.RowDefinitions>
                                     <RowDefinition Height="Auto" />
                                     <RowDefinition Height="*" />
@@ -671,7 +670,7 @@
                                     Grid.Column="0"
                                     AutomationProperties.IsInAccessibleTree="True"
                                     AutomationProperties.Name="{u:I18n URI}"
-                                    AutomationId="LoginUriEntry"/>
+                                    AutomationId="LoginUriEntry" />
                                 <controls:IconButton
                                     StyleClass="box-row-button, box-row-button-platform"
                                     Text="{Binding Source={x:Static core:BitwardenIcons.Cog}}"
@@ -682,7 +681,7 @@
                                     Grid.RowSpan="2"
                                     AutomationProperties.IsInAccessibleTree="True"
                                     AutomationProperties.Name="{u:I18n Options}"
-                                    AutomationId="LoginUriOptionsButton"/>
+                                    AutomationId="LoginUriOptionsButton" />
                             </Grid>
                         </DataTemplate>
                     </controls:RepeaterView.ItemTemplate>
@@ -705,7 +704,7 @@
                         ItemsSource="{Binding FolderOptions, Mode=OneTime}"
                         SelectedIndex="{Binding FolderSelectedIndex}"
                         StyleClass="box-value"
-                        AutomationId="FolderPicker"/>
+                        AutomationId="FolderPicker" />
                 </StackLayout>
                 <StackLayout StyleClass="box-row, box-row-switch">
                     <Label
@@ -716,7 +715,7 @@
                         IsToggled="{Binding Cipher.Favorite}"
                         StyleClass="box-value"
                         HorizontalOptions="End"
-                        AutomationId="ItemFavoriteToggle"/>
+                        AutomationId="ItemFavoriteToggle" />
                 </StackLayout>
                 <StackLayout x:Name="_passwordPrompt" StyleClass="box-row, box-row-switch">
                     <Label
@@ -735,7 +734,7 @@
                         Toggled="PasswordPrompt_Toggled"
                         StyleClass="box-value"
                         HorizontalOptions="End"
-                        AutomationId="MasterPasswordRepromptToggle"/>
+                        AutomationId="MasterPasswordRepromptToggle" />
                 </StackLayout>
                 <BoxView StyleClass="box-row-separator" />
             </StackLayout>
@@ -773,7 +772,7 @@
                     Spacing="0"
                     BindableLayout.ItemsSource="{Binding Fields}"
                     BindableLayout.ItemTemplateSelector="{StaticResource CustomFieldItemTemplateSelector}"
-                    AutomationId="CustomFieldsList"/>
+                    AutomationId="CustomFieldsList" />
                 <Button Text="{u:I18n NewCustomField}" StyleClass="box-button-row"
                         Clicked="NewField_Clicked"
                         AutomationId="NewCustomFieldButton"></Button>
@@ -792,7 +791,7 @@
                         ItemsSource="{Binding OwnershipOptions, Mode=OneTime}"
                         SelectedIndex="{Binding OwnershipSelectedIndex}"
                         StyleClass="box-value"
-                        AutomationId="ItemOwnershipPicker"/>
+                        AutomationId="ItemOwnershipPicker" />
                 </StackLayout>
             </StackLayout>
             <StackLayout StyleClass="box" IsVisible="{Binding ShowCollections}">
@@ -804,7 +803,7 @@
                                 IsVisible="{Binding HasCollections, Converter={StaticResource inverseBool}}">
                     <StackLayout StyleClass="box-row, box-row-switch">
                         <Label Text="{u:I18n NoCollectionsToList}"
-                               AutomationId="NoCollectionsToListLabel"/>
+                               AutomationId="NoCollectionsToListLabel" />
                     </StackLayout>
                     <BoxView StyleClass="box-row-separator" />
                 </StackLayout>
@@ -819,12 +818,12 @@
                                         Text="{Binding Collection.Name}"
                                         StyleClass="box-label-regular"
                                         HorizontalOptions="StartAndExpand"
-                                        AutomationId="CollectionItemNameLabel"/>
+                                        AutomationId="CollectionItemNameLabel" />
                                     <Switch
                                         IsToggled="{Binding Checked}"
                                         StyleClass="box-value"
                                         HorizontalOptions="End"
-                                        AutomationId="CollectionItemSwitch"/>
+                                        AutomationId="CollectionItemSwitch" />
                                 </StackLayout>
                                 <BoxView StyleClass="box-row-separator" />
                             </StackLayout>


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [X] Other

## Objective
This PR adds more AutomationIDs that will help us to improve the quality of our Mobile Automation tests


## Code changes


* **CipherAddEditPage.xaml:**  Adding locators for all the Login/Card/SecureNote/Identity item fields
* **TextCustomFieldItemLayout.xaml:** Adding locators for title/value fields
* **BooleanCustomFieldItemLayout.xaml:** Adding locators for title/value fields
* **HiddenCustomFieldItemLayout.xaml:** Adding locators for title/value fields
* **LinkedCustomFieldItemLayout.xaml:** Adding locators for title/value fields

## Screenshots
<!--Required for any UI changes. Delete if not applicable-->



## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
