### PR TITLE
Adding AutomationIDs on Generator page elements

### DIFF
--- a/src/App/Pages/Generator/GeneratorHistoryPage.xaml
+++ b/src/App/Pages/Generator/GeneratorHistoryPage.xaml
@@ -27,7 +27,8 @@
                          Clicked="Clear_Clicked"
                          Order="Secondary"
                          x:Name="_clearItem"
-                         x:Key="clearItem" />
+                         x:Key="clearItem"
+                         AutomationId="ClearPasswordList"/>
             <ToolbarItem Icon="more_vert.png"
                          AutomationProperties.IsInAccessibleTree="True"
                          AutomationProperties.Name="{u:I18n Options}"
@@ -43,7 +44,8 @@
                Margin="20, 0"
                VerticalOptions="CenterAndExpand"
                HorizontalOptions="CenterAndExpand"
-               HorizontalTextAlignment="Center"></Label>
+               HorizontalTextAlignment="Center"
+               AutomationId="NoPasswordsDisplayedLabel"></Label>
         <controls:ExtendedCollectionView
                   IsVisible="{Binding ShowNoData, Converter={StaticResource inverseBool}}"
                   ItemsSource="{Binding History}"
@@ -56,7 +58,8 @@
                         StyleClass="list-row, list-row-platform"
                         Padding="10"
                         RowSpacing="0"
-                        ColumnSpacing="10">
+                        ColumnSpacing="10"
+                        AutomationId="GeneratedPasswordRow">
 
                         <Grid.RowDefinitions>
                             <RowDefinition Height="Auto" />
@@ -71,12 +74,14 @@
                             Grid.Column="0"
                             Grid.Row="0"
                             StyleClass="list-title, list-title-platform, text-html"
-                            Text="{Binding Password, Mode=OneWay, Converter={StaticResource coloredPassword}}" />
+                            Text="{Binding Password, Mode=OneWay, Converter={StaticResource coloredPassword}}"
+                            AutomationId="GeneratedPasswordValue" />
                         <Label LineBreakMode="TailTruncation"
                             Grid.Column="0"
                             Grid.Row="1"
                             StyleClass="list-subtitle, list-subtitle-platform"
-                            Text="{Binding Date, Mode=OneWay, Converter={StaticResource dateTime}}" />
+                            Text="{Binding Date, Mode=OneWay, Converter={StaticResource dateTime}}"
+                            AutomationId="GeneratedPasswordDateLabel" />
                         <controls:IconButton
                             StyleClass="list-row-button, list-row-button-platform"
                             Text="{Binding Source={x:Static core:BitwardenIcons.Paste}}"
@@ -86,7 +91,8 @@
                             Grid.Column="1"
                             Grid.RowSpan="2"
                             AutomationProperties.IsInAccessibleTree="True"
-                            AutomationProperties.Name="{u:I18n CopyPassword}" />
+                            AutomationProperties.Name="{u:I18n CopyPassword}"
+                            AutomationId="CopyPasswordValueButton"/>
                     </Grid>
                 </DataTemplate>
             </CollectionView.ItemTemplate>

--- a/src/App/Pages/Generator/GeneratorHistoryPage.xaml
+++ b/src/App/Pages/Generator/GeneratorHistoryPage.xaml
@@ -28,7 +28,7 @@
                          Order="Secondary"
                          x:Name="_clearItem"
                          x:Key="clearItem"
-                         AutomationId="ClearPasswordList"/>
+                         AutomationId="ClearPasswordList" />
             <ToolbarItem Icon="more_vert.png"
                          AutomationProperties.IsInAccessibleTree="True"
                          AutomationProperties.Name="{u:I18n Options}"
@@ -92,7 +92,7 @@
                             Grid.RowSpan="2"
                             AutomationProperties.IsInAccessibleTree="True"
                             AutomationProperties.Name="{u:I18n CopyPassword}"
-                            AutomationId="CopyPasswordValueButton"/>
+                            AutomationId="CopyPasswordValueButton" />
                     </Grid>
                 </DataTemplate>
             </CollectionView.ItemTemplate>

--- a/src/App/Pages/Generator/GeneratorPage.xaml
+++ b/src/App/Pages/Generator/GeneratorPage.xaml
@@ -71,7 +71,8 @@
                         <Label
                             Text="{u:I18n PasswordGeneratorPolicyInEffect}"
                             StyleClass="text-muted, text-sm, text-bold"
-                            HorizontalTextAlignment="Center" />
+                            HorizontalTextAlignment="Center"
+                            AutomationId="PasswordGeneratorPolicyInEffectLabel" />
                     </Frame>
                 </Grid>
                 <Grid IsVisible="{Binding IsUsername, Converter={StaticResource inverseBool}}"
@@ -82,21 +83,24 @@
                         x:Name="lblPassword"
                         StyleClass="text-lg, text-html"
                         Text="{Binding ColoredPassword, Mode=OneWay}"
-                        Margin="0, 20" />
+                        Margin="0, 20"
+                        AutomationId="GeneratedPasswordLabel" />
                     <controls:IconButton 
                         StyleClass="box-row-button, box-row-button-platform"
                         Text="{Binding Source={x:Static core:BitwardenIcons.Clone}}"
                         Command="{Binding CopyCommand}"
                         Grid.Column="1"
                         AutomationProperties.IsInAccessibleTree="True"
-                        AutomationProperties.Name="{u:I18n CopyPassword}" />
+                        AutomationProperties.Name="{u:I18n CopyPassword}"
+                        AutomationId="CopyValueButton" />
                     <controls:IconButton 
                         StyleClass="box-row-button, box-row-button-platform"
                         Text="{Binding Source={x:Static core:BitwardenIcons.Generate}}"
                         Command="{Binding RegenerateCommand}"
                         Grid.Column="2"
                         AutomationProperties.IsInAccessibleTree="True"
-                        AutomationProperties.Name="{u:I18n GeneratePassword}" />
+                        AutomationProperties.Name="{u:I18n GeneratePassword}"
+                        AutomationId="RegenerateValueButton"/>
                 </Grid>
                 <Grid IsVisible="{Binding IsUsername}"
                         StyleClass="box-row"                  
@@ -107,21 +111,24 @@
                         StyleClass="text-lg, text-html"
                         Text="{Binding ColoredUsername, Mode=OneWay}"
                         Margin="0, 20"
-                        HorizontalOptions="Start" />
+                        HorizontalOptions="Start"
+                        AutomationId="GeneratedUsernameValue" />
                     <controls:IconButton 
                         StyleClass="box-row-button, box-row-button-platform"
                         Text="{Binding Source={x:Static core:BitwardenIcons.Clone}}"
                         Command="{Binding CopyCommand}"
                         Grid.Column="1"
                         AutomationProperties.IsInAccessibleTree="True"
-                        AutomationProperties.Name="{u:I18n CopyUsername}" />
+                        AutomationProperties.Name="{u:I18n CopyUsername}"
+                        AutomationId="CopyValueButton" />
                     <controls:IconButton 
                         StyleClass="box-row-button, box-row-button-platform"
                         Text="{Binding Source={x:Static core:BitwardenIcons.Generate}}"
                         Command="{Binding RegenerateUsernameCommand}"
                         Grid.Column="2"
                         AutomationProperties.IsInAccessibleTree="True"
-                        AutomationProperties.Name="{u:I18n GenerateUsername}" />
+                        AutomationProperties.Name="{u:I18n GenerateUsername}"
+                        AutomationId="RegenerateValueButton" />
                 </Grid>
                 <BoxView StyleClass="box-row-separator"/>
                 <StackLayout StyleClass="box"
@@ -135,7 +142,8 @@
                         ItemsSource="{Binding GeneratorTypeOptions, Mode=OneTime}"
                         SelectedItem="{Binding GeneratorTypeSelected}"
                         ItemDisplayBinding="{Binding ., Converter={StaticResource localizableEnum}}"
-                        StyleClass="box-value" />
+                        StyleClass="box-value"
+                        AutomationId="GeneratorTypePicker" />
                 </StackLayout>
                 <Label Text="{u:I18n Options, Header=True}"
                        StyleClass="box-header, box-header-platform"
@@ -161,7 +169,8 @@
                         ItemsSource="{Binding UsernameTypeOptions, Mode=OneTime}"
                         SelectedItem="{Binding UsernameTypeSelected}"
                         ItemDisplayBinding="{Binding ., Converter={StaticResource localizableEnum}}"
-                        StyleClass="box-value" />
+                        StyleClass="box-value"
+                        AutomationId="UsernameTypePicker"/>
                     <Label
                         StyleClass="box-footer-label"
                         Text="{Binding UsernameTypeDescriptionLabel}" />
@@ -172,7 +181,8 @@
                             StyleClass="box-label" />
                         <Entry x:Name="_plusAddressedEmailEntry"
                             Text="{Binding PlusAddressedEmail}"
-                            StyleClass="box-value" />
+                            StyleClass="box-value"
+                            AutomationId="PlusAddressedEmailEntry" />
                         <Label IsVisible="{Binding ShowUsernameEmailType}"
                             Text="{u:I18n EmailType}"
                             StyleClass="box-label"
@@ -203,7 +213,8 @@
                         <Entry
                             x:Name="_catchAllEmailDomainNameEntry"
                             Text="{Binding CatchAllEmailDomain}"
-                            StyleClass="box-value" />
+                            StyleClass="box-value"
+                            AutomationId="CatchAllEmailDomainEntry"/>
                         <Label IsVisible="{Binding ShowUsernameEmailType}"
                             Text="{u:I18n EmailType}"
                             StyleClass="box-label" 
@@ -236,7 +247,8 @@
                             ItemsSource="{Binding ForwardedEmailServiceTypeOptions, Mode=OneTime}"
                             SelectedItem="{Binding ForwardedEmailServiceSelected}"
                             ItemDisplayBinding="{Binding ., Converter={StaticResource localizableEnum}}"
-                            StyleClass="box-value" />
+                            StyleClass="box-value"
+                            AutomationId="ServiceTypePicker" />
                         <!--ANONADDY OPTIONS-->
                         <Grid IsVisible="{Binding ForwardedEmailServiceSelected, Converter={StaticResource enumToBool}, ConverterParameter={x:Static enums:ForwardedEmailServiceType.AnonAddy}}"
                               Grid.RowDefinitions="Auto,*"
@@ -249,13 +261,15 @@
                                 x:Name="_anonAddyApiAccessTokenEntry"
                                 Text="{Binding AnonAddyApiAccessToken}"
                                 IsPassword="{Binding ShowAnonAddyApiAccessToken, Converter={StaticResource inverseBool}}"
-                                Grid.Row="1"/>
+                                Grid.Row="1"
+                                AutomationId="AnonAddyApiAccessTokenEntry" />
                             <controls:IconButton
                                 StyleClass="box-row-button, box-row-button-platform"
                                 Text="{Binding ShowAnonAddyApiAccessToken, Converter={StaticResource inverseBool, iconGlyphConverter}, ConverterParameter={x:Static u:BooleanGlyphType.Eye}}"
                                 Command="{Binding ToggleForwardedEmailHiddenValueCommand}"
                                 Grid.Row="1"
-                                Grid.Column="1"/>
+                                Grid.Column="1"
+                                AutomationId="ShowAnonAddyApiAccessTokenButton" />
                         </Grid>
                         <Label IsVisible="{Binding ForwardedEmailServiceSelected, Converter={StaticResource enumToBool}, ConverterParameter={x:Static enums:ForwardedEmailServiceType.AnonAddy}}"
                             Text="{u:I18n DomainNameRequiredParenthesis}"
@@ -264,7 +278,8 @@
                         <Entry IsVisible="{Binding ForwardedEmailServiceSelected, Converter={StaticResource enumToBool}, ConverterParameter={x:Static enums:ForwardedEmailServiceType.AnonAddy}}"
                             x:Name="_anonAddyDomainNameEntry"
                             Text="{Binding AnonAddyDomainName}"
-                            StyleClass="box-value"/>
+                            StyleClass="box-value"
+                            AutomationId="AnonAddyDomainNameEntry" />
                         <!--FIREFOX RELAY OPTIONS-->
                         <Grid StyleClass="box-row, box-row-input"
                               IsVisible="{Binding ForwardedEmailServiceSelected, Converter={StaticResource enumToBool}, ConverterParameter={x:Static enums:ForwardedEmailServiceType.FirefoxRelay}}"
@@ -278,13 +293,15 @@
                                 Text="{Binding FirefoxRelayApiAccessToken}"
                                 StyleClass="box-value"
                                 Grid.Row="1"
-                                IsPassword="{Binding ShowFirefoxRelayApiAccessToken, Converter={StaticResource inverseBool}}"/>
+                                IsPassword="{Binding ShowFirefoxRelayApiAccessToken, Converter={StaticResource inverseBool}}"
+                                AutomationId="FirefoxRelayApiAccessTokenEntry" />
                             <controls:IconButton
                                 StyleClass="box-row-button, box-row-button-platform"
                                 Text="{Binding ShowFirefoxRelayApiAccessToken, Converter={StaticResource inverseBool, iconGlyphConverter}, ConverterParameter={x:Static u:BooleanGlyphType.Eye}}"
                                 Command="{Binding ToggleForwardedEmailHiddenValueCommand}"
                                 Grid.Row="1"
-                                Grid.Column="1"/>
+                                Grid.Column="1"
+                                AutomationId="ShowFirefoxRelayApiAccessTokenButton" />
                         </Grid>
                         <!--SIMPLELOGIN OPTIONS-->
                         <Grid StyleClass="box-row, box-row-input"
@@ -299,13 +316,15 @@
                                 Text="{Binding SimpleLoginApiKey}"
                                 StyleClass="box-value" 
                                 Grid.Row="1"
-                                IsPassword="{Binding ShowSimpleLoginApiKey, Converter={StaticResource inverseBool}}"/>
+                                IsPassword="{Binding ShowSimpleLoginApiKey, Converter={StaticResource inverseBool}}"
+                                AutomationId="SimpleLoginApiKeyEntry" />
                             <controls:IconButton 
                                 StyleClass="box-row-button, box-row-button-platform"
                                 Text="{Binding ShowSimpleLoginApiKey, Converter={StaticResource inverseBool, iconGlyphConverter}, ConverterParameter={x:Static u:BooleanGlyphType.Eye}}"
                                 Command="{Binding ToggleForwardedEmailHiddenValueCommand}"
                                 Grid.Row="1"
-                                Grid.Column="1"/>
+                                Grid.Column="1"
+                                AutomationId="ShowSimpleLoginApiKeyButton" />
                         </Grid>
                         <!--DUCKDUCKGO OPTIONS-->
                         <Grid StyleClass="box-row, box-row-input"
@@ -320,13 +339,15 @@
                                 Text="{Binding DuckDuckGoApiKey}"
                                 StyleClass="box-value"
                                 Grid.Row="1"
-                                IsPassword="{Binding ShowDuckDuckGoApiKey, Converter={StaticResource inverseBool}}"/>
+                                IsPassword="{Binding ShowDuckDuckGoApiKey, Converter={StaticResource inverseBool}}"
+                                AutomationId="DuckDuckGoApiKeyEntry" />
                             <controls:IconButton
                                 StyleClass="box-row-button, box-row-button-platform"
                                 Text="{Binding ShowDuckDuckGoApiKey, Converter={StaticResource inverseBool, iconGlyphConverter}, ConverterParameter={x:Static u:BooleanGlyphType.Eye}}"
                                 Command="{Binding ToggleForwardedEmailHiddenValueCommand}"
                                 Grid.Row="1"
-                                Grid.Column="1"/>
+                                Grid.Column="1"
+                                AutomationId="ShowDuckDuckGoApiKeyButton" />
                         </Grid>
                         <!--FASTMAIL OPTIONS-->
                         <Grid StyleClass="box-row, box-row-input"
@@ -341,13 +362,15 @@
                                 Text="{Binding FastmailApiKey}"
                                 StyleClass="box-value"
                                 Grid.Row="1"
-                                IsPassword="{Binding ShowFastmailApiKey, Converter={StaticResource inverseBool}}"/>
+                                IsPassword="{Binding ShowFastmailApiKey, Converter={StaticResource inverseBool}}"
+                                AutomationId="FastmailApiKeyEntry" />
                             <controls:IconButton
                                 StyleClass="box-row-button, box-row-button-platform"
                                 Text="{Binding ShowFastmailApiKey, Converter={StaticResource iconGlyphConverter}, ConverterParameter={x:Static u:BooleanGlyphType.Eye}}"
                                 Command="{Binding ToggleForwardedEmailHiddenValueCommand}"
                                 Grid.Row="1"
-                                Grid.Column="1"/>
+                                Grid.Column="1"
+                                AutomationId="ShowFastmailApiKeyButton" />
                         </Grid>
                     </StackLayout>                    
                     <!--RANDOM WORD OPTIONS-->
@@ -359,7 +382,8 @@
                         <Switch
                             IsToggled="{Binding CapitalizeRandomWordUsername}"
                             StyleClass="box-value"
-                            HorizontalOptions="End" />
+                            HorizontalOptions="End"
+                            AutomationId="CapitalizeRandomWordUsernameToggle"/>
                     </Grid>
                     <BoxView IsVisible="{Binding UsernameTypeSelected, Converter={StaticResource enumToBool}, ConverterParameter={x:Static enums:UsernameType.RandomWord}}"
                         StyleClass="box-row-separator" />
@@ -371,7 +395,8 @@
                         <Switch
                             IsToggled="{Binding IncludeNumberRandomWordUsername}"
                             StyleClass="box-value"
-                            HorizontalOptions="End" />
+                            HorizontalOptions="End"
+                            AutomationId="IncludeNumberRandomWordUsernameToggle" />
                     </Grid>
                     <BoxView IsVisible="{Binding UsernameTypeSelected, Converter={StaticResource enumToBool}, ConverterParameter={x:Static enums:UsernameType.RandomWord}}"
                         StyleClass="box-row-separator" />
@@ -386,7 +411,8 @@
                             x:Name="_passwordTypePicker"
                             ItemsSource="{Binding PasswordTypeOptions, Mode=OneTime}"
                             SelectedIndex="{Binding PasswordTypeSelectedIndex}"
-                            StyleClass="box-value" />
+                            StyleClass="box-value"
+                            AutomationId="PasswordTypePicker" />
                     </StackLayout>
                     <StackLayout Spacing="0"
                                  Padding="0"
@@ -403,12 +429,14 @@
                                 HorizontalOptions="FillAndExpand"
                                 HorizontalTextAlignment="End"
                                 VerticalOptions="FillAndExpand"
-                                VerticalTextAlignment="Center" />
+                                VerticalTextAlignment="Center"
+                                AutomationId="NumberOfWordsLabel" />
                             <controls:ExtendedStepper
                                 Value="{Binding NumWords}"
                                 Maximum="20"
                                 Minimum="3"
-                                Increment="1" />
+                                Increment="1"
+                                AutomationId="NumberOfWordsStepper" />
                         </StackLayout>
                         <BoxView StyleClass="box-row-separator" />
                         <StackLayout StyleClass="box-row, box-row-input">
@@ -419,7 +447,8 @@
                                 Text="{Binding WordSeparator}"
                                 IsSpellCheckEnabled="False"
                                 IsTextPredictionEnabled="False"
-                                StyleClass="box-value">
+                                StyleClass="box-value"
+                                AutomationId="WordSeparatorEntry" >
                                 <Entry.Effects>
                                     <effects:NoEmojiKeyboardEffect />
                                 </Entry.Effects>
@@ -435,7 +464,8 @@
                                 IsEnabled="{Binding EnforcedPolicyOptions.Capitalize,
                                     Converter={StaticResource inverseBool}}"
                                 StyleClass="box-value"
-                                HorizontalOptions="End" />
+                                HorizontalOptions="End"
+                                AutomationId="CapitalizePassphraseToggle" />
                         </StackLayout>
                         <BoxView StyleClass="box-row-separator" />
                         <StackLayout StyleClass="box-row, box-row-switch">
@@ -448,7 +478,8 @@
                                 IsEnabled="{Binding EnforcedPolicyOptions.IncludeNumber,
                                     Converter={StaticResource inverseBool}}"
                                 StyleClass="box-value"
-                                HorizontalOptions="End" />
+                                HorizontalOptions="End"
+                                AutomationId="IncludeNumbersToggle" />
                         </StackLayout>
                     </StackLayout>
                     <StackLayout Spacing="0" Padding="0" IsVisible="{Binding IsPassword}">
@@ -462,7 +493,8 @@
                                 StyleClass="box-sub-label"
                                 VerticalOptions="CenterAndExpand"
                                 HorizontalTextAlignment="End"
-                                WidthRequest="50" />
+                                WidthRequest="50"
+                                AutomationId="PasswordLengthLabel" />
                             <controls:ExtendedSlider
                                 DragCompleted="LengthSlider_DragCompleted"
                                 Value="{Binding Length}"
@@ -471,7 +503,8 @@
                                 VerticalOptions="CenterAndExpand"
                                 HorizontalOptions="FillAndExpand"
                                 Maximum="128"
-                                Minimum="5" />
+                                Minimum="5"
+                                AutomationId="PasswordLengthSlider" />
                         </StackLayout>
                         <BoxView StyleClass="box-row-separator" />
                         <StackLayout StyleClass="box-row, box-row-switch">
@@ -488,7 +521,8 @@
                                 StyleClass="box-value"
                                 HorizontalOptions="End" 
                                 AutomationProperties.IsInAccessibleTree="True"
-                                AutomationProperties.Name="{u:I18n UppercaseAtoZ}"/>
+                                AutomationProperties.Name="{u:I18n UppercaseAtoZ}"
+                                AutomationId="UppercaseAtoZToggle" />
                         </StackLayout>
                         <BoxView StyleClass="box-row-separator" />
                         <StackLayout StyleClass="box-row, box-row-switch">
@@ -505,7 +539,8 @@
                                 StyleClass="box-value"
                                 HorizontalOptions="End"
                                 AutomationProperties.IsInAccessibleTree="True"
-                                AutomationProperties.Name="{u:I18n LowercaseAtoZ}"/>
+                                AutomationProperties.Name="{u:I18n LowercaseAtoZ}"
+                                AutomationId="LowercaseAtoZToggle" />
                         </StackLayout>
                         <BoxView StyleClass="box-row-separator" />
                         <StackLayout StyleClass="box-row, box-row-switch">
@@ -522,7 +557,8 @@
                                 StyleClass="box-value"
                                 HorizontalOptions="End" 
                                 AutomationProperties.IsInAccessibleTree="True"
-                                AutomationProperties.Name="{u:I18n NumbersZeroToNine}"/>
+                                AutomationProperties.Name="{u:I18n NumbersZeroToNine}"
+                                AutomationId="NumbersZeroToNineToggle" />
                         </StackLayout>
                         <BoxView StyleClass="box-row-separator" />
                         <StackLayout StyleClass="box-row, box-row-switch">
@@ -539,7 +575,8 @@
                                 StyleClass="box-value"
                                 HorizontalOptions="End"
                                 AutomationProperties.IsInAccessibleTree="True"
-                                AutomationProperties.Name="{u:I18n SpecialCharacters}"/>
+                                AutomationProperties.Name="{u:I18n SpecialCharacters}"
+                                AutomationId="SpecialCharactersToggle" />
                         </StackLayout>
                         <BoxView StyleClass="box-row-separator" />
                         <StackLayout StyleClass="box-row, box-row-stepper">
@@ -554,12 +591,14 @@
                                 HorizontalOptions="FillAndExpand"
                                 HorizontalTextAlignment="End"
                                 VerticalOptions="FillAndExpand"
-                                VerticalTextAlignment="Center" />
+                                VerticalTextAlignment="Center"
+                                AutomationId="MinNumberValueLabel" />
                             <controls:ExtendedStepper
                                 Value="{Binding MinNumber}"
                                 Maximum="5"
                                 Minimum="0"
-                                Increment="1" />
+                                Increment="1"
+                                AutomationId="MinNumberStepper" />
                         </StackLayout>
                         <BoxView StyleClass="box-row-separator" />
                         <StackLayout StyleClass="box-row, box-row-stepper">
@@ -574,12 +613,14 @@
                                 HorizontalOptions="FillAndExpand"
                                 HorizontalTextAlignment="End"
                                 VerticalOptions="FillAndExpand"
-                                VerticalTextAlignment="Center" />
+                                VerticalTextAlignment="Center"
+                                AutomationId="MinSpecialValueLabel" />
                             <controls:ExtendedStepper
                                 Value="{Binding MinSpecial}"
                                 Maximum="5"
                                 Minimum="0"
-                                Increment="1" />
+                                Increment="1"
+                                AutomationId="MinSpecialStepper" />
                         </StackLayout>
                         <BoxView StyleClass="box-row-separator" />
                         <StackLayout StyleClass="box-row, box-row-switch">
@@ -590,7 +631,8 @@
                             <Switch
                                 IsToggled="{Binding AvoidAmbiguousChars}"
                                 StyleClass="box-value"
-                                HorizontalOptions="End" />
+                                HorizontalOptions="End"
+                                AutomationId="AvoidAmbiguousCharsToggle" />
                         </StackLayout>
                         <BoxView StyleClass="box-row-separator" />
                     </StackLayout>

--- a/src/App/Pages/Generator/GeneratorPage.xaml
+++ b/src/App/Pages/Generator/GeneratorPage.xaml
@@ -100,7 +100,7 @@
                         Grid.Column="2"
                         AutomationProperties.IsInAccessibleTree="True"
                         AutomationProperties.Name="{u:I18n GeneratePassword}"
-                        AutomationId="RegenerateValueButton"/>
+                        AutomationId="RegenerateValueButton" />
                 </Grid>
                 <Grid IsVisible="{Binding IsUsername}"
                         StyleClass="box-row"                  
@@ -170,7 +170,7 @@
                         SelectedItem="{Binding UsernameTypeSelected}"
                         ItemDisplayBinding="{Binding ., Converter={StaticResource localizableEnum}}"
                         StyleClass="box-value"
-                        AutomationId="UsernameTypePicker"/>
+                        AutomationId="UsernameTypePicker" />
                     <Label
                         StyleClass="box-footer-label"
                         Text="{Binding UsernameTypeDescriptionLabel}" />
@@ -214,7 +214,7 @@
                             x:Name="_catchAllEmailDomainNameEntry"
                             Text="{Binding CatchAllEmailDomain}"
                             StyleClass="box-value"
-                            AutomationId="CatchAllEmailDomainEntry"/>
+                            AutomationId="CatchAllEmailDomainEntry" />
                         <Label IsVisible="{Binding ShowUsernameEmailType}"
                             Text="{u:I18n EmailType}"
                             StyleClass="box-label" 
@@ -383,7 +383,7 @@
                             IsToggled="{Binding CapitalizeRandomWordUsername}"
                             StyleClass="box-value"
                             HorizontalOptions="End"
-                            AutomationId="CapitalizeRandomWordUsernameToggle"/>
+                            AutomationId="CapitalizeRandomWordUsernameToggle" />
                     </Grid>
                     <BoxView IsVisible="{Binding UsernameTypeSelected, Converter={StaticResource enumToBool}, ConverterParameter={x:Static enums:UsernameType.RandomWord}}"
                         StyleClass="box-row-separator" />
@@ -448,7 +448,7 @@
                                 IsSpellCheckEnabled="False"
                                 IsTextPredictionEnabled="False"
                                 StyleClass="box-value"
-                                AutomationId="WordSeparatorEntry" >
+                                AutomationId="WordSeparatorEntry">
                                 <Entry.Effects>
                                     <effects:NoEmojiKeyboardEffect />
                                 </Entry.Effects>


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [X] Other

## Objective
This PR adds more AutomationIDs that will help us to improve the quality of our Mobile Automation tests


## Code changes
* **GeneratorPage.xaml:** Adding IDs for all the interactable elements displayed for passwords/usernames
* **GeneratorPageHistory.xaml:** Adding IDs for each cell, apart from the locators for each nested element

## Screenshots



## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
