### PR TITLE
Adding AutomationIDs on Generator page elements

### DIFF
--- a/src/App/Pages/Generator/GeneratorHistoryPage.xaml
+++ b/src/App/Pages/Generator/GeneratorHistoryPage.xaml
@@ -28,7 +28,7 @@
                          Order="Secondary"
                          x:Name="_clearItem"
                          x:Key="clearItem"
-                         AutomationId="ClearPasswordList"/>
+                         AutomationId="ClearPasswordList" />
             <ToolbarItem Icon="more_vert.png"
                          AutomationProperties.IsInAccessibleTree="True"
                          AutomationProperties.Name="{u:I18n Options}"
@@ -92,7 +92,7 @@
                             Grid.RowSpan="2"
                             AutomationProperties.IsInAccessibleTree="True"
                             AutomationProperties.Name="{u:I18n CopyPassword}"
-                            AutomationId="CopyPasswordValueButton"/>
+                            AutomationId="CopyPasswordValueButton" />
                     </Grid>
                 </DataTemplate>
             </CollectionView.ItemTemplate>

--- a/src/App/Pages/Generator/GeneratorPage.xaml
+++ b/src/App/Pages/Generator/GeneratorPage.xaml
@@ -100,7 +100,7 @@
                         Grid.Column="2"
                         AutomationProperties.IsInAccessibleTree="True"
                         AutomationProperties.Name="{u:I18n GeneratePassword}"
-                        AutomationId="RegenerateValueButton"/>
+                        AutomationId="RegenerateValueButton" />
                 </Grid>
                 <Grid IsVisible="{Binding IsUsername}"
                         StyleClass="box-row"                  
@@ -170,7 +170,7 @@
                         SelectedItem="{Binding UsernameTypeSelected}"
                         ItemDisplayBinding="{Binding ., Converter={StaticResource localizableEnum}}"
                         StyleClass="box-value"
-                        AutomationId="UsernameTypePicker"/>
+                        AutomationId="UsernameTypePicker" />
                     <Label
                         StyleClass="box-footer-label"
                         Text="{Binding UsernameTypeDescriptionLabel}" />
@@ -214,7 +214,7 @@
                             x:Name="_catchAllEmailDomainNameEntry"
                             Text="{Binding CatchAllEmailDomain}"
                             StyleClass="box-value"
-                            AutomationId="CatchAllEmailDomainEntry"/>
+                            AutomationId="CatchAllEmailDomainEntry" />
                         <Label IsVisible="{Binding ShowUsernameEmailType}"
                             Text="{u:I18n EmailType}"
                             StyleClass="box-label" 
@@ -383,7 +383,7 @@
                             IsToggled="{Binding CapitalizeRandomWordUsername}"
                             StyleClass="box-value"
                             HorizontalOptions="End"
-                            AutomationId="CapitalizeRandomWordUsernameToggle"/>
+                            AutomationId="CapitalizeRandomWordUsernameToggle" />
                     </Grid>
                     <BoxView IsVisible="{Binding UsernameTypeSelected, Converter={StaticResource enumToBool}, ConverterParameter={x:Static enums:UsernameType.RandomWord}}"
                         StyleClass="box-row-separator" />
@@ -448,7 +448,7 @@
                                 IsSpellCheckEnabled="False"
                                 IsTextPredictionEnabled="False"
                                 StyleClass="box-value"
-                                AutomationId="WordSeparatorEntry" >
+                                AutomationId="WordSeparatorEntry">
                                 <Entry.Effects>
                                     <effects:NoEmojiKeyboardEffect />
                                 </Entry.Effects>


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [X] Other

## Objective
This PR adds more AutomationIDs that will help us to improve the quality of our Mobile Automation tests


## Code changes
* **GeneratorPage.xaml:** Adding IDs for all the interactable elements displayed for passwords/usernames
* **GeneratorPageHistory.xaml:** Adding IDs for each cell, apart from the locators for each nested element

## Screenshots



## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
