### PR TITLE
[PM-2611] Adding IDs for Cipher/Send search results

### DIFF
--- a/src/App/Controls/CipherViewCell/CipherViewCell.xaml
+++ b/src/App/Controls/CipherViewCell/CipherViewCell.xaml
@@ -9,7 +9,8 @@
     StyleClass="list-row, list-row-platform"
     RowSpacing="0"
     ColumnSpacing="0"
-    x:DataType="controls:CipherViewCellViewModel">
+    x:DataType="controls:CipherViewCellViewModel"
+    AutomationId="CipherCell">
 
     <Grid.Resources>
         <u:IconGlyphConverter x:Key="iconGlyphConverter"/>
@@ -36,7 +37,8 @@
         IsVisible="{Binding ShowIconImage, Converter={StaticResource inverseBool}}"
         Text="{Binding Cipher, Converter={StaticResource iconGlyphConverter}}"
         ShouldUpdateFontSizeDynamicallyForAccesibility="True"
-        AutomationProperties.IsInAccessibleTree="False" />
+        AutomationProperties.IsInAccessibleTree="False"
+        AutomationId="CipherTypeIcon"/>
 
     <ff:CachedImage
         x:Name="_iconImage"
@@ -52,7 +54,8 @@
         Aspect="AspectFit"
         IsVisible="{Binding ShowIconImage}"
         Source="{Binding IconImageSource, Mode=OneTime}"
-        AutomationProperties.IsInAccessibleTree="False" />
+        AutomationProperties.IsInAccessibleTree="False"
+        AutomationId="CipherWebsiteIcon"/>
 
     <Grid RowSpacing="0" ColumnSpacing="0" Grid.Row="0" Grid.Column="1" VerticalOptions="Center" Padding="0, 7">
         <Grid.RowDefinitions>
@@ -71,7 +74,8 @@
             Grid.Column="0"
             Grid.Row="0"
             StyleClass="list-title, list-title-platform"
-            Text="{Binding Cipher.Name}" />
+            Text="{Binding Cipher.Name}"
+            AutomationId="CipherNameLabel" />
         <Label
             LineBreakMode="TailTruncation"
             Grid.Column="0"
@@ -80,7 +84,8 @@
             StyleClass="list-subtitle, list-subtitle-platform"
             Text="{Binding Cipher.SubTitle}"
             IsVisible="{Binding Source={RelativeSource Self}, Path=Text,
-                        Converter={StaticResource stringHasValueConverter}}"/>
+                        Converter={StaticResource stringHasValueConverter}}"
+            AutomationId="CipherSubTitleLabel" />
         <controls:IconLabel
             Grid.Column="1"
             Grid.Row="0"
@@ -91,7 +96,8 @@
             Text="{Binding Source={x:Static core:BitwardenIcons.Collection}}"
             IsVisible="{Binding Cipher.Shared, Mode=OneTime}"
             AutomationProperties.IsInAccessibleTree="True"
-            AutomationProperties.Name="{u:I18n Shared}" />
+            AutomationProperties.Name="{u:I18n Shared}"
+            AutomationId="CipherInCollectionIcon" />
         <controls:IconLabel
             Grid.Column="2"
             Grid.Row="0"
@@ -102,7 +108,8 @@
             Text="{Binding Source={x:Static core:BitwardenIcons.Paperclip}}"
             IsVisible="{Binding Cipher.HasAttachments, Mode=OneTime}"
             AutomationProperties.IsInAccessibleTree="True"
-            AutomationProperties.Name="{u:I18n Attachments}" />
+            AutomationProperties.Name="{u:I18n Attachments}"
+            AutomationId="CipherWithAttachmentsIcon" />
     </Grid>
 
     <controls:MiButton
@@ -114,6 +121,7 @@
         VerticalOptions="CenterAndExpand"
         HorizontalOptions="EndAndExpand"
         AutomationProperties.IsInAccessibleTree="True"
-        AutomationProperties.Name="{u:I18n Options}" />
+        AutomationProperties.Name="{u:I18n Options}"
+        AutomationId="CipherOptionsButton" />
 
 </controls:ExtendedGrid>

--- a/src/App/Controls/CipherViewCell/CipherViewCell.xaml
+++ b/src/App/Controls/CipherViewCell/CipherViewCell.xaml
@@ -38,7 +38,7 @@
         Text="{Binding Cipher, Converter={StaticResource iconGlyphConverter}}"
         ShouldUpdateFontSizeDynamicallyForAccesibility="True"
         AutomationProperties.IsInAccessibleTree="False"
-        AutomationId="CipherTypeIcon"/>
+        AutomationId="CipherTypeIcon" />
 
     <ff:CachedImage
         x:Name="_iconImage"
@@ -55,7 +55,7 @@
         IsVisible="{Binding ShowIconImage}"
         Source="{Binding IconImageSource, Mode=OneTime}"
         AutomationProperties.IsInAccessibleTree="False"
-        AutomationId="CipherWebsiteIcon"/>
+        AutomationId="CipherWebsiteIcon" />
 
     <Grid RowSpacing="0" ColumnSpacing="0" Grid.Row="0" Grid.Column="1" VerticalOptions="Center" Padding="0, 7">
         <Grid.RowDefinitions>

--- a/src/App/Controls/SendViewCell/SendViewCell.xaml
+++ b/src/App/Controls/SendViewCell/SendViewCell.xaml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+﻿<?xml version="1.0" encoding="UTF-8"?>
 <controls:ExtendedGrid xmlns="http://xamarin.com/schemas/2014/forms"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     x:Class="Bit.App.Controls.SendViewCell"
@@ -54,14 +54,16 @@
             Grid.Column="0"
             Grid.Row="0"
             StyleClass="list-title, list-title-platform"
-            Text="{Binding Send.Name}" />
+            Text="{Binding Send.Name}"
+            AutomationId="SendNameLabel" />
         <Label
             LineBreakMode="TailTruncation"
             Grid.Column="0"
             Grid.Row="1"
             Grid.ColumnSpan="6"
             StyleClass="list-subtitle, list-subtitle-platform"
-            Text="{Binding Send.DisplayDate}" />
+            Text="{Binding Send.DisplayDate}"
+            AutomationId="SendDateLabel" />
         <controls:IconLabel
             Grid.Column="1"
             Grid.Row="0"
@@ -72,7 +74,8 @@
             Text="{Binding Source={x:Static core:BitwardenIcons.ExclamationTriangle}}"
             IsVisible="{Binding Send.Disabled, Mode=OneTime}"
             AutomationProperties.IsInAccessibleTree="True"
-            AutomationProperties.Name="{u:I18n Disabled}" />
+            AutomationProperties.Name="{u:I18n Disabled}"
+            AutomationId="DisabledSendLabel" />
         <controls:IconLabel
             Grid.Column="2"
             Grid.Row="0"
@@ -83,7 +86,8 @@
             Text="{Binding Source={x:Static core:BitwardenIcons.Key}}"
             IsVisible="{Binding Send.HasPassword, Mode=OneTime}"
             AutomationProperties.IsInAccessibleTree="True"
-            AutomationProperties.Name="{u:I18n Password}" />
+            AutomationProperties.Name="{u:I18n Password}"
+            AutomationId="PasswordProtectedSendLabel" />
         <controls:IconLabel
             Grid.Column="3"
             Grid.Row="0"
@@ -94,7 +98,8 @@
             Text="{Binding Source={x:Static core:BitwardenIcons.Ban}}"
             IsVisible="{Binding Send.MaxAccessCountReached, Mode=OneTime}"
             AutomationProperties.IsInAccessibleTree="True"
-            AutomationProperties.Name="{u:I18n MaxAccessCountReached}" />
+            AutomationProperties.Name="{u:I18n MaxAccessCountReached}"
+            AutomationId="SendMaxAccessCountReachedLabel" />
         <controls:IconLabel
             Grid.Column="4"
             Grid.Row="0"
@@ -105,7 +110,8 @@
             Text="{Binding Source={x:Static core:BitwardenIcons.Clock}}"
             IsVisible="{Binding Send.Expired, Mode=OneTime}"
             AutomationProperties.IsInAccessibleTree="True"
-            AutomationProperties.Name="{u:I18n Expired}" />
+            AutomationProperties.Name="{u:I18n Expired}"
+            AutomationId="ExpiredSendLabel" />
         <controls:IconLabel
             Grid.Column="5"
             Grid.Row="0"
@@ -116,7 +122,8 @@
             Text="{Binding Source={x:Static core:BitwardenIcons.Trash}}"
             IsVisible="{Binding Send.PendingDelete, Mode=OneTime}"
             AutomationProperties.IsInAccessibleTree="True"
-            AutomationProperties.Name="{u:I18n PendingDelete}" />
+            AutomationProperties.Name="{u:I18n PendingDelete}"
+            AutomationId="SendWithPendingDeletionLabel" />
     </Grid>
 
     <controls:MiButton
@@ -129,6 +136,7 @@
         VerticalOptions="CenterAndExpand"
         HorizontalOptions="EndAndExpand"
         AutomationProperties.IsInAccessibleTree="True"
-        AutomationProperties.Name="{u:I18n Options}" />
+        AutomationProperties.Name="{u:I18n Options}"
+        AutomationId="SendOptionsButton" />
 
 </controls:ExtendedGrid>

--- a/src/App/Pages/Send/SendsPage.xaml
+++ b/src/App/Pages/Send/SendsPage.xaml
@@ -67,13 +67,15 @@
                SelectionMode="Single"
                SelectionChanged="RowSelected"
                StyleClass="list, list-platform"
-               ExtraDataForLogging="Sends Page">
+               ExtraDataForLogging="Sends Page"
+               AutomationId="SendCellList">
             <CollectionView.ItemTemplate>
                 <DataTemplate x:DataType="views:SendView">
                     <controls:SendViewCell
                         Send="{Binding .}"
                         ButtonCommand="{Binding BindingContext.SendOptionsCommand, Source={x:Reference _page}}"
-                        ShowOptions="{Binding BindingContext.SendEnabled, Source={x:Reference _page}}" />
+                        ShowOptions="{Binding BindingContext.SendEnabled, Source={x:Reference _page}}"
+                        AutomationId="SendCell" />
                 </DataTemplate>
             </CollectionView.ItemTemplate>
         </controls:ExtendedCollectionView>

--- a/src/App/Pages/Vault/CiphersPage.xaml
+++ b/src/App/Pages/Vault/CiphersPage.xaml
@@ -41,7 +41,8 @@
                     HorizontalOptions="FillAndExpand"
                     TextChanged="SearchBar_TextChanged"
                     SearchButtonPressed="SearchBar_SearchButtonPressed"
-                    Placeholder="{Binding PageTitle}" />
+                    Placeholder="{Binding PageTitle}"
+                    AutomationId="SearchBar" />
             </StackLayout>
             <BoxView StyleClass="list-section-separator-bottom, list-section-separator-bottom-platform"
                      x:Name="_separator" x:Key="separator" />
@@ -91,7 +92,8 @@
                 Source="empty_items_state" />
             <Label
                 Text="{u:I18n ThereAreNoItemsThatMatchTheSearch}"
-                HorizontalTextAlignment="Center" />
+                HorizontalTextAlignment="Center"
+                AutomationId="NoSearchResultsLabel" />
             <Button
                 Text="{u:I18n AddAnItem}"
                 Command="{Binding AddCipherCommand}"
@@ -104,7 +106,8 @@
                 SelectionMode="Single"
                 SelectionChanged="RowSelected"
                 StyleClass="list, list-platform"
-                ExtraDataForLogging="Ciphers Page">
+                ExtraDataForLogging="Ciphers Page"
+                AutomationId="CipherList">
             <CollectionView.ItemTemplate>
                 <DataTemplate x:DataType="views:CipherView">
                     <controls:CipherViewCell


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [X] Other

## Objective
This PR adds more AutomationIDs that will help us to improve the quality of our Mobile Automation tests

## Code changes
* **CipherViewCell.xaml:** Adding locators for Cipher cell elements
* **SendViewCell.xaml:** Adding locators for Send cell elements
* **CiphersPage.xaml:** Adding locators for cipher list, empty list label and Search bar
* **SendsPage.xaml:** Adding ids for each send cell

## Screenshots
<!--Required for any UI changes. Delete if not applicable-->



## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
