### PR TITLE
[PM-724] Pad activity result lock delay by 1s

### DIFF
--- a/src/Core/Services/VaultTimeoutService.cs
+++ b/src/Core/Services/VaultTimeoutService.cs
@@ -132,7 +132,7 @@ namespace Bit.Core.Services
             {
                 if (ResetTimeoutDelay)
                 {
-                    DelayTimeoutMs = null;
+                    DelayTimeoutMs = 1000;
                     ResetTimeoutDelay = false;
                 }
                 return false;


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
This PR slightly modifies the behavior introduced in #2539 by setting the lock delay to 1 second instead of relying on lifecycle events to remove the delay completely.  QA has devices and/or configurations that call `ShouldTimeoutAsync()` more than once on return resulting in returning to a locked app.  Adding back a bit of time covers for these devices while still satisfying the original issue by keeping the unlock window short.

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **VaultTimeoutService.cs:** Change `DelayTimeoutMs` from `null` to `1000`

## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
