### PR TITLE
[PM-2737] Adding AutomationIDs for Send page elements

### DIFF
--- a/src/App/Pages/Send/SendAddEditPage.xaml
+++ b/src/App/Pages/Send/SendAddEditPage.xaml
@@ -71,7 +71,8 @@
                             <Label
                                 Text="{u:I18n SendDisabledWarning}"
                                 StyleClass="text-muted, text-sm, text-bold"
-                                HorizontalTextAlignment="Center" />
+                                HorizontalTextAlignment="Center"
+                                AutomationId="SendDisabledWarningMessageLabel" />
                         </Frame>
                         <Frame
                             IsVisible="{Binding SendOptionsPolicyInEffect}"
@@ -83,7 +84,8 @@
                             <Label
                                 Text="{u:I18n SendOptionsPolicyInEffect}"
                                 StyleClass="text-muted, text-sm, text-bold"
-                                HorizontalTextAlignment="Center" />
+                                HorizontalTextAlignment="Center"
+                                AutomationId="SendOptionsPolicyInEffectLabel" />
                         </Frame>
                         <StackLayout StyleClass="box-row">
                             <Label
@@ -93,7 +95,8 @@
                                 x:Name="_nameEntry"
                                 Text="{Binding Send.Name}"
                                 IsEnabled="{Binding SendEnabled}"
-                                StyleClass="box-value" />
+                                StyleClass="box-value"
+                                AutomationId="SendNameEntry" />
                             <Label
                                 Text="{u:I18n NameInfo}"
                                 StyleClass="box-footer-label"
@@ -123,6 +126,7 @@
                                     AutomationProperties.IsInAccessibleTree="True"
                                     AutomationProperties.Name="{u:I18n File}"
                                     AutomationProperties.HelpText="{Binding FileTypeAccessibilityLabel}"
+                                    AutomationId="SendFileButton"
                                     Grid.Column="0">
                                 </Button>
                                 <Button
@@ -135,6 +139,7 @@
                                     AutomationProperties.IsInAccessibleTree="True"
                                     AutomationProperties.Name="{u:I18n Text}"
                                     AutomationProperties.HelpText="{Binding TextTypeAccessibilityLabel}"
+                                    AutomationId="SendTextButton"
                                     Grid.Column="1">
                                 </Button>
                             </Grid>
@@ -152,12 +157,14 @@
                                     Text="{Binding Send.File.FileName, Mode=OneWay}"
                                     StyleClass="box-value"
                                     VerticalTextAlignment="Center"
-                                    HorizontalOptions="StartAndExpand" />
+                                    HorizontalOptions="StartAndExpand"
+                                    AutomationId="SendFileNameLabel" />
                                 <Label
                                     Text="{Binding Send.File.SizeName, Mode=OneWay}"
                                     StyleClass="box-sub-label"
                                     HorizontalTextAlignment="End"
-                                    VerticalTextAlignment="Center" />
+                                    VerticalTextAlignment="Center"
+                                    AutomationId="SendFileSizeLabel" />
                             </StackLayout>
                             <StackLayout
                                 IsVisible="{Binding EditMode, Converter={StaticResource inverseBool}}"
@@ -168,20 +175,23 @@
                                     LineBreakMode="CharacterWrap"
                                     StyleClass="text-sm, text-muted"
                                     HorizontalOptions="FillAndExpand"
-                                    HorizontalTextAlignment="Center" />
+                                    HorizontalTextAlignment="Center"
+                                    AutomationId="SendNoFileChosenLabel" />
                                 <Label
                                     IsVisible="{Binding FileName, Converter={StaticResource notNull}}"
                                     Text="{Binding FileName}"
                                     LineBreakMode="CharacterWrap"
                                     StyleClass="text-sm, text-muted"
                                     HorizontalOptions="FillAndExpand"
-                                    HorizontalTextAlignment="Center" />
+                                    HorizontalTextAlignment="Center"
+                                    AutomationId="SendCurrentFileNameLabel" />
                                 <Button
                                     Text="{u:I18n ChooseFile}"
                                     IsVisible="{Binding IsAddFromShare, Converter={StaticResource inverseBool}}"
                                     IsEnabled="{Binding SendEnabled}"
                                     StyleClass="box-button-row"
-                                    Clicked="ChooseFile_Clicked" />
+                                    Clicked="ChooseFile_Clicked"
+                                    AutomationId="SendChooseFileButton" />
                                 <Label
                                     Margin="0, 5, 0, 0"
                                     Text="{u:I18n MaxFileSize}"
@@ -207,7 +217,8 @@
                                 Text="{Binding Send.Text.Text}"
                                 IsEnabled="{Binding SendEnabled}"
                                 StyleClass="box-value"
-                                Margin="{Binding EditorMargins}" 
+                                Margin="{Binding EditorMargins}"
+                                AutomationId="SendTextContentEntry"
                                 effects:ScrollEnabledEffect.IsScrollEnabled="false" >
                                 <Editor.Behaviors>
                                     <behaviors:EditorPreventAutoBottomScrollingOnFocusedBehavior ParentScrollView="{x:Reference _scrollView}" />
@@ -235,7 +246,8 @@
                                     IsToggled="{Binding Send.Text.Hidden}"
                                     IsEnabled="{Binding SendEnabled}"
                                     HorizontalOptions="End"
-                                    Margin="10,0,0,0" />
+                                    Margin="10,0,0,0"
+                                    AutomationId="SendHideTextByDefaultToggle" />
                             </StackLayout>
                         </StackLayout>
                         <StackLayout
@@ -249,7 +261,8 @@
                                 IsToggled="{Binding ShareOnSave}"
                                 IsEnabled="{Binding SendEnabled}"
                                 HorizontalOptions="End"
-                                Margin="10,0,0,0" />
+                                Margin="10,0,0,0"
+                                AutomationId="SendShareSendAfterSaveToggle" />
                         </StackLayout>
                         <StackLayout
                             Orientation="Horizontal"
@@ -263,21 +276,24 @@
                                 StyleClass="box-row-button"
                                 TextColor="{DynamicResource PrimaryColor}"
                                 Margin="0"
-                                AutomationProperties.IsInAccessibleTree="False"/>
+                                AutomationProperties.IsInAccessibleTree="False"
+                                AutomationId="SendShowHideOptionsButton" />
                             <controls:IconButton
                                 x:Name="_btnOptionsUp"
                                 Text="{Binding Source={x:Static core:BitwardenIcons.ChevronUp}}"
                                 StyleClass="box-row-button"
                                 TextColor="{DynamicResource PrimaryColor}"
                                 IsVisible="{Binding ShowOptions}" 
-                                AutomationProperties.IsInAccessibleTree="False"/>
+                                AutomationProperties.IsInAccessibleTree="False"
+                                AutomationId="SendOptionsDisplayed" />
                             <controls:IconButton
                                 x:Name="_btnOptionsDown"
                                 Text="{Binding Source={x:Static core:BitwardenIcons.AngleDown}}"
                                 StyleClass="box-row-button"
                                 TextColor="{DynamicResource PrimaryColor}"
                                 IsVisible="{Binding ShowOptions, Converter={StaticResource inverseBool}}" 
-                                AutomationProperties.IsInAccessibleTree="False"/>
+                                AutomationProperties.IsInAccessibleTree="False"
+                                AutomationId="SendOptionsHidden" />
                         </StackLayout>
                         <StackLayout IsVisible="{Binding ShowOptions}">
                             <StackLayout
@@ -294,7 +310,8 @@
                                     IsEnabled="{Binding SendEnabled}"
                                     StyleClass="box-value"
                                     AutomationProperties.IsInAccessibleTree="True"
-                                    AutomationProperties.Name="{u:I18n DeletionTime}" />
+                                    AutomationProperties.Name="{u:I18n DeletionTime}"
+                                    AutomationId="SendDeletionOptionsPicker" />
                                 <Grid
                                     IsVisible="{Binding ShowDeletionCustomPickers}"
                                     Margin="0,5,0,0">
@@ -308,14 +325,16 @@
                                         IsEnabled="{Binding SendEnabled}"
                                         AutomationProperties.IsInAccessibleTree="True"
                                         AutomationProperties.Name="{u:I18n DeletionDate}"
-                                        Grid.Column="0" />
+                                        Grid.Column="0"
+                                        AutomationId="SendCustomDeletionDatePicker" />
                                     <controls:ExtendedTimePicker
                                         NullableTime="{Binding DeletionDateTimeViewModel.Time, Mode=TwoWay}"
                                         Format="t"
                                         IsEnabled="{Binding SendEnabled}"
                                         AutomationProperties.IsInAccessibleTree="True"
                                         AutomationProperties.Name="{u:I18n DeletionTime}"
-                                        Grid.Column="1" />
+                                        Grid.Column="1"
+                                        AutomationId="SendCustomDeletionTimePicker" />
                                 </Grid>
                                 <Label
                                     Text="{u:I18n DeletionDateInfo}"
@@ -334,7 +353,8 @@
                                     IsEnabled="{Binding SendEnabled}"
                                     StyleClass="box-value"
                                     AutomationProperties.IsInAccessibleTree="True"
-                                    AutomationProperties.Name="{u:I18n ExpirationTime}" />
+                                    AutomationProperties.Name="{u:I18n ExpirationTime}"
+                                    AutomationId="SendExpirationOptionsPicker"/>
                                 <Grid
                                     IsVisible="{Binding ShowExpirationCustomPickers}"
                                     Margin="0,5,0,0">
@@ -349,7 +369,8 @@
                                         IsEnabled="{Binding SendEnabled}"
                                         AutomationProperties.IsInAccessibleTree="True"
                                         AutomationProperties.Name="{u:I18n ExpirationDate}"
-                                        Grid.Column="0" />
+                                        Grid.Column="0"
+                                        AutomationId="SendCustomExpirationDatePicker" />
                                     <controls:ExtendedTimePicker
                                         NullableTime="{Binding ExpirationDateTimeViewModel.Time, Mode=TwoWay}"
                                         PlaceHolder="--:-- --"
@@ -357,7 +378,8 @@
                                         IsEnabled="{Binding SendEnabled}"
                                         AutomationProperties.IsInAccessibleTree="True"
                                         AutomationProperties.Name="{u:I18n ExpirationTime}"
-                                        Grid.Column="1" />
+                                        Grid.Column="1"
+                                        AutomationId="SendCustomExpirationTimePicker" />
                                 </Grid>
                                 <StackLayout
                                     Orientation="Horizontal"
@@ -374,7 +396,8 @@
                                         FontSize="{Binding SegmentedButtonFontSize}"
                                         IsEnabled="{Binding SendEnabled}"
                                         StyleClass="box-row-button"
-                                        Clicked="ClearExpirationDate_Clicked" />
+                                        Clicked="ClearExpirationDate_Clicked"
+                                        AutomationId="SendClearExpirationDateButton" />
                                 </StackLayout>
                             </StackLayout>
                             <StackLayout
@@ -393,13 +416,15 @@
                                         Keyboard="Numeric"
                                         MaxLength="9"
                                         TextChanged="OnMaxAccessCountTextChanged"
-                                        HorizontalOptions="FillAndExpand" />
+                                        HorizontalOptions="FillAndExpand"
+                                        AutomationId="SendMaxAccessCountEntry" />
                                     <controls:ExtendedStepper
                                         x:Name="_maxAccessCountStepper"
                                         Value="{Binding MaxAccessCount}"
                                         Maximum="999999999"
                                         IsEnabled="{Binding SendEnabled}"
-                                        Margin="10,0,0,0" />
+                                        Margin="10,0,0,0"
+                                        AutomationId="SendMaxAccessCountStepper" />
                                 </StackLayout>
                                 <Label
                                     Text="{u:I18n MaximumAccessCountInfo}"
@@ -419,7 +444,8 @@
                                     <Label
                                         Text="{Binding Send.AccessCount, Mode=OneWay}"
                                         StyleClass="box-label"
-                                        VerticalTextAlignment="Center" />
+                                        VerticalTextAlignment="Center"
+                                        AutomationId="SendCurrentAccessCountLabel" />
                                 </StackLayout>
                             </StackLayout>
                             <StackLayout
@@ -436,7 +462,8 @@
                                         StyleClass="box-value"
                                         IsSpellCheckEnabled="False"
                                         IsTextPredictionEnabled="False"
-                                        HorizontalOptions="FillAndExpand" />
+                                        HorizontalOptions="FillAndExpand"
+                                        AutomationId="SendNewPasswordEntry" />
                                     <controls:IconButton
                                         IsEnabled="{Binding SendEnabled}"
                                         StyleClass="box-row-button, box-row-button-platform"
@@ -445,7 +472,8 @@
                                         Margin="10,0,0,0"
                                         AutomationProperties.IsInAccessibleTree="True"
                                         AutomationProperties.Name="{u:I18n ToggleVisibility}"
-                                        AutomationProperties.HelpText="{Binding PasswordVisibilityAccessibilityText}" />
+                                        AutomationProperties.HelpText="{Binding PasswordVisibilityAccessibilityText}"
+                                        AutomationId="SendShowHidePasswordButton" />
                                 </StackLayout>
                                 <Label
                                     Text="{u:I18n PasswordInfo}"
@@ -464,7 +492,8 @@
                                     IsEnabled="{Binding SendEnabled}"
                                     StyleClass="box-value"
                                     Margin="{Binding EditorMargins}"
-                                    effects:ScrollEnabledEffect.IsScrollEnabled="false" >
+                                    effects:ScrollEnabledEffect.IsScrollEnabled="false"
+                                    AutomationId="SendNotesEntry">
                                     <Editor.Behaviors>
                                         <behaviors:EditorPreventAutoBottomScrollingOnFocusedBehavior ParentScrollView="{x:Reference _scrollView}" />
                                     </Editor.Behaviors>
@@ -492,7 +521,8 @@
                                     IsToggled="{Binding Send.HideEmail}"
                                     IsEnabled="{Binding DisableHideEmailControl, Converter={StaticResource inverseBool}}"
                                     HorizontalOptions="End"
-                                    Margin="10,0,0,0" />
+                                    Margin="10,0,0,0"
+                                    AutomationId="SendHideEmailSwitch" />
                             </StackLayout>
                             <StackLayout
                                 StyleClass="box-row, box-row-switch"
@@ -506,7 +536,8 @@
                                     IsToggled="{Binding Send.Disabled}"
                                     IsEnabled="{Binding SendEnabled}"
                                     HorizontalOptions="End"
-                                    Margin="10,0,0,0" />
+                                    Margin="10,0,0,0"
+                                    AutomationId="SendDeactivateSwitch" />
                             </StackLayout>
                         </StackLayout>
 

--- a/src/App/Pages/Send/SendAddEditPage.xaml
+++ b/src/App/Pages/Send/SendAddEditPage.xaml
@@ -354,7 +354,7 @@
                                     StyleClass="box-value"
                                     AutomationProperties.IsInAccessibleTree="True"
                                     AutomationProperties.Name="{u:I18n ExpirationTime}"
-                                    AutomationId="SendExpirationOptionsPicker"/>
+                                    AutomationId="SendExpirationOptionsPicker" />
                                 <Grid
                                     IsVisible="{Binding ShowExpirationCustomPickers}"
                                     Margin="0,5,0,0">

--- a/src/App/Pages/Send/SendGroupingsPage/SendGroupingsPage.xaml
+++ b/src/App/Pages/Send/SendGroupingsPage/SendGroupingsPage.xaml
@@ -49,7 +49,7 @@
             </DataTemplate>
 
             <DataTemplate x:Key="sendGroupTemplate"
-                          x:DataType="pages:SendGroupingsPageListItem" >
+                          x:DataType="pages:SendGroupingsPageListItem">
                 <controls:ExtendedStackLayout Orientation="Horizontal" 
                                               StyleClass="list-row, list-row-platform" AutomationId="{Binding AutomationId}">
                     <controls:IconLabel Text="{Binding Icon, Mode=OneWay}"

--- a/src/App/Pages/Send/SendGroupingsPage/SendGroupingsPage.xaml
+++ b/src/App/Pages/Send/SendGroupingsPage/SendGroupingsPage.xaml
@@ -44,13 +44,14 @@
                 <controls:SendViewCell
                     Send="{Binding Send}"
                     ButtonCommand="{Binding BindingContext.SendOptionsCommand, Source={x:Reference _page}}"
-                    ShowOptions="{Binding BindingContext.SendEnabled, Source={x:Reference _page}}" />
+                    ShowOptions="{Binding BindingContext.SendEnabled, Source={x:Reference _page}}"
+                    AutomationId="SendCell" />
             </DataTemplate>
 
             <DataTemplate x:Key="sendGroupTemplate"
-                          x:DataType="pages:SendGroupingsPageListItem">
+                          x:DataType="pages:SendGroupingsPageListItem" >
                 <controls:ExtendedStackLayout Orientation="Horizontal" 
-                                              StyleClass="list-row, list-row-platform">
+                                              StyleClass="list-row, list-row-platform" AutomationId="{Binding AutomationId}">
                     <controls:IconLabel Text="{Binding Icon, Mode=OneWay}"
                                       HorizontalOptions="Start"
                                       VerticalOptions="Center"
@@ -64,12 +65,14 @@
                            LineBreakMode="TailTruncation"
                            HorizontalOptions="FillAndExpand"
                            VerticalOptions="CenterAndExpand"
-                           StyleClass="list-title" />
+                           StyleClass="list-title"
+                           AutomationId="SendFilterNameLabel" />
                     <Label Text="{Binding ItemCount, Mode=OneWay}"
                            HorizontalOptions="End"
                            VerticalOptions="CenterAndExpand"
                            HorizontalTextAlignment="End"
-                           StyleClass="list-sub" />
+                           StyleClass="list-sub"
+                           AutomationId="SendFilterCountLabel" />
                 </controls:ExtendedStackLayout>
             </DataTemplate>
 

--- a/src/App/Pages/Send/SendGroupingsPage/SendGroupingsPage.xaml
+++ b/src/App/Pages/Send/SendGroupingsPage/SendGroupingsPage.xaml
@@ -51,7 +51,8 @@
             <DataTemplate x:Key="sendGroupTemplate"
                           x:DataType="pages:SendGroupingsPageListItem">
                 <controls:ExtendedStackLayout Orientation="Horizontal" 
-                                              StyleClass="list-row, list-row-platform" AutomationId="{Binding AutomationId}">
+                                              StyleClass="list-row, list-row-platform"
+                                              AutomationId="{Binding AutomationId}">
                     <controls:IconLabel Text="{Binding Icon, Mode=OneWay}"
                                       HorizontalOptions="Start"
                                       VerticalOptions="Center"

--- a/src/App/Pages/Send/SendGroupingsPage/SendGroupingsPageListItem.cs
+++ b/src/App/Pages/Send/SendGroupingsPage/SendGroupingsPageListItem.cs
@@ -81,12 +81,8 @@ namespace Bit.App.Pages
                     {
                         case SendType.Text:
                             return "SendTextFilter";
-                            break;
                         case SendType.File:
                             return "SendFileFilter";
-                            break;
-                        default:
-                            break;
                     }
                 }
                 return null;

--- a/src/App/Pages/Send/SendGroupingsPage/SendGroupingsPageListItem.cs
+++ b/src/App/Pages/Send/SendGroupingsPage/SendGroupingsPageListItem.cs
@@ -9,7 +9,6 @@ namespace Bit.App.Pages
     {
         private string _icon;
         private string _name;
-        private string _automationId;
 
         public SendView Send { get; set; }
         public SendType? Type { get; set; }
@@ -74,23 +73,23 @@ namespace Bit.App.Pages
             {
                 if (_name != null)
                 {
-                    _automationId = "SendItem";
+                    return "SendItem";
                 }
                 if (Type != null)
                 {
                     switch (Type.Value)
                     {
                         case SendType.Text:
-                            _automationId = "SendTextFilter";
+                            return "SendTextFilter";
                             break;
                         case SendType.File:
-                            _automationId = "SendFileFilter";
+                            return "SendFileFilter";
                             break;
                         default:
                             break;
                     }
                 }
-                return _automationId;
+                return null;
             }
         }
     }

--- a/src/App/Pages/Send/SendGroupingsPage/SendGroupingsPageListItem.cs
+++ b/src/App/Pages/Send/SendGroupingsPage/SendGroupingsPageListItem.cs
@@ -9,6 +9,7 @@ namespace Bit.App.Pages
     {
         private string _icon;
         private string _name;
+        private string _automationId;
 
         public SendView Send { get; set; }
         public SendType? Type { get; set; }
@@ -64,6 +65,32 @@ namespace Bit.App.Pages
                     }
                 }
                 return _icon;
+            }
+        }
+
+        public string AutomationId
+        {
+            get
+            {
+                if (_name != null)
+                {
+                    _automationId = "SendItem";
+                }
+                if (Type != null)
+                {
+                    switch (Type.Value)
+                    {
+                        case SendType.Text:
+                            _automationId = "SendTextFilter";
+                            break;
+                        case SendType.File:
+                            _automationId = "SendFileFilter";
+                            break;
+                        default:
+                            break;
+                    }
+                }
+                return _automationId;
             }
         }
     }

--- a/src/App/Pages/Send/SendsPage.xaml
+++ b/src/App/Pages/Send/SendsPage.xaml
@@ -59,7 +59,8 @@
                Margin="20, 0"
                VerticalOptions="CenterAndExpand"
                HorizontalOptions="CenterAndExpand"
-               HorizontalTextAlignment="Center" />
+               HorizontalTextAlignment="Center"
+               AutomationId="NoSendDisplayedLabel" />
         <controls:ExtendedCollectionView
                IsVisible="{Binding ShowList}"
                ItemsSource="{Binding Sends}"

--- a/src/App/Pages/Vault/AttachmentsPage.xaml
+++ b/src/App/Pages/Vault/AttachmentsPage.xaml
@@ -33,23 +33,25 @@
             <StackLayout StyleClass="box">
                 <StackLayout StyleClass="box-row" Padding="10, 20"
                              IsVisible="{Binding HasAttachments, Converter={StaticResource inverseBool}}">
-                    <Label Text="{u:I18n NoAttachments}" HorizontalTextAlignment="Center" />
+                    <Label Text="{u:I18n NoAttachments}" HorizontalTextAlignment="Center" AutomationId="NoAttachmentsLabel" />
                 </StackLayout>
-                <controls:RepeaterView ItemsSource="{Binding Attachments}" IsVisible="{Binding HasAttachments}">
+                <controls:RepeaterView ItemsSource="{Binding Attachments}" IsVisible="{Binding HasAttachments}" AutomationId="AttachmentsList">
                     <controls:RepeaterView.ItemTemplate>
                         <DataTemplate x:DataType="views:AttachmentView">
                             <StackLayout Spacing="0" Padding="0">
-                                <StackLayout Orientation="Horizontal" StyleClass="box-row" Spacing="10">
+                                <StackLayout Orientation="Horizontal" StyleClass="box-row" Spacing="10" AutomationId="AttachmentRow">
                                     <Label
                                         Text="{Binding FileName, Mode=OneWay}"
                                         StyleClass="box-value"
                                         VerticalTextAlignment="Center"
-                                        HorizontalOptions="StartAndExpand" />
+                                        HorizontalOptions="StartAndExpand"
+                                        AutomationId="AttachmentFileNameLabel" />
                                     <Label
                                         Text="{Binding SizeName, Mode=OneWay}"
                                         StyleClass="box-sub-label"
                                         HorizontalTextAlignment="End"
-                                        VerticalTextAlignment="Center" />
+                                        VerticalTextAlignment="Center"
+                                        AutomationId="AttachmentFileSizeLabel" />
                                     <controls:IconButton 
                                         StyleClass="box-row-button, box-row-button-platform"
                                         Text="{Binding Source={x:Static core:BitwardenIcons.Trash}}"
@@ -57,7 +59,8 @@
                                         CommandParameter="{Binding .}"
                                         VerticalOptions="Center"
                                         AutomationProperties.IsInAccessibleTree="True"
-                                        AutomationProperties.Name="{u:I18n Delete}" />
+                                        AutomationProperties.Name="{u:I18n Delete}"
+                                        AutomationId="AttachmentDeleteButton" />
                                 </StackLayout>
                                 <BoxView StyleClass="box-row-separator" />
                             </StackLayout>
@@ -77,17 +80,20 @@
                         LineBreakMode="CharacterWrap"
                         StyleClass="text-sm, text-muted"
                         HorizontalOptions="FillAndExpand"
-                        HorizontalTextAlignment="Center" />
+                        HorizontalTextAlignment="Center"
+                        AutomationId="NoFileChosenLabel" />
                     <Label
                         IsVisible="{Binding FileName, Converter={StaticResource notNull}}"
                         Text="{Binding FileName}"
                         LineBreakMode="CharacterWrap"
                         StyleClass="text-sm, text-muted"
                         HorizontalOptions="FillAndExpand"
-                        HorizontalTextAlignment="Center" />
+                        HorizontalTextAlignment="Center"
+                        AutomationId="NewAttachmentNameLabel" />
                 </StackLayout>
                 <Button Text="{u:I18n ChooseFile}" StyleClass="box-button-row"
-                        Clicked="ChooseFile_Clicked"></Button>
+                        Clicked="ChooseFile_Clicked"
+                        AutomationId="ChooseFileButton"></Button>
                 <Label
                     Margin="0, 10, 0, 0"
                     Text="{u:I18n MaxFileSize}"


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [X] Other

## Objective
This PR adds more AutomationIDs that will help us to improve the quality of our Mobile Automation tests

## Code changes

* **SendAddEditPage.xaml:** Adding IDs for each Send element
* **SendGroupingsPage.xaml:** Adding IDs for Send lists
* **SendGroupingsPageListItem.xaml:** Adding a new variable to make AutomationIDs dynamic
* **SendsPage.xaml:** Adding IDs for label displayed when send list is empty


## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
