### PR TITLE
[PM-2678] Adding IDs for Settings Page elements

### DIFF
--- a/src/App/Pages/Settings/SettingsPage/SettingsPage.xaml
+++ b/src/App/Pages/Settings/SettingsPage/SettingsPage.xaml
@@ -20,7 +20,8 @@
                 x:Key="regularTemplate"
                 x:DataType="pages:SettingsPageListItem">
                 <controls:ExtendedStackLayout Orientation="Horizontal"
-                             StyleClass="list-row, list-row-platform">
+                             StyleClass="list-row, list-row-platform"
+                             AutomationId="{Binding AutomationId}">
                     <Frame
                         IsVisible="{Binding UseFrame}"
                         Padding="10"
@@ -37,14 +38,16 @@
                            LineBreakMode="{Binding LineBreakMode}"
                            HorizontalOptions="StartAndExpand"
                            VerticalOptions="CenterAndExpand"
-                           StyleClass="list-title"/>
+                           StyleClass="list-title"
+                           AutomationId="SettingTitleLabel" />
                     <Label Text="{Binding SubLabel, Mode=OneWay}"
                            IsVisible="{Binding ShowSubLabel}"
                            HorizontalOptions="End"
                            HorizontalTextAlignment="End"
                            VerticalOptions="CenterAndExpand"
                            TextColor="{Binding SubLabelColor}"
-                           StyleClass="list-sub" />
+                           StyleClass="list-sub"
+                           AutomationId="SettingStatusLabel" />
                 </controls:ExtendedStackLayout>
             </DataTemplate>
             <DataTemplate
@@ -57,7 +60,8 @@
                         Padding="10"
                         HasShadow="False"
                         BackgroundColor="Transparent"
-                        BorderColor="{DynamicResource PrimaryColor}">
+                        BorderColor="{DynamicResource PrimaryColor}"
+                        AutomationId="SettingActivePolicyTextLabel">
                         <Label
                             Text="{Binding Name, Mode=OneWay}"
                             StyleClass="text-muted, text-sm, text-bold"
@@ -75,7 +79,8 @@
                                 VerticalOptions="Center"
                                 FontSize="Small"
                                 TextColor="{Binding SubLabelColor}"
-                                StyleClass="list-sub" Margin="-5"/>
+                                StyleClass="list-sub" Margin="-5"
+                                AutomationId="SettingCustomVaultTimeoutPicker" />
                     <controls:ExtendedStackLayout.GestureRecognizers>
 			            <TapGestureRecognizer Tapped="ActivateTimePicker"/>
 		            </controls:ExtendedStackLayout.GestureRecognizers>

--- a/src/App/Pages/Settings/SettingsPage/SettingsPageListItem.cs
+++ b/src/App/Pages/Settings/SettingsPage/SettingsPageListItem.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 using System.Threading.Tasks;
 using Bit.App.Resources;
 using Bit.App.Utilities;
@@ -22,5 +23,24 @@ namespace Bit.App.Pages
         public Color SubLabelColor => SubLabelTextEnabled ?
             ThemeManager.GetResourceColor("SuccessColor") :
             ThemeManager.GetResourceColor("MutedColor");
+        public string AutomationId
+        {
+            get
+            {
+                if (!UseFrame)
+                {
+                    var idText = new CultureInfo("en-US", false)
+                    .TextInfo
+                    .ToTitleCase(Name)
+                    .Replace(" ", String.Empty)
+                    .Replace("-", String.Empty);
+                    return $"{idText}Cell";
+                }
+                else
+                {
+                    return "EnabledPolicyCell";
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [X] Other

## Objective
This PR adds more AutomationIDs that will help us to improve the quality of our Mobile Automation tests


## Code changes
* **SettingsPage.xaml:** Adding IDs for all the setting options + statuses
* **SettingsPageListItem.cs:** Adding new `AutomationId` variable


## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
