### PR TITLE
[PM-2688] Adding IDs for Options and Folders pages

### DIFF
--- a/src/App/Pages/Settings/FolderAddEditPage.xaml
+++ b/src/App/Pages/Settings/FolderAddEditPage.xaml
@@ -13,13 +13,16 @@
     </ContentPage.BindingContext>
 
     <ContentPage.ToolbarItems>
-        <ToolbarItem Text="{u:I18n Cancel}" Clicked="Close_Clicked" Order="Primary" Priority="-1" />
-        <ToolbarItem Text="{u:I18n Save}" Clicked="Save_Clicked" Order="Primary" />
+        <ToolbarItem Text="{u:I18n Cancel}" Clicked="Close_Clicked" Order="Primary" Priority="-1"
+                     AutomationId="CancelButton" />
+        <ToolbarItem Text="{u:I18n Save}" Clicked="Save_Clicked" Order="Primary"
+                     AutomationId="SaveFolderButton" />
         <ToolbarItem Text="{u:I18n Delete}"
                      Clicked="Delete_Clicked"
                      Order="Secondary"
                      IsDestructive="True"
-                     x:Name="_deleteItem" />
+                     x:Name="_deleteItem"
+                     AutomationId="DeleteFolderButton" />
     </ContentPage.ToolbarItems>
     
     <ContentPage.Resources>
@@ -43,7 +46,8 @@
                         StyleClass="box-value"
                         x:Name="_nameEntry"
                         ReturnType="Go"
-                        ReturnCommand="{Binding SubmitCommand}" />
+                        ReturnCommand="{Binding SubmitCommand}"
+                        AutomationId="FolderNameEntry" />
                 </StackLayout>
             </StackLayout>
         </StackLayout>

--- a/src/App/Pages/Settings/FoldersPage.xaml
+++ b/src/App/Pages/Settings/FoldersPage.xaml
@@ -31,7 +31,8 @@
                        Margin="20, 0"
                        VerticalOptions="CenterAndExpand"
                        HorizontalOptions="CenterAndExpand"
-                       HorizontalTextAlignment="Center"></Label>
+                       HorizontalTextAlignment="Center"
+                       AutomationId="NoFoldersLabel"></Label>
                 <controls:ExtendedCollectionView
                           IsVisible="{Binding ShowNoData, Converter={StaticResource inverseBool}}"
                           ItemsSource="{Binding Folders}"
@@ -44,10 +45,12 @@
                         <DataTemplate x:DataType="views:FolderView">
                             <controls:ExtendedStackLayout
                                 StyleClass="list-row, list-row-platform"
-                                Padding="10">
+                                Padding="10"
+                                AutomationId="FolderCell">
                                 <Label LineBreakMode="TailTruncation"
                                         StyleClass="list-title, list-title-platform"
-                                        Text="{Binding Name, Mode=OneWay}" />
+                                        Text="{Binding Name, Mode=OneWay}"
+                                        AutomationId="FolderName" />
                             </controls:ExtendedStackLayout>
                         </DataTemplate>
                     </CollectionView.ItemTemplate>

--- a/src/App/Pages/Settings/OptionsPage.xaml
+++ b/src/App/Pages/Settings/OptionsPage.xaml
@@ -146,8 +146,7 @@
                     <Switch
                         IsToggled="{Binding AutofillSavePrompt}"
                         StyleClass="box-value"
-                        HorizontalOptions="End"
-                        />
+                        HorizontalOptions="End" />
                 </StackLayout>
                 <Label
                     Text="{u:I18n AskToAddLoginDescription}"

--- a/src/App/Pages/Settings/OptionsPage.xaml
+++ b/src/App/Pages/Settings/OptionsPage.xaml
@@ -27,7 +27,8 @@
                         x:Name="_themePicker"
                         ItemsSource="{Binding ThemeOptions, Mode=OneTime}"
                         SelectedIndex="{Binding ThemeSelectedIndex}"
-                        StyleClass="box-value" />
+                        StyleClass="box-value"
+                        AutomationId="ThemeSelectorPicker" />
                 </StackLayout>
                 <Label
                     StyleClass="box-footer-label"
@@ -44,7 +45,8 @@
                         x:Name="_autoDarkThemePicker"
                         ItemsSource="{Binding AutoDarkThemeOptions, Mode=OneTime}"
                         SelectedIndex="{Binding AutoDarkThemeSelectedIndex}"
-                        StyleClass="box-value" />
+                        StyleClass="box-value"
+                        AutomationId="DefaultDarkThemePicker" />
                 </StackLayout>
                 <Label
                     StyleClass="box-footer-label"
@@ -59,7 +61,8 @@
                         x:Name="_uriMatchPicker"
                         ItemsSource="{Binding UriMatchOptions, Mode=OneTime}"
                         SelectedIndex="{Binding UriMatchSelectedIndex}"
-                        StyleClass="box-value" />
+                        StyleClass="box-value"
+                        AutomationId="DefaultUriMatchDetectionPicker" />
                 </StackLayout>
                 <Label
                     Text="{u:I18n DefaultUriMatchDetectionDescription}"
@@ -74,7 +77,8 @@
                         x:Name="_clearClipboardPicker"
                         ItemsSource="{Binding ClearClipboardOptions, Mode=OneTime}"
                         SelectedIndex="{Binding ClearClipboardSelectedIndex}"
-                        StyleClass="box-value" />
+                        StyleClass="box-value"
+                        AutomationId="ClearClipboardPicker" />
                 </StackLayout>
                 <Label
                     Text="{u:I18n ClearClipboardDescription}"
@@ -90,7 +94,8 @@
                         ItemsSource="{Binding LocalesOptions, Mode=OneTime}"
                         SelectedItem="{Binding SelectedLocale}"
                         ItemDisplayBinding="{Binding Value}"
-                        StyleClass="box-value" />
+                        StyleClass="box-value"
+                        AutomationId="LanguagePicker" />
                 </StackLayout>
                 <Label
                     Text="{u:I18n LanguageChangeRequiresAppRestart}"
@@ -105,7 +110,8 @@
                     <Switch
                         IsToggled="{Binding AutoTotpCopy}"
                         StyleClass="box-value"
-                        HorizontalOptions="End" />
+                        HorizontalOptions="End"
+                        AutomationId="CopyTotpAutomaticallyToggle" />
                 </StackLayout>
                 <Label
                     Text="{u:I18n CopyTotpAutomaticallyDescription}"
@@ -120,7 +126,8 @@
                     <Switch
                         IsToggled="{Binding Favicon}"
                         StyleClass="box-value"
-                        HorizontalOptions="End" />
+                        HorizontalOptions="End"
+                        AutomationId="ShowWebsiteIconsToggle" />
                 </StackLayout>
                 <Label
                     Text="{u:I18n ShowWebsiteIconsDescription}"
@@ -139,7 +146,8 @@
                     <Switch
                         IsToggled="{Binding AutofillSavePrompt}"
                         StyleClass="box-value"
-                        HorizontalOptions="End" />
+                        HorizontalOptions="End"
+                        />
                 </StackLayout>
                 <Label
                     Text="{u:I18n AskToAddLoginDescription}"


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [X] Other

## Objective
This PR adds more AutomationIDs that will help us to improve the quality of our Mobile Automation tests


## Code changes
* **FolderAddEditPage.xaml:**  Adding AutomationIDs
* **FoldersPage.xaml:** Adding IDs for cells and setting statuses
* **OptionsPage.xaml:** Adduig IDs to elements


## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
