### PR TITLE
[PM-1063] Re-prompt for Master Password Can be Bypassed When Using Gboard Inline Autofill

### DIFF
--- a/src/App/Pages/Vault/CiphersPageViewModel.cs
+++ b/src/App/Pages/Vault/CiphersPageViewModel.cs
@@ -208,6 +208,11 @@ namespace Bit.App.Pages
             }
             else if (selection == AppResources.Autofill || selection == AppResources.AutofillAndSave)
             {
+                if (cipher.Reprompt != CipherRepromptType.None && !await _passwordRepromptService.ShowPasswordPromptAsync())
+                {
+                    return;
+                }
+
                 if (selection == AppResources.AutofillAndSave)
                 {
                     var uris = cipher.Login?.Uris?.ToList();


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

An issue has been identified that allows users to bypass the master password re-prompt on vault items that require a re-prompt within Android. If a user has opted to allow inline autofill, they can use the filter feature to find the item they are attempting to autofill, and select "Autofill" from that list of items to bypass the required re-prompt.

This code change adds a check shortly after selecting "Autofill" or "Autofill and Save", checking if the cipher requires a re-prompt, and forcing the user to enter the password before the autofill occurs.


## Code changes

* **src/App/Pages/Vault/CiphersPageViewModel.cs:** Added a conditional check within the`SelectCipherAsync` method that identifies if a master password re-prompt is required. If not, then the autofill occurs as expected. If so, then we prompt the user for the master password before autofilling.

## Screenshots

https://github.com/bitwarden/mobile/assets/16629865/58add0b9-22ed-4f78-9ebf-32818bc7361f

