### PR TITLE
[PM-2378] Display error toast on duplicate Passkey when moving cipher to an organization

### DIFF
--- a/src/App/Pages/Vault/SharePageViewModel.cs
+++ b/src/App/Pages/Vault/SharePageViewModel.cs
@@ -113,8 +113,15 @@ namespace Bit.App.Pages
             try
             {
                 await _deviceActionService.ShowLoadingAsync(AppResources.Saving);
-                await _cipherService.ShareWithServerAsync(cipherView, OrganizationId, checkedCollectionIds);
+                var error = await _cipherService.ShareWithServerAsync(cipherView, OrganizationId, checkedCollectionIds);
                 await _deviceActionService.HideLoadingAsync();
+
+                if (error == ICipherService.ShareWithServerError.DuplicatedPasskeyInOrg)
+                {
+                    _platformUtilsService.ShowToast(null, null, AppResources.ThisItemCannotBeSharedWithTheOrganizationBecauseThereIsOneAlreadyWithTheSamePasskey);
+                    return false;
+                }
+
                 var movedItemToOrgText = string.Format(AppResources.MovedItemToOrg, cipherView.Name,
                    (await _organizationService.GetAsync(OrganizationId)).Name);
                 _platformUtilsService.ShowToast("success", null, movedItemToOrgText);

--- a/src/App/Resources/AppResources.Designer.cs
+++ b/src/App/Resources/AppResources.Designer.cs
@@ -6237,6 +6237,16 @@ namespace Bit.App.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to This item cannot be shared with the organization because there is one already with the same passkey..
+        /// </summary>
+        public static string ThisItemCannotBeSharedWithTheOrganizationBecauseThereIsOneAlreadyWithTheSamePasskey {
+            get {
+                return ResourceManager.GetString("ThisItemCannotBeSharedWithTheOrganizationBecauseThereIsOneAlreadyWithTheSamePassk" +
+                        "ey", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to This request is no longer valid.
         /// </summary>
         public static string ThisRequestIsNoLongerValid {

--- a/src/App/Resources/AppResources.resx
+++ b/src/App/Resources/AppResources.resx
@@ -2671,4 +2671,7 @@ Do you want to switch to this account?</value>
   <data name="InvalidAPIToken" xml:space="preserve">
     <value>Invalid API token</value>
   </data>
+  <data name="ThisItemCannotBeSharedWithTheOrganizationBecauseThereIsOneAlreadyWithTheSamePasskey" xml:space="preserve">
+    <value>This item cannot be shared with the organization because there is one already with the same passkey.</value>
+  </data>
 </root>

--- a/src/Core/Abstractions/ICipherService.cs
+++ b/src/Core/Abstractions/ICipherService.cs
@@ -10,6 +10,12 @@ namespace Bit.Core.Abstractions
 {
     public interface ICipherService
     {
+        public enum ShareWithServerError
+        {
+            None,
+            DuplicatedPasskeyInOrg
+        }
+
         Task ClearAsync(string userId);
         Task ClearCacheAsync();
         Task DeleteAsync(List<string> ids);
@@ -31,7 +37,7 @@ namespace Bit.Core.Abstractions
         Task SaveCollectionsWithServerAsync(Cipher cipher);
         Task SaveNeverDomainAsync(string domain);
         Task SaveWithServerAsync(Cipher cipher);
-        Task ShareWithServerAsync(CipherView cipher, string organizationId, HashSet<string> collectionIds);
+        Task<ShareWithServerError> ShareWithServerAsync(CipherView cipher, string organizationId, HashSet<string> collectionIds);
         Task UpdateLastUsedDateAsync(string id);
         Task UpsertAsync(CipherData cipher);
         Task UpsertAsync(List<CipherData> cipher);

--- a/src/Core/Models/Domain/Fido2Key.cs
+++ b/src/Core/Models/Domain/Fido2Key.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Threading.Tasks;
 using Bit.Core.Models.Data;
 using Bit.Core.Models.View;
@@ -8,23 +7,25 @@ namespace Bit.Core.Models.Domain
 {
     public class Fido2Key : Domain
     {
+        public static HashSet<string> EncryptableProperties => new HashSet<string>
+        {
+            nameof(NonDiscoverableId),
+            nameof(KeyType),
+            nameof(KeyAlgorithm),
+            nameof(KeyCurve),
+            nameof(KeyValue),
+            nameof(RpId),
+            nameof(RpName),
+            nameof(UserHandle),
+            nameof(UserName),
+            nameof(Counter)
+        };
+
         public Fido2Key() { }
 
         public Fido2Key(Fido2KeyData data, bool alreadyEncrypted = false)
         {
-            BuildDomainModel(this, data, new HashSet<string>
-            {
-                nameof(NonDiscoverableId),
-                nameof(KeyType),
-                nameof(KeyAlgorithm),
-                nameof(KeyCurve),
-                nameof(KeyValue),
-                nameof(RpId),
-                nameof(RpName),
-                nameof(UserHandle),
-                nameof(UserName),
-                nameof(Counter)
-            }, alreadyEncrypted);
+            BuildDomainModel(this, data, EncryptableProperties, alreadyEncrypted);
         }
 
         public EncString NonDiscoverableId { get; set; }
@@ -40,37 +41,13 @@ namespace Bit.Core.Models.Domain
 
         public async Task<Fido2KeyView> DecryptAsync(string orgId)
         {
-            return await DecryptObjAsync(new Fido2KeyView(), this, new HashSet<string>
-            {
-                nameof(NonDiscoverableId),
-                nameof(KeyType),
-                nameof(KeyAlgorithm),
-                nameof(KeyCurve),
-                nameof(KeyValue),
-                nameof(RpId),
-                nameof(RpName),
-                nameof(UserHandle),
-                nameof(UserName),
-                nameof(Counter)
-            }, orgId);
+            return await DecryptObjAsync(new Fido2KeyView(), this, EncryptableProperties, orgId);
         }
 
         public Fido2KeyData ToFido2KeyData()
         {
             var data = new Fido2KeyData();
-            BuildDataModel(this, data, new HashSet<string>
-            {
-                nameof(NonDiscoverableId),
-                nameof(KeyType),
-                nameof(KeyAlgorithm),
-                nameof(KeyCurve),
-                nameof(KeyValue),
-                nameof(RpId),
-                nameof(RpName),
-                nameof(UserHandle),
-                nameof(UserName),
-                nameof(Counter)
-            });
+            BuildDataModel(this, data, EncryptableProperties);
             return data;
         }
     }

--- a/src/Core/Models/View/Fido2KeyView.cs
+++ b/src/Core/Models/View/Fido2KeyView.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using Bit.Core.Enums;
 
 namespace Bit.Core.Models.View
@@ -21,5 +20,7 @@ namespace Bit.Core.Models.View
         public override List<KeyValuePair<string, LinkedIdType>> LinkedFieldOptions => new List<KeyValuePair<string, LinkedIdType>>();
         public bool CanLaunch => !string.IsNullOrEmpty(RpId);
         public string LaunchUri => $"https://{RpId}";
+
+        public bool IsUniqueAgainst(Fido2KeyView fido2View) => fido2View?.RpId != RpId || fido2View?.UserName != UserName;
     }
 }

--- a/src/Core/Services/CipherService.cs
+++ b/src/Core/Services/CipherService.cs
@@ -1138,6 +1138,11 @@ namespace Bit.Core.Services
                             cipher.Login.Uris.Add(loginUri);
                         }
                     }
+                    if (model.Login.Fido2Key != null)
+                    {
+                        cipher.Login.Fido2Key = new Fido2Key();
+                        await EncryptObjPropertyAsync(model.Login.Fido2Key, cipher.Login.Fido2Key, Fido2Key.EncryptableProperties, key);
+                    }
                     break;
                 case CipherType.SecureNote:
                     cipher.SecureNote = new SecureNote
@@ -1183,19 +1188,7 @@ namespace Bit.Core.Services
                     break;
                 case CipherType.Fido2Key:
                     cipher.Fido2Key = new Fido2Key();
-                    await EncryptObjPropertyAsync(model.Fido2Key, cipher.Fido2Key, new HashSet<string>
-                    {
-                        nameof(Fido2Key.NonDiscoverableId),
-                        nameof(Fido2Key.KeyType),
-                        nameof(Fido2Key.KeyAlgorithm),
-                        nameof(Fido2Key.KeyCurve),
-                        nameof(Fido2Key.KeyValue),
-                        nameof(Fido2Key.RpId),
-                        nameof(Fido2Key.RpName),
-                        nameof(Fido2Key.UserHandle),
-                        nameof(Fido2Key.UserName),
-                        nameof(Fido2Key.Counter)
-                    }, key);
+                    await EncryptObjPropertyAsync(model.Fido2Key, cipher.Fido2Key, Fido2Key.EncryptableProperties, key);
                     break;
                 default:
                     throw new Exception("Unknown cipher type.");

--- a/src/Core/Services/CipherService.cs
+++ b/src/Core/Services/CipherService.cs
@@ -574,12 +574,16 @@ namespace Bit.Core.Services
             var orgCiphers = decCiphers.Where(c => c.OrganizationId == organizationId);
             if (cipher.Login?.Fido2Key != null)
             {
-                return !orgCiphers.Any(c => c.Login?.Fido2Key?.RpId == cipher.Login.Fido2Key.RpId);
+                return !orgCiphers.Any(c => !cipher.Login.Fido2Key.IsUniqueAgainst(c.Login?.Fido2Key)
+                                            ||
+                                            !cipher.Login.Fido2Key.IsUniqueAgainst(c.Fido2Key));
             }
 
             if (cipher.Fido2Key != null)
             {
-                return !orgCiphers.Any(c => c.Fido2Key?.RpId == cipher.Fido2Key.RpId);
+                return !orgCiphers.Any(c => !cipher.Fido2Key.IsUniqueAgainst(c.Login?.Fido2Key)
+                                            ||
+                                            !cipher.Fido2Key.IsUniqueAgainst(c.Fido2Key));
             }
 
             return true;

--- a/src/Core/Services/CipherService.cs
+++ b/src/Core/Services/CipherService.cs
@@ -532,8 +532,13 @@ namespace Bit.Core.Services
             await UpsertAsync(data);
         }
 
-        public async Task ShareWithServerAsync(CipherView cipher, string organizationId, HashSet<string> collectionIds)
+        public async Task<ICipherService.ShareWithServerError> ShareWithServerAsync(CipherView cipher, string organizationId, HashSet<string> collectionIds)
         {
+            if (!await ValidateCanBeSharedWithOrgAsync(cipher, organizationId))
+            {
+                return ICipherService.ShareWithServerError.DuplicatedPasskeyInOrg;
+            }
+
             var attachmentTasks = new List<Task>();
             if (cipher.Attachments != null)
             {
@@ -554,6 +559,30 @@ namespace Bit.Core.Services
             var userId = await _stateService.GetActiveUserIdAsync();
             var data = new CipherData(response, userId, collectionIds);
             await UpsertAsync(data);
+
+            return ICipherService.ShareWithServerError.None;
+        }
+
+        private async Task<bool> ValidateCanBeSharedWithOrgAsync(CipherView cipher, string organizationId)
+        {
+            if (cipher.Login?.Fido2Key is null && cipher.Fido2Key is null)
+            {
+                return true;
+            }
+
+            var decCiphers = await GetAllDecryptedAsync();
+            var orgCiphers = decCiphers.Where(c => c.OrganizationId == organizationId);
+            if (cipher.Login?.Fido2Key != null)
+            {
+                return !orgCiphers.Any(c => c.Login?.Fido2Key?.RpId == cipher.Login.Fido2Key.RpId);
+            }
+
+            if (cipher.Fido2Key != null)
+            {
+                return !orgCiphers.Any(c => c.Fido2Key?.RpId == cipher.Fido2Key.RpId);
+            }
+
+            return true;
         }
 
         public async Task<Cipher> SaveAttachmentRawWithServerAsync(Cipher cipher, string filename, byte[] data)


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Display error toast on duplicate passkey when moving item to an organization.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **SharePageViewModel:** Added check of duplicate passkey error and show the toast to the user in that case
* **ICipherService:** Added `ShareWithServerError` to return the appropriate response to the caller when sharing cipher to an org. I cannot throw an `ApiException` with the error inside given that `AppResources` is not available in the `Core` project. Also another way would be to create and throw a specific exception for this and handle it on the caller but I thought this was better and the caller can handle the different paths more directly.
* **CipherService:** Added the validation to check whether the cipher has a FIdo2Key and if so, check if the organization already has any ciphers with the same `RpId` (duplicate passkey) to return an error if that's the case.


## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
