### PR TITLE
[AC-1425] Fix iOS blank vault load

### DIFF
--- a/src/App/Pages/Vault/GroupingsPage/GroupingsPageViewModel.cs
+++ b/src/App/Pages/Vault/GroupingsPage/GroupingsPageViewModel.cs
@@ -330,13 +330,16 @@ namespace Bit.App.Pages
                         items.AddRange(itemGroup);
                     }
 
-                    if (Device.RuntimePlatform == Device.iOS)
+                    Device.BeginInvokeOnMainThread(() =>
                     {
-                        // HACK: [PS-536] Fix to avoid blank list after back navigation on unlocking with previous page info
-                        // because of update to XF v5.0.0.2401
-                        GroupedItems.Clear();
-                    }
-                    GroupedItems.ReplaceRange(items);
+                        if (Device.RuntimePlatform == Device.iOS)
+                        {
+                            // HACK: [PS-536] Fix to avoid blank list after back navigation on unlocking with previous page info
+                            // because of update to XF v5.0.0.2401
+                            GroupedItems.Clear();
+                        }
+                        GroupedItems.ReplaceRange(items);
+                    });
                 }
                 else
                 {
@@ -356,21 +359,24 @@ namespace Bit.App.Pages
                         items.AddRange(itemGroup);
                     }
 
-                    if (groupedItems.Any())
+                    Device.BeginInvokeOnMainThread(() =>
                     {
-                        if (Device.RuntimePlatform == Device.iOS)
+                        if (groupedItems.Any())
                         {
-                            // HACK: [PS-536] Fix to avoid blank list after back navigation on unlocking with previous page info
-                            // because of update to XF v5.0.0.2401
+                            if (Device.RuntimePlatform == Device.iOS)
+                            {
+                                // HACK: [PS-536] Fix to avoid blank list after back navigation on unlocking with previous page info
+                                // because of update to XF v5.0.0.2401
+                                GroupedItems.Clear();
+                            }
+                            GroupedItems.ReplaceRange(new List<IGroupingsPageListItem> { new GroupingsPageHeaderListItem(groupedItems[0].Name, groupedItems[0].ItemCount) });
+                            GroupedItems.AddRange(items);
+                        }
+                        else
+                        {
                             GroupedItems.Clear();
                         }
-                        GroupedItems.ReplaceRange(new List<IGroupingsPageListItem> { new GroupingsPageHeaderListItem(groupedItems[0].Name, groupedItems[0].ItemCount) });
-                        GroupedItems.AddRange(items);
-                    }
-                    else
-                    {
-                        GroupedItems.Clear();
-                    }
+                    });
                 }
             }
             finally
@@ -378,9 +384,12 @@ namespace Bit.App.Pages
                 _doingLoad = false;
                 Loaded = true;
                 Loading = false;
-                ShowNoData = (MainPage && !HasCiphers) || !groupedItems.Any();
-                ShowList = !ShowNoData;
-                DisableRefreshing();
+                Device.BeginInvokeOnMainThread(() =>
+                {
+                    ShowNoData = (MainPage && !HasCiphers) || !groupedItems.Any();
+                    ShowList = !ShowNoData;
+                    DisableRefreshing();
+                });
             }
         }
 


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
This PR attempts to fix an issue happening from time to time, where the vault view's list doesn't load
Even though I couldn't reproduce the issue, I forced in the code the properties not to propagate changes to the view which end in this state, and based on these assumptions this fix is presented.

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **GroupingPageViewModel:** Added a bunch of main thread invocations for the properties expected to change from the view, so in case there is another thread executing the load, the property changed will be invoked in the main thread.


## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
