### PR TITLE
[PM-1201] Change timeout actions available based on hasMasterPassword

### DIFF
--- a/src/App/Pages/Settings/SettingsPage/SettingsPageViewModel.cs
+++ b/src/App/Pages/Settings/SettingsPage/SettingsPageViewModel.cs
@@ -852,9 +852,9 @@ namespace Bit.App.Pages
             return _vaultTimeoutOptions.FirstOrDefault(o => o.Key == key).Value;
         }
 
-        private string CreateSelectableOption(string option, bool selected) => selected ? $"✓ {option}" : option;
+        private string CreateSelectableOption(string option, bool selected) => selected ? ToSelectedOption(option) : option;
 
-        private bool CompareSelection(string selection, string compareTo) => selection == compareTo || selection == $"✓ {compareTo}";
+        private bool CompareSelection(string selection, string compareTo) => selection == compareTo || selection == ToSelectedOption(compareTo);
 
         private string ToSelectedOption(string option) => $"✓ {option}";
 

--- a/src/App/Pages/Settings/SettingsPage/SettingsPageViewModel.cs
+++ b/src/App/Pages/Settings/SettingsPage/SettingsPageViewModel.cs
@@ -898,6 +898,7 @@ namespace Bit.App.Pages
 
             _vaultTimeoutActionDisplayValue = _vaultTimeoutActionOptions.First(o => o.Value == VaultTimeoutAction.Logout).Key;
             await _vaultTimeoutService.SetVaultTimeoutOptionsAsync(_vaultTimeout, VaultTimeoutAction.Logout);
+            _deviceActionService.Toast(AppResources.VaultTimeoutActionChangedToLogOut);
         }
     }
 }

--- a/src/App/Resources/AppResources.Designer.cs
+++ b/src/App/Resources/AppResources.Designer.cs
@@ -6858,6 +6858,15 @@ namespace Bit.App.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Vault timeout action changed to log out.
+        /// </summary>
+        public static string VaultTimeoutActionChangedToLogOut {
+            get {
+                return ResourceManager.GetString("VaultTimeoutActionChangedToLogOut", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Your organization policies have set your vault timeout action to {0}..
         /// </summary>
         public static string VaultTimeoutActionPolicyInEffect {

--- a/src/App/Resources/AppResources.resx
+++ b/src/App/Resources/AppResources.resx
@@ -2676,4 +2676,7 @@ Do you want to switch to this account?</value>
   <data name="LoggingInAsX" xml:space="preserve">
     <value>Logging in as {0}</value>
   </data>
+  <data name="VaultTimeoutActionChangedToLogOut" xml:space="preserve">
+    <value>Vault timeout action changed to log out</value>
+  </data>
 </root>


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
For users without a master password, the unlock settings need to be different:
- Vault timeout action defaults to “log out”
- Vault timeout action “lock” is only available as an option if the user has enabled PIN unlock or biometrics unlock.
- If user disables PIN/Biometric unlock methods, then the vault timeout action defaults back to “log out”


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->
- Get DecryptionOptions to check if the user has master password set. 
if the user doesn't have a master password set up:
- Change PIN and Biometric disable logic to reset timeout action to Logout
- Change default timeout action to logout if there is no saved action.

## Screenshots
<!--Required for any UI changes. Delete if not applicable-->

https://github.com/bitwarden/mobile/assets/4648522/972cd706-61a7-4c35-bab6-9368848dc6d2






## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
