### PR TITLE
[PM-2320] Improve Android block Auto-fill URIs

### DIFF
--- a/src/Android/Android.csproj
+++ b/src/Android/Android.csproj
@@ -233,6 +233,14 @@
       <SubType></SubType>
       <Generator></Generator>
     </AndroidResource>
+    <AndroidResource Include="Resources\layout\validatable_input_dialog_layout.xml">
+      <SubType></SubType>
+      <Generator></Generator>
+    </AndroidResource>
+    <AndroidResource Include="Resources\drawable\empty_uris_placeholder.xml">
+      <SubType></SubType>
+      <Generator></Generator>
+    </AndroidResource>
   </ItemGroup>
   <ItemGroup>
     <AndroidResource Include="Resources\drawable\splash_screen.xml" />

--- a/src/Android/Android.csproj
+++ b/src/Android/Android.csproj
@@ -241,6 +241,10 @@
       <SubType></SubType>
       <Generator></Generator>
     </AndroidResource>
+    <AndroidResource Include="Resources\drawable\empty_uris_placeholder_dark.xml">
+      <SubType></SubType>
+      <Generator></Generator>
+    </AndroidResource>
   </ItemGroup>
   <ItemGroup>
     <AndroidResource Include="Resources\drawable\splash_screen.xml" />

--- a/src/Android/Renderers/CustomLabelRenderer.cs
+++ b/src/Android/Renderers/CustomLabelRenderer.cs
@@ -1,10 +1,10 @@
-﻿using System;
-using Bit.App.Controls;
-using System.ComponentModel;
-using Xamarin.Forms.Platform.Android;
+﻿using System.ComponentModel;
 using Android.Content;
-using Xamarin.Forms;
+using Android.OS;
+using Bit.App.Controls;
 using Bit.Droid.Renderers;
+using Xamarin.Forms;
+using Xamarin.Forms.Platform.Android;
 
 [assembly: ExportRenderer(typeof(CustomLabel), typeof(CustomLabelRenderer))]
 namespace Bit.Droid.Renderers
@@ -14,6 +14,19 @@ namespace Bit.Droid.Renderers
         public CustomLabelRenderer(Context context)
             : base(context)
         { }
+
+        protected override void OnElementChanged(ElementChangedEventArgs<Label> e)
+        {
+            base.OnElementChanged(e);
+
+            if (Control != null && e.NewElement is CustomLabel label)
+            {
+                if (label.FontWeight.HasValue && Build.VERSION.SdkInt >= BuildVersionCodes.P)
+                {
+                    Control.Typeface = Android.Graphics.Typeface.Create(null, label.FontWeight.Value, false);
+                }
+            }
+        }
 
         protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
         {
@@ -28,4 +41,3 @@ namespace Bit.Droid.Renderers
         }
     }
 }
-

--- a/src/Android/Resources/drawable/empty_uris_placeholder.xml
+++ b/src/Android/Resources/drawable/empty_uris_placeholder.xml
@@ -1,0 +1,35 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" xmlns:aapt="http://schemas.android.com/aapt"
+    android:viewportWidth="129"
+    android:viewportHeight="124"
+    android:width="129dp"
+    android:height="124dp">
+    <path
+        android:pathData="M126.8227 61.9441A59.6843 59.6843 0 0 1 7.4541 61.9441A59.6843 59.6843 0 0 1 126.8227 61.9441Z"
+        android:fillColor="#F0F0F0"
+        android:strokeColor="#89929F"
+        android:strokeWidth="3" />
+    <path
+        android:pathData="M21.6167 100.851C52.597 103.31 79.6937 80.3264 82.1391 49.5156C83.6205 30.8497 76.0789 14.8844 62.7275 3.63385"
+        android:strokeColor="#89929F"
+        android:strokeWidth="1.5"
+        android:strokeLineCap="round" />
+    <path
+        android:pathData="M14.5633 34.2845C12.2035 66.7711 38.5225 96.3429 72.6666 98.8232C74.2596 98.9389 78.629 98.9975 80.1951 99C84.6245 98.8232 97.8063 96.593 106.813 91.8485C113.439 88.3581 119.745 84.6984 124.644 79.1121"
+        android:strokeColor="#89929F"
+        android:strokeWidth="1.5"
+        android:strokeLineCap="round" />
+    <path
+        android:pathData="M124.502 48.5051C106.554 24.3817 68.8237 21.6709 41.4178 42.0617C24.8146 54.4149 14.7327 72.4183 13.9255 90.1427"
+        android:strokeColor="#89929F"
+        android:strokeWidth="1.5"
+        android:strokeLineCap="round" />
+    <path
+        android:pathData="M83.4034 28.3934A5 5 0 0 1 73.4034 28.3934A5 5 0 0 1 83.4034 28.3934Z"
+        android:fillColor="#89929F" />
+    <path
+        android:pathData="M24.7698 66.5518A5 5 0 0 1 14.7698 66.5518A5 5 0 0 1 24.7698 66.5518Z"
+        android:fillColor="#89929F" />
+    <path
+        android:pathData="M57.344 94.4726A5 5 0 0 1 47.344 94.4726A5 5 0 0 1 57.344 94.4726Z"
+        android:fillColor="#89929F" />
+</vector>

--- a/src/Android/Resources/drawable/empty_uris_placeholder_dark.xml
+++ b/src/Android/Resources/drawable/empty_uris_placeholder_dark.xml
@@ -1,0 +1,35 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" xmlns:aapt="http://schemas.android.com/aapt"
+    android:viewportWidth="129"
+    android:viewportHeight="124"
+    android:width="129dp"
+    android:height="124dp">
+    <path
+        android:pathData="M126.8227 61.9441A59.6843 59.6843 0 0 1 7.4541 61.9441A59.6843 59.6843 0 0 1 126.8227 61.9441Z"
+        android:fillColor="@android:color/transparent"
+        android:strokeColor="#A3A3A3"
+        android:strokeWidth="3" />
+    <path
+        android:pathData="M21.6167 100.851C52.597 103.31 79.6937 80.3264 82.1391 49.5156C83.6205 30.8497 76.0789 14.8844 62.7275 3.63385"
+        android:strokeColor="#A3A3A3"
+        android:strokeWidth="1.5"
+        android:strokeLineCap="round" />
+    <path
+        android:pathData="M14.5633 34.2845C12.2035 66.7711 38.5225 96.3429 72.6666 98.8232C74.2596 98.9389 78.629 98.9975 80.1951 99C84.6245 98.8232 97.8063 96.593 106.813 91.8485C113.439 88.3581 119.745 84.6984 124.644 79.1121"
+        android:strokeColor="#A3A3A3"
+        android:strokeWidth="1.5"
+        android:strokeLineCap="round" />
+    <path
+        android:pathData="M124.502 48.5051C106.554 24.3817 68.8237 21.6709 41.4178 42.0617C24.8146 54.4149 14.7327 72.4183 13.9255 90.1427"
+        android:strokeColor="#A3A3A3"
+        android:strokeWidth="1.5"
+        android:strokeLineCap="round" />
+    <path
+        android:pathData="M83.4034 28.3934A5 5 0 0 1 73.4034 28.3934A5 5 0 0 1 83.4034 28.3934Z"
+        android:fillColor="#A3A3A3" />
+    <path
+        android:pathData="M24.7698 66.5518A5 5 0 0 1 14.7698 66.5518A5 5 0 0 1 24.7698 66.5518Z"
+        android:fillColor="#A3A3A3" />
+    <path
+        android:pathData="M57.344 94.4726A5 5 0 0 1 47.344 94.4726A5 5 0 0 1 57.344 94.4726Z"
+        android:fillColor="#A3A3A3" />
+</vector>

--- a/src/Android/Resources/layout/validatable_input_dialog_layout.xml
+++ b/src/Android/Resources/layout/validatable_input_dialog_layout.xml
@@ -1,0 +1,27 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:paddingLeft="30dp"
+    android:paddingRight="30dp">
+    <TextView
+        android:id="@+id/lblHeader"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:textSize="@dimen/dialog_header_text_size"
+        android:layout_marginTop="5dp"
+        android:layout_marginBottom="-3dp"
+        android:labelFor="@+id/txtValue"/>
+    <EditText
+        android:id="@id/txtValue"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:textSize="@dimen/dialog_input_text_size"/>
+    <TextView
+        android:id="@+id/lblValueSubinfo"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:textSize="@dimen/dialog_sub_value_info_text_size"/>
+</LinearLayout>
+

--- a/src/Android/Resources/values/dimens.xml
+++ b/src/Android/Resources/values/dimens.xml
@@ -2,4 +2,7 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
   <dimen name="design_bottom_navigation_text_size" tools:override="true">15sp</dimen>
   <dimen name="design_bottom_navigation_active_text_size" tools:override="true">15sp</dimen>
+  <dimen name="dialog_input_text_size">16sp</dimen>
+  <dimen name="dialog_header_text_size">12sp</dimen>
+  <dimen name="dialog_sub_value_info_text_size">12sp</dimen>
 </resources>

--- a/src/Android/Services/DeviceActionService.cs
+++ b/src/Android/Services/DeviceActionService.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using Android.App;
 using Android.Content;
 using Android.Content.PM;
+using Android.Media;
 using Android.Nfc;
 using Android.OS;
 using Android.Provider;
@@ -13,11 +14,17 @@ using Android.Views.InputMethods;
 using Android.Widget;
 using Bit.App.Abstractions;
 using Bit.App.Resources;
+using Bit.App.Utilities;
+using Bit.App.Utilities.Prompts;
 using Bit.Core.Abstractions;
 using Bit.Core.Enums;
 using Bit.Core.Utilities;
 using Bit.Droid.Utilities;
 using Plugin.CurrentActivity;
+using Xamarin.Forms.Platform.Android;
+using static Android.Icu.Text.CaseMap;
+using static Android.Renderscripts.ScriptGroup;
+using static Android.Util.EventLogTags;
 using static Bit.App.Pages.SettingsPageViewModel;
 
 namespace Bit.Droid.Services
@@ -209,10 +216,7 @@ namespace Bit.Droid.Services
             }
             if (numericKeyboard)
             {
-                input.InputType = InputTypes.ClassNumber | InputTypes.NumberFlagDecimal | InputTypes.NumberFlagSigned;
-#pragma warning disable CS0618 // Type or member is obsolete
-                input.KeyListener = DigitsKeyListener.GetInstance(false, false);
-#pragma warning restore CS0618 // Type or member is obsolete
+                SetNumericKeyboardTo(input);
             }
             if (password)
             {
@@ -245,6 +249,82 @@ namespace Bit.Droid.Services
             {
                 input.RequestFocus();
             }
+            return result.Task;
+        }
+
+        public Task<ValidatablePromptResponse?> DisplayValidatablePromptAsync(ValidatablePromptConfig config)
+        {
+            var activity = (MainActivity)CrossCurrentActivity.Current.Activity;
+            if (activity == null)
+            {
+                return Task.FromResult<ValidatablePromptResponse?>(null);
+            }
+
+            var alertBuilder = new AlertDialog.Builder(activity);
+            alertBuilder.SetTitle(config.Title);
+            var view = activity.LayoutInflater.Inflate(Resource.Layout.validatable_input_dialog_layout, null);
+            alertBuilder.SetView(view);
+            
+            var result = new TaskCompletionSource<ValidatablePromptResponse?>();
+
+            alertBuilder.SetPositiveButton(config.OkButtonText ?? AppResources.Ok, listener: null);
+            alertBuilder.SetNegativeButton(config.CancelButtonText ?? AppResources.Cancel, (sender, args) => result.TrySetResult(null));
+            if (!string.IsNullOrEmpty(config.ThirdButtonText))
+            {
+                alertBuilder.SetNeutralButton(config.ThirdButtonText, (sender, args) => result.TrySetResult(new ValidatablePromptResponse(null, true)));
+            }
+
+            var alert = alertBuilder.Create();
+
+            var input = view.FindViewById<EditText>(Resource.Id.txtValue);
+            var lblHeader = view.FindViewById<TextView>(Resource.Id.lblHeader);
+            var lblValueSubinfo = view.FindViewById<TextView>(Resource.Id.lblValueSubinfo);
+
+            lblHeader.Text = config.Subtitle;
+            lblValueSubinfo.Text = config.ValueSubInfo;
+
+            var defaultSubInfoColor = lblValueSubinfo.TextColors;
+
+            input.InputType = InputTypes.ClassText;
+
+            if (config.NumericKeyboard)
+            {
+                SetNumericKeyboardTo(input);
+            }
+
+            input.ImeOptions = input.ImeOptions | (ImeAction)ImeFlags.NoPersonalizedLearning | (ImeAction)ImeFlags.NoExtractUi;
+            input.Text = config.Text ?? string.Empty;
+            input.SetSelection(config.Text?.Length ?? 0);
+            input.AfterTextChanged += (sender, args) =>
+            {
+                if (lblValueSubinfo.Text != config.ValueSubInfo)
+                {
+                    lblValueSubinfo.Text = config.ValueSubInfo;
+                    lblHeader.SetTextColor(defaultSubInfoColor);
+                    lblValueSubinfo.SetTextColor(defaultSubInfoColor);
+                }
+            };
+
+            alert.Window.SetSoftInputMode(SoftInput.StateVisible);
+            alert.Show();
+
+            var positiveButton = alert.GetButton((int)DialogButtonType.Positive);
+            positiveButton.Click += (sender, args) =>
+            {
+                var error = config.ValidateText(input.Text);
+                if (error != null)
+                {
+                    lblHeader.SetTextColor(ThemeManager.GetResourceColor("DangerColor").ToAndroid());
+                    lblValueSubinfo.SetTextColor(ThemeManager.GetResourceColor("DangerColor").ToAndroid());
+                    lblValueSubinfo.Text = error;
+                    lblValueSubinfo.SendAccessibilityEvent(Android.Views.Accessibility.EventTypes.ViewFocused);
+                    return;
+                }
+
+                result.TrySetResult(new ValidatablePromptResponse(input.Text, false));
+                alert.Dismiss();
+            };
+
             return result.Task;
         }
 
@@ -524,6 +604,14 @@ namespace Bit.Droid.Services
         {
             // only used by iOS
             throw new NotImplementedException();
+        }
+
+        private void SetNumericKeyboardTo(EditText editText)
+        {
+            editText.InputType = InputTypes.ClassNumber | InputTypes.NumberFlagDecimal | InputTypes.NumberFlagSigned;
+#pragma warning disable CS0618 // Type or member is obsolete
+            editText.KeyListener = DigitsKeyListener.GetInstance(false, false);
+#pragma warning restore CS0618 // Type or member is obsolete
         }
     }
 }

--- a/src/App/Abstractions/IDeviceActionService.cs
+++ b/src/App/Abstractions/IDeviceActionService.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading.Tasks;
+using Bit.App.Utilities.Prompts;
 using Bit.Core.Enums;
 using Bit.Core.Models;
 
@@ -18,6 +19,7 @@ namespace Bit.App.Abstractions
         Task<string> DisplayPromptAync(string title = null, string description = null, string text = null,
             string okButtonText = null, string cancelButtonText = null, bool numericKeyboard = false,
             bool autofocus = true, bool password = false);
+        Task<ValidatablePromptResponse?> DisplayValidatablePromptAsync(ValidatablePromptConfig config);
         Task<string> DisplayAlertAsync(string title, string message, string cancel, params string[] buttons);
         Task<string> DisplayActionSheetAsync(string title, string cancel, string destruction, params string[] buttons);
 

--- a/src/App/App.csproj
+++ b/src/App/App.csproj
@@ -146,6 +146,7 @@
     <Folder Include="Controls\IconLabelButton\" />
     <Folder Include="Controls\PasswordStrengthProgressBar\" />
     <Folder Include="Utilities\Automation\" />
+    <Folder Include="Utilities\Prompts\" />
   </ItemGroup>
 
   <ItemGroup>
@@ -442,5 +443,6 @@
     <None Remove="MessagePack.MSBuild.Tasks" />
     <None Remove="Controls\PasswordStrengthProgressBar\" />
     <None Remove="Utilities\Automation\" />
+    <None Remove="Utilities\Prompts\" />
   </ItemGroup>
 </Project>

--- a/src/App/Controls/CustomLabel.cs
+++ b/src/App/Controls/CustomLabel.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Xamarin.Forms;
+﻿using Xamarin.Forms;
 
 namespace Bit.App.Controls
 {
@@ -8,6 +7,7 @@ namespace Bit.App.Controls
         public CustomLabel()
         {
         }
+
+        public int? FontWeight { get; set; }
     }
 }
-

--- a/src/App/Pages/Settings/BlockAutofillUrisPage.xaml
+++ b/src/App/Pages/Settings/BlockAutofillUrisPage.xaml
@@ -1,0 +1,85 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<pages:BaseContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    x:Class="Bit.App.Pages.BlockAutofillUrisPage"
+    xmlns:pages="clr-namespace:Bit.App.Pages"
+    xmlns:controls="clr-namespace:Bit.App.Controls"
+    xmlns:u="clr-namespace:Bit.App.Utilities"
+    xmlns:core="clr-namespace:Bit.Core;assembly=BitwardenCore"
+    x:DataType="pages:BlockAutofillUrisPageViewModel"
+    Title="{u:I18n BlockAutoFill}">
+    <ContentPage.BindingContext>
+        <pages:BlockAutofillUrisPageViewModel />
+    </ContentPage.BindingContext>
+    <ContentPage.Resources>
+        <ResourceDictionary>
+            <u:InverseBoolConverter x:Key="inverseBool" />
+        </ResourceDictionary>
+    </ContentPage.Resources>
+    <StackLayout Orientation="Vertical">
+        <Image
+            HorizontalOptions="Center"
+            WidthRequest="120"
+            HeightRequest="120"
+            Margin="0,100,0,0"
+            Source="empty_uris_placeholder"
+            IsVisible="{Binding ShowList, Converter={StaticResource inverseBool}}"
+            AutomationProperties.IsInAccessibleTree="True"
+            AutomationProperties.Name="{u:I18n ThereAreNoBlockedURIs}" />
+        <controls:CustomLabel
+            StyleClass="box-label-regular"
+            Text="{u:I18n AutoFillWillNotBeOfferedForTheseURIs}"
+            FontWeight="500"
+            HorizontalTextAlignment="Center"
+            Margin="14,10,14,0"/>
+        <controls:ExtendedCollectionView
+            ItemsSource="{Binding BlockedUris}"
+            IsVisible="{Binding ShowList}"
+            VerticalOptions="FillAndExpand"
+            Margin="0,5,0,0"
+            SelectionMode="None"
+            StyleClass="list, list-platform"
+            ExtraDataForLogging="Blocked Autofill Uris"
+            AutomationId="BlockedUrisCellList">
+            <CollectionView.ItemTemplate>
+                <DataTemplate x:DataType="pages:BlockAutofillUriItemViewModel">
+                    <StackLayout
+                        Orientation="Vertical"
+                        AutomationId="BlockedUriCell">
+                        <StackLayout
+                            Orientation="Horizontal">
+                            <controls:CustomLabel
+                                VerticalOptions="Center"
+                                StyleClass="box-label-regular"
+                                Text="{Binding Uri}"
+                                MaxLines="2"
+                                LineBreakMode="TailTruncation"
+                                FontWeight="500"
+                                Margin="15,0,0,0"
+                                HorizontalOptions="StartAndExpand"/>
+                            <controls:IconButton
+                                StyleClass="box-row-button-muted, box-row-button-platform"
+                                Text="{Binding Source={x:Static core:BitwardenIcons.PencilSquare}}"
+                                Command="{Binding EditUriCommand}"
+                                Margin="5,0,15,0"
+                                AutomationProperties.IsInAccessibleTree="True"
+                                AutomationProperties.Name="{u:I18n EditURI}"
+                                AutomationId="EditUriButton" />
+                        </StackLayout>
+                        <BoxView StyleClass="box-row-separator" />
+                    </StackLayout>
+                </DataTemplate>
+            </CollectionView.ItemTemplate>
+        </controls:ExtendedCollectionView>
+        <Button
+            Text="{u:I18n NewBlockedURI}"
+            Command="{Binding AddUriCommand}"
+            VerticalOptions="End"
+            HeightRequest="40"
+            Opacity="0.8"
+            Margin="14,5,14,10"
+            AutomationProperties.IsInAccessibleTree="True"
+            AutomationProperties.Name="{u:I18n NewBlockedURI}"
+            AutomationId="NewBlockedUriButton" />
+    </StackLayout>
+</pages:BaseContentPage>

--- a/src/App/Pages/Settings/BlockAutofillUrisPage.xaml
+++ b/src/App/Pages/Settings/BlockAutofillUrisPage.xaml
@@ -18,11 +18,11 @@
     </ContentPage.Resources>
     <StackLayout Orientation="Vertical">
         <Image
+            x:Name="_emptyUrisPlaceholder"
             HorizontalOptions="Center"
             WidthRequest="120"
             HeightRequest="120"
             Margin="0,100,0,0"
-            Source="empty_uris_placeholder"
             IsVisible="{Binding ShowList, Converter={StaticResource inverseBool}}"
             AutomationProperties.IsInAccessibleTree="True"
             AutomationProperties.Name="{u:I18n ThereAreNoBlockedURIs}" />

--- a/src/App/Pages/Settings/BlockAutofillUrisPage.xaml.cs
+++ b/src/App/Pages/Settings/BlockAutofillUrisPage.xaml.cs
@@ -1,0 +1,24 @@
+﻿using Bit.Core.Utilities;
+
+namespace Bit.App.Pages
+{
+    public partial class BlockAutofillUrisPage : BaseContentPage
+    {
+        private readonly BlockAutofillUrisPageViewModel _vm;
+
+        public BlockAutofillUrisPage ()
+        {
+            InitializeComponent();
+
+            _vm = BindingContext as BlockAutofillUrisPageViewModel;
+            _vm.Page = this;
+        }
+
+        protected override void OnAppearing()
+        {
+            base.OnAppearing();
+
+            _vm.InitAsync().FireAndForget(_ => Navigation.PopAsync());
+        }
+    }
+}

--- a/src/App/Pages/Settings/BlockAutofillUrisPage.xaml.cs
+++ b/src/App/Pages/Settings/BlockAutofillUrisPage.xaml.cs
@@ -1,8 +1,13 @@
-﻿using Bit.Core.Utilities;
+﻿using System.Threading.Tasks;
+using Bit.App.Styles;
+using Bit.App.Utilities;
+using Bit.Core.Utilities;
+using Xamarin.Essentials;
+using Xamarin.Forms;
 
 namespace Bit.App.Pages
 {
-    public partial class BlockAutofillUrisPage : BaseContentPage
+    public partial class BlockAutofillUrisPage : BaseContentPage, IThemeDirtablePage
     {
         private readonly BlockAutofillUrisPageViewModel _vm;
 
@@ -19,6 +24,21 @@ namespace Bit.App.Pages
             base.OnAppearing();
 
             _vm.InitAsync().FireAndForget(_ => Navigation.PopAsync());
+
+            UpdatePlaceholder();
+        }
+
+        public override async Task UpdateOnThemeChanged()
+        {
+            await base.UpdateOnThemeChanged();
+
+            UpdatePlaceholder();
+        }
+
+        private void UpdatePlaceholder()
+        {
+            MainThread.BeginInvokeOnMainThread(() =>
+                _emptyUrisPlaceholder.Source = ImageSource.FromFile(ThemeManager.UsingLightTheme ? "empty_uris_placeholder" : "empty_uris_placeholder_dark"));
         }
     }
 }

--- a/src/App/Pages/Settings/BlockAutofillUrisPage.xaml.cs
+++ b/src/App/Pages/Settings/BlockAutofillUrisPage.xaml.cs
@@ -6,7 +6,7 @@ namespace Bit.App.Pages
     {
         private readonly BlockAutofillUrisPageViewModel _vm;
 
-        public BlockAutofillUrisPage ()
+        public BlockAutofillUrisPage()
         {
             InitializeComponent();
 

--- a/src/App/Pages/Settings/BlockAutofillUrisPageViewModel.cs
+++ b/src/App/Pages/Settings/BlockAutofillUrisPageViewModel.cs
@@ -1,0 +1,181 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Windows.Input;
+using Bit.App.Abstractions;
+using Bit.App.Resources;
+using Bit.Core;
+using Bit.Core.Abstractions;
+using Bit.Core.Utilities;
+using Xamarin.CommunityToolkit.ObjectModel;
+using Xamarin.Essentials;
+using Xamarin.Forms;
+
+namespace Bit.App.Pages
+{
+    public class BlockAutofillUrisPageViewModel : BaseViewModel
+    {
+        private const char URI_SEPARARTOR = ',';
+        private const string URI_FORMAT = "https://domain.com";
+
+        private readonly IStateService _stateService;
+        private readonly IDeviceActionService _deviceActionService;
+
+        public BlockAutofillUrisPageViewModel()
+        {
+            _stateService = ServiceContainer.Resolve<IStateService>();
+            _deviceActionService = ServiceContainer.Resolve<IDeviceActionService>();
+
+            AddUriCommand = new AsyncCommand(AddUriAsync,
+                onException: ex => HandleException(ex),
+                allowsMultipleExecutions: false);
+
+            EditUriCommand = new AsyncCommand<BlockAutofillUriItemViewModel>(EditUriAsync,
+                onException: ex => HandleException(ex),
+                allowsMultipleExecutions: false);
+        }
+
+        public ObservableRangeCollection<BlockAutofillUriItemViewModel> BlockedUris { get; set; } = new ObservableRangeCollection<BlockAutofillUriItemViewModel>();
+
+        public bool ShowList => BlockedUris.Any();
+
+        public ICommand AddUriCommand { get; }
+
+        public ICommand EditUriCommand { get; }
+
+        public async Task InitAsync()
+        {
+            var blockedUrisList = await _stateService.GetAutofillBlacklistedUrisAsync();
+            if (blockedUrisList?.Any() != true)
+            {
+                return;
+            }
+            await MainThread.InvokeOnMainThreadAsync(() =>
+            {
+                BlockedUris.AddRange(blockedUrisList.OrderBy(uri => uri).Select(u => new BlockAutofillUriItemViewModel(u, EditUriCommand)).ToList());
+                TriggerPropertyChanged(nameof(ShowList));
+            });
+        }
+
+        private async Task AddUriAsync()
+        {
+            var response = await _deviceActionService.DisplayValidatablePromptAsync(new Utilities.Prompts.ValidatablePromptConfig
+            {
+                Title = AppResources.NewUri,
+                Subtitle = AppResources.EnterURI,
+                ValueSubInfo = string.Format(AppResources.FormatXSeparateMultipleURIsWithAComma, URI_FORMAT),
+                OkButtonText = AppResources.Save,
+                ValidateText = ValidateUris
+            });
+            if (response?.Text is null)
+            {
+                return;
+            }
+
+            await MainThread.InvokeOnMainThreadAsync(() =>
+            {
+                foreach (var uri in response.Value.Text.Split(URI_SEPARARTOR).Where(s => !string.IsNullOrEmpty(s)))
+                {
+                    var cleanedUri = uri.Replace(Environment.NewLine, string.Empty).Trim();
+                    BlockedUris.Add(new BlockAutofillUriItemViewModel(cleanedUri, EditUriCommand));
+                }
+
+                BlockedUris = new ObservableRangeCollection<BlockAutofillUriItemViewModel>(BlockedUris.OrderBy(b => b.Uri));
+                TriggerPropertyChanged(nameof(BlockedUris));
+                TriggerPropertyChanged(nameof(ShowList));
+            });
+            await UpdateAutofillBlacklistedUrisAsync();
+            _deviceActionService.Toast(AppResources.URISaved);
+        }
+
+        private async Task EditUriAsync(BlockAutofillUriItemViewModel uriItemViewModel)
+        {
+            var response = await _deviceActionService.DisplayValidatablePromptAsync(new Utilities.Prompts.ValidatablePromptConfig
+            {
+                Title = AppResources.EditURI,
+                Subtitle = AppResources.EnterURI,
+                Text = uriItemViewModel.Uri,
+                ValueSubInfo = string.Format(AppResources.FormatX, URI_FORMAT),
+                OkButtonText = AppResources.Save,
+                ThirdButtonText = AppResources.Remove,
+                ValidateText = ValidateUris
+            });
+            if (response is null)
+            {
+                return;
+            }
+
+            if (response.Value.ExecuteThirdAction)
+            {
+                await MainThread.InvokeOnMainThreadAsync(() =>
+                {
+                    BlockedUris.Remove(uriItemViewModel);
+                    TriggerPropertyChanged(nameof(ShowList));
+                });
+                await UpdateAutofillBlacklistedUrisAsync();
+                _deviceActionService.Toast(AppResources.URIRemoved);
+                return;
+            }
+
+            var cleanedUri = response.Value.Text.Replace(Environment.NewLine, string.Empty).Trim();
+            await MainThread.InvokeOnMainThreadAsync(() =>
+            {
+                BlockedUris.Remove(uriItemViewModel);
+                BlockedUris.Add(new BlockAutofillUriItemViewModel(cleanedUri, EditUriCommand));
+                BlockedUris = new ObservableRangeCollection<BlockAutofillUriItemViewModel>(BlockedUris.OrderBy(b => b.Uri));
+                TriggerPropertyChanged(nameof(BlockedUris));
+                TriggerPropertyChanged(nameof(ShowList));
+            });
+            await UpdateAutofillBlacklistedUrisAsync();
+            _deviceActionService.Toast(AppResources.URISaved);
+        }
+
+        private string ValidateUris(string uris)
+        {
+            if (string.IsNullOrWhiteSpace(uris))
+            {
+                return string.Format(AppResources.FormatX, URI_FORMAT);
+            }
+
+            foreach (var uri in uris.Split(URI_SEPARARTOR).Where(u => !string.IsNullOrWhiteSpace(u)))
+            {
+                var cleanedUri = uri.Replace(Environment.NewLine, string.Empty).Trim();
+                if (!cleanedUri.StartsWith("http://") && !cleanedUri.StartsWith("https://") &&
+                    !cleanedUri.StartsWith(Constants.AndroidAppProtocol))
+                {
+                    return AppResources.InvalidFormatUseHttpsHttpOrAndroidApp;
+                }
+
+                if (!Uri.TryCreate(cleanedUri, UriKind.Absolute, out var _))
+                {
+                    return AppResources.InvalidURI;
+                }
+
+                if (BlockedUris.Any(uriItem => uriItem.Uri == cleanedUri))
+                {
+                    return AppResources.ThisURIIsAlreadyBlocked;
+                }
+            }
+
+            return null;
+        }
+
+        private async Task UpdateAutofillBlacklistedUrisAsync()
+        {
+            await _stateService.SetAutofillBlacklistedUrisAsync(BlockedUris.Any() ? BlockedUris.Select(bu => bu.Uri).ToList() : null);
+        }
+    }
+
+    public class BlockAutofillUriItemViewModel : ExtendedViewModel
+    {
+        public BlockAutofillUriItemViewModel(string uri, ICommand editUriCommand)
+        {
+            Uri = uri;
+            EditUriCommand = new Command(() => editUriCommand.Execute(this));
+        }
+
+        public string Uri { get; }
+
+        public ICommand EditUriCommand { get; }
+    }
+}

--- a/src/App/Pages/Settings/BlockAutofillUrisPageViewModel.cs
+++ b/src/App/Pages/Settings/BlockAutofillUrisPageViewModel.cs
@@ -65,7 +65,7 @@ namespace Bit.App.Pages
                 Subtitle = AppResources.EnterURI,
                 ValueSubInfo = string.Format(AppResources.FormatXSeparateMultipleURIsWithAComma, URI_FORMAT),
                 OkButtonText = AppResources.Save,
-                ValidateText = ValidateUris
+                ValidateText = text => ValidateUris(text, true)
             });
             if (response?.Text is null)
             {
@@ -98,7 +98,7 @@ namespace Bit.App.Pages
                 ValueSubInfo = string.Format(AppResources.FormatX, URI_FORMAT),
                 OkButtonText = AppResources.Save,
                 ThirdButtonText = AppResources.Remove,
-                ValidateText = ValidateUris
+                ValidateText = text => ValidateUris(text, false)
             });
             if (response is null)
             {
@@ -130,11 +130,16 @@ namespace Bit.App.Pages
             _deviceActionService.Toast(AppResources.URISaved);
         }
 
-        private string ValidateUris(string uris)
+        private string ValidateUris(string uris, bool allowMultipleUris)
         {
             if (string.IsNullOrWhiteSpace(uris))
             {
                 return string.Format(AppResources.FormatX, URI_FORMAT);
+            }
+
+            if (!allowMultipleUris && uris.Contains(URI_SEPARARTOR))
+            {
+                return AppResources.CannotEditMultipleURIsAtOnce;
             }
 
             foreach (var uri in uris.Split(URI_SEPARARTOR).Where(u => !string.IsNullOrWhiteSpace(u)))
@@ -153,7 +158,7 @@ namespace Bit.App.Pages
 
                 if (BlockedUris.Any(uriItem => uriItem.Uri == cleanedUri))
                 {
-                    return AppResources.ThisURIIsAlreadyBlocked;
+                    return string.Format(AppResources.TheURIXIsAlreadyBlocked, cleanedUri);
                 }
             }
 

--- a/src/App/Pages/Settings/OptionsPage.xaml
+++ b/src/App/Pages/Settings/OptionsPage.xaml
@@ -153,22 +153,14 @@
                     StyleClass="box-footer-label, box-footer-label-switch" />
             </StackLayout>
             <StackLayout StyleClass="box" IsVisible="{Binding ShowAndroidAutofillSettings}">
-                <StackLayout StyleClass="box-row, box-row-input">
-                    <Label
-                        Text="{u:I18n AutofillBlockedUris}"
-                        StyleClass="box-label" />
-                    <Editor
-                        x:Name="_autofillBlockedUrisEditor"
-                        Text="{Binding AutofillBlockedUris}"
-                        StyleClass="box-value"
-                        AutoSize="TextChanges"
-                        IsSpellCheckEnabled="False"
-                        IsTextPredictionEnabled="False"
-                        Keyboard="Url"
-                        Unfocused="AutofillBlockedUrisEditor_Unfocused" />
-                </StackLayout>
+                <StackLayout.GestureRecognizers>
+                    <TapGestureRecognizer Command="{Binding GoToBlockAutofillUrisCommand}" />
+                </StackLayout.GestureRecognizers>
                 <Label
-                    Text="{u:I18n AutofillBlockedUrisDescription}"
+                    Text="{u:I18n BlockAutoFill}"
+                    StyleClass="box-label-regular" />
+                <Label
+                    Text="{u:I18n AutoFillWillNotBeOfferedForTheseURIs}"
                     StyleClass="box-footer-label" />
             </StackLayout>
         </StackLayout>

--- a/src/App/Pages/Settings/OptionsPage.xaml.cs
+++ b/src/App/Pages/Settings/OptionsPage.xaml.cs
@@ -1,6 +1,4 @@
-﻿using Bit.App.Abstractions;
-using Bit.App.Resources;
-using Bit.Core.Abstractions;
+﻿using Bit.Core.Abstractions;
 using Bit.Core.Utilities;
 using Xamarin.Forms;
 using Xamarin.Forms.PlatformConfiguration;
@@ -42,17 +40,6 @@ namespace Bit.App.Pages
         {
             base.OnAppearing();
             await _vm.InitAsync();
-        }
-
-        protected async override void OnDisappearing()
-        {
-            base.OnDisappearing();
-            await _vm.UpdateAutofillBlockedUris();
-        }
-
-        private async void AutofillBlockedUrisEditor_Unfocused(object sender, FocusEventArgs e)
-        {
-            await _vm.UpdateAutofillBlockedUris();
         }
 
         private async void Close_Clicked(object sender, System.EventArgs e)

--- a/src/App/Resources/AppResources.Designer.cs
+++ b/src/App/Resources/AppResources.Designer.cs
@@ -1274,6 +1274,15 @@ namespace Bit.App.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Cannot edit multiple URIs at once.
+        /// </summary>
+        public static string CannotEditMultipleURIsAtOnce {
+            get {
+                return ResourceManager.GetString("CannotEditMultipleURIsAtOnce", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Cannot open the app &quot;{0}&quot;..
         /// </summary>
         public static string CannotOpenApp {
@@ -6219,6 +6228,15 @@ namespace Bit.App.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The URI {0} is already blocked.
+        /// </summary>
+        public static string TheURIXIsAlreadyBlocked {
+            get {
+                return ResourceManager.GetString("TheURIXIsAlreadyBlocked", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to 30 days.
         /// </summary>
         public static string ThirtyDays {
@@ -6251,15 +6269,6 @@ namespace Bit.App.Resources {
         public static string ThisRequestIsNoLongerValid {
             get {
                 return ResourceManager.GetString("ThisRequestIsNoLongerValid", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to This URI is already blocked.
-        /// </summary>
-        public static string ThisURIIsAlreadyBlocked {
-            get {
-                return ResourceManager.GetString("ThisURIIsAlreadyBlocked", resourceCulture);
             }
         }
         

--- a/src/App/Resources/AppResources.Designer.cs
+++ b/src/App/Resources/AppResources.Designer.cs
@@ -797,15 +797,6 @@ namespace Bit.App.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Auto-fill will not be offered for blocked URIs. Separate multiple URIs with a comma. For example: &quot;https://twitter.com, androidapp://com.twitter.android&quot;..
-        /// </summary>
-        public static string AutofillBlockedUrisDescription {
-            get {
-                return ResourceManager.GetString("AutofillBlockedUrisDescription", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Do you want to auto-fill or view this item?.
         /// </summary>
         public static string AutofillOrView {
@@ -937,6 +928,15 @@ namespace Bit.App.Resources {
         public static string AutofillTurnOn5 {
             get {
                 return ResourceManager.GetString("AutofillTurnOn5", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Auto-fill will not be offered for these URIs..
+        /// </summary>
+        public static string AutoFillWillNotBeOfferedForTheseURIs {
+            get {
+                return ResourceManager.GetString("AutoFillWillNotBeOfferedForTheseURIs", resourceCulture);
             }
         }
         
@@ -1225,6 +1225,15 @@ namespace Bit.App.Resources {
         public static string Black {
             get {
                 return ResourceManager.GetString("Black", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Block auto-fill.
+        /// </summary>
+        public static string BlockAutoFill {
+            get {
+                return ResourceManager.GetString("BlockAutoFill", resourceCulture);
             }
         }
         
@@ -2147,6 +2156,15 @@ namespace Bit.App.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Edit URI.
+        /// </summary>
+        public static string EditURI {
+            get {
+                return ResourceManager.GetString("EditURI", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Email.
         /// </summary>
         public static string Email {
@@ -2296,6 +2314,15 @@ namespace Bit.App.Resources {
         public static string EnterTheVerificationCodeThatWasSentToYourEmail {
             get {
                 return ResourceManager.GetString("EnterTheVerificationCodeThatWasSentToYourEmail", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Enter URI.
+        /// </summary>
+        public static string EnterURI {
+            get {
+                return ResourceManager.GetString("EnterURI", resourceCulture);
             }
         }
         
@@ -2948,6 +2975,24 @@ namespace Bit.App.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Format: {0}.
+        /// </summary>
+        public static string FormatX {
+            get {
+                return ResourceManager.GetString("FormatX", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Format: {0}. Separate multiple URIs with a comma..
+        /// </summary>
+        public static string FormatXSeparateMultipleURIsWithAComma {
+            get {
+                return ResourceManager.GetString("FormatXSeparateMultipleURIsWithAComma", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Forwarded email alias.
         /// </summary>
         public static string ForwardedEmailAlias {
@@ -3290,6 +3335,15 @@ namespace Bit.App.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Invalid format. Use https://, http://, or androidapp://.
+        /// </summary>
+        public static string InvalidFormatUseHttpsHttpOrAndroidApp {
+            get {
+                return ResourceManager.GetString("InvalidFormatUseHttpsHttpOrAndroidApp", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Invalid master password. Try again..
         /// </summary>
         public static string InvalidMasterPassword {
@@ -3304,6 +3358,15 @@ namespace Bit.App.Resources {
         public static string InvalidPIN {
             get {
                 return ResourceManager.GetString("InvalidPIN", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Invalid URI.
+        /// </summary>
+        public static string InvalidURI {
+            get {
+                return ResourceManager.GetString("InvalidURI", resourceCulture);
             }
         }
         
@@ -4215,6 +4278,15 @@ namespace Bit.App.Resources {
         public static string NewAroundHere {
             get {
                 return ResourceManager.GetString("NewAroundHere", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to New blocked URI.
+        /// </summary>
+        public static string NewBlockedURI {
+            get {
+                return ResourceManager.GetString("NewBlockedURI", resourceCulture);
             }
         }
         
@@ -6120,6 +6192,15 @@ namespace Bit.App.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to There are no blocked URIs.
+        /// </summary>
+        public static string ThereAreNoBlockedURIs {
+            get {
+                return ResourceManager.GetString("ThereAreNoBlockedURIs", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to There are no items in your vault that match &quot;{0}&quot;.
         /// </summary>
         public static string ThereAreNoItemsInYourVaultThatMatchX {
@@ -6170,6 +6251,15 @@ namespace Bit.App.Resources {
         public static string ThisRequestIsNoLongerValid {
             get {
                 return ResourceManager.GetString("ThisRequestIsNoLongerValid", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to This URI is already blocked.
+        /// </summary>
+        public static string ThisURIIsAlreadyBlocked {
+            get {
+                return ResourceManager.GetString("ThisURIIsAlreadyBlocked", resourceCulture);
             }
         }
         
@@ -6588,11 +6678,29 @@ namespace Bit.App.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to URI removed.
+        /// </summary>
+        public static string URIRemoved {
+            get {
+                return ResourceManager.GetString("URIRemoved", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to URIs.
         /// </summary>
         public static string URIs {
             get {
                 return ResourceManager.GetString("URIs", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to URI saved.
+        /// </summary>
+        public static string URISaved {
+            get {
+                return ResourceManager.GetString("URISaved", resourceCulture);
             }
         }
         

--- a/src/App/Resources/AppResources.resx
+++ b/src/App/Resources/AppResources.resx
@@ -1585,9 +1585,6 @@ Scanning will happen automatically.</value>
   <data name="AutofillBlockedUris" xml:space="preserve">
     <value>Auto-fill blocked URIs</value>
   </data>
-  <data name="AutofillBlockedUrisDescription" xml:space="preserve">
-    <value>Auto-fill will not be offered for blocked URIs. Separate multiple URIs with a comma. For example: "https://twitter.com, androidapp://com.twitter.android".</value>
-  </data>
   <data name="AskToAddLogin" xml:space="preserve">
     <value>Ask to add login</value>
   </data>
@@ -2642,5 +2639,48 @@ Do you want to switch to this account?</value>
   </data>
   <data name="InvalidAPIToken" xml:space="preserve">
     <value>Invalid API token</value>
+  </data>
+  <data name="BlockAutoFill" xml:space="preserve">
+    <value>Block auto-fill</value>
+  </data>
+  <data name="AutoFillWillNotBeOfferedForTheseURIs" xml:space="preserve">
+    <value>Auto-fill will not be offered for these URIs.</value>
+  </data>
+  <data name="NewBlockedURI" xml:space="preserve">
+    <value>New blocked URI</value>
+  </data>
+  <data name="URISaved" xml:space="preserve">
+    <value>URI saved</value>
+  </data>
+  <data name="InvalidFormatUseHttpsHttpOrAndroidApp" xml:space="preserve">
+    <value>Invalid format. Use https://, http://, or androidapp://</value>
+    <comment>https://, http://, androidapp:// should not be translated</comment>
+  </data>
+  <data name="EditURI" xml:space="preserve">
+    <value>Edit URI</value>
+  </data>
+  <data name="EnterURI" xml:space="preserve">
+    <value>Enter URI</value>
+  </data>
+  <data name="FormatXSeparateMultipleURIsWithAComma" xml:space="preserve">
+    <value>Format: {0}. Separate multiple URIs with a comma.</value>
+  </data>
+  <data name="FormatX" xml:space="preserve">
+    <value>Format: {0}</value>
+  </data>
+  <data name="InvalidURI" xml:space="preserve">
+    <value>Invalid URI</value>
+  </data>
+  <data name="URISaved" xml:space="preserve">
+    <value>URI saved</value>
+  </data>
+  <data name="URIRemoved" xml:space="preserve">
+    <value>URI removed</value>
+  </data>
+  <data name="ThereAreNoBlockedURIs" xml:space="preserve">
+    <value>There are no blocked URIs</value>
+  </data>
+  <data name="ThisURIIsAlreadyBlocked" xml:space="preserve">
+    <value>This URI is already blocked</value>
   </data>
 </root>

--- a/src/App/Resources/AppResources.resx
+++ b/src/App/Resources/AppResources.resx
@@ -2680,7 +2680,10 @@ Do you want to switch to this account?</value>
   <data name="ThereAreNoBlockedURIs" xml:space="preserve">
     <value>There are no blocked URIs</value>
   </data>
-  <data name="ThisURIIsAlreadyBlocked" xml:space="preserve">
-    <value>This URI is already blocked</value>
+  <data name="TheURIXIsAlreadyBlocked" xml:space="preserve">
+    <value>The URI {0} is already blocked</value>
+  </data>
+  <data name="CannotEditMultipleURIsAtOnce" xml:space="preserve">
+    <value>Cannot edit multiple URIs at once</value>
   </data>
 </root>

--- a/src/App/Styles/Base.xaml
+++ b/src/App/Styles/Base.xaml
@@ -430,6 +430,22 @@
     </Style>
     <Style TargetType="Button"
            ApplyToDerivedTypes="True"
+           Class="box-row-button-muted">
+        <Setter Property="BackgroundColor"
+                Value="Transparent" />
+        <Setter Property="BorderWidth"
+                Value="0" />
+        <Setter Property="Padding"
+                Value="0" />
+        <Setter Property="TextColor"
+                Value="{DynamicResource MutedColor}" />
+        <Setter Property="HorizontalOptions"
+                Value="End" />
+        <Setter Property="VerticalOptions"
+                Value="CenterAndExpand" />
+    </Style>
+    <Style TargetType="Button"
+           ApplyToDerivedTypes="True"
            Class="box-overlay">
         <Setter Property="BackgroundColor"
                 Value="Transparent" />

--- a/src/App/Utilities/Prompts/ValidatablePromptConfig.cs
+++ b/src/App/Utilities/Prompts/ValidatablePromptConfig.cs
@@ -1,0 +1,29 @@
+﻿using System;
+
+namespace Bit.App.Utilities.Prompts
+{
+    public class ValidatablePromptConfig
+    {
+        public string Title { get; set; }
+        public string Subtitle { get; set; }
+        public string Text { get; set; }
+        public Func<string, string> ValidateText { get; set; }
+        public string ValueSubInfo { get; set; }
+        public string OkButtonText { get; set; }
+        public string CancelButtonText { get; set; }
+        public string ThirdButtonText { get; set; }
+        public bool NumericKeyboard { get; set; }
+    }
+
+    public struct ValidatablePromptResponse
+    {
+        public ValidatablePromptResponse(string text, bool executeThirdAction)
+        {
+            Text = text;
+            ExecuteThirdAction = executeThirdAction;
+        }
+
+        public string Text { get; set; }
+        public bool ExecuteThirdAction { get; set; }
+    }
+}

--- a/src/iOS.Core/Services/DeviceActionService.cs
+++ b/src/iOS.Core/Services/DeviceActionService.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Bit.App.Abstractions;
 using Bit.App.Resources;
+using Bit.App.Utilities.Prompts;
 using Bit.Core.Enums;
 using Bit.iOS.Core.Utilities;
 using Bit.iOS.Core.Views;
@@ -145,6 +146,11 @@ namespace Bit.iOS.Core.Services
             });
             vc.PresentViewController(alert, true, null);
             return result.Task;
+        }
+
+        public Task<ValidatablePromptResponse?> DisplayValidatablePromptAsync(ValidatablePromptConfig config)
+        {
+            throw new NotImplementedException();
         }
 
         public void RateApp()


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Improve current way to block Auto-fill URIs. This is an Android feature.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->


* **BlockAutofillUrisPage.xaml:** New view to display blocked autofill URIs.
* * **BlockAutofillUrisPage.xaml.cs:** New view to display blocked autofill URIs. Added this as theme dirtable to change the placeholder corresponding to the current app theme.
* **BlockAutofillUrisPageViewModel.cs:** New view model to handle the logic for blocked autofill URIs and also validation on input.
* **OptionsPage.xaml:** Changed UI to be simpler and just navigate to the new view
* **OptionsPage.xaml.cs:** Removed old blocked Uris logic
* **OptionsPageViewModel.cs:** Removed old blocked Uris logic and added navigation to new view
* **DeviceActionService.cs:** Added new `DisplayValidatablePromptAsync(...)` method that shows a custom alert dialog with a custom view that has validations and execute the validations when pressing `save`. The dialog is dismissed on `save` only when all validations are valid. Also, added a few improvements for accessibility.
* **validatable_input_dialog_layout.xml:** Custom dialog view to display input that can be validated
* **dimens.xml:** Custom dimensions for `validatable_input_dialog_layout.xml`
* **CustomLabel.cs:** Added ability to change the font weight
* **CustomLabelRenderer.cs:** Added ability to change the font weight on API 28+
* **ValidatablePromptConfig.cs:** Config parameters for `DeviceActionService.DisplayValidatablePromptAsync`. Chose struct over method parameters to have more flexibility and because they are a lot.
* **empty_uris_placeholder.xml:** New icon to be displayed when there are no Uris in the list
* **empty_uris_placeholder_dark.xml:** New icon to be displayed when there are no Uris in the list on dark themes (transparent fill color)

## Screenshots
<!--Required for any UI changes. Delete if not applicable-->

### Options Block autofill light
<img width="314" alt="Options Block autofill light" src="https://github.com/bitwarden/mobile/assets/15682323/0da929c3-cf22-467f-80a1-06be59779353">

### Options Block autofill dark
<img width="314" alt="Options Block autofill dark" src="https://github.com/bitwarden/mobile/assets/15682323/4ca32460-4323-4239-b360-f1ef3ffaf397">

### Block autofill empty light
<img width="314" alt="Block autofill empty light" src="https://github.com/bitwarden/mobile/assets/15682323/95dacda8-6b57-4ed1-9ee1-c84d5584eefe">

### Block autofill empty dark
<img width="314" alt="Block autofill empty dark" src="https://github.com/bitwarden/mobile/assets/15682323/e1cf5fef-25b5-4976-bb39-bca850b92b3c">

### Block autofill multiple items light
<img width="314" alt="Block autofill multiple items light" src="https://github.com/bitwarden/mobile/assets/15682323/9f8bce05-950c-4848-a455-04a64d77690e">

### Block autofill multiple items dark
<img width="314" alt="Block autofill multiple items dark" src="https://github.com/bitwarden/mobile/assets/15682323/c99cbc0c-e101-4959-8484-af87fa724dd9">

### Block autofill new uri
<img width="314" alt="Block autofill new uri" src="https://github.com/bitwarden/mobile/assets/15682323/7c5f3123-833d-483d-a3c6-08b364e78e55">

### Block autofill new uri error
<img width="314" alt="Block autofill new uri error" src="https://github.com/bitwarden/mobile/assets/15682323/d8a1a07d-28b3-43b4-a8be-0a3753a577f9">

### Block Autofill edit uri
<img width="314" alt="Block Autofill edit uri" src="https://github.com/bitwarden/mobile/assets/15682323/c917ad8b-b7ce-46b5-85f4-310595699308">


## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
