### PR TITLE
[PM-3018] Catch additional exception types when validating intents

### DIFF
--- a/src/Android/Utilities/IntentExtensions.cs
+++ b/src/Android/Utilities/IntentExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using Android.Content;
 using Android.OS;
+using Java.Lang;
 
 namespace Bit.Droid.Utilities
 {
@@ -13,7 +14,12 @@ namespace Bit.Droid.Utilities
                 // Note: getting the bundle like this will cause to call unparcel() internally
                 var b = intent?.Extras?.GetBundle("trashstringwhichhasnousebuttocheckunparcel");
             }
-            catch (BadParcelableException)
+            catch (Exception ex) when
+            (
+                ex is BadParcelableException ||
+                ex is ClassNotFoundException ||
+                ex is RuntimeException
+            )
             {
                 intent.ReplaceExtras((Bundle)null);
             }


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
This PR fixes an additional app crash during intent validation if a bad actor is trying to pass a custom class extra (reported in hackerone)

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **IntentExtensions.cs:** add catches for `ClassNotFoundException` and `RuntimeException` in `Validate`

## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
