### PR TITLE
[PM-3021] Add support for Browser in /e/ OS

### DIFF
--- a/src/Android/Accessibility/AccessibilityHelpers.cs
+++ b/src/Android/Accessibility/AccessibilityHelpers.cs
@@ -90,6 +90,7 @@ namespace Bit.Droid.Accessibility
             new Browser("com.yjllq.kito", "search_box"),
             new Browser("com.yujian.ResideMenuDemo", "search_box"),
             new Browser("com.z28j.feel", "g2"),
+            new Browser("foundation.e.browser", "url_bar"),
             new Browser("idm.internet.download.manager", "search"),
             new Browser("idm.internet.download.manager.adm.lite", "search"),
             new Browser("idm.internet.download.manager.plus", "search"),

--- a/src/Android/Autofill/AutofillHelpers.cs
+++ b/src/Android/Autofill/AutofillHelpers.cs
@@ -111,6 +111,7 @@ namespace Bit.Droid.Autofill
             "com.yjllq.kito",
             "com.yujian.ResideMenuDemo",
             "com.z28j.feel",
+            "foundation.e.browser",
             "idm.internet.download.manager",
             "idm.internet.download.manager.adm.lite",
             "idm.internet.download.manager.plus",

--- a/src/Android/Resources/xml/autofillservice.xml
+++ b/src/Android/Resources/xml/autofillservice.xml
@@ -186,6 +186,9 @@
     android:name="com.z28j.feel"
     android:maxLongVersionCode="10000000000"/>
   <compatibility-package
+    android:name="foundation.e.browser"
+    android:maxLongVersionCode="10000000000"/>
+  <compatibility-package
     android:name="idm.internet.download.manager"
     android:maxLongVersionCode="10000000000"/>
   <compatibility-package


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [x] Other

## Objective

Add support for [/e/ OS browser ](https://gitlab.e.foundation/e/os/browser).

## Code changes

Add foundation.e.browser as supported package.

* **file.ext:** Description of what was changed and why

## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
