### PR TITLE
[PM-1564] Export individual item cipher key

### DIFF
--- a/src/Core/Models/Export/Cipher.cs
+++ b/src/Core/Models/Export/Cipher.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using Bit.Core.Enums;
+using Bit.Core.Models.Domain;
 using Bit.Core.Models.View;
 using Newtonsoft.Json;
 
@@ -46,6 +47,7 @@ namespace Bit.Core.Models.Export
             Name = obj.Name?.EncryptedString;
             Notes = obj.Notes?.EncryptedString;
             Favorite = obj.Favorite;
+            Key = obj.Key?.EncryptedString;
 
             Fields = obj.Fields?.Select(f => new Field(f)).ToList();
 
@@ -82,6 +84,8 @@ namespace Bit.Core.Models.Export
         public Card Card { get; set; }
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public Identity Identity { get; set; }
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public string Key { get; set; }
 
         public CipherView ToView(Cipher req, CipherView view = null)
         {


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
Add `Key` to the Cipher Export model when creating an account protected export

## Code changes
* **Core/Models/Export/Cipher.cs:** Added the new `Cipher Encryption Key` as an encrypted value on the export model

## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
