### PR TITLE
[PM-3097] Fix passkeys can be moved to org on different types

### DIFF
--- a/src/Core/Models/View/Fido2KeyView.cs
+++ b/src/Core/Models/View/Fido2KeyView.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using Bit.Core.Enums;
 
 namespace Bit.Core.Models.View
@@ -21,5 +20,7 @@ namespace Bit.Core.Models.View
         public override List<KeyValuePair<string, LinkedIdType>> LinkedFieldOptions => new List<KeyValuePair<string, LinkedIdType>>();
         public bool CanLaunch => !string.IsNullOrEmpty(RpId);
         public string LaunchUri => $"https://{RpId}";
+
+        public bool IsUniqueAgainst(Fido2KeyView fido2View) => fido2View?.RpId != RpId || fido2View?.UserName != UserName;
     }
 }

--- a/src/Core/Services/CipherService.cs
+++ b/src/Core/Services/CipherService.cs
@@ -574,12 +574,16 @@ namespace Bit.Core.Services
             var orgCiphers = decCiphers.Where(c => c.OrganizationId == organizationId);
             if (cipher.Login?.Fido2Key != null)
             {
-                return !orgCiphers.Any(c => c.Login?.Fido2Key?.RpId == cipher.Login.Fido2Key.RpId);
+                return !orgCiphers.Any(c => !cipher.Login.Fido2Key.IsUniqueAgainst(c.Login?.Fido2Key)
+                                            ||
+                                            !cipher.Login.Fido2Key.IsUniqueAgainst(c.Fido2Key));
             }
 
             if (cipher.Fido2Key != null)
             {
-                return !orgCiphers.Any(c => c.Fido2Key?.RpId == cipher.Fido2Key.RpId);
+                return !orgCiphers.Any(c => !cipher.Fido2Key.IsUniqueAgainst(c.Login?.Fido2Key)
+                                            ||
+                                            !cipher.Fido2Key.IsUniqueAgainst(c.Fido2Key));
             }
 
             return true;


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Handle Passkeys duplication when moved to org where a different type of passkey is present there with same RpID and Username.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **Fido2KeyView:** Added uniqueness check method with RpID and Username
* **CipherService:** Augmented the org's ciphers check on different passkey types (discoverable/non-discoverable)


## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
