### PR TITLE
Auth/pm 2713/drop master key dependency

### DIFF
--- a/src/Android/MainApplication.cs
+++ b/src/Android/MainApplication.cs
@@ -156,9 +156,9 @@ namespace Bit.Droid
                 messagingService, broadcasterService);
             var autofillHandler = new AutofillHandler(stateService, messagingService, clipboardService,
                 platformUtilsService, new LazyResolve<IEventService>());
-            var biometricService = new BiometricService(stateService);
             var cryptoFunctionService = new PclCryptoFunctionService(cryptoPrimitiveService);
             var cryptoService = new CryptoService(stateService, cryptoFunctionService);
+            var biometricService = new BiometricService(stateService, cryptoService);
             var passwordRepromptService = new MobilePasswordRepromptService(platformUtilsService, cryptoService);
 
             ServiceContainer.Register<ISynchronousStorageService>(preferencesStorage);

--- a/src/Android/Services/BiometricService.cs
+++ b/src/Android/Services/BiometricService.cs
@@ -2,6 +2,7 @@
 using System.Threading.Tasks;
 using Android.OS;
 using Android.Security.Keystore;
+using Bit.App.Services;
 using Bit.Core.Abstractions;
 using Bit.Core.Services;
 using Java.Security;
@@ -9,10 +10,8 @@ using Javax.Crypto;
 
 namespace Bit.Droid.Services
 {
-    public class BiometricService : IBiometricService
+    public class BiometricService : BaseBiometricService
     {
-        private readonly IStateService _stateService;
-
         private const string KeyName = "com.8bit.bitwarden.biometric_integrity";
 
         private const string KeyStoreName = "AndroidKeyStore";
@@ -24,14 +23,14 @@ namespace Bit.Droid.Services
 
         private readonly KeyStore _keystore;
 
-        public BiometricService(IStateService stateService)
+        public BiometricService(IStateService stateService, ICryptoService cryptoService)
+            : base(stateService, cryptoService)
         {
-            _stateService = stateService;
             _keystore = KeyStore.GetInstance(KeyStoreName);
             _keystore.Load(null);
         }
 
-        public async Task<bool> SetupBiometricAsync(string bioIntegritySrcKey = null)
+        public override async Task<bool> SetupBiometricAsync(string bioIntegritySrcKey = null)
         {
             if (Build.VERSION.SdkInt >= BuildVersionCodes.M)
             {
@@ -41,7 +40,7 @@ namespace Bit.Droid.Services
             return true;
         }
 
-        public async Task<bool> IsSystemBiometricIntegrityValidAsync(string bioIntegritySrcKey = null)
+        public override async Task<bool> IsSystemBiometricIntegrityValidAsync(string bioIntegritySrcKey = null)
         {
             if (Build.VERSION.SdkInt < BuildVersionCodes.M)
             {

--- a/src/App/Pages/Accounts/LockPage.xaml
+++ b/src/App/Pages/Accounts/LockPage.xaml
@@ -46,7 +46,7 @@
                     <StackLayout StyleClass="box">
                         <Grid
                             StyleClass="box-row"
-                            IsVisible="{Binding PinLock}"
+                            IsVisible="{Binding PinEnabled}"
                             Padding="0, 10, 0, 0">
                             <Grid.RowDefinitions>
                                 <RowDefinition Height="Auto" />
@@ -89,7 +89,7 @@
                         <Grid
                             x:Name="_passwordGrid"
                             StyleClass="box-row"
-                            IsVisible="{Binding PinLock, Converter={StaticResource inverseBool}}"
+                            IsVisible="{Binding PinEnabled, Converter={StaticResource inverseBool}}"
                             Padding="0, 10, 0, 0">
                             <Grid.RowDefinitions>
                                 <RowDefinition Height="Auto" />

--- a/src/App/Pages/Accounts/LockPage.xaml.cs
+++ b/src/App/Pages/Accounts/LockPage.xaml.cs
@@ -44,7 +44,7 @@ namespace Bit.App.Pages
         {
             get
             {
-                if (_vm?.PinLock ?? false)
+                if (_vm?.PinEnabled ?? false)
                 {
                     return _pin;
                 }
@@ -54,7 +54,7 @@ namespace Bit.App.Pages
 
         public async Task PromptBiometricAfterResumeAsync()
         {
-            if (_vm.BiometricLock)
+            if (_vm.BiometricEnabled)
             {
                 await Task.Delay(500);
                 if (!_promptedAfterResume)
@@ -91,13 +91,13 @@ namespace Bit.App.Pages
 
             _vm.FocusSecretEntry += PerformFocusSecretEntry;
 
-            if (!_vm.BiometricLock)
+            if (!_vm.BiometricEnabled)
             {
                 RequestFocus(SecretEntry);
             }
             else
             {
-                if (_vm.UsingKeyConnector && !_vm.PinLock)
+                if (_vm.UsingKeyConnector && !_vm.PinEnabled)
                 {
                     _passwordGrid.IsVisible = false;
                     _unlockButton.IsVisible = false;

--- a/src/App/Pages/Accounts/LockPageViewModel.cs
+++ b/src/App/Pages/Accounts/LockPageViewModel.cs
@@ -319,20 +319,20 @@ namespace Bit.App.Pages
             else
             {
                 var masterKey = await _cryptoService.MakeMasterKeyAsync(MasterPassword, _email, kdfConfig);
-                var storedKeyHash = await _cryptoService.GetPasswordHashAsync();
+                var storedKeyHash = await _cryptoService.GetMasterKeyHashAsync();
                 var passwordValid = false;
                 MasterPasswordPolicyOptions enforcedMasterPasswordOptions = null;
 
                 if (storedKeyHash != null)
                 {
                     // Offline unlock possible
-                    passwordValid = await _cryptoService.CompareAndUpdatePasswordHashAsync(MasterPassword, masterKey);
+                    passwordValid = await _cryptoService.CompareAndUpdateKeyHashAsync(MasterPassword, masterKey);
                 }
                 else
                 {
                     // Online unlock required
                     await _deviceActionService.ShowLoadingAsync(AppResources.Loading);
-                    var keyHash = await _cryptoService.HashPasswordAsync(MasterPassword, masterKey, HashPurpose.ServerAuthorization);
+                    var keyHash = await _cryptoService.HashMasterKeyAsync(MasterPassword, masterKey, HashPurpose.ServerAuthorization);
                     var request = new PasswordVerificationRequest();
                     request.MasterPasswordHash = keyHash;
 
@@ -341,8 +341,8 @@ namespace Bit.App.Pages
                         var response = await _apiService.PostAccountVerifyPasswordAsync(request);
                         enforcedMasterPasswordOptions = response.MasterPasswordPolicy;
                         passwordValid = true;
-                        var localKeyHash = await _cryptoService.HashPasswordAsync(MasterPassword, masterKey, HashPurpose.LocalAuthorization);
-                        await _cryptoService.SetPasswordHashAsync(localKeyHash);
+                        var localKeyHash = await _cryptoService.HashMasterKeyAsync(MasterPassword, masterKey, HashPurpose.LocalAuthorization);
+                        await _cryptoService.SetMasterKeyHashAsync(localKeyHash);
                     }
                     catch (Exception e)
                     {

--- a/src/App/Pages/Accounts/LockPageViewModel.cs
+++ b/src/App/Pages/Accounts/LockPageViewModel.cs
@@ -38,16 +38,15 @@ namespace Bit.App.Pages
         private string _masterPassword;
         private string _pin;
         private bool _showPassword;
-        private bool _pinLock;
-        private bool _biometricLock;
+        private PinLockEnum _pinStatus;
+        private bool _pinEnabled;
+        private bool _biometricEnabled;
         private bool _biometricIntegrityValid = true;
         private bool _biometricButtonVisible;
         private bool _usingKeyConnector;
         private string _biometricButtonText;
         private string _loggedInAsText;
         private string _lockedVerifyText;
-        private bool _isPinProtected;
-        private bool _isPinProtectedWithKey;
 
         public LockPageViewModel()
         {
@@ -100,10 +99,10 @@ namespace Bit.App.Pages
                 });
         }
 
-        public bool PinLock
+        public bool PinEnabled
         {
-            get => _pinLock;
-            set => SetProperty(ref _pinLock, value);
+            get => _pinEnabled;
+            set => SetProperty(ref _pinEnabled, value);
         }
 
         public bool UsingKeyConnector
@@ -111,10 +110,10 @@ namespace Bit.App.Pages
             get => _usingKeyConnector;
         }
 
-        public bool BiometricLock
+        public bool BiometricEnabled
         {
-            get => _biometricLock;
-            set => SetProperty(ref _biometricLock, value);
+            get => _biometricEnabled;
+            set => SetProperty(ref _biometricEnabled, value);
         }
 
         public bool BiometricIntegrityValid
@@ -162,14 +161,18 @@ namespace Bit.App.Pages
 
         public async Task InitAsync()
         {
-            (_isPinProtected, _isPinProtectedWithKey) = await _vaultTimeoutService.IsPinLockSetAsync();
-            PinLock = (_isPinProtected && await _stateService.GetPinProtectedKeyAsync() != null) ||
-                      _isPinProtectedWithKey;
-            BiometricLock = await _vaultTimeoutService.IsBiometricLockSetAsync() && await _cryptoService.HasKeyAsync();
+            _pinStatus = await _vaultTimeoutService.IsPinLockSetAsync();
+
+            var ephemeralPinSet = await _stateService.GetUserKeyPinEphemeralAsync()
+                ?? await _stateService.GetPinProtectedKeyAsync();
+            PinEnabled = (_pinStatus == PinLockEnum.Transient && ephemeralPinSet != null) ||
+                      _pinStatus == PinLockEnum.Persistent;
+
+            BiometricEnabled = await _vaultTimeoutService.IsBiometricLockSetAsync() && await _cryptoService.HasEncryptedUserKeyAsync();
 
             // Users with key connector and without biometric or pin has no MP to unlock with
             _usingKeyConnector = await _keyConnectorService.GetUsesKeyConnector();
-            if (_usingKeyConnector && !(BiometricLock || PinLock))
+            if (_usingKeyConnector && !(BiometricEnabled || PinEnabled))
             {
                 await _vaultTimeoutService.LogOutAsync();
                 return;
@@ -188,7 +191,7 @@ namespace Bit.App.Pages
             }
             var webVaultHostname = CoreHelpers.GetHostname(webVault);
             LoggedInAsText = string.Format(AppResources.LoggedInAsOn, _email, webVaultHostname);
-            if (PinLock)
+            if (PinEnabled)
             {
                 PageTitle = AppResources.VerifyPIN;
                 LockedVerifyText = AppResources.VaultLockedPIN;
@@ -207,7 +210,7 @@ namespace Bit.App.Pages
                 }
             }
 
-            if (BiometricLock)
+            if (BiometricEnabled)
             {
                 BiometricIntegrityValid = await _platformUtilsService.IsBiometricIntegrityValidAsync();
                 if (!_biometricIntegrityValid)
@@ -229,14 +232,14 @@ namespace Bit.App.Pages
 
         public async Task SubmitAsync()
         {
-            if (PinLock && string.IsNullOrWhiteSpace(Pin))
+            if (PinEnabled && string.IsNullOrWhiteSpace(Pin))
             {
                 await Page.DisplayAlert(AppResources.AnErrorHasOccurred,
                     string.Format(AppResources.ValidationFieldRequired, AppResources.PIN),
                     AppResources.Ok);
                 return;
             }
-            if (!PinLock && string.IsNullOrWhiteSpace(MasterPassword))
+            if (!PinEnabled && string.IsNullOrWhiteSpace(MasterPassword))
             {
                 await Page.DisplayAlert(AppResources.AnErrorHasOccurred,
                     string.Format(AppResources.ValidationFieldRequired, AppResources.MasterPassword),
@@ -247,34 +250,54 @@ namespace Bit.App.Pages
             ShowPassword = false;
             var kdfConfig = await _stateService.GetActiveUserCustomDataAsync(a => new KdfConfig(a?.Profile));
 
-            if (PinLock)
+            if (PinEnabled)
             {
                 var failed = true;
                 try
                 {
-                    if (_isPinProtected)
+                    EncString userKeyPin = null;
+                    EncString oldPinProtected = null;
+                    if (_pinStatus == PinLockEnum.Persistent)
                     {
-                        var key = await _cryptoService.MakeKeyFromPinAsync(Pin, _email,
+                        userKeyPin = await _stateService.GetUserKeyPinAsync();
+                        var oldEncryptedKey = await _stateService.GetPinProtectedAsync();
+                        oldPinProtected = oldEncryptedKey != null ? new EncString(oldEncryptedKey) : null;
+                    }
+                    else if (_pinStatus == PinLockEnum.Transient)
+                    {
+                        userKeyPin = await _stateService.GetUserKeyPinEphemeralAsync();
+                        oldPinProtected = await _stateService.GetPinProtectedKeyAsync();
+                    }
+
+                    UserKey userKey;
+                    if (oldPinProtected != null)
+                    {
+                        userKey = await _cryptoService.DecryptAndMigrateOldPinKeyAsync(
+                            _pinStatus == PinLockEnum.Transient,
+                            Pin,
+                            _email,
                             kdfConfig,
-                            await _stateService.GetPinProtectedKeyAsync());
-                        var encKey = await _cryptoService.GetEncKeyAsync(key);
-                        var protectedPin = await _stateService.GetProtectedPinAsync();
-                        var decPin = await _cryptoService.DecryptToUtf8Async(new EncString(protectedPin), encKey);
-                        failed = decPin != Pin;
-                        if (!failed)
-                        {
-                            Pin = string.Empty;
-                            await AppHelpers.ResetInvalidUnlockAttemptsAsync();
-                            await SetKeyAndContinueAsync(key);
-                        }
+                            oldPinProtected
+                        );
                     }
                     else
                     {
-                        var key = await _cryptoService.MakeKeyFromPinAsync(Pin, _email, kdfConfig);
-                        failed = false;
+                        userKey = await _cryptoService.DecryptUserKeyWithPinAsync(
+                            Pin,
+                            _email,
+                            kdfConfig,
+                            userKeyPin
+                        );
+                    }
+
+                    var protectedPin = await _stateService.GetProtectedPinAsync();
+                    var decryptedPin = await _cryptoService.DecryptToUtf8Async(new EncString(protectedPin), userKey);
+                    failed = decryptedPin != Pin;
+                    if (!failed)
+                    {
                         Pin = string.Empty;
                         await AppHelpers.ResetInvalidUnlockAttemptsAsync();
-                        await SetKeyAndContinueAsync(key);
+                        await SetKeyAndContinueAsync(userKey);
                     }
                 }
                 catch
@@ -302,10 +325,12 @@ namespace Bit.App.Pages
 
                 if (storedKeyHash != null)
                 {
+                    // Offline unlock possible
                     passwordValid = await _cryptoService.CompareAndUpdatePasswordHashAsync(MasterPassword, masterKey);
                 }
                 else
                 {
+                    // Online unlock required
                     await _deviceActionService.ShowLoadingAsync(AppResources.Loading);
                     var keyHash = await _cryptoService.HashPasswordAsync(MasterPassword, masterKey, HashPurpose.ServerAuthorization);
                     var request = new PasswordVerificationRequest();
@@ -327,16 +352,6 @@ namespace Bit.App.Pages
                 }
                 if (passwordValid)
                 {
-                    // TODO(Jake): Update this to use new PinKeyEphemeral
-                    if (_isPinProtected)
-                    {
-                        var protectedPin = await _stateService.GetProtectedPinAsync();
-                        var encKey = await _cryptoService.GetEncKeyAsync(masterKey);
-                        var decPin = await _cryptoService.DecryptToUtf8Async(new EncString(protectedPin), encKey);
-                        var pinKey = await _cryptoService.MakePinKeyAsync(decPin, _email, kdfConfig);
-                        await _stateService.SetPinProtectedKeyAsync(await _cryptoService.EncryptAsync(masterKey.Key, pinKey));
-                    }
-
                     if (await RequirePasswordChangeAsync(enforcedMasterPasswordOptions))
                     {
                         // Save the ForcePasswordResetReason to force a password reset after unlock
@@ -346,10 +361,13 @@ namespace Bit.App.Pages
 
                     MasterPassword = string.Empty;
                     await AppHelpers.ResetInvalidUnlockAttemptsAsync();
-                    await SetKeyAndContinueAsync(masterKey);
+
+                    var userKey = await _cryptoService.DecryptUserKeyWithMasterKeyAsync(masterKey);
+                    await _cryptoService.SetMasterKeyAsync(masterKey);
+                    await SetKeyAndContinueAsync(userKey);
 
                     // Re-enable biometrics
-                    if (BiometricLock & !BiometricIntegrityValid)
+                    if (BiometricEnabled & !BiometricIntegrityValid)
                     {
                         await _biometricService.SetupBiometricAsync();
                     }
@@ -426,7 +444,7 @@ namespace Bit.App.Pages
         public void TogglePassword()
         {
             ShowPassword = !ShowPassword;
-            var secret = PinLock ? Pin : MasterPassword;
+            var secret = PinEnabled ? Pin : MasterPassword;
             _secretEntryFocusWeakEventManager.RaiseEvent(string.IsNullOrEmpty(secret) ? 0 : secret.Length, nameof(FocusSecretEntry));
         }
 
@@ -434,12 +452,12 @@ namespace Bit.App.Pages
         {
             BiometricIntegrityValid = await _platformUtilsService.IsBiometricIntegrityValidAsync();
             BiometricButtonVisible = BiometricIntegrityValid;
-            if (!BiometricLock || !BiometricIntegrityValid)
+            if (!BiometricEnabled || !BiometricIntegrityValid)
             {
                 return;
             }
             var success = await _platformUtilsService.AuthenticateBiometricAsync(null,
-                PinLock ? AppResources.PIN : AppResources.MasterPassword,
+                PinEnabled ? AppResources.PIN : AppResources.MasterPassword,
                 () => _secretEntryFocusWeakEventManager.RaiseEvent((int?)null, nameof(FocusSecretEntry)));
             await _stateService.SetBiometricLockedAsync(!success);
             if (success)
@@ -448,7 +466,6 @@ namespace Bit.App.Pages
             }
         }
 
-        // TODO(Jake): Update to store UserKey
         private async Task SetKeyAndContinueAsync(UserKey key)
         {
             var hasKey = await _cryptoService.HasUserKeyAsync();

--- a/src/App/Pages/Accounts/LockPageViewModel.cs
+++ b/src/App/Pages/Accounts/LockPageViewModel.cs
@@ -462,7 +462,7 @@ namespace Bit.App.Pages
             await _stateService.SetBiometricLockedAsync(!success);
             if (success)
             {
-                var userKey = await _stateService.GetUserKeyBiometricUnlockAsync();
+                var userKey = await _cryptoService.GetBiometricUnlockKeyAsync();
                 await SetUserKeyAndContinueAsync(userKey);
             }
         }

--- a/src/App/Pages/Accounts/LockPageViewModel.cs
+++ b/src/App/Pages/Accounts/LockPageViewModel.cs
@@ -163,7 +163,7 @@ namespace Bit.App.Pages
         {
             _pinStatus = await _vaultTimeoutService.GetPinLockTypeAsync();
 
-            var ephemeralPinSet = await _stateService.GetUserKeyPinEphemeralAsync()
+            var ephemeralPinSet = await _stateService.GetPinKeyEncryptedUserKeyEphemeralAsync()
                 ?? await _stateService.GetPinProtectedKeyAsync();
             PinEnabled = (_pinStatus == PinLockType.Transient && ephemeralPinSet != null) ||
                       _pinStatus == PinLockType.Persistent;
@@ -259,13 +259,13 @@ namespace Bit.App.Pages
                     EncString oldPinProtected = null;
                     if (_pinStatus == PinLockType.Persistent)
                     {
-                        userKeyPin = await _stateService.GetUserKeyPinAsync();
+                        userKeyPin = await _stateService.GetPinKeyEncryptedUserKeyAsync();
                         var oldEncryptedKey = await _stateService.GetPinProtectedAsync();
                         oldPinProtected = oldEncryptedKey != null ? new EncString(oldEncryptedKey) : null;
                     }
                     else if (_pinStatus == PinLockType.Transient)
                     {
-                        userKeyPin = await _stateService.GetUserKeyPinEphemeralAsync();
+                        userKeyPin = await _stateService.GetPinKeyEncryptedUserKeyEphemeralAsync();
                         oldPinProtected = await _stateService.GetPinProtectedKeyAsync();
                     }
 

--- a/src/App/Pages/Accounts/LockPageViewModel.cs
+++ b/src/App/Pages/Accounts/LockPageViewModel.cs
@@ -171,7 +171,7 @@ namespace Bit.App.Pages
             BiometricEnabled = await _vaultTimeoutService.IsBiometricLockSetAsync() && await _cryptoService.HasEncryptedUserKeyAsync();
 
             // Users with key connector and without biometric or pin has no MP to unlock with
-            _usingKeyConnector = await _keyConnectorService.GetUsesKeyConnector();
+            _usingKeyConnector = await _keyConnectorService.GetUsesKeyConnectorAsync();
             if (_usingKeyConnector && !(BiometricEnabled || PinEnabled))
             {
                 await _vaultTimeoutService.LogOutAsync();

--- a/src/App/Pages/Accounts/LockPageViewModel.cs
+++ b/src/App/Pages/Accounts/LockPageViewModel.cs
@@ -168,7 +168,7 @@ namespace Bit.App.Pages
             PinEnabled = (_pinStatus == PinLockType.Transient && ephemeralPinSet != null) ||
                       _pinStatus == PinLockType.Persistent;
 
-            BiometricEnabled = await _vaultTimeoutService.IsBiometricLockSetAsync() && await _cryptoService.HasEncryptedUserKeyAsync();
+            BiometricEnabled = await _vaultTimeoutService.IsBiometricLockSetAsync() && await _biometricService.CanUseBiometricsUnlockAsync();
 
             // Users with key connector and without biometric or pin has no MP to unlock with
             _usingKeyConnector = await _keyConnectorService.GetUsesKeyConnectorAsync();

--- a/src/App/Pages/Accounts/LockPageViewModel.cs
+++ b/src/App/Pages/Accounts/LockPageViewModel.cs
@@ -161,7 +161,7 @@ namespace Bit.App.Pages
 
         public async Task InitAsync()
         {
-            _pinStatus = await _vaultTimeoutService.IsPinLockSetAsync();
+            _pinStatus = await _vaultTimeoutService.GetPinLockTypeAsync();
 
             var ephemeralPinSet = await _stateService.GetUserKeyPinEphemeralAsync()
                 ?? await _stateService.GetPinProtectedKeyAsync();

--- a/src/App/Pages/Accounts/LockPageViewModel.cs
+++ b/src/App/Pages/Accounts/LockPageViewModel.cs
@@ -297,7 +297,7 @@ namespace Bit.App.Pages
                     {
                         Pin = string.Empty;
                         await AppHelpers.ResetInvalidUnlockAttemptsAsync();
-                        await SetKeyAndContinueAsync(userKey);
+                        await SetUserKeyAndContinueAsync(userKey);
                     }
                 }
                 catch
@@ -364,7 +364,7 @@ namespace Bit.App.Pages
 
                     var userKey = await _cryptoService.DecryptUserKeyWithMasterKeyAsync(masterKey);
                     await _cryptoService.SetMasterKeyAsync(masterKey);
-                    await SetKeyAndContinueAsync(userKey);
+                    await SetUserKeyAndContinueAsync(userKey);
 
                     // Re-enable biometrics
                     if (BiometricEnabled & !BiometricIntegrityValid)
@@ -462,11 +462,12 @@ namespace Bit.App.Pages
             await _stateService.SetBiometricLockedAsync(!success);
             if (success)
             {
-                await DoContinueAsync();
+                var userKey = await _stateService.GetUserKeyBiometricUnlockAsync();
+                await SetUserKeyAndContinueAsync(userKey);
             }
         }
 
-        private async Task SetKeyAndContinueAsync(UserKey key)
+        private async Task SetUserKeyAndContinueAsync(UserKey key)
         {
             var hasKey = await _cryptoService.HasUserKeyAsync();
             if (!hasKey)

--- a/src/App/Pages/Accounts/LockPageViewModel.cs
+++ b/src/App/Pages/Accounts/LockPageViewModel.cs
@@ -332,7 +332,7 @@ namespace Bit.App.Pages
                         var protectedPin = await _stateService.GetProtectedPinAsync();
                         var encKey = await _cryptoService.GetEncKeyAsync(key);
                         var decPin = await _cryptoService.DecryptToUtf8Async(new EncString(protectedPin), encKey);
-                        var pinKey = await _cryptoService.MakePinKeyAysnc(decPin, _email, kdfConfig);
+                        var pinKey = await _cryptoService.MakePinKeyAsync(decPin, _email, kdfConfig);
                         await _stateService.SetPinProtectedKeyAsync(await _cryptoService.EncryptAsync(key.Key, pinKey));
                     }
 

--- a/src/App/Pages/Accounts/LockPageViewModel.cs
+++ b/src/App/Pages/Accounts/LockPageViewModel.cs
@@ -449,12 +449,12 @@ namespace Bit.App.Pages
         }
 
         // TODO(Jake): Update to store UserKey
-        private async Task SetKeyAndContinueAsync(SymmetricCryptoKey key)
+        private async Task SetKeyAndContinueAsync(UserKey key)
         {
-            var hasKey = await _cryptoService.HasKeyAsync();
+            var hasKey = await _cryptoService.HasUserKeyAsync();
             if (!hasKey)
             {
-                await _cryptoService.SetKeyAsync(key);
+                await _cryptoService.SetUserKeyAsync(key);
             }
             await DoContinueAsync();
         }

--- a/src/App/Pages/Accounts/LockPageViewModel.cs
+++ b/src/App/Pages/Accounts/LockPageViewModel.cs
@@ -296,13 +296,13 @@ namespace Bit.App.Pages
             else
             {
                 var key = await _cryptoService.MakeKeyAsync(MasterPassword, _email, kdfConfig);
-                var storedKeyHash = await _cryptoService.GetKeyHashAsync();
+                var storedKeyHash = await _cryptoService.GetPasswordHashAsync();
                 var passwordValid = false;
                 MasterPasswordPolicyOptions enforcedMasterPasswordOptions = null;
 
                 if (storedKeyHash != null)
                 {
-                    passwordValid = await _cryptoService.CompareAndUpdateKeyHashAsync(MasterPassword, key);
+                    passwordValid = await _cryptoService.CompareAndUpdatePasswordHashAsync(MasterPassword, key);
                 }
                 else
                 {
@@ -317,7 +317,7 @@ namespace Bit.App.Pages
                         enforcedMasterPasswordOptions = response.MasterPasswordPolicy;
                         passwordValid = true;
                         var localKeyHash = await _cryptoService.HashPasswordAsync(MasterPassword, key, HashPurpose.LocalAuthorization);
-                        await _cryptoService.SetKeyHashAsync(localKeyHash);
+                        await _cryptoService.SetPasswordHashAsync(localKeyHash);
                     }
                     catch (Exception e)
                     {

--- a/src/App/Pages/Accounts/LockPageViewModel.cs
+++ b/src/App/Pages/Accounts/LockPageViewModel.cs
@@ -38,7 +38,7 @@ namespace Bit.App.Pages
         private string _masterPassword;
         private string _pin;
         private bool _showPassword;
-        private PinLockEnum _pinStatus;
+        private PinLockType _pinStatus;
         private bool _pinEnabled;
         private bool _biometricEnabled;
         private bool _biometricIntegrityValid = true;
@@ -165,8 +165,8 @@ namespace Bit.App.Pages
 
             var ephemeralPinSet = await _stateService.GetUserKeyPinEphemeralAsync()
                 ?? await _stateService.GetPinProtectedKeyAsync();
-            PinEnabled = (_pinStatus == PinLockEnum.Transient && ephemeralPinSet != null) ||
-                      _pinStatus == PinLockEnum.Persistent;
+            PinEnabled = (_pinStatus == PinLockType.Transient && ephemeralPinSet != null) ||
+                      _pinStatus == PinLockType.Persistent;
 
             BiometricEnabled = await _vaultTimeoutService.IsBiometricLockSetAsync() && await _cryptoService.HasEncryptedUserKeyAsync();
 
@@ -257,13 +257,13 @@ namespace Bit.App.Pages
                 {
                     EncString userKeyPin = null;
                     EncString oldPinProtected = null;
-                    if (_pinStatus == PinLockEnum.Persistent)
+                    if (_pinStatus == PinLockType.Persistent)
                     {
                         userKeyPin = await _stateService.GetUserKeyPinAsync();
                         var oldEncryptedKey = await _stateService.GetPinProtectedAsync();
                         oldPinProtected = oldEncryptedKey != null ? new EncString(oldEncryptedKey) : null;
                     }
-                    else if (_pinStatus == PinLockEnum.Transient)
+                    else if (_pinStatus == PinLockType.Transient)
                     {
                         userKeyPin = await _stateService.GetUserKeyPinEphemeralAsync();
                         oldPinProtected = await _stateService.GetPinProtectedKeyAsync();
@@ -273,7 +273,7 @@ namespace Bit.App.Pages
                     if (oldPinProtected != null)
                     {
                         userKey = await _cryptoService.DecryptAndMigrateOldPinKeyAsync(
-                            _pinStatus == PinLockEnum.Transient,
+                            _pinStatus == PinLockType.Transient,
                             Pin,
                             _email,
                             kdfConfig,

--- a/src/App/Pages/Accounts/RegisterPageViewModel.cs
+++ b/src/App/Pages/Accounts/RegisterPageViewModel.cs
@@ -177,25 +177,28 @@ namespace Bit.App.Pages
             Name = string.IsNullOrWhiteSpace(Name) ? null : Name;
             Email = Email.Trim().ToLower();
             var kdfConfig = new KdfConfig(KdfType.PBKDF2_SHA256, Constants.Pbkdf2Iterations, null, null);
-            var masterKey = await _cryptoService.MakeMasterKeyAsync(MasterPassword, Email, kdfConfig);
-            var encKey = await _cryptoService.MakeEncKeyAsync(masterKey);
-            var hashedPassword = await _cryptoService.HashPasswordAsync(MasterPassword, masterKey);
-            var keys = await _cryptoService.MakeKeyPairAsync(encKey.Item1);
+            var newMasterKey = await _cryptoService.MakeMasterKeyAsync(MasterPassword, Email, kdfConfig);
+            var (newUserKey, newProtectedUserKey) = await _cryptoService.EncryptUserKeyWithMasterKeyAsync(
+                newMasterKey,
+                await _cryptoService.MakeUserKeyAsync()
+            );
+            var hashedPassword = await _cryptoService.HashPasswordAsync(MasterPassword, newMasterKey);
+            var (newPublicKey, newProtectedPrivateKey) = await _cryptoService.MakeKeyPairAsync(newUserKey);
             var request = new RegisterRequest
             {
                 Email = Email,
                 Name = Name,
                 MasterPasswordHash = hashedPassword,
                 MasterPasswordHint = Hint,
-                Key = encKey.Item2.EncryptedString,
+                Key = newProtectedUserKey.EncryptedString,
                 Kdf = kdfConfig.Type,
                 KdfIterations = kdfConfig.Iterations,
                 KdfMemory = kdfConfig.Memory,
                 KdfParallelism = kdfConfig.Parallelism,
                 Keys = new KeysRequest
                 {
-                    PublicKey = keys.Item1,
-                    EncryptedPrivateKey = keys.Item2.EncryptedString
+                    PublicKey = newPublicKey,
+                    EncryptedPrivateKey = newProtectedPrivateKey.EncryptedString
                 },
                 CaptchaResponse = _captchaToken,
             };

--- a/src/App/Pages/Accounts/RegisterPageViewModel.cs
+++ b/src/App/Pages/Accounts/RegisterPageViewModel.cs
@@ -178,10 +178,7 @@ namespace Bit.App.Pages
             Email = Email.Trim().ToLower();
             var kdfConfig = new KdfConfig(KdfType.PBKDF2_SHA256, Constants.Pbkdf2Iterations, null, null);
             var newMasterKey = await _cryptoService.MakeMasterKeyAsync(MasterPassword, Email, kdfConfig);
-            var (newUserKey, newProtectedUserKey) = await _cryptoService.EncryptUserKeyWithMasterKeyAsync(
-                newMasterKey,
-                await _cryptoService.MakeUserKeyAsync()
-            );
+            var (newUserKey, newProtectedUserKey) = await _cryptoService.EncryptUserKeyWithMasterKeyAsync(newMasterKey);
             var hashedPassword = await _cryptoService.HashMasterKeyAsync(MasterPassword, newMasterKey);
             var (newPublicKey, newProtectedPrivateKey) = await _cryptoService.MakeKeyPairAsync(newUserKey);
             var request = new RegisterRequest

--- a/src/App/Pages/Accounts/RegisterPageViewModel.cs
+++ b/src/App/Pages/Accounts/RegisterPageViewModel.cs
@@ -182,7 +182,7 @@ namespace Bit.App.Pages
                 newMasterKey,
                 await _cryptoService.MakeUserKeyAsync()
             );
-            var hashedPassword = await _cryptoService.HashPasswordAsync(MasterPassword, newMasterKey);
+            var hashedPassword = await _cryptoService.HashMasterKeyAsync(MasterPassword, newMasterKey);
             var (newPublicKey, newProtectedPrivateKey) = await _cryptoService.MakeKeyPairAsync(newUserKey);
             var request = new RegisterRequest
             {

--- a/src/App/Pages/Accounts/RegisterPageViewModel.cs
+++ b/src/App/Pages/Accounts/RegisterPageViewModel.cs
@@ -177,9 +177,9 @@ namespace Bit.App.Pages
             Name = string.IsNullOrWhiteSpace(Name) ? null : Name;
             Email = Email.Trim().ToLower();
             var kdfConfig = new KdfConfig(KdfType.PBKDF2_SHA256, Constants.Pbkdf2Iterations, null, null);
-            var key = await _cryptoService.MakeKeyAsync(MasterPassword, Email, kdfConfig);
-            var encKey = await _cryptoService.MakeEncKeyAsync(key);
-            var hashedPassword = await _cryptoService.HashPasswordAsync(MasterPassword, key);
+            var masterKey = await _cryptoService.MakeMasterKeyAsync(MasterPassword, Email, kdfConfig);
+            var encKey = await _cryptoService.MakeEncKeyAsync(masterKey);
+            var hashedPassword = await _cryptoService.HashPasswordAsync(MasterPassword, masterKey);
             var keys = await _cryptoService.MakeKeyPairAsync(encKey.Item1);
             var request = new RegisterRequest
             {

--- a/src/App/Pages/Accounts/RemoveMasterPasswordPageViewModel.cs
+++ b/src/App/Pages/Accounts/RemoveMasterPasswordPageViewModel.cs
@@ -30,14 +30,14 @@ namespace Bit.App.Pages
 
         public async Task Init()
         {
-            Organization = await _keyConnectorService.GetManagingOrganization();
+            Organization = await _keyConnectorService.GetManagingOrganizationAsync();
         }
 
         public async Task MigrateAccount()
         {
             await _deviceActionService.ShowLoadingAsync(AppResources.Loading);
 
-            await _keyConnectorService.MigrateUser();
+            await _keyConnectorService.MigrateUserAsync();
             await _syncService.FullSyncAsync(true);
 
             await _deviceActionService.HideLoadingAsync();

--- a/src/App/Pages/Accounts/SetPasswordPageViewModel.cs
+++ b/src/App/Pages/Accounts/SetPasswordPageViewModel.cs
@@ -206,9 +206,9 @@ namespace Bit.App.Pages
                     // Grab Organization Keys
                     var response = await _apiService.GetOrganizationKeysAsync(OrgId);
                     var publicKey = CoreHelpers.Base64UrlDecode(response.PublicKey);
-                    // Grab user's Encryption Key and encrypt with Org Public Key
-                    var userEncKey = await _cryptoService.GetEncKeyAsync();
-                    var encryptedKey = await _cryptoService.RsaEncryptAsync(userEncKey.Key, publicKey);
+                    // Grab User Key and encrypt with Org Public Key
+                    var userKey = await _cryptoService.GetUserKeyAsync();
+                    var encryptedKey = await _cryptoService.RsaEncryptAsync(userKey.Key, publicKey);
                     // Request
                     var resetRequest = new OrganizationUserResetPasswordEnrollmentRequest
                     {

--- a/src/App/Pages/Accounts/SetPasswordPageViewModel.cs
+++ b/src/App/Pages/Accounts/SetPasswordPageViewModel.cs
@@ -199,7 +199,7 @@ namespace Bit.App.Pages
                 await _cryptoService.SetMasterKeyAsync(newMasterKey);
                 await _cryptoService.SetMasterKeyHashAsync(localMasterPasswordHash);
                 await _cryptoService.SetMasterKeyEncryptedUserKeyAsync(newProtectedUserKey.EncryptedString);
-                await _cryptoService.SetPrivateKeyAsync(newProtectedPrivateKey.EncryptedString);
+                await _cryptoService.SetUserPrivateKeyAsync(newProtectedPrivateKey.EncryptedString);
 
                 if (ResetPasswordAutoEnroll)
                 {

--- a/src/App/Pages/Accounts/SetPasswordPageViewModel.cs
+++ b/src/App/Pages/Accounts/SetPasswordPageViewModel.cs
@@ -166,8 +166,8 @@ namespace Bit.App.Pages
             var kdfConfig = new KdfConfig(KdfType.PBKDF2_SHA256, Constants.Pbkdf2Iterations, null, null);
             var email = await _stateService.GetEmailAsync();
             var newMasterKey = await _cryptoService.MakeMasterKeyAsync(MasterPassword, email, kdfConfig);
-            var masterPasswordHash = await _cryptoService.HashPasswordAsync(MasterPassword, newMasterKey, HashPurpose.ServerAuthorization);
-            var localMasterPasswordHash = await _cryptoService.HashPasswordAsync(MasterPassword, newMasterKey, HashPurpose.LocalAuthorization);
+            var masterPasswordHash = await _cryptoService.HashMasterKeyAsync(MasterPassword, newMasterKey, HashPurpose.ServerAuthorization);
+            var localMasterPasswordHash = await _cryptoService.HashMasterKeyAsync(MasterPassword, newMasterKey, HashPurpose.LocalAuthorization);
 
             var (newUserKey, newProtectedUserKey) = await _cryptoService.EncryptUserKeyWithMasterKeyAsync(newMasterKey,
                 await _cryptoService.GetUserKeyAsync() ?? await _cryptoService.MakeUserKeyAsync());
@@ -197,7 +197,7 @@ namespace Bit.App.Pages
                 await _apiService.SetPasswordAsync(request);
                 await _stateService.SetKdfConfigurationAsync(kdfConfig);
                 await _cryptoService.SetMasterKeyAsync(newMasterKey);
-                await _cryptoService.SetPasswordHashAsync(localMasterPasswordHash);
+                await _cryptoService.SetMasterKeyHashAsync(localMasterPasswordHash);
                 await _cryptoService.SetMasterKeyEncryptedUserKeyAsync(newProtectedUserKey.EncryptedString);
                 await _cryptoService.SetPrivateKeyAsync(keys.Item2.EncryptedString);
 

--- a/src/App/Pages/Accounts/SetPasswordPageViewModel.cs
+++ b/src/App/Pages/Accounts/SetPasswordPageViewModel.cs
@@ -207,7 +207,7 @@ namespace Bit.App.Pages
                 await _cryptoService.SetKeyAsync(key);
                 await _cryptoService.SetPasswordHashAsync(localMasterPasswordHash);
                 await _cryptoService.SetEncKeyAsync(encKey.Item2.EncryptedString);
-                await _cryptoService.SetEncPrivateKeyAsync(keys.Item2.EncryptedString);
+                await _cryptoService.SetPrivateKeyAsync(keys.Item2.EncryptedString);
 
                 if (ResetPasswordAutoEnroll)
                 {

--- a/src/App/Pages/Accounts/SetPasswordPageViewModel.cs
+++ b/src/App/Pages/Accounts/SetPasswordPageViewModel.cs
@@ -195,6 +195,7 @@ namespace Bit.App.Pages
                 // Set Password and relevant information
                 await _apiService.SetPasswordAsync(request);
                 await _stateService.SetKdfConfigurationAsync(kdfConfig);
+                await _cryptoService.SetUserKeyAsync(newUserKey);
                 await _cryptoService.SetMasterKeyAsync(newMasterKey);
                 await _cryptoService.SetMasterKeyHashAsync(localMasterPasswordHash);
                 await _cryptoService.SetMasterKeyEncryptedUserKeyAsync(newProtectedUserKey.EncryptedString);

--- a/src/App/Pages/Accounts/SetPasswordPageViewModel.cs
+++ b/src/App/Pages/Accounts/SetPasswordPageViewModel.cs
@@ -169,8 +169,7 @@ namespace Bit.App.Pages
             var masterPasswordHash = await _cryptoService.HashMasterKeyAsync(MasterPassword, newMasterKey, HashPurpose.ServerAuthorization);
             var localMasterPasswordHash = await _cryptoService.HashMasterKeyAsync(MasterPassword, newMasterKey, HashPurpose.LocalAuthorization);
 
-            var (newUserKey, newProtectedUserKey) = await _cryptoService.EncryptUserKeyWithMasterKeyAsync(newMasterKey,
-                await _cryptoService.GetUserKeyAsync() ?? await _cryptoService.MakeUserKeyAsync());
+            var (newUserKey, newProtectedUserKey) = await _cryptoService.EncryptUserKeyWithMasterKeyAsync(newMasterKey);
 
             var (newPublicKey, newProtectedPrivateKey) = await _cryptoService.MakeKeyPairAsync(newUserKey);
             var request = new SetPasswordRequest

--- a/src/App/Pages/Accounts/SetPasswordPageViewModel.cs
+++ b/src/App/Pages/Accounts/SetPasswordPageViewModel.cs
@@ -205,7 +205,7 @@ namespace Bit.App.Pages
                 await _apiService.SetPasswordAsync(request);
                 await _stateService.SetKdfConfigurationAsync(kdfConfig);
                 await _cryptoService.SetKeyAsync(key);
-                await _cryptoService.SetKeyHashAsync(localMasterPasswordHash);
+                await _cryptoService.SetPasswordHashAsync(localMasterPasswordHash);
                 await _cryptoService.SetEncKeyAsync(encKey.Item2.EncryptedString);
                 await _cryptoService.SetEncPrivateKeyAsync(keys.Item2.EncryptedString);
 

--- a/src/App/Pages/Accounts/SetPasswordPageViewModel.cs
+++ b/src/App/Pages/Accounts/SetPasswordPageViewModel.cs
@@ -204,7 +204,7 @@ namespace Bit.App.Pages
                 // Set Password and relevant information
                 await _apiService.SetPasswordAsync(request);
                 await _stateService.SetKdfConfigurationAsync(kdfConfig);
-                await _cryptoService.SetKeyAsync(masterKey);
+                await _cryptoService.SetMasterKeyAsync(masterKey);
                 await _cryptoService.SetPasswordHashAsync(localMasterPasswordHash);
                 await _cryptoService.SetEncKeyAsync(encKey.Item2.EncryptedString);
                 await _cryptoService.SetPrivateKeyAsync(keys.Item2.EncryptedString);

--- a/src/App/Pages/Accounts/SetPasswordPageViewModel.cs
+++ b/src/App/Pages/Accounts/SetPasswordPageViewModel.cs
@@ -172,7 +172,7 @@ namespace Bit.App.Pages
             var (newUserKey, newProtectedUserKey) = await _cryptoService.EncryptUserKeyWithMasterKeyAsync(newMasterKey,
                 await _cryptoService.GetUserKeyAsync() ?? await _cryptoService.MakeUserKeyAsync());
 
-            var keys = await _cryptoService.MakeKeyPairAsync(newUserKey);
+            var (newPublicKey, newProtectedPrivateKey) = await _cryptoService.MakeKeyPairAsync(newUserKey);
             var request = new SetPasswordRequest
             {
                 MasterPasswordHash = masterPasswordHash,
@@ -185,8 +185,8 @@ namespace Bit.App.Pages
                 OrgIdentifier = OrgIdentifier,
                 Keys = new KeysRequest
                 {
-                    PublicKey = keys.Item1,
-                    EncryptedPrivateKey = keys.Item2.EncryptedString
+                    PublicKey = newPublicKey,
+                    EncryptedPrivateKey = newProtectedPrivateKey.EncryptedString
                 }
             };
 
@@ -199,7 +199,7 @@ namespace Bit.App.Pages
                 await _cryptoService.SetMasterKeyAsync(newMasterKey);
                 await _cryptoService.SetMasterKeyHashAsync(localMasterPasswordHash);
                 await _cryptoService.SetMasterKeyEncryptedUserKeyAsync(newProtectedUserKey.EncryptedString);
-                await _cryptoService.SetPrivateKeyAsync(keys.Item2.EncryptedString);
+                await _cryptoService.SetPrivateKeyAsync(newProtectedPrivateKey.EncryptedString);
 
                 if (ResetPasswordAutoEnroll)
                 {

--- a/src/App/Pages/Accounts/UpdateTempPasswordPageViewModel.cs
+++ b/src/App/Pages/Accounts/UpdateTempPasswordPageViewModel.cs
@@ -93,12 +93,12 @@ namespace Bit.App.Pages
             var kdfConfig = await _stateService.GetActiveUserCustomDataAsync(a => new KdfConfig(a?.Profile));
             var email = await _stateService.GetEmailAsync();
 
-            // Create new key and hash new password
-            var key = await _cryptoService.MakeKeyAsync(MasterPassword, email, kdfConfig);
-            var masterPasswordHash = await _cryptoService.HashPasswordAsync(MasterPassword, key);
+            // Create new master key and hash new password
+            var masterKey = await _cryptoService.MakeMasterKeyAsync(MasterPassword, email, kdfConfig);
+            var masterPasswordHash = await _cryptoService.HashPasswordAsync(MasterPassword, masterKey);
 
             // Create new encKey for the User
-            var newEncKey = await _cryptoService.RemakeEncKeyAsync(key);
+            var newEncKey = await _cryptoService.RemakeEncKeyAsync(masterKey);
 
             // Initiate API action
             try

--- a/src/App/Pages/Accounts/UpdateTempPasswordPageViewModel.cs
+++ b/src/App/Pages/Accounts/UpdateTempPasswordPageViewModel.cs
@@ -97,8 +97,8 @@ namespace Bit.App.Pages
             var masterKey = await _cryptoService.MakeMasterKeyAsync(MasterPassword, email, kdfConfig);
             var masterPasswordHash = await _cryptoService.HashPasswordAsync(MasterPassword, masterKey);
 
-            // Create new encKey for the User
-            var newEncKey = await _cryptoService.RemakeEncKeyAsync(masterKey);
+            // Encrypt user key with new master key
+            var (userKey, newProtectedUserKey) = await _cryptoService.EncryptUserKeyWithMasterKeyAsync(masterKey);
 
             // Initiate API action
             try
@@ -108,10 +108,10 @@ namespace Bit.App.Pages
                 switch (_reason)
                 {
                     case ForcePasswordResetReason.AdminForcePasswordReset:
-                        await UpdateTempPasswordAsync(masterPasswordHash, newEncKey.Item2.EncryptedString);
+                        await UpdateTempPasswordAsync(masterPasswordHash, newProtectedUserKey.EncryptedString);
                         break;
                     case ForcePasswordResetReason.WeakMasterPasswordOnLogin:
-                        await UpdatePasswordAsync(masterPasswordHash, newEncKey.Item2.EncryptedString);
+                        await UpdatePasswordAsync(masterPasswordHash, newProtectedUserKey.EncryptedString);
                         break;
                     default:
                         throw new ArgumentOutOfRangeException();

--- a/src/App/Pages/Accounts/UpdateTempPasswordPageViewModel.cs
+++ b/src/App/Pages/Accounts/UpdateTempPasswordPageViewModel.cs
@@ -95,7 +95,7 @@ namespace Bit.App.Pages
 
             // Create new master key and hash new password
             var masterKey = await _cryptoService.MakeMasterKeyAsync(MasterPassword, email, kdfConfig);
-            var masterPasswordHash = await _cryptoService.HashPasswordAsync(MasterPassword, masterKey);
+            var masterPasswordHash = await _cryptoService.HashMasterKeyAsync(MasterPassword, masterKey);
 
             // Encrypt user key with new master key
             var (userKey, newProtectedUserKey) = await _cryptoService.EncryptUserKeyWithMasterKeyAsync(masterKey);
@@ -155,7 +155,7 @@ namespace Bit.App.Pages
 
         private async Task UpdatePasswordAsync(string newMasterPasswordHash, string newEncKey)
         {
-            var currentPasswordHash = await _cryptoService.HashPasswordAsync(CurrentMasterPassword, null);
+            var currentPasswordHash = await _cryptoService.HashMasterKeyAsync(CurrentMasterPassword, null);
 
             var request = new PasswordRequest
             {

--- a/src/App/Pages/Settings/ExportVaultPageViewModel.cs
+++ b/src/App/Pages/Settings/ExportVaultPageViewModel.cs
@@ -67,7 +67,7 @@ namespace Bit.App.Pages
             _initialized = true;
             FileFormatSelectedIndex = FileFormatOptions.FindIndex(k => k.Key == "json");
             DisablePrivateVaultPolicyEnabled = await _policyService.PolicyAppliesToUser(PolicyType.DisablePersonalVaultExport);
-            UseOTPVerification = await _keyConnectorService.GetUsesKeyConnector();
+            UseOTPVerification = await _keyConnectorService.GetUsesKeyConnectorAsync();
 
             if (UseOTPVerification)
             {
@@ -165,7 +165,7 @@ namespace Bit.App.Pages
                 return;
             }
 
-            var verificationType = await _keyConnectorService.GetUsesKeyConnector()
+            var verificationType = await _keyConnectorService.GetUsesKeyConnectorAsync()
                 ? VerificationType.OTP
                 : VerificationType.MasterPassword;
             if (!await _userVerificationService.VerifyUser(Secret, verificationType))

--- a/src/App/Pages/Settings/SettingsPage/SettingsPageViewModel.cs
+++ b/src/App/Pages/Settings/SettingsPage/SettingsPageViewModel.cs
@@ -139,7 +139,7 @@ namespace Bit.App.Pages
             }
 
             var pinSet = await _vaultTimeoutService.IsPinLockSetAsync();
-            _pin = pinSet.Item1 || pinSet.Item2;
+            _pin = pinSet != PinLockEnum.Disabled;
             _biometric = await _vaultTimeoutService.IsBiometricLockSetAsync();
             _screenCaptureAllowed = await _stateService.GetScreenCaptureAllowedAsync();
 

--- a/src/App/Pages/Settings/SettingsPage/SettingsPageViewModel.cs
+++ b/src/App/Pages/Settings/SettingsPage/SettingsPageViewModel.cs
@@ -446,11 +446,11 @@ namespace Bit.App.Pages
 
                     if (masterPassOnRestart)
                     {
-                        await _stateService.SetUserKeyPinEphemeralAsync(protectedPinKey);
+                        await _stateService.SetPinKeyEncryptedUserKeyEphemeralAsync(protectedPinKey);
                     }
                     else
                     {
-                        await _stateService.SetUserKeyPinAsync(protectedPinKey);
+                        await _stateService.SetPinKeyEncryptedUserKeyAsync(protectedPinKey);
                     }
                 }
                 else

--- a/src/App/Pages/Settings/SettingsPage/SettingsPageViewModel.cs
+++ b/src/App/Pages/Settings/SettingsPage/SettingsPageViewModel.cs
@@ -139,7 +139,7 @@ namespace Bit.App.Pages
             }
 
             var pinSet = await _vaultTimeoutService.IsPinLockSetAsync();
-            _pin = pinSet != PinLockEnum.Disabled;
+            _pin = pinSet != PinLockType.Disabled;
             _biometric = await _vaultTimeoutService.IsBiometricLockSetAsync();
             _screenCaptureAllowed = await _stateService.GetScreenCaptureAllowedAsync();
 

--- a/src/App/Pages/Settings/SettingsPage/SettingsPageViewModel.cs
+++ b/src/App/Pages/Settings/SettingsPage/SettingsPageViewModel.cs
@@ -439,18 +439,18 @@ namespace Bit.App.Pages
                     var email = await _stateService.GetEmailAsync();
                     var pinKey = await _cryptoService.MakePinKeyAsync(pin, email, kdfConfig);
                     var userKey = await _cryptoService.GetUserKeyAsync();
-                    var pinProtectedKey = await _cryptoService.EncryptAsync(userKey.Key, pinKey);
+                    var protectedPinKey = await _cryptoService.EncryptAsync(userKey.Key, pinKey);
 
                     var encPin = await _cryptoService.EncryptAsync(pin);
                     await _stateService.SetProtectedPinAsync(encPin.EncryptedString);
 
                     if (masterPassOnRestart)
                     {
-                        await _stateService.SetUserKeyPinEphemeralAsync(pinProtectedKey);
+                        await _stateService.SetUserKeyPinEphemeralAsync(protectedPinKey);
                     }
                     else
                     {
-                        await _stateService.SetUserKeyPinAsync(pinProtectedKey);
+                        await _stateService.SetUserKeyPinAsync(protectedPinKey);
                     }
                 }
                 else

--- a/src/App/Pages/Settings/SettingsPage/SettingsPageViewModel.cs
+++ b/src/App/Pages/Settings/SettingsPage/SettingsPageViewModel.cs
@@ -437,7 +437,7 @@ namespace Bit.App.Pages
 
                     var kdfConfig = await _stateService.GetActiveUserCustomDataAsync(a => new KdfConfig(a?.Profile));
                     var email = await _stateService.GetEmailAsync();
-                    var pinKey = await _cryptoService.MakePinKeyAysnc(pin, email, kdfConfig);
+                    var pinKey = await _cryptoService.MakePinKeyAsync(pin, email, kdfConfig);
                     var key = await _cryptoService.GetKeyAsync();
                     var pinProtectedKey = await _cryptoService.EncryptAsync(key.Key, pinKey);
 

--- a/src/App/Pages/Settings/SettingsPage/SettingsPageViewModel.cs
+++ b/src/App/Pages/Settings/SettingsPage/SettingsPageViewModel.cs
@@ -491,7 +491,7 @@ namespace Bit.App.Pages
                 await _stateService.SetBiometricUnlockAsync(null);
             }
             await _stateService.SetBiometricLockedAsync(false);
-            await _cryptoService.ToggleKeyAsync();
+            await _cryptoService.ToggleKeysAsync();
             BuildList();
         }
 

--- a/src/App/Pages/Settings/SettingsPage/SettingsPageViewModel.cs
+++ b/src/App/Pages/Settings/SettingsPage/SettingsPageViewModel.cs
@@ -149,7 +149,7 @@ namespace Bit.App.Pages
             }
 
             _showChangeMasterPassword = IncludeLinksWithSubscriptionInfo() &&
-                !await _keyConnectorService.GetUsesKeyConnector();
+                !await _keyConnectorService.GetUsesKeyConnectorAsync();
             _reportLoggingEnabled = await _loggerService.IsEnabled();
             _approvePasswordlessLoginRequests = await _stateService.GetApprovePasswordlessLoginsAsync();
             _shouldConnectToWatch = await _stateService.GetShouldConnectToWatchAsync();
@@ -429,7 +429,7 @@ namespace Bit.App.Pages
                 if (!string.IsNullOrWhiteSpace(pin))
                 {
                     var masterPassOnRestart = false;
-                    if (!await _keyConnectorService.GetUsesKeyConnector())
+                    if (!await _keyConnectorService.GetUsesKeyConnectorAsync())
                     {
                         masterPassOnRestart = await _platformUtilsService.ShowDialogAsync(
                             AppResources.PINRequireMasterPasswordRestart, AppResources.UnlockWithPIN,

--- a/src/App/Pages/Settings/SettingsPage/SettingsPageViewModel.cs
+++ b/src/App/Pages/Settings/SettingsPage/SettingsPageViewModel.cs
@@ -491,7 +491,7 @@ namespace Bit.App.Pages
                 await _stateService.SetBiometricUnlockAsync(null);
             }
             await _stateService.SetBiometricLockedAsync(false);
-            await _cryptoService.ToggleKeysAsync();
+            await _cryptoService.RefreshKeysAsync();
             BuildList();
         }
 

--- a/src/App/Pages/Settings/SettingsPage/SettingsPageViewModel.cs
+++ b/src/App/Pages/Settings/SettingsPage/SettingsPageViewModel.cs
@@ -138,7 +138,7 @@ namespace Bit.App.Pages
                     t.Value != null).ToList();
             }
 
-            var pinSet = await _vaultTimeoutService.IsPinLockSetAsync();
+            var pinSet = await _vaultTimeoutService.GetPinLockTypeAsync();
             _pin = pinSet != PinLockType.Disabled;
             _biometric = await _vaultTimeoutService.IsBiometricLockSetAsync();
             _screenCaptureAllowed = await _stateService.GetScreenCaptureAllowedAsync();

--- a/src/App/Pages/Settings/SettingsPage/SettingsPageViewModel.cs
+++ b/src/App/Pages/Settings/SettingsPage/SettingsPageViewModel.cs
@@ -323,6 +323,7 @@ namespace Bit.App.Pages
             }
             if (oldTimeout != newTimeout)
             {
+                await _cryptoService.RefreshKeysAsync();
                 await Device.InvokeOnMainThreadAsync(BuildList);
             }
         }

--- a/src/App/Pages/TabsPage.cs
+++ b/src/App/Pages/TabsPage.cs
@@ -94,7 +94,7 @@ namespace Bit.App.Pages
                 }
             });
             await UpdateVaultButtonTitleAsync();
-            if (await _keyConnectorService.UserNeedsMigration())
+            if (await _keyConnectorService.UserNeedsMigrationAsync())
             {
                 _messagingService.Send("convertAccountToKeyConnector");
             }

--- a/src/App/Pages/Vault/AttachmentsPageViewModel.cs
+++ b/src/App/Pages/Vault/AttachmentsPageViewModel.cs
@@ -74,7 +74,7 @@ namespace Bit.App.Pages
             _cipherDomain = await _cipherService.GetAsync(CipherId);
             Cipher = await _cipherDomain.DecryptAsync();
             LoadAttachments();
-            _hasUpdatedKey = await _cryptoService.HasEncKeyAsync();
+            _hasUpdatedKey = await _cryptoService.HasUserKeyAsync();
             var canAccessPremium = await _stateService.CanAccessPremiumAsync();
             _canAccessAttachments = canAccessPremium || Cipher.OrganizationId != null;
             if (!_canAccessAttachments)

--- a/src/App/Pages/Vault/CipherAddEditPage.xaml.cs
+++ b/src/App/Pages/Vault/CipherAddEditPage.xaml.cs
@@ -176,7 +176,7 @@ namespace Bit.App.Pages
                 }
             });
             // Hide password reprompt option if using key connector
-            _passwordPrompt.IsVisible = !await _keyConnectorService.GetUsesKeyConnector();
+            _passwordPrompt.IsVisible = !await _keyConnectorService.GetUsesKeyConnectorAsync();
         }
 
         protected override void OnDisappearing()

--- a/src/App/Services/BaseBiometricService.cs
+++ b/src/App/Services/BaseBiometricService.cs
@@ -1,0 +1,25 @@
+﻿using System.Threading.Tasks;
+using Bit.Core.Abstractions;
+
+namespace Bit.App.Services
+{
+    public abstract class BaseBiometricService : IBiometricService
+    {
+        protected readonly IStateService _stateService;
+        protected readonly ICryptoService _cryptoService;
+
+        protected BaseBiometricService(IStateService stateService, ICryptoService cryptoService)
+        {
+            _stateService = stateService;
+            _cryptoService = cryptoService;
+        }
+
+        public async Task<bool> CanUseBiometricsUnlockAsync()
+        {
+            return await _cryptoService.HasEncryptedUserKeyAsync() || await _stateService.GetKeyEncryptedAsync() != null;
+        }
+
+        public abstract Task<bool> IsSystemBiometricIntegrityValidAsync(string bioIntegritySrcKey = null);
+        public abstract Task<bool> SetupBiometricAsync(string bioIntegritySrcKey = null);
+    }
+}

--- a/src/App/Services/MobilePasswordRepromptService.cs
+++ b/src/App/Services/MobilePasswordRepromptService.cs
@@ -44,7 +44,7 @@ namespace Bit.App.Services
         public async Task<bool> Enabled()
         {
             var keyConnectorService = ServiceContainer.Resolve<IKeyConnectorService>("keyConnectorService");
-            return !await keyConnectorService.GetUsesKeyConnector();
+            return !await keyConnectorService.GetUsesKeyConnectorAsync();
         }
     }
 }

--- a/src/App/Services/MobilePasswordRepromptService.cs
+++ b/src/App/Services/MobilePasswordRepromptService.cs
@@ -38,7 +38,7 @@ namespace Bit.App.Services
                 return false;
             };
 
-            return await _cryptoService.CompareAndUpdatePasswordHashAsync(password, null);
+            return await _cryptoService.CompareAndUpdateKeyHashAsync(password, null);
         }
 
         public async Task<bool> Enabled()

--- a/src/App/Services/MobilePasswordRepromptService.cs
+++ b/src/App/Services/MobilePasswordRepromptService.cs
@@ -38,7 +38,7 @@ namespace Bit.App.Services
                 return false;
             };
 
-            return await _cryptoService.CompareAndUpdateKeyHashAsync(password, null);
+            return await _cryptoService.CompareAndUpdatePasswordHashAsync(password, null);
         }
 
         public async Task<bool> Enabled()

--- a/src/App/Utilities/AccountManagement/AccountsManager.cs
+++ b/src/App/Utilities/AccountManagement/AccountsManager.cs
@@ -206,6 +206,7 @@ namespace Bit.App.Utilities.AccountManagement
 
         private async Task AddAccountAsync()
         {
+            await AppHelpers.ClearServiceCacheAsync();
             await Device.InvokeOnMainThreadAsync(() =>
             {
                 Options.HideAccountSwitcher = false;

--- a/src/App/Utilities/VerificationActionsFlowHelper.cs
+++ b/src/App/Utilities/VerificationActionsFlowHelper.cs
@@ -121,7 +121,7 @@ namespace Bit.App.Utilities
                     }
 
                     var parameters = GetParameters();
-                    parameters.Secret = await _cryptoService.HashPasswordAsync(password, null);
+                    parameters.Secret = await _cryptoService.HashMasterKeyAsync(password, null);
                     parameters.VerificationType = VerificationType.MasterPassword;
                     await ExecuteAsync(parameters);
                     break;

--- a/src/App/Utilities/VerificationActionsFlowHelper.cs
+++ b/src/App/Utilities/VerificationActionsFlowHelper.cs
@@ -107,7 +107,7 @@ namespace Bit.App.Utilities
 
         public async Task ValidateAndExecuteAsync()
         {
-            var verificationType = await _keyConnectorService.GetUsesKeyConnector()
+            var verificationType = await _keyConnectorService.GetUsesKeyConnectorAsync()
                 ? VerificationType.OTP
                 : VerificationType.MasterPassword;
 

--- a/src/Core/Abstractions/IApiService.cs
+++ b/src/Core/Abstractions/IApiService.cs
@@ -70,7 +70,7 @@ namespace Bit.Core.Abstractions
         Task<OrganizationAutoEnrollStatusResponse> GetOrganizationAutoEnrollStatusAsync(string identifier);
         Task PutOrganizationUserResetPasswordEnrollmentAsync(string orgId, string userId,
             OrganizationUserResetPasswordEnrollmentRequest request);
-        Task<KeyConnectorUserKeyResponse> GetMasterKeyFromKeyConnector(string keyConnectorUrl);
+        Task<KeyConnectorUserKeyResponse> GetMasterKeyFromKeyConnectorAsync(string keyConnectorUrl);
         Task PostUserKeyToKeyConnector(string keyConnectorUrl, KeyConnectorUserKeyRequest request);
         Task PostSetKeyConnectorKey(SetKeyConnectorKeyRequest request);
         Task PostConvertToKeyConnector();

--- a/src/Core/Abstractions/IApiService.cs
+++ b/src/Core/Abstractions/IApiService.cs
@@ -70,7 +70,7 @@ namespace Bit.Core.Abstractions
         Task<OrganizationAutoEnrollStatusResponse> GetOrganizationAutoEnrollStatusAsync(string identifier);
         Task PutOrganizationUserResetPasswordEnrollmentAsync(string orgId, string userId,
             OrganizationUserResetPasswordEnrollmentRequest request);
-        Task<KeyConnectorUserKeyResponse> GetUserKeyFromKeyConnector(string keyConnectorUrl);
+        Task<KeyConnectorUserKeyResponse> GetMasterKeyFromKeyConnector(string keyConnectorUrl);
         Task PostUserKeyToKeyConnector(string keyConnectorUrl, KeyConnectorUserKeyRequest request);
         Task PostSetKeyConnectorKey(SetKeyConnectorKeyRequest request);
         Task PostConvertToKeyConnector();

--- a/src/Core/Abstractions/IBiometricService.cs
+++ b/src/Core/Abstractions/IBiometricService.cs
@@ -4,6 +4,7 @@ namespace Bit.Core.Abstractions
 {
     public interface IBiometricService
     {
+        Task<bool> CanUseBiometricsUnlockAsync();
         Task<bool> SetupBiometricAsync(string bioIntegritySrcKey = null);
         Task<bool> IsSystemBiometricIntegrityValidAsync(string bioIntegritySrcKey = null);
     }

--- a/src/Core/Abstractions/ICryptoService.cs
+++ b/src/Core/Abstractions/ICryptoService.cs
@@ -12,6 +12,7 @@ namespace Bit.Core.Abstractions
         Task SetUserKeyAsync(UserKey userKey);
         Task<UserKey> GetUserKeyAsync(string userId = null);
         Task<bool> HasUserKeyAsync(string userId = null);
+        Task<UserKey> MakeUserKeyAsync();
         Task ClearUserKeyAsync(string userId = null);
         Task SetMasterKeyEncryptedUserKeyAsync(string value, string userId = null);
         Task SetMasterKeyAsync(MasterKey masterKey, string userId = null);

--- a/src/Core/Abstractions/ICryptoService.cs
+++ b/src/Core/Abstractions/ICryptoService.cs
@@ -37,8 +37,8 @@ namespace Bit.Core.Abstractions
         Task<Dictionary<string, OrgKey>> GetOrgKeysAsync();
         Task ClearOrgKeysAsync(bool memoryOnly = false, string userId = null);
         Task<byte[]> GetPublicKeyAsync();
-        Task SetPrivateKeyAsync(string encPrivateKey);
-        Task<byte[]> GetPrivateKeyAsync();
+        Task SetUserPrivateKeyAsync(string encPrivateKey);
+        Task<byte[]> GetUserPrivateKeyAsync();
         Task<List<string>> GetFingerprintAsync(string userId, byte[] publicKey = null);
         Task<Tuple<string, EncString>> MakeKeyPairAsync(SymmetricCryptoKey key = null);
         Task ClearKeyPairAsync(bool memoryOnly = false, string userId = null);

--- a/src/Core/Abstractions/ICryptoService.cs
+++ b/src/Core/Abstractions/ICryptoService.cs
@@ -25,8 +25,7 @@ namespace Bit.Core.Abstractions
         Task ClearMasterKeyAsync(string userId = null);
         Task<Tuple<UserKey, EncString>> EncryptUserKeyWithMasterKeyAsync(MasterKey masterKey);
         Task<UserKey> DecryptUserKeyWithMasterKeyAsync(MasterKey masterKey, EncString encUserKey = null, string userId = null);
-        Task<Tuple<SymmetricCryptoKey, EncString>> MakeDataEncKeyAsync(UserKey key);
-        Task<Tuple<SymmetricCryptoKey, EncString>> MakeDataEncKeyAsync(OrgKey key);
+        Task<Tuple<SymmetricCryptoKey, EncString>> MakeDataEncKeyAsync<TKey>(TKey key) where TKey : SymmetricCryptoKey;
         Task<string> HashMasterKeyAsync(string password, MasterKey key, HashPurpose hashPurpose = HashPurpose.ServerAuthorization);
         Task SetMasterKeyHashAsync(string keyHash);
         Task<string> GetMasterKeyHashAsync();

--- a/src/Core/Abstractions/ICryptoService.cs
+++ b/src/Core/Abstractions/ICryptoService.cs
@@ -18,6 +18,9 @@ namespace Bit.Core.Abstractions
         Task<MasterKey> GetMasterKeyAsync(string userId = null);
         Task<MasterKey> MakeMasterKeyAsync(string password, string email, KdfConfig kdfConfig);
         Task ClearMasterKeyAsync(string userId = null);
+        Task<Tuple<UserKey, EncString>> EncryptUserKeyWithMasterKeyAsync(MasterKey masterKey, UserKey userKey = null);
+        Task<UserKey> DecryptUserKeyWithMasterKeyAsync(MasterKey masterKey, EncString encUserKey = null, string userId = null);
+        Task<string> HashPasswordAsync(string password, SymmetricCryptoKey key, HashPurpose hashPurpose = HashPurpose.ServerAuthorization);
         Task SetPasswordHashAsync(string keyHash);
         Task<string> GetPasswordHashAsync();
         Task ClearPasswordHashAsync(string userId = null);
@@ -41,21 +44,28 @@ namespace Bit.Core.Abstractions
         Task<byte[]> RsaDecryptAsync(string encValue, byte[] privateKey = null);
         Task<int> RandomNumberAsync(int min, int max);
         Task<string> RandomStringAsync(int length);
-
-        Task ClearEncKeyAsync(bool memoryOnly = false, string userId = null);
-        Task ClearKeyAsync(string userId = null);
-        Task ClearPinProtectedKeyAsync(string userId = null);
-        void ClearCache();
         Task<byte[]> DecryptFromBytesAsync(byte[] encBytes, SymmetricCryptoKey key);
         Task<byte[]> DecryptToBytesAsync(EncString encString, SymmetricCryptoKey key = null);
         Task<string> DecryptToUtf8Async(EncString encString, SymmetricCryptoKey key = null);
         Task<EncString> EncryptAsync(byte[] plainValue, SymmetricCryptoKey key = null);
         Task<EncString> EncryptAsync(string plainValue, SymmetricCryptoKey key = null);
         Task<EncByteArray> EncryptToBytesAsync(byte[] plainValue, SymmetricCryptoKey key = null);
+
+
+
+
+
+
+
+
+
+        Task ClearEncKeyAsync(bool memoryOnly = false, string userId = null);
+        Task ClearKeyAsync(string userId = null);
+        Task ClearPinProtectedKeyAsync(string userId = null);
+        void ClearCache();
         Task<SymmetricCryptoKey> GetEncKeyAsync(SymmetricCryptoKey key = null);
         Task<SymmetricCryptoKey> GetKeyAsync(string userId = null);
         Task<bool> HasEncKeyAsync();
-        Task<string> HashPasswordAsync(string password, SymmetricCryptoKey key, HashPurpose hashPurpose = HashPurpose.ServerAuthorization);
         Task<bool> HasKeyAsync(string userId = null);
         Task<Tuple<SymmetricCryptoKey, EncString>> MakeEncKeyAsync(SymmetricCryptoKey key);
         Task<SymmetricCryptoKey> MakeKeyAsync(string password, string salt, KdfConfig config);

--- a/src/Core/Abstractions/ICryptoService.cs
+++ b/src/Core/Abstractions/ICryptoService.cs
@@ -27,11 +27,11 @@ namespace Bit.Core.Abstractions
         Task<UserKey> DecryptUserKeyWithMasterKeyAsync(MasterKey masterKey, EncString encUserKey = null, string userId = null);
         Task<Tuple<SymmetricCryptoKey, EncString>> MakeDataEncKeyAsync(UserKey key);
         Task<Tuple<SymmetricCryptoKey, EncString>> MakeDataEncKeyAsync(OrgKey key);
-        Task<string> HashPasswordAsync(string password, SymmetricCryptoKey key, HashPurpose hashPurpose = HashPurpose.ServerAuthorization);
-        Task SetPasswordHashAsync(string keyHash);
-        Task<string> GetPasswordHashAsync();
-        Task ClearPasswordHashAsync(string userId = null);
-        Task<bool> CompareAndUpdatePasswordHashAsync(string masterPassword, MasterKey key);
+        Task<string> HashMasterKeyAsync(string password, MasterKey key, HashPurpose hashPurpose = HashPurpose.ServerAuthorization);
+        Task SetMasterKeyHashAsync(string keyHash);
+        Task<string> GetMasterKeyHashAsync();
+        Task ClearMasterKeyHashAsync(string userId = null);
+        Task<bool> CompareAndUpdateKeyHashAsync(string masterPassword, MasterKey key);
         Task SetOrgKeysAsync(IEnumerable<ProfileOrganizationResponse> orgs);
         Task<OrgKey> GetOrgKeyAsync(string orgId);
         Task<Dictionary<string, OrgKey>> GetOrgKeysAsync();

--- a/src/Core/Abstractions/ICryptoService.cs
+++ b/src/Core/Abstractions/ICryptoService.cs
@@ -10,7 +10,7 @@ namespace Bit.Core.Abstractions
     public interface ICryptoService
     {
         void ClearCache();
-        Task ToggleKeysAsync();
+        Task RefreshKeysAsync();
         Task SetUserKeyAsync(UserKey userKey, string userId = null);
         Task<UserKey> GetUserKeyAsync(string userId = null);
         Task<UserKey> GetUserKeyWithLegacySupportAsync(string userId = null);

--- a/src/Core/Abstractions/ICryptoService.cs
+++ b/src/Core/Abstractions/ICryptoService.cs
@@ -36,7 +36,7 @@ namespace Bit.Core.Abstractions
         Task<OrgKey> GetOrgKeyAsync(string orgId);
         Task<Dictionary<string, OrgKey>> GetOrgKeysAsync();
         Task ClearOrgKeysAsync(bool memoryOnly = false, string userId = null);
-        Task<byte[]> GetPublicKeyAsync();
+        Task<byte[]> GetUserPublicKeyAsync();
         Task SetUserPrivateKeyAsync(string encPrivateKey);
         Task<byte[]> GetUserPrivateKeyAsync();
         Task<List<string>> GetFingerprintAsync(string userId, byte[] publicKey = null);

--- a/src/Core/Abstractions/ICryptoService.cs
+++ b/src/Core/Abstractions/ICryptoService.cs
@@ -9,7 +9,7 @@ namespace Bit.Core.Abstractions
 {
     public interface ICryptoService
     {
-        Task SetUserKeyAsync(UserKey userKey);
+        Task SetUserKeyAsync(UserKey userKey, string userId = null);
         Task<UserKey> GetUserKeyAsync(string userId = null);
         Task<bool> HasUserKeyAsync(string userId = null);
         Task<UserKey> MakeUserKeyAsync();

--- a/src/Core/Abstractions/ICryptoService.cs
+++ b/src/Core/Abstractions/ICryptoService.cs
@@ -25,7 +25,7 @@ namespace Bit.Core.Abstractions
         Task ClearMasterKeyAsync(string userId = null);
         Task<Tuple<UserKey, EncString>> EncryptUserKeyWithMasterKeyAsync(MasterKey masterKey);
         Task<UserKey> DecryptUserKeyWithMasterKeyAsync(MasterKey masterKey, EncString encUserKey = null, string userId = null);
-        Task<Tuple<SymmetricCryptoKey, EncString>> MakeDataEncKeyAsync<TKey>(TKey key) where TKey : SymmetricCryptoKey;
+        Task<Tuple<SymmetricCryptoKey, EncString>> MakeDataEncKeyAsync(SymmetricCryptoKey key);
         Task<string> HashMasterKeyAsync(string password, MasterKey key, HashPurpose hashPurpose = HashPurpose.ServerAuthorization);
         Task SetMasterKeyHashAsync(string keyHash);
         Task<string> GetMasterKeyHashAsync();

--- a/src/Core/Abstractions/ICryptoService.cs
+++ b/src/Core/Abstractions/ICryptoService.cs
@@ -23,7 +23,7 @@ namespace Bit.Core.Abstractions
         Task<MasterKey> GetMasterKeyAsync(string userId = null);
         Task<MasterKey> MakeMasterKeyAsync(string password, string email, KdfConfig kdfConfig);
         Task ClearMasterKeyAsync(string userId = null);
-        Task<Tuple<UserKey, EncString>> EncryptUserKeyWithMasterKeyAsync(MasterKey masterKey, UserKey userKey = null);
+        Task<Tuple<UserKey, EncString>> EncryptUserKeyWithMasterKeyAsync(MasterKey masterKey);
         Task<UserKey> DecryptUserKeyWithMasterKeyAsync(MasterKey masterKey, EncString encUserKey = null, string userId = null);
         Task<Tuple<SymmetricCryptoKey, EncString>> MakeDataEncKeyAsync(UserKey key);
         Task<Tuple<SymmetricCryptoKey, EncString>> MakeDataEncKeyAsync(OrgKey key);

--- a/src/Core/Abstractions/ICryptoService.cs
+++ b/src/Core/Abstractions/ICryptoService.cs
@@ -42,11 +42,10 @@ namespace Bit.Core.Abstractions
         Task<Tuple<string, EncString>> MakeKeyPairAsync(SymmetricCryptoKey key = null);
         Task ClearKeyPairAsync(bool memoryOnly = false, string userId = null);
         Task<PinKey> MakePinKeyAsync(string pin, string salt, KdfConfig config);
+        Task ClearPinKeysAsync(string userId = null);
         Task<UserKey> DecryptUserKeyWithPinAsync(string pin, string salt, KdfConfig kdfConfig, EncString pinProtectedUserKey = null);
         Task<MasterKey> DecryptMasterKeyWithPinAsync(string pin, string salt, KdfConfig kdfConfig, EncString pinProtectedMasterKey = null);
         Task<SymmetricCryptoKey> MakeSendKeyAsync(byte[] keyMaterial);
-        // TODO(Jake): This isn't used, delete?
-        Task ClearKeysAsync(string userId = null);
         Task<EncString> RsaEncryptAsync(byte[] data, byte[] publicKey = null);
         Task<byte[]> RsaDecryptAsync(string encValue, byte[] privateKey = null);
         Task<int> RandomNumberAsync(int min, int max);
@@ -67,15 +66,11 @@ namespace Bit.Core.Abstractions
 
 
 
-        Task ClearEncKeyAsync(bool memoryOnly = false, string userId = null);
-        Task ClearKeyAsync(string userId = null);
-        Task ClearPinProtectedKeyAsync(string userId = null);
         void ClearCache();
+
         Task<SymmetricCryptoKey> GetEncKeyAsync(SymmetricCryptoKey key = null);
         Task<SymmetricCryptoKey> GetKeyAsync(string userId = null);
-        Task<bool> HasKeyAsync(string userId = null);
         Task<Tuple<SymmetricCryptoKey, EncString>> MakeEncKeyAsync(SymmetricCryptoKey key);
-        // TODO(Jake): This isn't used, delete
         Task SetEncKeyAsync(string encKey);
         Task SetKeyAsync(SymmetricCryptoKey key);
     }

--- a/src/Core/Abstractions/ICryptoService.cs
+++ b/src/Core/Abstractions/ICryptoService.cs
@@ -13,6 +13,7 @@ namespace Bit.Core.Abstractions
         Task SetUserKeyAsync(UserKey userKey, string userId = null);
         Task<UserKey> GetUserKeyAsync(string userId = null);
         Task<bool> HasUserKeyAsync(string userId = null);
+        Task<bool> HasEncryptedUserKeyAsync(string userId = null);
         Task<UserKey> MakeUserKeyAsync();
         Task ClearUserKeyAsync(string userId = null);
         Task SetMasterKeyEncryptedUserKeyAsync(string value, string userId = null);
@@ -38,7 +39,8 @@ namespace Bit.Core.Abstractions
         Task<Tuple<string, EncString>> MakeKeyPairAsync(SymmetricCryptoKey key = null);
         Task ClearKeyPairAsync(bool memoryOnly = false, string userId = null);
         Task<PinKey> MakePinKeyAsync(string pin, string salt, KdfConfig config);
-        // Task<UserKey> DecryptUserKeyWithPin(string pin, string salt, KdfConfig kdfConfig, EncString pinProtectedUserKey = null);
+        Task<UserKey> DecryptUserKeyWithPinAsync(string pin, string salt, KdfConfig kdfConfig, EncString pinProtectedUserKey = null);
+        Task<MasterKey> DecryptMasterKeyWithPinAsync(string pin, string salt, KdfConfig kdfConfig, EncString pinProtectedMasterKey = null);
         Task<SymmetricCryptoKey> MakeSendKeyAsync(byte[] keyMaterial);
         // TODO(Jake): This isn't used, delete?
         Task ClearKeysAsync(string userId = null);
@@ -52,6 +54,7 @@ namespace Bit.Core.Abstractions
         Task<EncString> EncryptAsync(byte[] plainValue, SymmetricCryptoKey key = null);
         Task<EncString> EncryptAsync(string plainValue, SymmetricCryptoKey key = null);
         Task<EncByteArray> EncryptToBytesAsync(byte[] plainValue, SymmetricCryptoKey key = null);
+        Task<UserKey> DecryptAndMigrateOldPinKeyAsync(bool masterPasswordOnRestart, string pin, string email, KdfConfig kdfConfig, EncString oldPinKey);
 
 
 

--- a/src/Core/Abstractions/ICryptoService.cs
+++ b/src/Core/Abstractions/ICryptoService.cs
@@ -9,6 +9,7 @@ namespace Bit.Core.Abstractions
 {
     public interface ICryptoService
     {
+        Task ToggleKeysAsync();
         Task SetUserKeyAsync(UserKey userKey, string userId = null);
         Task<UserKey> GetUserKeyAsync(string userId = null);
         Task<bool> HasUserKeyAsync(string userId = null);
@@ -25,7 +26,7 @@ namespace Bit.Core.Abstractions
         Task SetPasswordHashAsync(string keyHash);
         Task<string> GetPasswordHashAsync();
         Task ClearPasswordHashAsync(string userId = null);
-        Task<bool> CompareAndUpdatePasswordHashAsync(string masterPassword, SymmetricCryptoKey key);
+        Task<bool> CompareAndUpdatePasswordHashAsync(string masterPassword, MasterKey key);
         Task SetOrgKeysAsync(IEnumerable<ProfileOrganizationResponse> orgs);
         Task<OrgKey> GetOrgKeyAsync(string orgId);
         Task<Dictionary<string, OrgKey>> GetOrgKeysAsync();
@@ -75,6 +76,5 @@ namespace Bit.Core.Abstractions
         Task<Tuple<SymmetricCryptoKey, EncString>> RemakeEncKeyAsync(SymmetricCryptoKey key);
         Task SetEncKeyAsync(string encKey);
         Task SetKeyAsync(SymmetricCryptoKey key);
-        Task ToggleKeyAsync();
     }
 }

--- a/src/Core/Abstractions/ICryptoService.cs
+++ b/src/Core/Abstractions/ICryptoService.cs
@@ -9,9 +9,21 @@ namespace Bit.Core.Abstractions
 {
     public interface ICryptoService
     {
+        Task SetUserKeyAsync(UserKey userKey);
+        Task<UserKey> GetUserKeyAsync(string userId = null);
+        Task<bool> HasUserKeyAsync(string userId = null);
+        Task ClearUserKeyAsync(string userId = null);
+        Task SetMasterKeyEncryptedUserKeyAsync(string value, string userId = null);
+        Task SetMasterKeyAsync(MasterKey masterKey, string userId = null);
+        Task<MasterKey> GetMasterKeyAsync(string userId = null);
+        Task ClearMasterKeyAsync(string userId = null);
+        Task SetPasswordHashAsync(string keyHash);
+        Task<string> GetPasswordHashAsync();
+        Task ClearPasswordHashAsync(string userId = null);
+        Task<bool> CompareAndUpdatePasswordHashAsync(string masterPassword, SymmetricCryptoKey key);
+
         Task ClearEncKeyAsync(bool memoryOnly = false, string userId = null);
         Task ClearKeyAsync(string userId = null);
-        Task ClearKeyHashAsync(string userId = null);
         Task ClearKeyPairAsync(bool memoryOnly = false, string userId = null);
         Task ClearKeysAsync(string userId = null);
         Task ClearOrgKeysAsync(bool memoryOnly = false, string userId = null);
@@ -26,12 +38,10 @@ namespace Bit.Core.Abstractions
         Task<SymmetricCryptoKey> GetEncKeyAsync(SymmetricCryptoKey key = null);
         Task<List<string>> GetFingerprintAsync(string userId, byte[] publicKey = null);
         Task<SymmetricCryptoKey> GetKeyAsync(string userId = null);
-        Task<string> GetKeyHashAsync();
         Task<SymmetricCryptoKey> GetOrgKeyAsync(string orgId);
         Task<Dictionary<string, SymmetricCryptoKey>> GetOrgKeysAsync();
         Task<byte[]> GetPrivateKeyAsync();
         Task<byte[]> GetPublicKeyAsync();
-        Task<bool> CompareAndUpdateKeyHashAsync(string masterPassword, SymmetricCryptoKey key);
         Task<bool> HasEncKeyAsync();
         Task<string> HashPasswordAsync(string password, SymmetricCryptoKey key, HashPurpose hashPurpose = HashPurpose.ServerAuthorization);
         Task<bool> HasKeyAsync(string userId = null);
@@ -50,7 +60,6 @@ namespace Bit.Core.Abstractions
         Task SetEncKeyAsync(string encKey);
         Task SetEncPrivateKeyAsync(string encPrivateKey);
         Task SetKeyAsync(SymmetricCryptoKey key);
-        Task SetKeyHashAsync(string keyHash);
         Task SetOrgKeysAsync(IEnumerable<ProfileOrganizationResponse> orgs);
         Task ToggleKeyAsync();
     }

--- a/src/Core/Abstractions/ICryptoService.cs
+++ b/src/Core/Abstractions/ICryptoService.cs
@@ -73,10 +73,8 @@ namespace Bit.Core.Abstractions
         Task<bool> HasEncKeyAsync();
         Task<bool> HasKeyAsync(string userId = null);
         Task<Tuple<SymmetricCryptoKey, EncString>> MakeEncKeyAsync(SymmetricCryptoKey key);
-        Task<SymmetricCryptoKey> MakeKeyFromPinAsync(string pin, string salt, KdfConfig config, EncString protectedKeyEs = null);
         // TODO(Jake): This isn't used, delete
         Task<Tuple<EncString, SymmetricCryptoKey>> MakeShareKeyAsync();
-        Task<Tuple<SymmetricCryptoKey, EncString>> RemakeEncKeyAsync(SymmetricCryptoKey key);
         Task SetEncKeyAsync(string encKey);
         Task SetKeyAsync(SymmetricCryptoKey key);
     }

--- a/src/Core/Abstractions/ICryptoService.cs
+++ b/src/Core/Abstractions/ICryptoService.cs
@@ -21,6 +21,7 @@ namespace Bit.Core.Abstractions
         Task SetMasterKeyEncryptedUserKeyAsync(string value, string userId = null);
         Task<UserKey> GetAutoUnlockKeyAsync(string userId = null);
         Task<bool> HasAutoUnlockKeyAsync(string userId = null);
+        Task<UserKey> GetBiometricUnlockKeyAsync(string userId = null);
         Task SetMasterKeyAsync(MasterKey masterKey, string userId = null);
         Task<MasterKey> GetMasterKeyAsync(string userId = null);
         Task<MasterKey> MakeMasterKeyAsync(string password, string email, KdfConfig kdfConfig);

--- a/src/Core/Abstractions/ICryptoService.cs
+++ b/src/Core/Abstractions/ICryptoService.cs
@@ -9,6 +9,7 @@ namespace Bit.Core.Abstractions
 {
     public interface ICryptoService
     {
+        void ClearCache();
         Task ToggleKeysAsync();
         Task SetUserKeyAsync(UserKey userKey, string userId = null);
         Task<UserKey> GetUserKeyAsync(string userId = null);
@@ -57,21 +58,5 @@ namespace Bit.Core.Abstractions
         Task<EncString> EncryptAsync(string plainValue, SymmetricCryptoKey key = null);
         Task<EncByteArray> EncryptToBytesAsync(byte[] plainValue, SymmetricCryptoKey key = null);
         Task<UserKey> DecryptAndMigrateOldPinKeyAsync(bool masterPasswordOnRestart, string pin, string email, KdfConfig kdfConfig, EncString oldPinKey);
-
-
-
-
-
-
-
-
-
-        void ClearCache();
-
-        Task<SymmetricCryptoKey> GetEncKeyAsync(SymmetricCryptoKey key = null);
-        Task<SymmetricCryptoKey> GetKeyAsync(string userId = null);
-        Task<Tuple<SymmetricCryptoKey, EncString>> MakeEncKeyAsync(SymmetricCryptoKey key);
-        Task SetEncKeyAsync(string encKey);
-        Task SetKeyAsync(SymmetricCryptoKey key);
     }
 }

--- a/src/Core/Abstractions/ICryptoService.cs
+++ b/src/Core/Abstractions/ICryptoService.cs
@@ -12,6 +12,7 @@ namespace Bit.Core.Abstractions
         Task ToggleKeysAsync();
         Task SetUserKeyAsync(UserKey userKey, string userId = null);
         Task<UserKey> GetUserKeyAsync(string userId = null);
+        Task<UserKey> GetUserKeyWithLegacySupportAsync(string userId = null);
         Task<bool> HasUserKeyAsync(string userId = null);
         Task<bool> HasEncryptedUserKeyAsync(string userId = null);
         Task<UserKey> MakeUserKeyAsync();
@@ -23,6 +24,8 @@ namespace Bit.Core.Abstractions
         Task ClearMasterKeyAsync(string userId = null);
         Task<Tuple<UserKey, EncString>> EncryptUserKeyWithMasterKeyAsync(MasterKey masterKey, UserKey userKey = null);
         Task<UserKey> DecryptUserKeyWithMasterKeyAsync(MasterKey masterKey, EncString encUserKey = null, string userId = null);
+        Task<Tuple<SymmetricCryptoKey, EncString>> MakeDataEncKeyAsync(UserKey key);
+        Task<Tuple<SymmetricCryptoKey, EncString>> MakeDataEncKeyAsync(OrgKey key);
         Task<string> HashPasswordAsync(string password, SymmetricCryptoKey key, HashPurpose hashPurpose = HashPurpose.ServerAuthorization);
         Task SetPasswordHashAsync(string keyHash);
         Task<string> GetPasswordHashAsync();
@@ -70,11 +73,9 @@ namespace Bit.Core.Abstractions
         void ClearCache();
         Task<SymmetricCryptoKey> GetEncKeyAsync(SymmetricCryptoKey key = null);
         Task<SymmetricCryptoKey> GetKeyAsync(string userId = null);
-        Task<bool> HasEncKeyAsync();
         Task<bool> HasKeyAsync(string userId = null);
         Task<Tuple<SymmetricCryptoKey, EncString>> MakeEncKeyAsync(SymmetricCryptoKey key);
         // TODO(Jake): This isn't used, delete
-        Task<Tuple<EncString, SymmetricCryptoKey>> MakeShareKeyAsync();
         Task SetEncKeyAsync(string encKey);
         Task SetKeyAsync(SymmetricCryptoKey key);
     }

--- a/src/Core/Abstractions/ICryptoService.cs
+++ b/src/Core/Abstractions/ICryptoService.cs
@@ -19,6 +19,8 @@ namespace Bit.Core.Abstractions
         Task<UserKey> MakeUserKeyAsync();
         Task ClearUserKeyAsync(string userId = null);
         Task SetMasterKeyEncryptedUserKeyAsync(string value, string userId = null);
+        Task<UserKey> GetAutoUnlockKeyAsync(string userId = null);
+        Task<bool> HasAutoUnlockKeyAsync(string userId = null);
         Task SetMasterKeyAsync(MasterKey masterKey, string userId = null);
         Task<MasterKey> GetMasterKeyAsync(string userId = null);
         Task<MasterKey> MakeMasterKeyAsync(string password, string email, KdfConfig kdfConfig);

--- a/src/Core/Abstractions/ICryptoService.cs
+++ b/src/Core/Abstractions/ICryptoService.cs
@@ -69,7 +69,6 @@ namespace Bit.Core.Abstractions
         Task<bool> HasEncKeyAsync();
         Task<bool> HasKeyAsync(string userId = null);
         Task<Tuple<SymmetricCryptoKey, EncString>> MakeEncKeyAsync(SymmetricCryptoKey key);
-        Task<SymmetricCryptoKey> MakeKeyAsync(string password, string salt, KdfConfig config);
         Task<SymmetricCryptoKey> MakeKeyFromPinAsync(string pin, string salt, KdfConfig config, EncString protectedKeyEs = null);
         // TODO(Jake): This isn't used, delete
         Task<Tuple<EncString, SymmetricCryptoKey>> MakeShareKeyAsync();

--- a/src/Core/Abstractions/ICryptoService.cs
+++ b/src/Core/Abstractions/ICryptoService.cs
@@ -16,17 +16,34 @@ namespace Bit.Core.Abstractions
         Task SetMasterKeyEncryptedUserKeyAsync(string value, string userId = null);
         Task SetMasterKeyAsync(MasterKey masterKey, string userId = null);
         Task<MasterKey> GetMasterKeyAsync(string userId = null);
+        Task<MasterKey> MakeMasterKeyAsync(string password, string email, KdfConfig kdfConfig);
         Task ClearMasterKeyAsync(string userId = null);
         Task SetPasswordHashAsync(string keyHash);
         Task<string> GetPasswordHashAsync();
         Task ClearPasswordHashAsync(string userId = null);
         Task<bool> CompareAndUpdatePasswordHashAsync(string masterPassword, SymmetricCryptoKey key);
+        Task SetOrgKeysAsync(IEnumerable<ProfileOrganizationResponse> orgs);
+        Task<OrgKey> GetOrgKeyAsync(string orgId);
+        Task<Dictionary<string, OrgKey>> GetOrgKeysAsync();
+        Task ClearOrgKeysAsync(bool memoryOnly = false, string userId = null);
+        Task<byte[]> GetPublicKeyAsync();
+        Task SetPrivateKeyAsync(string encPrivateKey);
+        Task<byte[]> GetPrivateKeyAsync();
+        Task<List<string>> GetFingerprintAsync(string userId, byte[] publicKey = null);
+        Task<Tuple<string, EncString>> MakeKeyPairAsync(SymmetricCryptoKey key = null);
+        Task ClearKeyPairAsync(bool memoryOnly = false, string userId = null);
+        Task<PinKey> MakePinKeyAsync(string pin, string salt, KdfConfig config);
+        // Task<UserKey> DecryptUserKeyWithPin(string pin, string salt, KdfConfig kdfConfig, EncString pinProtectedUserKey = null);
+        Task<SymmetricCryptoKey> MakeSendKeyAsync(byte[] keyMaterial);
+        // TODO(Jake): This isn't used, delete?
+        Task ClearKeysAsync(string userId = null);
+        Task<EncString> RsaEncryptAsync(byte[] data, byte[] publicKey = null);
+        Task<byte[]> RsaDecryptAsync(string encValue, byte[] privateKey = null);
+        Task<int> RandomNumberAsync(int min, int max);
+        Task<string> RandomStringAsync(int length);
 
         Task ClearEncKeyAsync(bool memoryOnly = false, string userId = null);
         Task ClearKeyAsync(string userId = null);
-        Task ClearKeyPairAsync(bool memoryOnly = false, string userId = null);
-        Task ClearKeysAsync(string userId = null);
-        Task ClearOrgKeysAsync(bool memoryOnly = false, string userId = null);
         Task ClearPinProtectedKeyAsync(string userId = null);
         void ClearCache();
         Task<byte[]> DecryptFromBytesAsync(byte[] encBytes, SymmetricCryptoKey key);
@@ -36,31 +53,18 @@ namespace Bit.Core.Abstractions
         Task<EncString> EncryptAsync(string plainValue, SymmetricCryptoKey key = null);
         Task<EncByteArray> EncryptToBytesAsync(byte[] plainValue, SymmetricCryptoKey key = null);
         Task<SymmetricCryptoKey> GetEncKeyAsync(SymmetricCryptoKey key = null);
-        Task<List<string>> GetFingerprintAsync(string userId, byte[] publicKey = null);
         Task<SymmetricCryptoKey> GetKeyAsync(string userId = null);
-        Task<SymmetricCryptoKey> GetOrgKeyAsync(string orgId);
-        Task<Dictionary<string, SymmetricCryptoKey>> GetOrgKeysAsync();
-        Task<byte[]> GetPrivateKeyAsync();
-        Task<byte[]> GetPublicKeyAsync();
         Task<bool> HasEncKeyAsync();
         Task<string> HashPasswordAsync(string password, SymmetricCryptoKey key, HashPurpose hashPurpose = HashPurpose.ServerAuthorization);
         Task<bool> HasKeyAsync(string userId = null);
         Task<Tuple<SymmetricCryptoKey, EncString>> MakeEncKeyAsync(SymmetricCryptoKey key);
         Task<SymmetricCryptoKey> MakeKeyAsync(string password, string salt, KdfConfig config);
         Task<SymmetricCryptoKey> MakeKeyFromPinAsync(string pin, string salt, KdfConfig config, EncString protectedKeyEs = null);
-        Task<Tuple<string, EncString>> MakeKeyPairAsync(SymmetricCryptoKey key = null);
-        Task<SymmetricCryptoKey> MakePinKeyAysnc(string pin, string salt, KdfConfig config);
+        // TODO(Jake): This isn't used, delete
         Task<Tuple<EncString, SymmetricCryptoKey>> MakeShareKeyAsync();
-        Task<SymmetricCryptoKey> MakeSendKeyAsync(byte[] keyMaterial);
-        Task<int> RandomNumberAsync(int min, int max);
-        Task<string> RandomStringAsync(int length);
         Task<Tuple<SymmetricCryptoKey, EncString>> RemakeEncKeyAsync(SymmetricCryptoKey key);
-        Task<EncString> RsaEncryptAsync(byte[] data, byte[] publicKey = null);
-        Task<byte[]> RsaDecryptAsync(string encValue, byte[] privateKey = null);
         Task SetEncKeyAsync(string encKey);
-        Task SetEncPrivateKeyAsync(string encPrivateKey);
         Task SetKeyAsync(SymmetricCryptoKey key);
-        Task SetOrgKeysAsync(IEnumerable<ProfileOrganizationResponse> orgs);
         Task ToggleKeyAsync();
     }
 }

--- a/src/Core/Abstractions/IKeyConnectorService.cs
+++ b/src/Core/Abstractions/IKeyConnectorService.cs
@@ -6,11 +6,11 @@ namespace Bit.Core.Abstractions
 {
     public interface IKeyConnectorService
     {
-        Task SetUsesKeyConnector(bool usesKeyConnector);
-        Task<bool> GetUsesKeyConnector();
-        Task<bool> UserNeedsMigration();
-        Task MigrateUser();
-        Task GetAndSetKey(string url);
-        Task<Organization> GetManagingOrganization();
+        Task SetUsesKeyConnectorAsync(bool usesKeyConnector);
+        Task<bool> GetUsesKeyConnectorAsync();
+        Task<bool> UserNeedsMigrationAsync();
+        Task MigrateUserAsync();
+        Task GetAndSetMasterKeyAsync(string url);
+        Task<Organization> GetManagingOrganizationAsync();
     }
 }

--- a/src/Core/Abstractions/IStateService.cs
+++ b/src/Core/Abstractions/IStateService.cs
@@ -44,18 +44,18 @@ namespace Bit.Core.Abstractions
         Task<bool> CanAccessPremiumAsync(string userId = null);
         Task<string> GetProtectedPinAsync(string userId = null);
         Task SetPersonalPremiumAsync(bool value, string userId = null);
-        Task<string> GetUserKeyPin(string userId = null);
-        Task SetUserKeyPin(string value, string userId = null);
-        Task<EncString> GetUserKeyPinEphemeral(string userId = null);
-        Task SetUserKeyPinEphemeral(EncString value, string userId = null);
+        Task<string> GetUserKeyPinAsync(string userId = null);
+        Task SetUserKeyPinAsync(EncString value, string userId = null);
+        Task<EncString> GetUserKeyPinEphemeralAsync(string userId = null);
+        Task SetUserKeyPinEphemeralAsync(EncString value, string userId = null);
         Task SetProtectedPinAsync(string value, string userId = null);
-        [Obsolete("Use GetUserKeyPin instead, left for migration purposes")]
+        [Obsolete("Use GetUserKeyPinAsync instead, left for migration purposes")]
         Task<string> GetPinProtectedAsync(string userId = null);
-        [Obsolete("Use SetUserKeyPin instead")]
+        [Obsolete("Use SetUserKeyPinAsync instead")]
         Task SetPinProtectedAsync(string value, string userId = null);
-        [Obsolete("Use GetUserKeyPinEphemeral instead, left for migration purposes")]
+        [Obsolete("Use GetUserKeyPinEphemeralAsync instead, left for migration purposes")]
         Task<EncString> GetPinProtectedKeyAsync(string userId = null);
-        [Obsolete("Use SetUserKeyPinEphemeral instead")]
+        [Obsolete("Use SetUserKeyPinEphemeralAsync instead")]
         Task SetPinProtectedKeyAsync(EncString value, string userId = null);
         Task SetKdfConfigurationAsync(KdfConfig config, string userId = null);
         Task<string> GetKeyHashAsync(string userId = null);

--- a/src/Core/Abstractions/IStateService.cs
+++ b/src/Core/Abstractions/IStateService.cs
@@ -17,8 +17,8 @@ namespace Bit.Core.Abstractions
         Task SetUserKeyAsync(UserKey value, string userId = null);
         Task<MasterKey> GetMasterKeyAsync(string userId = null);
         Task SetMasterKeyAsync(MasterKey value, string userId = null);
-        Task<string> GetUserKeyMasterKeyAsync(string userId = null);
-        Task SetUserKeyMasterKeyAsync(string value, string userId = null);
+        Task<string> GetMasterKeyEncryptedUserKeyAsync(string userId = null);
+        Task SetMasterKeyEncryptedUserKeyAsync(string value, string userId = null);
         Task<string> GetActiveUserIdAsync();
         Task<string> GetActiveUserEmailAsync();
         Task<T> GetActiveUserCustomDataAsync<T>(Func<Account, T> dataMapper);
@@ -44,10 +44,10 @@ namespace Bit.Core.Abstractions
         Task<bool> CanAccessPremiumAsync(string userId = null);
         Task<string> GetProtectedPinAsync(string userId = null);
         Task SetPersonalPremiumAsync(bool value, string userId = null);
-        Task<EncString> GetUserKeyPinAsync(string userId = null);
-        Task SetUserKeyPinAsync(EncString value, string userId = null);
-        Task<EncString> GetUserKeyPinEphemeralAsync(string userId = null);
-        Task SetUserKeyPinEphemeralAsync(EncString value, string userId = null);
+        Task<EncString> GetPinKeyEncryptedUserKeyAsync(string userId = null);
+        Task SetPinKeyEncryptedUserKeyAsync(EncString value, string userId = null);
+        Task<EncString> GetPinKeyEncryptedUserKeyEphemeralAsync(string userId = null);
+        Task SetPinKeyEncryptedUserKeyEphemeralAsync(EncString value, string userId = null);
         Task SetProtectedPinAsync(string value, string userId = null);
         [Obsolete("Use GetUserKeyPinAsync instead, left for migration purposes")]
         Task<string> GetPinProtectedAsync(string userId = null);

--- a/src/Core/Abstractions/IStateService.cs
+++ b/src/Core/Abstractions/IStateService.cs
@@ -19,6 +19,8 @@ namespace Bit.Core.Abstractions
         Task SetMasterKeyAsync(MasterKey value, string userId = null);
         Task<string> GetMasterKeyEncryptedUserKeyAsync(string userId = null);
         Task SetMasterKeyEncryptedUserKeyAsync(string value, string userId = null);
+        Task<UserKey> GetUserKeyAutoUnlockAsync(string userId = null);
+        Task SetUserKeyAutoUnlockAsync(string value, string userId = null);
         Task<string> GetActiveUserIdAsync();
         Task<string> GetActiveUserEmailAsync();
         Task<T> GetActiveUserCustomDataAsync<T>(Func<Account, T> dataMapper);
@@ -190,6 +192,9 @@ namespace Bit.Core.Abstractions
         Task SetEncKeyEncryptedAsync(string value, string userId = null);
         [Obsolete("Left for migration purposes")]
         Task SetKeyEncryptedAsync(string value, string userId = null);
+
+        [Obsolete("Use GetUserKeyAutoUnlock instead, left for migration purposes")]
+        Task<string> GetKeyEncryptedAsync(string userId = null);
         [Obsolete("Use GetMasterKeyAsync instead, left for migration purposes")]
         Task<SymmetricCryptoKey> GetKeyDecryptedAsync(string userId = null);
     }

--- a/src/Core/Abstractions/IStateService.cs
+++ b/src/Core/Abstractions/IStateService.cs
@@ -20,7 +20,7 @@ namespace Bit.Core.Abstractions
         Task<string> GetMasterKeyEncryptedUserKeyAsync(string userId = null);
         Task SetMasterKeyEncryptedUserKeyAsync(string value, string userId = null);
         Task<UserKey> GetUserKeyAutoUnlockAsync(string userId = null);
-        Task SetUserKeyAutoUnlockAsync(string value, string userId = null);
+        Task SetUserKeyAutoUnlockAsync(UserKey value, string userId = null);
         Task<string> GetActiveUserIdAsync();
         Task<string> GetActiveUserEmailAsync();
         Task<T> GetActiveUserCustomDataAsync<T>(Func<Account, T> dataMapper);
@@ -35,6 +35,8 @@ namespace Bit.Core.Abstractions
         Task<EnvironmentUrlData> GetPreAuthEnvironmentUrlsAsync();
         Task SetPreAuthEnvironmentUrlsAsync(EnvironmentUrlData value);
         Task<EnvironmentUrlData> GetEnvironmentUrlsAsync(string userId = null);
+        Task<UserKey> GetUserKeyBiometricUnlockAsync(string userId = null);
+        Task SetUserKeyBiometricUnlockAsync(UserKey value, string userId = null);
         Task<bool?> GetBiometricUnlockAsync(string userId = null);
         Task SetBiometricUnlockAsync(bool? value, string userId = null);
         Task<bool> GetBiometricLockedAsync(string userId = null);

--- a/src/Core/Abstractions/IStateService.cs
+++ b/src/Core/Abstractions/IStateService.cs
@@ -49,14 +49,6 @@ namespace Bit.Core.Abstractions
         Task<EncString> GetPinKeyEncryptedUserKeyEphemeralAsync(string userId = null);
         Task SetPinKeyEncryptedUserKeyEphemeralAsync(EncString value, string userId = null);
         Task SetProtectedPinAsync(string value, string userId = null);
-        [Obsolete("Use GetUserKeyPinAsync instead, left for migration purposes")]
-        Task<string> GetPinProtectedAsync(string userId = null);
-        [Obsolete("Use SetUserKeyPinAsync instead")]
-        Task SetPinProtectedAsync(string value, string userId = null);
-        [Obsolete("Use GetUserKeyPinEphemeralAsync instead, left for migration purposes")]
-        Task<EncString> GetPinProtectedKeyAsync(string userId = null);
-        [Obsolete("Use SetUserKeyPinEphemeralAsync instead")]
-        Task SetPinProtectedKeyAsync(EncString value, string userId = null);
         Task SetKdfConfigurationAsync(KdfConfig config, string userId = null);
         Task<string> GetKeyHashAsync(string userId = null);
         Task SetKeyHashAsync(string value, string userId = null);
@@ -184,17 +176,21 @@ namespace Bit.Core.Abstractions
         void SetLocale(string locale);
         ConfigResponse GetConfigs();
         void SetConfigs(ConfigResponse value);
-        [Obsolete("Use GetUserKeyMasterKey instead")]
+        [Obsolete("Use GetPinKeyEncryptedUserKeyAsync instead, left for migration purposes")]
+        Task<string> GetPinProtectedAsync(string userId = null);
+        [Obsolete("Use SetPinKeyEncryptedUserKeyAsync instead, left for migration purposes")]
+        Task SetPinProtectedAsync(string value, string userId = null);
+        [Obsolete("Use GetPinKeyEncryptedUserKeyEphemeralAsync instead, left for migration purposes")]
+        Task<EncString> GetPinProtectedKeyAsync(string userId = null);
+        [Obsolete("Use SetPinKeyEncryptedUserKeyEphemeralAsync instead, left for migration purposes")]
+        Task SetPinProtectedKeyAsync(EncString value, string userId = null);
+        [Obsolete("Use GetMasterKeyEncryptedUserKeyAsync instead, left for migration purposes")]
         Task<string> GetEncKeyEncryptedAsync(string userId = null);
-        [Obsolete("Use SetUserKeyMasterKey instead")]
+        [Obsolete("Use SetMasterKeyEncryptedUserKeyAsync instead, left for migration purposes")]
         Task SetEncKeyEncryptedAsync(string value, string userId = null);
-        [Obsolete]
-        Task<string> GetKeyEncryptedAsync(string userId = null);
-        [Obsolete]
+        [Obsolete("Left for migration purposes")]
         Task SetKeyEncryptedAsync(string value, string userId = null);
-        [Obsolete("Use GetMasterKey instead")]
+        [Obsolete("Use GetMasterKeyAsync instead, left for migration purposes")]
         Task<SymmetricCryptoKey> GetKeyDecryptedAsync(string userId = null);
-        [Obsolete("Use GetMasterKey instead")]
-        Task SetKeyDecryptedAsync(SymmetricCryptoKey value, string userId = null);
     }
 }

--- a/src/Core/Abstractions/IStateService.cs
+++ b/src/Core/Abstractions/IStateService.cs
@@ -13,6 +13,12 @@ namespace Bit.Core.Abstractions
     public interface IStateService
     {
         List<AccountView> AccountViews { get; }
+        Task<UserKey> GetUserKeyAsync(string userId = null);
+        Task SetUserKeyAsync(UserKey value, string userId = null);
+        Task<MasterKey> GetMasterKeyAsync(string userId = null);
+        Task SetMasterKeyAsync(MasterKey value, string userId = null);
+        Task<string> GetUserKeyMasterKeyAsync(string userId = null);
+        Task SetUserKeyMasterKeyAsync(string value, string userId = null);
         Task<string> GetActiveUserIdAsync();
         Task<string> GetActiveUserEmailAsync();
         Task<T> GetActiveUserCustomDataAsync<T>(Func<Account, T> dataMapper);
@@ -44,14 +50,8 @@ namespace Bit.Core.Abstractions
         Task<EncString> GetPinProtectedKeyAsync(string userId = null);
         Task SetPinProtectedKeyAsync(EncString value, string userId = null);
         Task SetKdfConfigurationAsync(KdfConfig config, string userId = null);
-        Task<string> GetKeyEncryptedAsync(string userId = null);
-        Task SetKeyEncryptedAsync(string value, string userId = null);
-        Task<SymmetricCryptoKey> GetKeyDecryptedAsync(string userId = null);
-        Task SetKeyDecryptedAsync(SymmetricCryptoKey value, string userId = null);
         Task<string> GetKeyHashAsync(string userId = null);
         Task SetKeyHashAsync(string value, string userId = null);
-        Task<string> GetEncKeyEncryptedAsync(string userId = null);
-        Task SetEncKeyEncryptedAsync(string value, string userId = null);
         Task<Dictionary<string, string>> GetOrgKeysEncryptedAsync(string userId = null);
         Task SetOrgKeysEncryptedAsync(Dictionary<string, string> value, string userId = null);
         Task<string> GetPrivateKeyEncryptedAsync(string userId = null);
@@ -176,5 +176,17 @@ namespace Bit.Core.Abstractions
         void SetLocale(string locale);
         ConfigResponse GetConfigs();
         void SetConfigs(ConfigResponse value);
+        [Obsolete("Use GetUserKeyMasterKey instead")]
+        Task<string> GetEncKeyEncryptedAsync(string userId = null);
+        [Obsolete("Use SetUserKeyMasterKey instead")]
+        Task SetEncKeyEncryptedAsync(string value, string userId = null);
+        [Obsolete]
+        Task<string> GetKeyEncryptedAsync(string userId = null);
+        [Obsolete]
+        Task SetKeyEncryptedAsync(string value, string userId = null);
+        [Obsolete("Use GetMasterKey instead")]
+        Task<SymmetricCryptoKey> GetKeyDecryptedAsync(string userId = null);
+        [Obsolete("Use GetMasterKey instead")]
+        Task SetKeyDecryptedAsync(SymmetricCryptoKey value, string userId = null);
     }
 }

--- a/src/Core/Abstractions/IStateService.cs
+++ b/src/Core/Abstractions/IStateService.cs
@@ -42,12 +42,20 @@ namespace Bit.Core.Abstractions
         Task<bool> IsAccountBiometricIntegrityValidAsync(string bioIntegritySrcKey, string userId = null);
         Task SetAccountBiometricIntegrityValidAsync(string bioIntegritySrcKey, string userId = null);
         Task<bool> CanAccessPremiumAsync(string userId = null);
-        Task SetPersonalPremiumAsync(bool value, string userId = null);
         Task<string> GetProtectedPinAsync(string userId = null);
+        Task SetPersonalPremiumAsync(bool value, string userId = null);
+        Task<string> GetUserKeyPin(string userId = null);
+        Task SetUserKeyPin(string value, string userId = null);
+        Task<EncString> GetUserKeyPinEphemeral(string userId = null);
+        Task SetUserKeyPinEphemeral(EncString value, string userId = null);
         Task SetProtectedPinAsync(string value, string userId = null);
+        [Obsolete("Use GetUserKeyPin instead, left for migration purposes")]
         Task<string> GetPinProtectedAsync(string userId = null);
+        [Obsolete("Use SetUserKeyPin instead")]
         Task SetPinProtectedAsync(string value, string userId = null);
+        [Obsolete("Use GetUserKeyPinEphemeral instead, left for migration purposes")]
         Task<EncString> GetPinProtectedKeyAsync(string userId = null);
+        [Obsolete("Use SetUserKeyPinEphemeral instead")]
         Task SetPinProtectedKeyAsync(EncString value, string userId = null);
         Task SetKdfConfigurationAsync(KdfConfig config, string userId = null);
         Task<string> GetKeyHashAsync(string userId = null);

--- a/src/Core/Abstractions/IStateService.cs
+++ b/src/Core/Abstractions/IStateService.cs
@@ -44,7 +44,7 @@ namespace Bit.Core.Abstractions
         Task<bool> CanAccessPremiumAsync(string userId = null);
         Task<string> GetProtectedPinAsync(string userId = null);
         Task SetPersonalPremiumAsync(bool value, string userId = null);
-        Task<string> GetUserKeyPinAsync(string userId = null);
+        Task<EncString> GetUserKeyPinAsync(string userId = null);
         Task SetUserKeyPinAsync(EncString value, string userId = null);
         Task<EncString> GetUserKeyPinEphemeralAsync(string userId = null);
         Task SetUserKeyPinEphemeralAsync(EncString value, string userId = null);

--- a/src/Core/Abstractions/IVaultTimeoutService.cs
+++ b/src/Core/Abstractions/IVaultTimeoutService.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Threading.Tasks;
 using Bit.Core.Enums;
+using Bit.Core.Services;
 
 namespace Bit.Core.Abstractions
 {
@@ -16,7 +17,7 @@ namespace Bit.Core.Abstractions
         Task<bool> ShouldLockAsync(string userId = null);
         Task<bool> IsLoggedOutByTimeoutAsync(string userId = null);
         Task<bool> ShouldLogOutByTimeoutAsync(string userId = null);
-        Task<Tuple<bool, bool>> IsPinLockSetAsync(string userId = null);
+        Task<PinLockEnum> IsPinLockSetAsync(string userId = null);
         Task<bool> IsBiometricLockSetAsync(string userId = null);
         Task LockAsync(bool allowSoftLock = false, bool userInitiated = false, string userId = null);
         Task LogOutAsync(bool userInitiated = true, string userId = null);

--- a/src/Core/Abstractions/IVaultTimeoutService.cs
+++ b/src/Core/Abstractions/IVaultTimeoutService.cs
@@ -17,7 +17,7 @@ namespace Bit.Core.Abstractions
         Task<bool> ShouldLockAsync(string userId = null);
         Task<bool> IsLoggedOutByTimeoutAsync(string userId = null);
         Task<bool> ShouldLogOutByTimeoutAsync(string userId = null);
-        Task<PinLockEnum> IsPinLockSetAsync(string userId = null);
+        Task<PinLockType> IsPinLockSetAsync(string userId = null);
         Task<bool> IsBiometricLockSetAsync(string userId = null);
         Task LockAsync(bool allowSoftLock = false, bool userInitiated = false, string userId = null);
         Task LogOutAsync(bool userInitiated = true, string userId = null);

--- a/src/Core/Abstractions/IVaultTimeoutService.cs
+++ b/src/Core/Abstractions/IVaultTimeoutService.cs
@@ -17,7 +17,7 @@ namespace Bit.Core.Abstractions
         Task<bool> ShouldLockAsync(string userId = null);
         Task<bool> IsLoggedOutByTimeoutAsync(string userId = null);
         Task<bool> ShouldLogOutByTimeoutAsync(string userId = null);
-        Task<PinLockType> IsPinLockSetAsync(string userId = null);
+        Task<PinLockType> GetPinLockTypeAsync(string userId = null);
         Task<bool> IsBiometricLockSetAsync(string userId = null);
         Task LockAsync(bool allowSoftLock = false, bool userInitiated = false, string userId = null);
         Task LogOutAsync(bool userInitiated = true, string userId = null);

--- a/src/Core/Constants.cs
+++ b/src/Core/Constants.cs
@@ -81,7 +81,7 @@ namespace Bit.Core
 
         public static string VaultTimeoutKey(string userId) => $"vaultTimeout_{userId}";
         public static string VaultTimeoutActionKey(string userId) => $"vaultTimeoutAction_{userId}";
-        public static string UserKeyKey(string userId) => $"userKey_{userId}";
+        public static string MasterKeyEncryptedUserKeyKey(string userId) => $"masterKeyEncryptedUserKey_{userId}";
         public static string CiphersKey(string userId) => $"ciphers_{userId}";
         public static string FoldersKey(string userId) => $"folders_{userId}";
         public static string CollectionsKey(string userId) => $"collections_{userId}";
@@ -93,7 +93,7 @@ namespace Bit.Core
         public static string EncOrgKeysKey(string userId) => $"encOrgKeys_{userId}";
         public static string EncPrivateKeyKey(string userId) => $"encPrivateKey_{userId}";
         public static string KeyHashKey(string userId) => $"keyHash_{userId}";
-        public static string UserKeyPinKey(string userId) => $"userKeyPin_{userId}";
+        public static string PinKeyEncryptedUserKeyKey(string userId) => $"pinKeyEncryptedUserKey_{userId}";
         public static string PassGenOptionsKey(string userId) => $"passwordGenerationOptions_{userId}";
         public static string PassGenHistoryKey(string userId) => $"generatedPasswordHistory_{userId}";
         public static string TwoFactorTokenKey(string email) => $"twoFactorToken_{email}";

--- a/src/Core/Constants.cs
+++ b/src/Core/Constants.cs
@@ -81,7 +81,7 @@ namespace Bit.Core
 
         public static string VaultTimeoutKey(string userId) => $"vaultTimeout_{userId}";
         public static string VaultTimeoutActionKey(string userId) => $"vaultTimeoutAction_{userId}";
-        public static string UserKeyKey(string userId) => $"UserKey_{userId}";
+        public static string UserKeyKey(string userId) => $"userKey_{userId}";
         public static string CiphersKey(string userId) => $"ciphers_{userId}";
         public static string FoldersKey(string userId) => $"folders_{userId}";
         public static string CollectionsKey(string userId) => $"collections_{userId}";
@@ -93,7 +93,7 @@ namespace Bit.Core
         public static string EncOrgKeysKey(string userId) => $"encOrgKeys_{userId}";
         public static string EncPrivateKeyKey(string userId) => $"encPrivateKey_{userId}";
         public static string KeyHashKey(string userId) => $"keyHash_{userId}";
-        public static string PinProtectedKey(string userId) => $"pinProtectedKey_{userId}";
+        public static string UserKeyPinKey(string userId) => $"userKeyPin_{userId}";
         public static string PassGenOptionsKey(string userId) => $"passwordGenerationOptions_{userId}";
         public static string PassGenHistoryKey(string userId) => $"generatedPasswordHistory_{userId}";
         public static string TwoFactorTokenKey(string email) => $"twoFactorToken_{email}";
@@ -126,5 +126,7 @@ namespace Bit.Core
         public static string KeyKey(string userId) => $"key_{userId}";
         [Obsolete]
         public static string EncKeyKey(string userId) => $"encKey_{userId}";
+        [Obsolete]
+        public static string PinProtectedKey(string userId) => $"pinProtectedKey_{userId}";
     }
 }

--- a/src/Core/Constants.cs
+++ b/src/Core/Constants.cs
@@ -82,6 +82,7 @@ namespace Bit.Core
         public static string VaultTimeoutKey(string userId) => $"vaultTimeout_{userId}";
         public static string VaultTimeoutActionKey(string userId) => $"vaultTimeoutAction_{userId}";
         public static string MasterKeyEncryptedUserKeyKey(string userId) => $"masterKeyEncryptedUserKey_{userId}";
+        public static string UserKeyAutoUnlockKey(string userId) => $"autoUnlock_{userId}";
         public static string CiphersKey(string userId) => $"ciphers_{userId}";
         public static string FoldersKey(string userId) => $"folders_{userId}";
         public static string CollectionsKey(string userId) => $"collections_{userId}";

--- a/src/Core/Constants.cs
+++ b/src/Core/Constants.cs
@@ -83,6 +83,7 @@ namespace Bit.Core
         public static string VaultTimeoutActionKey(string userId) => $"vaultTimeoutAction_{userId}";
         public static string MasterKeyEncryptedUserKeyKey(string userId) => $"masterKeyEncryptedUserKey_{userId}";
         public static string UserKeyAutoUnlockKey(string userId) => $"autoUnlock_{userId}";
+        public static string UserKeyBiometricUnlockKey(string userId) => $"biometricUnlock_{userId}";
         public static string CiphersKey(string userId) => $"ciphers_{userId}";
         public static string FoldersKey(string userId) => $"folders_{userId}";
         public static string CollectionsKey(string userId) => $"collections_{userId}";

--- a/src/Core/Constants.cs
+++ b/src/Core/Constants.cs
@@ -1,4 +1,6 @@
-﻿namespace Bit.Core
+﻿using System;
+
+namespace Bit.Core
 {
     public static class Constants
     {
@@ -79,6 +81,7 @@
 
         public static string VaultTimeoutKey(string userId) => $"vaultTimeout_{userId}";
         public static string VaultTimeoutActionKey(string userId) => $"vaultTimeoutAction_{userId}";
+        public static string UserKeyKey(string userId) => $"UserKey_{userId}";
         public static string CiphersKey(string userId) => $"ciphers_{userId}";
         public static string FoldersKey(string userId) => $"folders_{userId}";
         public static string CollectionsKey(string userId) => $"collections_{userId}";
@@ -87,10 +90,8 @@
         public static string NeverDomainsKey(string userId) => $"neverDomains_{userId}";
         public static string SendsKey(string userId) => $"sends_{userId}";
         public static string PoliciesKey(string userId) => $"policies_{userId}";
-        public static string KeyKey(string userId) => $"key_{userId}";
         public static string EncOrgKeysKey(string userId) => $"encOrgKeys_{userId}";
         public static string EncPrivateKeyKey(string userId) => $"encPrivateKey_{userId}";
-        public static string EncKeyKey(string userId) => $"encKey_{userId}";
         public static string KeyHashKey(string userId) => $"keyHash_{userId}";
         public static string PinProtectedKey(string userId) => $"pinProtectedKey_{userId}";
         public static string PassGenOptionsKey(string userId) => $"passwordGenerationOptions_{userId}";
@@ -121,5 +122,9 @@
         public static string PushCurrentTokenKey(string userId) => $"pushCurrentToken_{userId}";
         public static string ShouldConnectToWatchKey(string userId) => $"shouldConnectToWatch_{userId}";
         public static string ScreenCaptureAllowedKey(string userId) => $"screenCaptureAllowed_{userId}";
+        [Obsolete]
+        public static string KeyKey(string userId) => $"key_{userId}";
+        [Obsolete]
+        public static string EncKeyKey(string userId) => $"encKey_{userId}";
     }
 }

--- a/src/Core/Models/Domain/Account.cs
+++ b/src/Core/Models/Domain/Account.cs
@@ -117,9 +117,14 @@ namespace Bit.Core.Models.Domain
 
         public class AccountVolatileData
         {
-            public SymmetricCryptoKey Key;
-            public EncString PinProtectedKey;
+            public UserKey UserKey;
+            public MasterKey MasterKey;
+            public EncString UserKeyPinEphemeral;
             public bool? BiometricLocked;
+            [Obsolete("Jul 6 2023: Key has been deprecated. We will use the User Key in the future. It remains here for migration during app upgrade.")]
+            public SymmetricCryptoKey Key;
+            [Obsolete("Jul 6 2023: PinProtectedKey has been deprecated in favor of UserKeyPinEphemeral. It remains here for migration during app upgrade.")]
+            public EncString PinProtectedKey;
         }
     }
 }

--- a/src/Core/Models/Domain/Account.cs
+++ b/src/Core/Models/Domain/Account.cs
@@ -119,7 +119,7 @@ namespace Bit.Core.Models.Domain
         {
             public UserKey UserKey;
             public MasterKey MasterKey;
-            public EncString UserKeyPinEphemeral;
+            public EncString PinKeyEncryptedUserKeyEphemeral;
             public bool? BiometricLocked;
             [Obsolete("Jul 6 2023: Key has been deprecated. We will use the User Key in the future. It remains here for migration during app upgrade.")]
             public SymmetricCryptoKey Key;

--- a/src/Core/Models/Domain/SymmetricCryptoKey.cs
+++ b/src/Core/Models/Domain/SymmetricCryptoKey.cs
@@ -74,4 +74,18 @@ namespace Bit.Core.Models.Domain
         public string EncKeyB64 { get; set; }
         public string MacKeyB64 { get; set; }
     }
+
+    public class UserKey : SymmetricCryptoKey
+    {
+        public UserKey(byte[] key, EncryptionType? encType = null)
+            : base(key, encType)
+        { }
+    }
+
+    public class MasterKey : SymmetricCryptoKey
+    {
+        public MasterKey(byte[] key, EncryptionType? encType = null)
+            : base(key, encType)
+        { }
+    }
 }

--- a/src/Core/Models/Domain/SymmetricCryptoKey.cs
+++ b/src/Core/Models/Domain/SymmetricCryptoKey.cs
@@ -88,4 +88,18 @@ namespace Bit.Core.Models.Domain
             : base(key, encType)
         { }
     }
+
+    public class PinKey : SymmetricCryptoKey
+    {
+        public PinKey(byte[] key, EncryptionType? encType = null)
+            : base(key, encType)
+        { }
+    }
+
+    public class OrgKey : SymmetricCryptoKey
+    {
+        public OrgKey(byte[] key, EncryptionType? encType = null)
+            : base(key, encType)
+        { }
+    }
 }

--- a/src/Core/Services/ApiService.cs
+++ b/src/Core/Services/ApiService.cs
@@ -485,7 +485,7 @@ namespace Bit.Core.Services
 
         #region Key Connector
 
-        public async Task<KeyConnectorUserKeyResponse> GetUserKeyFromKeyConnector(string keyConnectorUrl)
+        public async Task<KeyConnectorUserKeyResponse> GetMasterKeyFromKeyConnector(string keyConnectorUrl)
         {
             using (var requestMessage = new HttpRequestMessage())
             {

--- a/src/Core/Services/ApiService.cs
+++ b/src/Core/Services/ApiService.cs
@@ -485,7 +485,7 @@ namespace Bit.Core.Services
 
         #region Key Connector
 
-        public async Task<KeyConnectorUserKeyResponse> GetMasterKeyFromKeyConnector(string keyConnectorUrl)
+        public async Task<KeyConnectorUserKeyResponse> GetMasterKeyFromKeyConnectorAsync(string keyConnectorUrl)
         {
             using (var requestMessage = new HttpRequestMessage())
             {

--- a/src/Core/Services/AuthService.cs
+++ b/src/Core/Services/AuthService.cs
@@ -508,7 +508,7 @@ namespace Bit.Core.Services
                         catch { }
                     }
 
-                    await _cryptoService.SetPrivateKeyAsync(tokenResponse.PrivateKey);
+                    await _cryptoService.SetUserPrivateKeyAsync(tokenResponse.PrivateKey);
                 }
                 else if (tokenResponse.KeyConnectorUrl != null)
                 {

--- a/src/Core/Services/AuthService.cs
+++ b/src/Core/Services/AuthService.cs
@@ -477,16 +477,20 @@ namespace Bit.Core.Services
 
                 if (code == null || tokenResponse.Key != null)
                 {
-                    if (tokenResponse.KeyConnectorUrl != null)
-                    {
-                        await _keyConnectorService.GetAndSetMasterKeyAsync(tokenResponse.KeyConnectorUrl);
-                    }
-
                     await _cryptoService.SetMasterKeyEncryptedUserKeyAsync(tokenResponse.Key);
 
                     if (masterKey != null)
                     {
                         await _cryptoService.SetMasterKeyAsync(masterKey);
+                    }
+                    if (tokenResponse.KeyConnectorUrl != null)
+                    {
+                        await _keyConnectorService.GetAndSetMasterKeyAsync(tokenResponse.KeyConnectorUrl);
+                    }
+
+                    masterKey ??= await _stateService.GetMasterKeyAsync();
+                    if (masterKey != null)
+                    {
                         var userKey = await _cryptoService.DecryptUserKeyWithMasterKeyAsync(masterKey);
                         await _cryptoService.SetUserKeyAsync(userKey);
                     }

--- a/src/Core/Services/AuthService.cs
+++ b/src/Core/Services/AuthService.cs
@@ -514,13 +514,15 @@ namespace Bit.Core.Services
                 {
                     // SSO Key Connector Onboarding
                     var password = await _cryptoFunctionService.RandomBytesAsync(64);
-                    var newMasterKey = await _cryptoService.MakeMasterKeyAsync(Convert.ToBase64String(password), _tokenService.GetEmail(), tokenResponse.KdfConfig);
+                    var newMasterKey = await _cryptoService.MakeMasterKeyAsync(
+                        Convert.ToBase64String(password),
+                        _tokenService.GetEmail(),
+                        tokenResponse.KdfConfig);
+
                     var keyConnectorRequest = new KeyConnectorUserKeyRequest(newMasterKey.EncKeyB64);
                     await _cryptoService.SetMasterKeyAsync(newMasterKey);
 
-                    var (newUserKey, newProtectedUserKey) = await _cryptoService.EncryptUserKeyWithMasterKeyAsync(
-                        newMasterKey,
-                        await _cryptoService.MakeUserKeyAsync());
+                    var (newUserKey, newProtectedUserKey) = await _cryptoService.EncryptUserKeyWithMasterKeyAsync(newMasterKey);
 
                     await _cryptoService.SetUserKeyAsync(newUserKey);
                     var (newPublicKey, newProtectedPrivateKey) = await _cryptoService.MakeKeyPairAsync();

--- a/src/Core/Services/AuthService.cs
+++ b/src/Core/Services/AuthService.cs
@@ -356,7 +356,7 @@ namespace Bit.Core.Services
                     throw;
                 }
             }
-            return await _cryptoService.MakeKeyAsync(masterPassword, email, kdfConfig);
+            return await _cryptoService.MakeMasterKeyAsync(masterPassword, email, kdfConfig);
         }
 
         private async Task<AuthResult> LogInHelperAsync(string email, string hashedPassword, string localHashedPassword,
@@ -511,11 +511,11 @@ namespace Bit.Core.Services
                 {
                     // SSO Key Connector Onboarding
                     var password = await _cryptoFunctionService.RandomBytesAsync(64);
-                    var k = await _cryptoService.MakeKeyAsync(Convert.ToBase64String(password), _tokenService.GetEmail(), tokenResponse.KdfConfig);
-                    var keyConnectorRequest = new KeyConnectorUserKeyRequest(k.EncKeyB64);
-                    await _cryptoService.SetKeyAsync(k);
+                    var masterKey = await _cryptoService.MakeMasterKeyAsync(Convert.ToBase64String(password), _tokenService.GetEmail(), tokenResponse.KdfConfig);
+                    var keyConnectorRequest = new KeyConnectorUserKeyRequest(masterKey.EncKeyB64);
+                    await _cryptoService.SetKeyAsync(masterKey);
 
-                    var encKey = await _cryptoService.MakeEncKeyAsync(k);
+                    var encKey = await _cryptoService.MakeEncKeyAsync(masterKey);
                     await _cryptoService.SetEncKeyAsync(encKey.Item2.EncryptedString);
                     var keyPair = await _cryptoService.MakeKeyPairAsync();
 

--- a/src/Core/Services/AuthService.cs
+++ b/src/Core/Services/AuthService.cs
@@ -46,6 +46,7 @@ namespace Bit.Core.Services
             II18nService i18nService,
             IPlatformUtilsService platformUtilsService,
             IMessagingService messagingService,
+            IKeyConnectorService keyConnectorService,
             IPasswordGenerationService passwordGenerationService,
             IPolicyService policyService,
             bool setCryptoKeys = true)
@@ -59,6 +60,7 @@ namespace Bit.Core.Services
             _i18nService = i18nService;
             _platformUtilsService = platformUtilsService;
             _messagingService = messagingService;
+            _keyConnectorService = keyConnectorService;
             _passwordGenerationService = passwordGenerationService;
             _policyService = policyService;
             _setCryptoKeys = setCryptoKeys;

--- a/src/Core/Services/AuthService.cs
+++ b/src/Core/Services/AuthService.cs
@@ -145,8 +145,8 @@ namespace Bit.Core.Services
             SelectedTwoFactorProviderType = null;
             _2faForcePasswordResetReason = null;
             var key = await MakePreloginKeyAsync(masterPassword, email);
-            var hashedPassword = await _cryptoService.HashPasswordAsync(masterPassword, key);
-            var localHashedPassword = await _cryptoService.HashPasswordAsync(masterPassword, key, HashPurpose.LocalAuthorization);
+            var hashedPassword = await _cryptoService.HashMasterKeyAsync(masterPassword, key);
+            var localHashedPassword = await _cryptoService.HashMasterKeyAsync(masterPassword, key, HashPurpose.LocalAuthorization);
             var result = await LogInHelperAsync(email, hashedPassword, localHashedPassword, null, null, null, key, null, null, null, captchaToken);
 
             if (await RequirePasswordChangeAsync(email, masterPassword))
@@ -236,8 +236,8 @@ namespace Bit.Core.Services
         {
             SelectedTwoFactorProviderType = null;
             var key = await MakePreloginKeyAsync(masterPassword, email);
-            var hashedPassword = await _cryptoService.HashPasswordAsync(masterPassword, key);
-            var localHashedPassword = await _cryptoService.HashPasswordAsync(masterPassword, key, HashPurpose.LocalAuthorization);
+            var hashedPassword = await _cryptoService.HashMasterKeyAsync(masterPassword, key);
+            var localHashedPassword = await _cryptoService.HashMasterKeyAsync(masterPassword, key, HashPurpose.LocalAuthorization);
             return await LogInHelperAsync(email, hashedPassword, localHashedPassword, null, null, null, key, twoFactorProvider,
                 twoFactorToken, remember);
         }
@@ -473,7 +473,7 @@ namespace Bit.Core.Services
 
                 if (localHashedPassword != null)
                 {
-                    await _cryptoService.SetPasswordHashAsync(localHashedPassword);
+                    await _cryptoService.SetMasterKeyHashAsync(localHashedPassword);
                 }
 
                 if (code == null || tokenResponse.Key != null)

--- a/src/Core/Services/AuthService.cs
+++ b/src/Core/Services/AuthService.cs
@@ -46,7 +46,6 @@ namespace Bit.Core.Services
             II18nService i18nService,
             IPlatformUtilsService platformUtilsService,
             IMessagingService messagingService,
-            IVaultTimeoutService vaultTimeoutService,
             IKeyConnectorService keyConnectorService,
             IPasswordGenerationService passwordGenerationService,
             IPolicyService policyService,
@@ -480,7 +479,7 @@ namespace Bit.Core.Services
                 {
                     if (tokenResponse.KeyConnectorUrl != null)
                     {
-                        await _keyConnectorService.GetAndSetKey(tokenResponse.KeyConnectorUrl);
+                        await _keyConnectorService.GetAndSetMasterKeyAsync(tokenResponse.KeyConnectorUrl);
                     }
 
                     await _cryptoService.SetMasterKeyEncryptedUserKeyAsync(tokenResponse.Key);

--- a/src/Core/Services/AuthService.cs
+++ b/src/Core/Services/AuthService.cs
@@ -520,11 +520,13 @@ namespace Bit.Core.Services
                         tokenResponse.KdfConfig);
 
                     var keyConnectorRequest = new KeyConnectorUserKeyRequest(newMasterKey.EncKeyB64);
-                    await _cryptoService.SetMasterKeyAsync(newMasterKey);
 
                     var (newUserKey, newProtectedUserKey) = await _cryptoService.EncryptUserKeyWithMasterKeyAsync(newMasterKey);
 
                     await _cryptoService.SetUserKeyAsync(newUserKey);
+                    await _cryptoService.SetMasterKeyEncryptedUserKeyAsync(newProtectedUserKey.EncryptedString);
+                    await _cryptoService.SetMasterKeyAsync(newMasterKey);
+
                     var (newPublicKey, newProtectedPrivateKey) = await _cryptoService.MakeKeyPairAsync();
 
                     try

--- a/src/Core/Services/AuthService.cs
+++ b/src/Core/Services/AuthService.cs
@@ -46,7 +46,6 @@ namespace Bit.Core.Services
             II18nService i18nService,
             IPlatformUtilsService platformUtilsService,
             IMessagingService messagingService,
-            IKeyConnectorService keyConnectorService,
             IPasswordGenerationService passwordGenerationService,
             IPolicyService policyService,
             bool setCryptoKeys = true)
@@ -60,7 +59,6 @@ namespace Bit.Core.Services
             _i18nService = i18nService;
             _platformUtilsService = platformUtilsService;
             _messagingService = messagingService;
-            _keyConnectorService = keyConnectorService;
             _passwordGenerationService = passwordGenerationService;
             _policyService = policyService;
             _setCryptoKeys = setCryptoKeys;

--- a/src/Core/Services/AuthService.cs
+++ b/src/Core/Services/AuthService.cs
@@ -470,10 +470,6 @@ namespace Bit.Core.Services
             _messagingService.Send("accountAdded");
             if (_setCryptoKeys)
             {
-                if (masterKey != null)
-                {
-                    await _cryptoService.SetMasterKeyAsync(masterKey);
-                }
 
                 if (localHashedPassword != null)
                 {
@@ -488,6 +484,13 @@ namespace Bit.Core.Services
                     }
 
                     await _cryptoService.SetMasterKeyEncryptedUserKeyAsync(tokenResponse.Key);
+
+                    if (masterKey != null)
+                    {
+                        await _cryptoService.SetMasterKeyAsync(masterKey);
+                        var userKey = await _cryptoService.DecryptUserKeyWithMasterKeyAsync(masterKey);
+                        await _cryptoService.SetUserKeyAsync(userKey);
+                    }
 
                     // User doesn't have a key pair yet (old account), let's generate one for them.
                     if (tokenResponse.PrivateKey == null)

--- a/src/Core/Services/AuthService.cs
+++ b/src/Core/Services/AuthService.cs
@@ -477,7 +477,7 @@ namespace Bit.Core.Services
 
                 if (localHashedPassword != null)
                 {
-                    await _cryptoService.SetKeyHashAsync(localHashedPassword);
+                    await _cryptoService.SetPasswordHashAsync(localHashedPassword);
                 }
 
                 if (code == null || tokenResponse.Key != null)

--- a/src/Core/Services/AuthService.cs
+++ b/src/Core/Services/AuthService.cs
@@ -505,7 +505,7 @@ namespace Bit.Core.Services
                         catch { }
                     }
 
-                    await _cryptoService.SetEncPrivateKeyAsync(tokenResponse.PrivateKey);
+                    await _cryptoService.SetPrivateKeyAsync(tokenResponse.PrivateKey);
                 }
                 else if (tokenResponse.KeyConnectorUrl != null)
                 {

--- a/src/Core/Services/CipherService.cs
+++ b/src/Core/Services/CipherService.cs
@@ -556,20 +556,9 @@ namespace Bit.Core.Services
 
         public async Task<Cipher> SaveAttachmentRawWithServerAsync(Cipher cipher, string filename, byte[] data)
         {
-            SymmetricCryptoKey attachmentKey;
-            EncString protectedAttachmentKey;
-            var orgKey = await _cryptoService.GetOrgKeyAsync(cipher.OrganizationId);
-            if (orgKey != null)
-            {
-                (attachmentKey, protectedAttachmentKey) = await _cryptoService.MakeDataEncKeyAsync(orgKey);
-            }
-            else
-            {
-                var userKey = await _cryptoService.GetUserKeyWithLegacySupportAsync();
-                (attachmentKey, protectedAttachmentKey) = await _cryptoService.MakeDataEncKeyAsync(userKey);
-            }
+            var (attachmentKey, protectedAttachmentKey, encKey) = await MakeAttachmentKeyAsync(cipher.OrganizationId);
 
-            var encFileName = await _cryptoService.EncryptAsync(filename, orgKey);
+            var encFileName = await _cryptoService.EncryptAsync(filename, encKey);
             var encFileData = await _cryptoService.EncryptToBytesAsync(data, attachmentKey);
 
             CipherResponse response;
@@ -806,6 +795,21 @@ namespace Bit.Core.Services
 
         // Helpers
 
+        private async Task<Tuple<SymmetricCryptoKey, EncString, SymmetricCryptoKey>> MakeAttachmentKeyAsync(string organizationId)
+        {
+            SymmetricCryptoKey attachmentKey;
+            EncString protectedAttachmentKey;
+            var orgKey = await _cryptoService.GetOrgKeyAsync(organizationId);
+            if (orgKey != null)
+            {
+                (attachmentKey, protectedAttachmentKey) = await _cryptoService.MakeDataEncKeyAsync(orgKey);
+                return new Tuple<SymmetricCryptoKey, EncString, SymmetricCryptoKey>(attachmentKey, protectedAttachmentKey, orgKey);
+            }
+            var userKey = await _cryptoService.GetUserKeyWithLegacySupportAsync();
+            (attachmentKey, protectedAttachmentKey) = await _cryptoService.MakeDataEncKeyAsync(userKey);
+            return new Tuple<SymmetricCryptoKey, EncString, SymmetricCryptoKey>(attachmentKey, protectedAttachmentKey, userKey);
+        }
+
         private async Task ShareAttachmentWithServerAsync(AttachmentView attachmentView, string cipherId,
             string organizationId)
         {
@@ -818,20 +822,9 @@ namespace Bit.Core.Services
             var bytes = await attachmentResponse.Content.ReadAsByteArrayAsync();
             var decBytes = await _cryptoService.DecryptFromBytesAsync(bytes, null);
 
-            SymmetricCryptoKey attachmentKey;
-            EncString protectedAttachmentKey;
-            var orgKey = await _cryptoService.GetOrgKeyAsync(organizationId);
-            if (orgKey != null)
-            {
-                (attachmentKey, protectedAttachmentKey) = await _cryptoService.MakeDataEncKeyAsync(orgKey);
-            }
-            else
-            {
-                var userKey = await _cryptoService.GetUserKeyWithLegacySupportAsync();
-                (attachmentKey, protectedAttachmentKey) = await _cryptoService.MakeDataEncKeyAsync(userKey);
-            }
+            var (attachmentKey, protectedAttachmentKey, encKey) = await MakeAttachmentKeyAsync(organizationId);
 
-            var encFileName = await _cryptoService.EncryptAsync(attachmentView.FileName, orgKey);
+            var encFileName = await _cryptoService.EncryptAsync(attachmentView.FileName, encKey);
             var encFileData = await _cryptoService.EncryptToBytesAsync(decBytes, attachmentKey);
 
             var boundary = string.Concat("--BWMobileFormBoundary", DateTime.UtcNow.Ticks);

--- a/src/Core/Services/CipherService.cs
+++ b/src/Core/Services/CipherService.cs
@@ -249,7 +249,7 @@ namespace Bit.Core.Services
             {
                 try
                 {
-                    var hashKey = await _cryptoService.HasKeyAsync();
+                    var hashKey = await _cryptoService.HasUserKeyAsync();
                     if (!hashKey)
                     {
                         throw new Exception("No key.");

--- a/src/Core/Services/CipherService.cs
+++ b/src/Core/Services/CipherService.cs
@@ -797,17 +797,10 @@ namespace Bit.Core.Services
 
         private async Task<Tuple<SymmetricCryptoKey, EncString, SymmetricCryptoKey>> MakeAttachmentKeyAsync(string organizationId)
         {
-            SymmetricCryptoKey attachmentKey;
-            EncString protectedAttachmentKey;
-            var orgKey = await _cryptoService.GetOrgKeyAsync(organizationId);
-            if (orgKey != null)
-            {
-                (attachmentKey, protectedAttachmentKey) = await _cryptoService.MakeDataEncKeyAsync(orgKey);
-                return new Tuple<SymmetricCryptoKey, EncString, SymmetricCryptoKey>(attachmentKey, protectedAttachmentKey, orgKey);
-            }
-            var userKey = await _cryptoService.GetUserKeyWithLegacySupportAsync();
-            (attachmentKey, protectedAttachmentKey) = await _cryptoService.MakeDataEncKeyAsync(userKey);
-            return new Tuple<SymmetricCryptoKey, EncString, SymmetricCryptoKey>(attachmentKey, protectedAttachmentKey, userKey);
+            var encryptionKey = await _cryptoService.GetOrgKeyAsync(organizationId)
+                ?? (SymmetricCryptoKey)await _cryptoService.GetUserKeyWithLegacySupportAsync();
+            var (attachmentKey, protectedAttachmentKey) = await _cryptoService.MakeDataEncKeyAsync(encryptionKey);
+            return new Tuple<SymmetricCryptoKey, EncString, SymmetricCryptoKey>(attachmentKey, protectedAttachmentKey, encryptionKey);
         }
 
         private async Task ShareAttachmentWithServerAsync(AttachmentView attachmentView, string cipherId,

--- a/src/Core/Services/CipherService.cs
+++ b/src/Core/Services/CipherService.cs
@@ -249,8 +249,7 @@ namespace Bit.Core.Services
             {
                 try
                 {
-                    var hashKey = await _cryptoService.HasUserKeyAsync();
-                    if (!hashKey)
+                    if (!await _cryptoService.HasUserKeyAsync())
                     {
                         throw new Exception("No key.");
                     }

--- a/src/Core/Services/CollectionService.cs
+++ b/src/Core/Services/CollectionService.cs
@@ -101,7 +101,7 @@ namespace Bit.Core.Services
             {
                 return _decryptedCollectionCache;
             }
-            var hasKey = await _cryptoService.HasKeyAsync();
+            var hasKey = await _cryptoService.HasUserKeyAsync();
             if (!hasKey)
             {
                 throw new Exception("No key.");

--- a/src/Core/Services/CryptoService.cs
+++ b/src/Core/Services/CryptoService.cs
@@ -684,7 +684,7 @@ namespace Bit.Core.Services
             // Refresh, set, or clear the auto key
             if (await _stateService.GetVaultTimeoutAsync(userId) == null)
             {
-                await _stateService.SetUserKeyAutoUnlockAsync(userKey.KeyB64, userId);
+                await _stateService.SetUserKeyAutoUnlockAsync(userKey, userId);
             }
             else
             {
@@ -971,7 +971,7 @@ namespace Bit.Core.Services
                 new EncString(encryptedUserKey),
                 userId);
             // Migrate
-            await _stateService.SetUserKeyAutoUnlockAsync(userKey.KeyB64, userId);
+            await _stateService.SetUserKeyAutoUnlockAsync(userKey, userId);
             await _stateService.SetKeyEncryptedAsync(null, userId);
             // Set encrypted user key just in case the user locks without syncing
             await SetMasterKeyEncryptedUserKeyAsync(encryptedUserKey);

--- a/src/Core/Services/CryptoService.cs
+++ b/src/Core/Services/CryptoService.cs
@@ -670,7 +670,7 @@ namespace Bit.Core.Services
 
         private async Task StoreAdditionalKeysAsync(UserKey userKey, string userId = null)
         {
-            // Refresh, set, or clear the pin key
+            // Set, refresh, or clear the pin key
             if (await _stateService.GetProtectedPinAsync(userId) != null)
             {
                 await UpdatePinKeyAsync(userKey, userId);
@@ -681,7 +681,7 @@ namespace Bit.Core.Services
                 await _stateService.SetPinKeyEncryptedUserKeyEphemeralAsync(null, userId);
             }
 
-            // Refresh, set, or clear the auto key
+            // Set, refresh, or clear the auto unlock key
             if (await _stateService.GetVaultTimeoutAsync(userId) == null)
             {
                 await _stateService.SetUserKeyAutoUnlockAsync(userKey, userId);
@@ -689,6 +689,16 @@ namespace Bit.Core.Services
             else
             {
                 await _stateService.SetUserKeyAutoUnlockAsync(null, userId);
+            }
+
+            // Set, refresh, or clear the biometric unlock key
+            if ((await _stateService.GetBiometricUnlockAsync(userId)).GetValueOrDefault())
+            {
+                await _stateService.SetUserKeyBiometricUnlockAsync(userKey, userId);
+            }
+            else
+            {
+                await _stateService.SetUserKeyBiometricUnlockAsync(null, userId);
             }
         }
 

--- a/src/Core/Services/CryptoService.cs
+++ b/src/Core/Services/CryptoService.cs
@@ -43,15 +43,10 @@ namespace Bit.Core.Services
             _orgKeys = null;
         }
 
-        public async Task ToggleKeysAsync()
+        public async Task RefreshKeysAsync()
         {
             // refresh or clear the pin key
             await SetUserKeyAsync(await GetUserKeyAsync());
-
-            // refresh or clear the encrypted user key
-            var encUserKey = await _stateService.GetUserKeyMasterKeyAsync();
-            await _stateService.SetUserKeyMasterKeyAsync(null);
-            await _stateService.SetUserKeyMasterKeyAsync(encUserKey);
         }
 
         public async Task SetUserKeyAsync(UserKey userKey, string userId = null)

--- a/src/Core/Services/CryptoService.cs
+++ b/src/Core/Services/CryptoService.cs
@@ -288,11 +288,11 @@ namespace Bit.Core.Services
                 return null;
             }
             var orgKeys = await GetOrgKeysAsync();
-            if (orgKeys?.TryGetValue(orgId, out var orgKey) == true)
+            if (orgKeys == null || !orgKeys.ContainsKey(orgId))
             {
-                return orgKey;
+                return null;
             }
-            return null;
+            return orgKeys[orgId];
         }
 
         public Task<Dictionary<string, OrgKey>> GetOrgKeysAsync()

--- a/src/Core/Services/CryptoService.cs
+++ b/src/Core/Services/CryptoService.cs
@@ -625,13 +625,13 @@ namespace Bit.Core.Services
                 encString.Iv, encString.Mac, key);
         }
 
-        public Task<EncString> EncryptAsync(string plainValue, SymmetricCryptoKey key = null)
+        public async Task<EncString> EncryptAsync(string plainValue, SymmetricCryptoKey key = null)
         {
             if (plainValue == null)
             {
                 return null;
             }
-            return EncryptAsync(Encoding.UTF8.GetBytes(plainValue), key);
+            return await EncryptAsync(Encoding.UTF8.GetBytes(plainValue), key);
         }
 
         public async Task<EncString> EncryptAsync(byte[] plainValue, SymmetricCryptoKey key = null)

--- a/src/Core/Services/CryptoService.cs
+++ b/src/Core/Services/CryptoService.cs
@@ -19,13 +19,11 @@ namespace Bit.Core.Services
         private readonly IStateService _stateService;
         private readonly ICryptoFunctionService _cryptoFunctionService;
 
-        private SymmetricCryptoKey _encKey;
         private SymmetricCryptoKey _legacyEtmKey;
         private string _passwordHash;
         private byte[] _publicKey;
         private byte[] _privateKey;
         private Dictionary<string, OrgKey> _orgKeys;
-        private Task<SymmetricCryptoKey> _getEncKeysTask;
         private Task<Dictionary<string, OrgKey>> _getOrgKeysTask;
 
         public CryptoService(
@@ -38,7 +36,6 @@ namespace Bit.Core.Services
 
         public void ClearCache()
         {
-            _encKey = null;
             _legacyEtmKey = null;
             _passwordHash = null;
             _publicKey = null;

--- a/src/Core/Services/CryptoService.cs
+++ b/src/Core/Services/CryptoService.cs
@@ -60,8 +60,8 @@ namespace Bit.Core.Services
             }
             else
             {
-                await _stateService.SetUserKeyPinAsync(null, userId);
-                await _stateService.SetUserKeyPinEphemeralAsync(null, userId);
+                await _stateService.SetPinKeyEncryptedUserKeyAsync(null, userId);
+                await _stateService.SetPinKeyEncryptedUserKeyEphemeralAsync(null, userId);
             }
         }
 
@@ -90,7 +90,7 @@ namespace Bit.Core.Services
 
         public async Task<bool> HasEncryptedUserKeyAsync(string userId = null)
         {
-            return await _stateService.GetUserKeyMasterKeyAsync(userId) != null;
+            return await _stateService.GetMasterKeyEncryptedUserKeyAsync(userId) != null;
         }
 
         public async Task<UserKey> MakeUserKeyAsync()
@@ -105,7 +105,7 @@ namespace Bit.Core.Services
 
         public Task SetMasterKeyEncryptedUserKeyAsync(string value, string userId = null)
         {
-            return _stateService.SetUserKeyMasterKeyAsync(value, userId);
+            return _stateService.SetMasterKeyEncryptedUserKeyAsync(value, userId);
         }
 
         public Task SetMasterKeyAsync(MasterKey masterKey, string userId = null)
@@ -154,7 +154,7 @@ namespace Bit.Core.Services
 
             if (encUserKey == null)
             {
-                var userKeyMasterKey = await _stateService.GetUserKeyMasterKeyAsync(userId);
+                var userKeyMasterKey = await _stateService.GetMasterKeyEncryptedUserKeyAsync(userId);
                 if (userKeyMasterKey == null)
                 {
                     throw new Exception("No encrypted user key found");
@@ -429,16 +429,16 @@ namespace Bit.Core.Services
         public Task ClearPinKeysAsync(string userId = null)
         {
             return Task.WhenAll(
-                _stateService.SetUserKeyPinAsync(null, userId),
-                _stateService.SetUserKeyPinEphemeralAsync(null, userId),
+                _stateService.SetPinKeyEncryptedUserKeyAsync(null, userId),
+                _stateService.SetPinKeyEncryptedUserKeyEphemeralAsync(null, userId),
                 _stateService.SetProtectedPinAsync(null, userId),
                 ClearDeprecatedPinKeysAsync(userId));
         }
 
         public async Task<UserKey> DecryptUserKeyWithPinAsync(string pin, string salt, KdfConfig kdfConfig, EncString pinProtectedUserKey = null)
         {
-            pinProtectedUserKey ??= await _stateService.GetUserKeyPinAsync();
-            pinProtectedUserKey ??= await _stateService.GetUserKeyPinEphemeralAsync();
+            pinProtectedUserKey ??= await _stateService.GetPinKeyEncryptedUserKeyAsync();
+            pinProtectedUserKey ??= await _stateService.GetPinKeyEncryptedUserKeyEphemeralAsync();
             if (pinProtectedUserKey == null)
             {
                 throw new Exception("No PIN protected user key found.");
@@ -683,12 +683,12 @@ namespace Bit.Core.Services
             );
             var encPin = await EncryptAsync(userKey.Key, pinKey);
 
-            if (await _stateService.GetUserKeyPinAsync(userId) != null)
+            if (await _stateService.GetPinKeyEncryptedUserKeyAsync(userId) != null)
             {
-                await _stateService.SetUserKeyPinAsync(encPin, userId);
+                await _stateService.SetPinKeyEncryptedUserKeyAsync(encPin, userId);
                 return;
             }
-            await _stateService.SetUserKeyPinEphemeralAsync(encPin, userId);
+            await _stateService.SetPinKeyEncryptedUserKeyEphemeralAsync(encPin, userId);
         }
 
         private async Task<EncryptedObject> AesEncryptAsync(byte[] data, SymmetricCryptoKey key)
@@ -964,12 +964,12 @@ namespace Bit.Core.Services
             if (masterPasswordOnRestart)
             {
                 await _stateService.SetPinProtectedKeyAsync(null);
-                await _stateService.SetUserKeyPinEphemeralAsync(pinProtectedKey);
+                await _stateService.SetPinKeyEncryptedUserKeyEphemeralAsync(pinProtectedKey);
             }
             else
             {
                 await _stateService.SetPinProtectedAsync(null);
-                await _stateService.SetUserKeyPinAsync(pinProtectedKey);
+                await _stateService.SetPinKeyEncryptedUserKeyAsync(pinProtectedKey);
 
                 // We previously only set the protected pin if MP on Restart was enabled
                 // now we set it regardless

--- a/src/Core/Services/CryptoService.cs
+++ b/src/Core/Services/CryptoService.cs
@@ -107,9 +107,9 @@ namespace Bit.Core.Services
 
         public async Task<bool> HasAutoUnlockKeyAsync(string userId = null)
         {
-            return (await GetAutoUnlockKeyAsync(userId) != null);
+            return await GetAutoUnlockKeyAsync(userId) != null;
         }
-        
+
         public Task SetMasterKeyAsync(MasterKey masterKey, string userId = null)
         {
             return _stateService.SetMasterKeyAsync(masterKey, userId);

--- a/src/Core/Services/CryptoService.cs
+++ b/src/Core/Services/CryptoService.cs
@@ -85,7 +85,7 @@ namespace Bit.Core.Services
 
             // Legacy support: encryption used to be done with the master key (derived from master password).
             // Users who have not migrated will have a null user key and must use the master key instead.
-            return (SymmetricCryptoKey)await GetMasterKeyAsync() as UserKey;
+            return new UserKey((await GetMasterKeyAsync()).Key);
         }
 
         public async Task<bool> HasUserKeyAsync(string userId = null)
@@ -124,7 +124,7 @@ namespace Bit.Core.Services
             if (masterKey == null)
             {
                 // Migration support
-                masterKey = await _stateService.GetKeyDecryptedAsync(userId) as MasterKey;
+                masterKey = new MasterKey((await _stateService.GetKeyDecryptedAsync(userId)).Key);
                 if (masterKey != null)
                 {
                     await SetMasterKeyAsync(masterKey, userId);

--- a/src/Core/Services/CryptoService.cs
+++ b/src/Core/Services/CryptoService.cs
@@ -143,9 +143,9 @@ namespace Bit.Core.Services
             return _stateService.SetMasterKeyAsync(null, userId);
         }
 
-        public async Task<Tuple<UserKey, EncString>> EncryptUserKeyWithMasterKeyAsync(MasterKey masterKey, UserKey userKey = null)
+        public async Task<Tuple<UserKey, EncString>> EncryptUserKeyWithMasterKeyAsync(MasterKey masterKey)
         {
-            userKey ??= await GetUserKeyAsync();
+            var userKey = await GetUserKeyAsync() ?? await MakeUserKeyAsync();
             return await BuildProtectedSymmetricKey(masterKey, userKey.Key, keyBytes => new UserKey(keyBytes));
         }
 

--- a/src/Core/Services/CryptoService.cs
+++ b/src/Core/Services/CryptoService.cs
@@ -354,7 +354,7 @@ namespace Bit.Core.Services
             {
                 return _publicKey;
             }
-            var privateKey = await GetPrivateKeyAsync();
+            var privateKey = await GetUserPrivateKeyAsync();
             if (privateKey == null)
             {
                 return null;
@@ -363,7 +363,7 @@ namespace Bit.Core.Services
             return _publicKey;
         }
 
-        public async Task SetPrivateKeyAsync(string encPrivateKey)
+        public async Task SetUserPrivateKeyAsync(string encPrivateKey)
         {
             if (encPrivateKey == null)
             {
@@ -373,7 +373,7 @@ namespace Bit.Core.Services
             _privateKey = null;
         }
 
-        public async Task<byte[]> GetPrivateKeyAsync()
+        public async Task<byte[]> GetUserPrivateKeyAsync()
         {
             if (_privateKey != null)
             {
@@ -519,7 +519,7 @@ namespace Bit.Core.Services
 
             if (privateKey is null)
             {
-                privateKey = await GetPrivateKeyAsync();
+                privateKey = await GetUserPrivateKeyAsync();
             }
 
             if (privateKey == null)

--- a/src/Core/Services/CryptoService.cs
+++ b/src/Core/Services/CryptoService.cs
@@ -184,16 +184,15 @@ namespace Bit.Core.Services
             return new UserKey(decUserKey);
         }
 
-        public async Task<Tuple<SymmetricCryptoKey, EncString>> MakeDataEncKeyAsync<TKey>(TKey key)
-        where TKey : SymmetricCryptoKey
+        public async Task<Tuple<SymmetricCryptoKey, EncString>> MakeDataEncKeyAsync(SymmetricCryptoKey key)
         {
             if (key is null)
             {
                 throw new ArgumentNullException(nameof(key));
             }
-            if (typeof(TKey) != typeof(UserKey) && typeof(TKey) != typeof(OrgKey))
+            if (!(key is UserKey) && !(key is OrgKey))
             {
-                throw new ArgumentException($"Data encryption keys must be of type UserKey or OrgKey. {typeof(TKey)} unsupported.");
+                throw new ArgumentException($"Data encryption keys must be of type UserKey or OrgKey. {key.GetType().FullName} unsupported.");
             }
 
             var newSymKey = await _cryptoFunctionService.RandomBytesAsync(64);
@@ -970,6 +969,8 @@ namespace Bit.Core.Services
                 var encPin = await EncryptAsync(pin, userKey);
                 await _stateService.SetProtectedPinAsync(encPin.EncryptedString);
             }
+            // Clear old key
+            await _stateService.SetEncKeyEncryptedAsync(null);
             return userKey;
         }
 

--- a/src/Core/Services/CryptoService.cs
+++ b/src/Core/Services/CryptoService.cs
@@ -673,7 +673,7 @@ namespace Bit.Core.Services
             // Refresh, set, or clear the pin key
             if (await _stateService.GetProtectedPinAsync(userId) != null)
             {
-                await UpdateUserKeyPinAsync(userKey, userId);
+                await UpdatePinKeyAsync(userKey, userId);
             }
             else
             {
@@ -692,7 +692,7 @@ namespace Bit.Core.Services
             }
         }
 
-        private async Task UpdateUserKeyPinAsync(UserKey userKey, string userId = null)
+        private async Task UpdatePinKeyAsync(UserKey userKey, string userId = null)
         {
             var pin = await DecryptToUtf8Async(new EncString(await _stateService.GetProtectedPinAsync(userId)));
             var pinKey = await MakePinKeyAsync(

--- a/src/Core/Services/CryptoService.cs
+++ b/src/Core/Services/CryptoService.cs
@@ -143,7 +143,7 @@ namespace Bit.Core.Services
         public async Task<Tuple<UserKey, EncString>> EncryptUserKeyWithMasterKeyAsync(MasterKey masterKey)
         {
             var userKey = await GetUserKeyAsync() ?? await MakeUserKeyAsync();
-            return await BuildProtectedSymmetricKey(masterKey, userKey.Key, keyBytes => new UserKey(keyBytes));
+            return await BuildProtectedSymmetricKeyAsync(masterKey, userKey.Key, keyBytes => new UserKey(keyBytes));
         }
 
         public async Task<UserKey> DecryptUserKeyWithMasterKeyAsync(MasterKey masterKey, EncString encUserKey = null, string userId = null)
@@ -198,7 +198,7 @@ namespace Bit.Core.Services
             }
 
             var newSymKey = await _cryptoFunctionService.RandomBytesAsync(64);
-            return await BuildProtectedSymmetricKey(key, newSymKey, keyBytes => new SymmetricCryptoKey(keyBytes));
+            return await BuildProtectedSymmetricKeyAsync(key, newSymKey, keyBytes => new SymmetricCryptoKey(keyBytes));
         }
 
         public async Task<string> HashMasterKeyAsync(string password, MasterKey masterKey, HashPurpose hashPurpose = HashPurpose.ServerAuthorization)
@@ -874,7 +874,7 @@ namespace Bit.Core.Services
         }
 
         // TODO: This needs to be moved into SymmetricCryptoKey model to remove the keyCreator hack
-        private async Task<Tuple<TKey, EncString>> BuildProtectedSymmetricKey<TKey>(SymmetricCryptoKey key,
+        private async Task<Tuple<TKey, EncString>> BuildProtectedSymmetricKeyAsync<TKey>(SymmetricCryptoKey key,
             byte[] encKey, Func<byte[], TKey> keyCreator) where TKey : SymmetricCryptoKey
         {
             EncString encKeyEnc = null;
@@ -898,7 +898,7 @@ namespace Bit.Core.Services
         private async Task<TKey> MakeKeyAsync<TKey>(string password, string salt, KdfConfig kdfConfig, Func<byte[], TKey> keyCreator)
         where TKey : SymmetricCryptoKey
         {
-            byte[] key = null;
+            byte[] key;
             if (kdfConfig.Type == null || kdfConfig.Type == KdfType.PBKDF2_SHA256)
             {
                 var iterations = kdfConfig.Iterations.GetValueOrDefault(5000);

--- a/src/Core/Services/CryptoService.cs
+++ b/src/Core/Services/CryptoService.cs
@@ -1193,23 +1193,6 @@ namespace Bit.Core.Services
         }
 
 
-        public async Task<SymmetricCryptoKey> MakeKeyFromPinAsync(string pin, string salt,
-            KdfConfig config, EncString protectedKeyCs = null)
-        {
-            if (protectedKeyCs == null)
-            {
-                var pinProtectedKey = await _stateService.GetPinProtectedAsync();
-                if (pinProtectedKey == null)
-                {
-                    throw new Exception("No PIN protected key found.");
-                }
-                protectedKeyCs = new EncString(pinProtectedKey);
-            }
-            var pinKey = await MakePinKeyAsync(pin, salt, config);
-            var decKey = await DecryptToBytesAsync(protectedKeyCs, pinKey);
-            return new SymmetricCryptoKey(decKey);
-        }
-
         // TODO(Jake): This isn't used, delete
         public async Task<Tuple<EncString, SymmetricCryptoKey>> MakeShareKeyAsync()
         {
@@ -1229,17 +1212,6 @@ namespace Bit.Core.Services
             var encKey = await _cryptoFunctionService.RandomBytesAsync(64);
             return await BuildProtectedSymmetricKey<SymmetricCryptoKey>(theKey, encKey);
         }
-
-        public async Task<Tuple<SymmetricCryptoKey, EncString>> RemakeEncKeyAsync(SymmetricCryptoKey key)
-        {
-            var encKey = await GetEncKeyAsync();
-            return await BuildProtectedSymmetricKey<SymmetricCryptoKey>(key, encKey.Key);
-        }
-
-
-
-
-
 
     }
 }

--- a/src/Core/Services/CryptoService.cs
+++ b/src/Core/Services/CryptoService.cs
@@ -51,6 +51,11 @@ namespace Bit.Core.Services
             return await GetUserKeyAsync(userId) != null;
         }
 
+        public async Task<UserKey> MakeUserKeyAsync()
+        {
+            return new UserKey(await _cryptoFunctionService.RandomBytesAsync(64));
+        }
+
         public async Task ClearUserKeyAsync(string userId = null)
         {
             await _stateService.SetUserKeyAsync(null, userId);

--- a/src/Core/Services/CryptoService.cs
+++ b/src/Core/Services/CryptoService.cs
@@ -683,7 +683,6 @@ namespace Bit.Core.Services
             );
             var encPin = await EncryptAsync(userKey.Key, pinKey);
 
-            // TODO(Jake): Does this logic make sense? Should we save something in state to indicate the preference?
             if (await _stateService.GetUserKeyPinAsync(userId) != null)
             {
                 await _stateService.SetUserKeyPinAsync(encPin, userId);

--- a/src/Core/Services/CryptoService.cs
+++ b/src/Core/Services/CryptoService.cs
@@ -184,26 +184,20 @@ namespace Bit.Core.Services
             return new UserKey(decUserKey);
         }
 
-        public async Task<Tuple<SymmetricCryptoKey, EncString>> MakeDataEncKeyAsync(UserKey userKey)
+        public async Task<Tuple<SymmetricCryptoKey, EncString>> MakeDataEncKeyAsync<TKey>(TKey key)
+        where TKey : SymmetricCryptoKey
         {
-            if (userKey is null)
+            if (key is null)
             {
-                throw new ArgumentNullException(nameof(userKey));
+                throw new ArgumentNullException(nameof(key));
+            }
+            if (typeof(TKey) != typeof(UserKey) && typeof(TKey) != typeof(OrgKey))
+            {
+                throw new ArgumentException($"Data encryption keys must be of type UserKey or OrgKey. {typeof(TKey)} unsupported.");
             }
 
             var newSymKey = await _cryptoFunctionService.RandomBytesAsync(64);
-            return await BuildProtectedSymmetricKey(userKey, newSymKey, keyBytes => new SymmetricCryptoKey(keyBytes));
-        }
-
-        public async Task<Tuple<SymmetricCryptoKey, EncString>> MakeDataEncKeyAsync(OrgKey orgKey)
-        {
-            if (orgKey is null)
-            {
-                throw new ArgumentNullException(nameof(orgKey));
-            }
-
-            var newSymKey = await _cryptoFunctionService.RandomBytesAsync(64);
-            return await BuildProtectedSymmetricKey(orgKey, newSymKey, keyBytes => new SymmetricCryptoKey(keyBytes));
+            return await BuildProtectedSymmetricKey(key, newSymKey, keyBytes => new SymmetricCryptoKey(keyBytes));
         }
 
         public async Task<string> HashMasterKeyAsync(string password, MasterKey masterKey, HashPurpose hashPurpose = HashPurpose.ServerAuthorization)

--- a/src/Core/Services/FolderService.cs
+++ b/src/Core/Services/FolderService.cs
@@ -77,7 +77,7 @@ namespace Bit.Core.Services
             {
                 return _decryptedFolderCache;
             }
-            var hasKey = await _cryptoService.HasKeyAsync();
+            var hasKey = await _cryptoService.HasUserKeyAsync();
             if (!hasKey)
             {
                 throw new Exception("No key.");

--- a/src/Core/Services/KeyConnectorService.cs
+++ b/src/Core/Services/KeyConnectorService.cs
@@ -60,11 +60,11 @@ namespace Bit.Core.Services
         public async Task MigrateUser()
         {
             var organization = await GetManagingOrganization();
-            var key = await _cryptoService.GetKeyAsync();
+            var masterKey = await _cryptoService.GetMasterKeyAsync();
 
             try
             {
-                var keyConnectorRequest = new KeyConnectorUserKeyRequest(key.EncKeyB64);
+                var keyConnectorRequest = new KeyConnectorUserKeyRequest(masterKey.EncKeyB64);
                 await _apiService.PostUserKeyToKeyConnector(organization.KeyConnectorUrl, keyConnectorRequest);
             }
             catch (Exception e)

--- a/src/Core/Services/KeyConnectorService.cs
+++ b/src/Core/Services/KeyConnectorService.cs
@@ -24,11 +24,11 @@ namespace Bit.Core.Services
             _organizationService = organizationService;
         }
 
-        public async Task GetAndSetKey(string url)
+        public async Task GetAndSetMasterKeyAsync(string url)
         {
             try
             {
-                var masterKeyResponse = await _apiService.GetMasterKeyFromKeyConnector(url);
+                var masterKeyResponse = await _apiService.GetMasterKeyFromKeyConnectorAsync(url);
                 var masterKeyArr = Convert.FromBase64String(masterKeyResponse.Key);
                 var masterKey = new MasterKey(masterKeyArr);
                 await _cryptoService.SetMasterKeyAsync(masterKey);
@@ -39,17 +39,17 @@ namespace Bit.Core.Services
             }
         }
 
-        public async Task SetUsesKeyConnector(bool usesKeyConnector)
+        public async Task SetUsesKeyConnectorAsync(bool usesKeyConnector)
         {
             await _stateService.SetUsesKeyConnectorAsync(usesKeyConnector);
         }
 
-        public async Task<bool> GetUsesKeyConnector()
+        public async Task<bool> GetUsesKeyConnectorAsync()
         {
             return await _stateService.GetUsesKeyConnectorAsync();
         }
 
-        public async Task<Organization> GetManagingOrganization()
+        public async Task<Organization> GetManagingOrganizationAsync()
         {
             var orgs = await _organizationService.GetAllAsync();
             return orgs.Find(o =>
@@ -57,9 +57,9 @@ namespace Bit.Core.Services
                 !o.IsAdmin);
         }
 
-        public async Task MigrateUser()
+        public async Task MigrateUserAsync()
         {
-            var organization = await GetManagingOrganization();
+            var organization = await GetManagingOrganizationAsync();
             var masterKey = await _cryptoService.GetMasterKeyAsync();
 
             try
@@ -75,11 +75,11 @@ namespace Bit.Core.Services
             await _apiService.PostConvertToKeyConnector();
         }
 
-        public async Task<bool> UserNeedsMigration()
+        public async Task<bool> UserNeedsMigrationAsync()
         {
             var loggedInUsingSso = await _tokenService.GetIsExternal();
-            var requiredByOrganization = await GetManagingOrganization() != null;
-            var userIsNotUsingKeyConnector = !await GetUsesKeyConnector();
+            var requiredByOrganization = await GetManagingOrganizationAsync() != null;
+            var userIsNotUsingKeyConnector = !await GetUsesKeyConnectorAsync();
 
             return loggedInUsingSso && requiredByOrganization && userIsNotUsingKeyConnector;
         }

--- a/src/Core/Services/KeyConnectorService.cs
+++ b/src/Core/Services/KeyConnectorService.cs
@@ -28,10 +28,10 @@ namespace Bit.Core.Services
         {
             try
             {
-                var userKeyResponse = await _apiService.GetUserKeyFromKeyConnector(url);
-                var keyArr = Convert.FromBase64String(userKeyResponse.Key);
-                var k = new SymmetricCryptoKey(keyArr);
-                await _cryptoService.SetKeyAsync(k);
+                var masterKeyResponse = await _apiService.GetMasterKeyFromKeyConnector(url);
+                var masterKeyArr = Convert.FromBase64String(masterKeyResponse.Key);
+                var masterKey = new MasterKey(masterKeyArr);
+                await _cryptoService.SetMasterKeyAsync(masterKey);
             }
             catch (Exception e)
             {

--- a/src/Core/Services/PasswordGenerationService.cs
+++ b/src/Core/Services/PasswordGenerationService.cs
@@ -247,7 +247,7 @@ namespace Bit.Core.Services
 
         public async Task<List<GeneratedPasswordHistory>> GetHistoryAsync()
         {
-            var hasKey = await _cryptoService.HasKeyAsync();
+            var hasKey = await _cryptoService.HasUserKeyAsync();
             if (!hasKey)
             {
                 return new List<GeneratedPasswordHistory>();
@@ -262,7 +262,7 @@ namespace Bit.Core.Services
 
         public async Task AddHistoryAsync(string password, CancellationToken token = default(CancellationToken))
         {
-            var hasKey = await _cryptoService.HasKeyAsync();
+            var hasKey = await _cryptoService.HasUserKeyAsync();
             if (!hasKey)
             {
                 return;

--- a/src/Core/Services/SendService.cs
+++ b/src/Core/Services/SendService.cs
@@ -143,7 +143,7 @@ namespace Bit.Core.Services
                 return _decryptedSendsCache;
             }
 
-            var hasKey = await _cryptoService.HasKeyAsync();
+            var hasKey = await _cryptoService.HasUserKeyAsync();
             if (!hasKey)
             {
                 throw new Exception("No Key.");

--- a/src/Core/Services/StateService.cs
+++ b/src/Core/Services/StateService.cs
@@ -251,7 +251,7 @@ namespace Bit.Core.Services
         public async Task SetUserKeyBiometricUnlockAsync(UserKey value, string userId = null)
         {
             await _storageMediatorService.SaveAsync(
-                await ComposeKeyAsync(Constants.UserKeyBiometricUnlockKey, userId), value, true);
+                await ComposeKeyAsync(Constants.UserKeyBiometricUnlockKey, userId), value?.KeyB64, true);
         }
 
         public async Task<bool?> GetBiometricUnlockAsync(string userId = null)
@@ -369,7 +369,7 @@ namespace Bit.Core.Services
         public async Task SetUserKeyAutoUnlockAsync(UserKey value, string userId = null)
         {
             await _storageMediatorService.SaveAsync(
-                await ComposeKeyAsync(Constants.UserKeyAutoUnlockKey, userId), value.KeyB64, true);
+                await ComposeKeyAsync(Constants.UserKeyAutoUnlockKey, userId), value?.KeyB64, true);
         }
 
         public async Task<bool> CanAccessPremiumAsync(string userId = null)
@@ -1478,6 +1478,7 @@ namespace Bit.Core.Services
             // Non-state storage
             await Task.WhenAll(
                 SetUserKeyAutoUnlockAsync(null, userId),
+                SetUserKeyBiometricUnlockAsync(null, userId),
                 SetProtectedPinAsync(null, userId),
                 SetKeyHashAsync(null, userId),
                 SetOrgKeysEncryptedAsync(null, userId),

--- a/src/Core/Services/StateService.cs
+++ b/src/Core/Services/StateService.cs
@@ -396,7 +396,7 @@ namespace Bit.Core.Services
         }
 
         // TODO(Jake): Does this need to be secure storage?
-        public async Task<string> GetUserKeyPin(string value, string userId = null)
+        public async Task<string> GetUserKeyPin(string userId = null)
         {
             return await _storageMediatorService.GetAsync<string>(Constants.UserKeyPinKey(userId), false);
         }

--- a/src/Core/Services/StateService.cs
+++ b/src/Core/Services/StateService.cs
@@ -241,6 +241,19 @@ namespace Bit.Core.Services
             ))?.Settings?.EnvironmentUrls;
         }
 
+        public async Task<UserKey> GetUserKeyBiometricUnlockAsync(string userId = null)
+        {
+            var keyB64 = await _storageMediatorService.GetAsync<string>(
+                await ComposeKeyAsync(Constants.UserKeyBiometricUnlockKey, userId), true);
+            return keyB64 == null ? null : new UserKey(Convert.FromBase64String(keyB64));
+        }
+
+        public async Task SetUserKeyBiometricUnlockAsync(UserKey value, string userId = null)
+        {
+            await _storageMediatorService.SaveAsync(
+                await ComposeKeyAsync(Constants.UserKeyBiometricUnlockKey, userId), value, true);
+        }
+
         public async Task<bool?> GetBiometricUnlockAsync(string userId = null)
         {
             var reconciledOptions = ReconcileOptions(new StorageOptions { UserId = userId },
@@ -353,10 +366,10 @@ namespace Bit.Core.Services
             return keyB64 == null ? null : new UserKey(Convert.FromBase64String(keyB64));
         }
 
-        public async Task SetUserKeyAutoUnlockAsync(string value, string userId = null)
+        public async Task SetUserKeyAutoUnlockAsync(UserKey value, string userId = null)
         {
             await _storageMediatorService.SaveAsync(
-                await ComposeKeyAsync(Constants.UserKeyAutoUnlockKey, userId), value, true);
+                await ComposeKeyAsync(Constants.UserKeyAutoUnlockKey, userId), value.KeyB64, true);
         }
 
         public async Task<bool> CanAccessPremiumAsync(string userId = null)

--- a/src/Core/Services/StateService.cs
+++ b/src/Core/Services/StateService.cs
@@ -396,9 +396,9 @@ namespace Bit.Core.Services
         }
 
         // TODO(Jake): Does this need to be secure storage?
-        public async Task<string> GetUserKeyPinAsync(string userId = null)
+        public async Task<EncString> GetUserKeyPinAsync(string userId = null)
         {
-            return await _storageMediatorService.GetAsync<string>(Constants.UserKeyPinKey(userId), false);
+            return new EncString(await _storageMediatorService.GetAsync<string>(Constants.UserKeyPinKey(userId), false));
         }
 
         // TODO(Jake): Does this need to be secure storage?

--- a/src/Core/Services/StateService.cs
+++ b/src/Core/Services/StateService.cs
@@ -334,12 +334,12 @@ namespace Bit.Core.Services
             await SaveAccountAsync(account, reconciledOptions);
         }
 
-        public async Task<string> GetUserKeyMasterKeyAsync(string userId = null)
+        public async Task<string> GetMasterKeyEncryptedUserKeyAsync(string userId = null)
         {
             return await _storageMediatorService.GetAsync<string>(Constants.UserKeyKey(userId), false);
         }
 
-        public async Task SetUserKeyMasterKeyAsync(string value, string userId = null)
+        public async Task SetMasterKeyEncryptedUserKeyAsync(string value, string userId = null)
         {
             await _storageMediatorService.SaveAsync(Constants.UserKeyKey(userId), value, false);
         }
@@ -395,25 +395,25 @@ namespace Bit.Core.Services
             await SetValueAsync(Constants.ProtectedPinKey(reconciledOptions.UserId), value, reconciledOptions);
         }
 
-        public async Task<EncString> GetUserKeyPinAsync(string userId = null)
+        public async Task<EncString> GetPinKeyEncryptedUserKeyAsync(string userId = null)
         {
             var key = await _storageMediatorService.GetAsync<string>(Constants.UserKeyPinKey(userId), false);
             return key != null ? new EncString(key) : null;
         }
 
-        public async Task SetUserKeyPinAsync(EncString value, string userId = null)
+        public async Task SetPinKeyEncryptedUserKeyAsync(EncString value, string userId = null)
         {
             await _storageMediatorService.SaveAsync(Constants.UserKeyPinKey(userId), value?.EncryptedString, false);
         }
 
-        public async Task<EncString> GetUserKeyPinEphemeralAsync(string userId = null)
+        public async Task<EncString> GetPinKeyEncryptedUserKeyEphemeralAsync(string userId = null)
         {
             return (await GetAccountAsync(
                 ReconcileOptions(new StorageOptions { UserId = userId }, await GetDefaultInMemoryOptionsAsync())
             ))?.VolatileData?.UserKeyPinEphemeral;
         }
 
-        public async Task SetUserKeyPinEphemeralAsync(EncString value, string userId = null)
+        public async Task SetPinKeyEncryptedUserKeyEphemeralAsync(EncString value, string userId = null)
         {
             var reconciledOptions = ReconcileOptions(new StorageOptions { UserId = userId },
                 await GetDefaultInMemoryOptionsAsync());
@@ -422,7 +422,7 @@ namespace Bit.Core.Services
             await SaveAccountAsync(account, reconciledOptions);
         }
 
-        [Obsolete("Use GetUserKeyPinAsync instead, left for migration purposes")]
+        [Obsolete("Use GetPinKeyEncryptedUserKeyAsync instead, left for migration purposes")]
         public async Task<string> GetPinProtectedAsync(string userId = null)
         {
             var reconciledOptions = ReconcileOptions(new StorageOptions { UserId = userId },
@@ -430,7 +430,7 @@ namespace Bit.Core.Services
             return await GetValueAsync<string>(Constants.PinProtectedKey(reconciledOptions.UserId), reconciledOptions);
         }
 
-        [Obsolete("Use SetUserKeyPinAsync instead")]
+        [Obsolete("Use SetPinKeyEncryptedUserKeyAsync instead")]
         public async Task SetPinProtectedAsync(string value, string userId = null)
         {
             var reconciledOptions = ReconcileOptions(new StorageOptions { UserId = userId },
@@ -438,7 +438,7 @@ namespace Bit.Core.Services
             await SetValueAsync(Constants.PinProtectedKey(reconciledOptions.UserId), value, reconciledOptions);
         }
 
-        [Obsolete("Use GetUserKeyPinEphemeralAsync instead, left for migration purposes")]
+        [Obsolete("Use GetPinKeyEncryptedUserKeyEphemeralAsync instead, left for migration purposes")]
         public async Task<EncString> GetPinProtectedKeyAsync(string userId = null)
         {
             return (await GetAccountAsync(
@@ -446,7 +446,7 @@ namespace Bit.Core.Services
             ))?.VolatileData?.PinProtectedKey;
         }
 
-        [Obsolete("Use SetUserKeyPinEphemeralAsync instead")]
+        [Obsolete("Use SetPinKeyEncryptedUserKeyEphemeralAsync instead")]
         public async Task SetPinProtectedKeyAsync(EncString value, string userId = null)
         {
             var reconciledOptions = ReconcileOptions(new StorageOptions { UserId = userId },

--- a/src/Core/Services/StateService.cs
+++ b/src/Core/Services/StateService.cs
@@ -336,12 +336,12 @@ namespace Bit.Core.Services
 
         public async Task<string> GetMasterKeyEncryptedUserKeyAsync(string userId = null)
         {
-            return await _storageMediatorService.GetAsync<string>(Constants.UserKeyKey(userId), false);
+            return await _storageMediatorService.GetAsync<string>(Constants.MasterKeyEncryptedUserKeyKey(userId), false);
         }
 
         public async Task SetMasterKeyEncryptedUserKeyAsync(string value, string userId = null)
         {
-            await _storageMediatorService.SaveAsync(Constants.UserKeyKey(userId), value, false);
+            await _storageMediatorService.SaveAsync(Constants.MasterKeyEncryptedUserKeyKey(userId), value, false);
         }
 
         public async Task<bool> CanAccessPremiumAsync(string userId = null)
@@ -397,13 +397,13 @@ namespace Bit.Core.Services
 
         public async Task<EncString> GetPinKeyEncryptedUserKeyAsync(string userId = null)
         {
-            var key = await _storageMediatorService.GetAsync<string>(Constants.UserKeyPinKey(userId), false);
+            var key = await _storageMediatorService.GetAsync<string>(Constants.PinKeyEncryptedUserKeyKey(userId), false);
             return key != null ? new EncString(key) : null;
         }
 
         public async Task SetPinKeyEncryptedUserKeyAsync(EncString value, string userId = null)
         {
-            await _storageMediatorService.SaveAsync(Constants.UserKeyPinKey(userId), value?.EncryptedString, false);
+            await _storageMediatorService.SaveAsync(Constants.PinKeyEncryptedUserKeyKey(userId), value?.EncryptedString, false);
         }
 
         public async Task<EncString> GetPinKeyEncryptedUserKeyEphemeralAsync(string userId = null)

--- a/src/Core/Services/StateService.cs
+++ b/src/Core/Services/StateService.cs
@@ -395,6 +395,35 @@ namespace Bit.Core.Services
             await SetValueAsync(Constants.ProtectedPinKey(reconciledOptions.UserId), value, reconciledOptions);
         }
 
+        // TODO(Jake): Does this need to be secure storage?
+        public async Task<string> GetUserKeyPin(string value, string userId = null)
+        {
+            return await _storageMediatorService.GetAsync<string>(Constants.UserKeyPinKey(userId), false);
+        }
+
+        // TODO(Jake): Does this need to be secure storage?
+        public async Task SetUserKeyPin(string value, string userId = null)
+        {
+            await _storageMediatorService.SaveAsync(Constants.UserKeyPinKey(userId), value, false);
+        }
+
+        public async Task<EncString> GetUserKeyPinEphemeral(string userId = null)
+        {
+            return (await GetAccountAsync(
+                ReconcileOptions(new StorageOptions { UserId = userId }, await GetDefaultInMemoryOptionsAsync())
+            ))?.VolatileData?.UserKeyPinEphemeral;
+        }
+
+        public async Task SetUserKeyPinEphemeral(EncString value, string userId = null)
+        {
+            var reconciledOptions = ReconcileOptions(new StorageOptions { UserId = userId },
+                await GetDefaultInMemoryOptionsAsync());
+            var account = await GetAccountAsync(reconciledOptions);
+            account.VolatileData.UserKeyPinEphemeral = value;
+            await SaveAccountAsync(account, reconciledOptions);
+        }
+
+        [Obsolete("Use GetUserKeyPin instead, left for migration purposes")]
         public async Task<string> GetPinProtectedAsync(string userId = null)
         {
             var reconciledOptions = ReconcileOptions(new StorageOptions { UserId = userId },
@@ -402,6 +431,7 @@ namespace Bit.Core.Services
             return await GetValueAsync<string>(Constants.PinProtectedKey(reconciledOptions.UserId), reconciledOptions);
         }
 
+        [Obsolete("Use SetUserKeyPin instead")]
         public async Task SetPinProtectedAsync(string value, string userId = null)
         {
             var reconciledOptions = ReconcileOptions(new StorageOptions { UserId = userId },
@@ -409,6 +439,7 @@ namespace Bit.Core.Services
             await SetValueAsync(Constants.PinProtectedKey(reconciledOptions.UserId), value, reconciledOptions);
         }
 
+        [Obsolete("Use GetUserKeyPinEphemeral instead, left for migration purposes")]
         public async Task<EncString> GetPinProtectedKeyAsync(string userId = null)
         {
             return (await GetAccountAsync(
@@ -416,6 +447,7 @@ namespace Bit.Core.Services
             ))?.VolatileData?.PinProtectedKey;
         }
 
+        [Obsolete("Use SetUserKeyPinEphemeral instead")]
         public async Task SetPinProtectedKeyAsync(EncString value, string userId = null)
         {
             var reconciledOptions = ReconcileOptions(new StorageOptions { UserId = userId },

--- a/src/Core/Services/StateService.cs
+++ b/src/Core/Services/StateService.cs
@@ -428,7 +428,7 @@ namespace Bit.Core.Services
         {
             return (await GetAccountAsync(
                 ReconcileOptions(new StorageOptions { UserId = userId }, await GetDefaultInMemoryOptionsAsync())
-            ))?.VolatileData?.UserKeyPinEphemeral;
+            ))?.VolatileData?.PinKeyEncryptedUserKeyEphemeral;
         }
 
         public async Task SetPinKeyEncryptedUserKeyEphemeralAsync(EncString value, string userId = null)
@@ -436,7 +436,7 @@ namespace Bit.Core.Services
             var reconciledOptions = ReconcileOptions(new StorageOptions { UserId = userId },
                 await GetDefaultInMemoryOptionsAsync());
             var account = await GetAccountAsync(reconciledOptions);
-            account.VolatileData.UserKeyPinEphemeral = value;
+            account.VolatileData.PinKeyEncryptedUserKeyEphemeral = value;
             await SaveAccountAsync(account, reconciledOptions);
         }
 

--- a/src/Core/Services/StateService.cs
+++ b/src/Core/Services/StateService.cs
@@ -302,6 +302,48 @@ namespace Bit.Core.Services
                 true, reconciledOptions);
         }
 
+        public async Task<UserKey> GetUserKeyAsync(string userId = null)
+        {
+            return (await GetAccountAsync(
+                ReconcileOptions(new StorageOptions { UserId = userId }, await GetDefaultInMemoryOptionsAsync())
+            ))?.VolatileData?.UserKey;
+        }
+
+        public async Task SetUserKeyAsync(UserKey value, string userId = null)
+        {
+            var reconciledOptions = ReconcileOptions(new StorageOptions { UserId = userId },
+                await GetDefaultInMemoryOptionsAsync());
+            var account = await GetAccountAsync(reconciledOptions);
+            account.VolatileData.UserKey = value;
+            await SaveAccountAsync(account, reconciledOptions);
+        }
+
+        public async Task<MasterKey> GetMasterKeyAsync(string userId = null)
+        {
+            return (await GetAccountAsync(
+                ReconcileOptions(new StorageOptions { UserId = userId }, await GetDefaultInMemoryOptionsAsync())
+            ))?.VolatileData?.MasterKey;
+        }
+
+        public async Task SetMasterKeyAsync(MasterKey value, string userId = null)
+        {
+            var reconciledOptions = ReconcileOptions(new StorageOptions { UserId = userId },
+                await GetDefaultInMemoryOptionsAsync());
+            var account = await GetAccountAsync(reconciledOptions);
+            account.VolatileData.MasterKey = value;
+            await SaveAccountAsync(account, reconciledOptions);
+        }
+
+        public async Task<string> GetUserKeyMasterKeyAsync(string userId = null)
+        {
+            return await _storageMediatorService.GetAsync<string>(Constants.UserKeyKey(userId), false);
+        }
+
+        public async Task SetUserKeyMasterKeyAsync(string value, string userId = null)
+        {
+            await _storageMediatorService.SaveAsync(Constants.UserKeyKey(userId), value, false);
+        }
+
         public async Task<bool> CanAccessPremiumAsync(string userId = null)
         {
             if (userId == null)
@@ -395,35 +437,6 @@ namespace Bit.Core.Services
             await SaveAccountAsync(account, reconciledOptions);
         }
 
-        public async Task<string> GetKeyEncryptedAsync(string userId = null)
-        {
-            var reconciledOptions = ReconcileOptions(new StorageOptions { UserId = userId },
-                await GetDefaultSecureStorageOptionsAsync());
-            return await GetValueAsync<string>(Constants.KeyKey(reconciledOptions.UserId), reconciledOptions);
-        }
-
-        public async Task SetKeyEncryptedAsync(string value, string userId)
-        {
-            var reconciledOptions = ReconcileOptions(new StorageOptions { UserId = userId },
-                await GetDefaultSecureStorageOptionsAsync());
-            await SetValueAsync(Constants.KeyKey(reconciledOptions.UserId), value, reconciledOptions);
-        }
-
-        public async Task<SymmetricCryptoKey> GetKeyDecryptedAsync(string userId = null)
-        {
-            return (await GetAccountAsync(
-                ReconcileOptions(new StorageOptions { UserId = userId }, await GetDefaultInMemoryOptionsAsync())
-            ))?.VolatileData?.Key;
-        }
-
-        public async Task SetKeyDecryptedAsync(SymmetricCryptoKey value, string userId = null)
-        {
-            var reconciledOptions = ReconcileOptions(new StorageOptions { UserId = userId },
-                await GetDefaultInMemoryOptionsAsync());
-            var account = await GetAccountAsync(reconciledOptions);
-            account.VolatileData.Key = value;
-            await SaveAccountAsync(account, reconciledOptions);
-        }
 
         public async Task<string> GetKeyHashAsync(string userId = null)
         {
@@ -439,19 +452,6 @@ namespace Bit.Core.Services
             await SetValueAsync(Constants.KeyHashKey(reconciledOptions.UserId), value, reconciledOptions);
         }
 
-        public async Task<string> GetEncKeyEncryptedAsync(string userId = null)
-        {
-            var reconciledOptions = ReconcileOptions(new StorageOptions { UserId = userId },
-                await GetDefaultStorageOptionsAsync());
-            return await GetValueAsync<string>(Constants.EncKeyKey(reconciledOptions.UserId), reconciledOptions);
-        }
-
-        public async Task SetEncKeyEncryptedAsync(string value, string userId)
-        {
-            var reconciledOptions = ReconcileOptions(new StorageOptions { UserId = userId },
-                await GetDefaultStorageOptionsAsync());
-            await SetValueAsync(Constants.EncKeyKey(reconciledOptions.UserId), value, reconciledOptions);
-        }
 
         public async Task<Dictionary<string, string>> GetOrgKeysEncryptedAsync(string userId = null)
         {
@@ -1655,6 +1655,56 @@ namespace Bit.Core.Services
         {
             await SetValueAsync(Constants.LastUserShouldConnectToWatchKey,
                 shouldConnect ?? await GetShouldConnectToWatchAsync(), await GetDefaultStorageOptionsAsync());
+        }
+
+        [Obsolete]
+        public async Task<string> GetEncKeyEncryptedAsync(string userId = null)
+        {
+            var reconciledOptions = ReconcileOptions(new StorageOptions { UserId = userId },
+                await GetDefaultStorageOptionsAsync());
+            return await GetValueAsync<string>(Constants.EncKeyKey(reconciledOptions.UserId), reconciledOptions);
+        }
+
+        [Obsolete]
+        public async Task SetEncKeyEncryptedAsync(string value, string userId)
+        {
+            var reconciledOptions = ReconcileOptions(new StorageOptions { UserId = userId },
+                await GetDefaultStorageOptionsAsync());
+            await SetValueAsync(Constants.EncKeyKey(reconciledOptions.UserId), value, reconciledOptions);
+        }
+
+        [Obsolete]
+        public async Task<string> GetKeyEncryptedAsync(string userId = null)
+        {
+            var reconciledOptions = ReconcileOptions(new StorageOptions { UserId = userId },
+                await GetDefaultSecureStorageOptionsAsync());
+            return await GetValueAsync<string>(Constants.KeyKey(reconciledOptions.UserId), reconciledOptions);
+        }
+
+        [Obsolete]
+        public async Task SetKeyEncryptedAsync(string value, string userId)
+        {
+            var reconciledOptions = ReconcileOptions(new StorageOptions { UserId = userId },
+                await GetDefaultSecureStorageOptionsAsync());
+            await SetValueAsync(Constants.KeyKey(reconciledOptions.UserId), value, reconciledOptions);
+        }
+
+        [Obsolete]
+        public async Task<SymmetricCryptoKey> GetKeyDecryptedAsync(string userId = null)
+        {
+            return (await GetAccountAsync(
+                ReconcileOptions(new StorageOptions { UserId = userId }, await GetDefaultInMemoryOptionsAsync())
+            ))?.VolatileData?.Key;
+        }
+
+        [Obsolete]
+        public async Task SetKeyDecryptedAsync(SymmetricCryptoKey value, string userId = null)
+        {
+            var reconciledOptions = ReconcileOptions(new StorageOptions { UserId = userId },
+                await GetDefaultInMemoryOptionsAsync());
+            var account = await GetAccountAsync(reconciledOptions);
+            account.VolatileData.Key = value;
+            await SaveAccountAsync(account, reconciledOptions);
         }
     }
 }

--- a/src/Core/Services/StateService.cs
+++ b/src/Core/Services/StateService.cs
@@ -422,39 +422,6 @@ namespace Bit.Core.Services
             await SaveAccountAsync(account, reconciledOptions);
         }
 
-        [Obsolete("Use GetPinKeyEncryptedUserKeyAsync instead, left for migration purposes")]
-        public async Task<string> GetPinProtectedAsync(string userId = null)
-        {
-            var reconciledOptions = ReconcileOptions(new StorageOptions { UserId = userId },
-                await GetDefaultStorageOptionsAsync());
-            return await GetValueAsync<string>(Constants.PinProtectedKey(reconciledOptions.UserId), reconciledOptions);
-        }
-
-        [Obsolete("Use SetPinKeyEncryptedUserKeyAsync instead")]
-        public async Task SetPinProtectedAsync(string value, string userId = null)
-        {
-            var reconciledOptions = ReconcileOptions(new StorageOptions { UserId = userId },
-                await GetDefaultStorageOptionsAsync());
-            await SetValueAsync(Constants.PinProtectedKey(reconciledOptions.UserId), value, reconciledOptions);
-        }
-
-        [Obsolete("Use GetPinKeyEncryptedUserKeyEphemeralAsync instead, left for migration purposes")]
-        public async Task<EncString> GetPinProtectedKeyAsync(string userId = null)
-        {
-            return (await GetAccountAsync(
-                ReconcileOptions(new StorageOptions { UserId = userId }, await GetDefaultInMemoryOptionsAsync())
-            ))?.VolatileData?.PinProtectedKey;
-        }
-
-        [Obsolete("Use SetPinKeyEncryptedUserKeyEphemeralAsync instead")]
-        public async Task SetPinProtectedKeyAsync(EncString value, string userId = null)
-        {
-            var reconciledOptions = ReconcileOptions(new StorageOptions { UserId = userId },
-                await GetDefaultInMemoryOptionsAsync());
-            var account = await GetAccountAsync(reconciledOptions);
-            account.VolatileData.PinProtectedKey = value;
-            await SaveAccountAsync(account, reconciledOptions);
-        }
 
         public async Task SetKdfConfigurationAsync(KdfConfig config, string userId = null)
         {
@@ -1688,7 +1655,41 @@ namespace Bit.Core.Services
                 shouldConnect ?? await GetShouldConnectToWatchAsync(), await GetDefaultStorageOptionsAsync());
         }
 
-        [Obsolete]
+        [Obsolete("Use GetPinKeyEncryptedUserKeyAsync instead, left for migration purposes")]
+        public async Task<string> GetPinProtectedAsync(string userId = null)
+        {
+            var reconciledOptions = ReconcileOptions(new StorageOptions { UserId = userId },
+                await GetDefaultStorageOptionsAsync());
+            return await GetValueAsync<string>(Constants.PinProtectedKey(reconciledOptions.UserId), reconciledOptions);
+        }
+
+        [Obsolete("Use SetPinKeyEncryptedUserKeyAsync instead")]
+        public async Task SetPinProtectedAsync(string value, string userId = null)
+        {
+            var reconciledOptions = ReconcileOptions(new StorageOptions { UserId = userId },
+                await GetDefaultStorageOptionsAsync());
+            await SetValueAsync(Constants.PinProtectedKey(reconciledOptions.UserId), value, reconciledOptions);
+        }
+
+        [Obsolete("Use GetPinKeyEncryptedUserKeyEphemeralAsync instead, left for migration purposes")]
+        public async Task<EncString> GetPinProtectedKeyAsync(string userId = null)
+        {
+            return (await GetAccountAsync(
+                ReconcileOptions(new StorageOptions { UserId = userId }, await GetDefaultInMemoryOptionsAsync())
+            ))?.VolatileData?.PinProtectedKey;
+        }
+
+        [Obsolete("Use SetPinKeyEncryptedUserKeyEphemeralAsync instead")]
+        public async Task SetPinProtectedKeyAsync(EncString value, string userId = null)
+        {
+            var reconciledOptions = ReconcileOptions(new StorageOptions { UserId = userId },
+                await GetDefaultInMemoryOptionsAsync());
+            var account = await GetAccountAsync(reconciledOptions);
+            account.VolatileData.PinProtectedKey = value;
+            await SaveAccountAsync(account, reconciledOptions);
+        }
+
+        [Obsolete("Use GetMasterKeyEncryptedUserKeyAsync instead, left for migration purposes")]
         public async Task<string> GetEncKeyEncryptedAsync(string userId = null)
         {
             var reconciledOptions = ReconcileOptions(new StorageOptions { UserId = userId },
@@ -1696,7 +1697,7 @@ namespace Bit.Core.Services
             return await GetValueAsync<string>(Constants.EncKeyKey(reconciledOptions.UserId), reconciledOptions);
         }
 
-        [Obsolete]
+        [Obsolete("Use SetMasterKeyEncryptedUserKeyAsync instead, left for migration purposes")]
         public async Task SetEncKeyEncryptedAsync(string value, string userId)
         {
             var reconciledOptions = ReconcileOptions(new StorageOptions { UserId = userId },
@@ -1704,15 +1705,7 @@ namespace Bit.Core.Services
             await SetValueAsync(Constants.EncKeyKey(reconciledOptions.UserId), value, reconciledOptions);
         }
 
-        [Obsolete]
-        public async Task<string> GetKeyEncryptedAsync(string userId = null)
-        {
-            var reconciledOptions = ReconcileOptions(new StorageOptions { UserId = userId },
-                await GetDefaultSecureStorageOptionsAsync());
-            return await GetValueAsync<string>(Constants.KeyKey(reconciledOptions.UserId), reconciledOptions);
-        }
-
-        [Obsolete]
+        [Obsolete("Left for migration purposes")]
         public async Task SetKeyEncryptedAsync(string value, string userId)
         {
             var reconciledOptions = ReconcileOptions(new StorageOptions { UserId = userId },
@@ -1720,22 +1713,12 @@ namespace Bit.Core.Services
             await SetValueAsync(Constants.KeyKey(reconciledOptions.UserId), value, reconciledOptions);
         }
 
-        [Obsolete]
+        [Obsolete("Use GetMasterKeyAsync instead, left for migration purposes")]
         public async Task<SymmetricCryptoKey> GetKeyDecryptedAsync(string userId = null)
         {
             return (await GetAccountAsync(
                 ReconcileOptions(new StorageOptions { UserId = userId }, await GetDefaultInMemoryOptionsAsync())
             ))?.VolatileData?.Key;
-        }
-
-        [Obsolete]
-        public async Task SetKeyDecryptedAsync(SymmetricCryptoKey value, string userId = null)
-        {
-            var reconciledOptions = ReconcileOptions(new StorageOptions { UserId = userId },
-                await GetDefaultInMemoryOptionsAsync());
-            var account = await GetAccountAsync(reconciledOptions);
-            account.VolatileData.Key = value;
-            await SaveAccountAsync(account, reconciledOptions);
         }
     }
 }

--- a/src/Core/Services/StateService.cs
+++ b/src/Core/Services/StateService.cs
@@ -396,25 +396,25 @@ namespace Bit.Core.Services
         }
 
         // TODO(Jake): Does this need to be secure storage?
-        public async Task<string> GetUserKeyPin(string userId = null)
+        public async Task<string> GetUserKeyPinAsync(string userId = null)
         {
             return await _storageMediatorService.GetAsync<string>(Constants.UserKeyPinKey(userId), false);
         }
 
         // TODO(Jake): Does this need to be secure storage?
-        public async Task SetUserKeyPin(string value, string userId = null)
+        public async Task SetUserKeyPinAsync(EncString value, string userId = null)
         {
-            await _storageMediatorService.SaveAsync(Constants.UserKeyPinKey(userId), value, false);
+            await _storageMediatorService.SaveAsync(Constants.UserKeyPinKey(userId), value.EncryptedString, false);
         }
 
-        public async Task<EncString> GetUserKeyPinEphemeral(string userId = null)
+        public async Task<EncString> GetUserKeyPinEphemeralAsync(string userId = null)
         {
             return (await GetAccountAsync(
                 ReconcileOptions(new StorageOptions { UserId = userId }, await GetDefaultInMemoryOptionsAsync())
             ))?.VolatileData?.UserKeyPinEphemeral;
         }
 
-        public async Task SetUserKeyPinEphemeral(EncString value, string userId = null)
+        public async Task SetUserKeyPinEphemeralAsync(EncString value, string userId = null)
         {
             var reconciledOptions = ReconcileOptions(new StorageOptions { UserId = userId },
                 await GetDefaultInMemoryOptionsAsync());
@@ -423,7 +423,7 @@ namespace Bit.Core.Services
             await SaveAccountAsync(account, reconciledOptions);
         }
 
-        [Obsolete("Use GetUserKeyPin instead, left for migration purposes")]
+        [Obsolete("Use GetUserKeyPinAsync instead, left for migration purposes")]
         public async Task<string> GetPinProtectedAsync(string userId = null)
         {
             var reconciledOptions = ReconcileOptions(new StorageOptions { UserId = userId },
@@ -431,7 +431,7 @@ namespace Bit.Core.Services
             return await GetValueAsync<string>(Constants.PinProtectedKey(reconciledOptions.UserId), reconciledOptions);
         }
 
-        [Obsolete("Use SetUserKeyPin instead")]
+        [Obsolete("Use SetUserKeyPinAsync instead")]
         public async Task SetPinProtectedAsync(string value, string userId = null)
         {
             var reconciledOptions = ReconcileOptions(new StorageOptions { UserId = userId },
@@ -439,7 +439,7 @@ namespace Bit.Core.Services
             await SetValueAsync(Constants.PinProtectedKey(reconciledOptions.UserId), value, reconciledOptions);
         }
 
-        [Obsolete("Use GetUserKeyPinEphemeral instead, left for migration purposes")]
+        [Obsolete("Use GetUserKeyPinEphemeralAsync instead, left for migration purposes")]
         public async Task<EncString> GetPinProtectedKeyAsync(string userId = null)
         {
             return (await GetAccountAsync(
@@ -447,7 +447,7 @@ namespace Bit.Core.Services
             ))?.VolatileData?.PinProtectedKey;
         }
 
-        [Obsolete("Use SetUserKeyPinEphemeral instead")]
+        [Obsolete("Use SetUserKeyPinEphemeralAsync instead")]
         public async Task SetPinProtectedKeyAsync(EncString value, string userId = null)
         {
             var reconciledOptions = ReconcileOptions(new StorageOptions { UserId = userId },

--- a/src/Core/Services/StateService.cs
+++ b/src/Core/Services/StateService.cs
@@ -395,16 +395,15 @@ namespace Bit.Core.Services
             await SetValueAsync(Constants.ProtectedPinKey(reconciledOptions.UserId), value, reconciledOptions);
         }
 
-        // TODO(Jake): Does this need to be secure storage?
         public async Task<EncString> GetUserKeyPinAsync(string userId = null)
         {
-            return new EncString(await _storageMediatorService.GetAsync<string>(Constants.UserKeyPinKey(userId), false));
+            var key = await _storageMediatorService.GetAsync<string>(Constants.UserKeyPinKey(userId), false);
+            return key != null ? new EncString(key) : null;
         }
 
-        // TODO(Jake): Does this need to be secure storage?
         public async Task SetUserKeyPinAsync(EncString value, string userId = null)
         {
-            await _storageMediatorService.SaveAsync(Constants.UserKeyPinKey(userId), value.EncryptedString, false);
+            await _storageMediatorService.SaveAsync(Constants.UserKeyPinKey(userId), value?.EncryptedString, false);
         }
 
         public async Task<EncString> GetUserKeyPinEphemeralAsync(string userId = null)

--- a/src/Core/Services/SyncService.cs
+++ b/src/Core/Services/SyncService.cs
@@ -328,7 +328,7 @@ namespace Bit.Core.Services
                 return;
             }
             await _cryptoService.SetEncKeyAsync(response.Key);
-            await _cryptoService.SetEncPrivateKeyAsync(response.PrivateKey);
+            await _cryptoService.SetPrivateKeyAsync(response.PrivateKey);
             await _cryptoService.SetOrgKeysAsync(response.Organizations);
             await _stateService.SetSecurityStampAsync(response.SecurityStamp);
             var organizations = response.Organizations.ToDictionary(o => o.Id, o => new OrganizationData(o));

--- a/src/Core/Services/SyncService.cs
+++ b/src/Core/Services/SyncService.cs
@@ -327,7 +327,7 @@ namespace Bit.Core.Services
                 }
                 return;
             }
-            await _cryptoService.SetEncKeyAsync(response.Key);
+            await _cryptoService.SetMasterKeyEncryptedUserKeyAsync(response.Key);
             await _cryptoService.SetPrivateKeyAsync(response.PrivateKey);
             await _cryptoService.SetOrgKeysAsync(response.Organizations);
             await _stateService.SetSecurityStampAsync(response.SecurityStamp);

--- a/src/Core/Services/SyncService.cs
+++ b/src/Core/Services/SyncService.cs
@@ -328,7 +328,7 @@ namespace Bit.Core.Services
                 return;
             }
             await _cryptoService.SetMasterKeyEncryptedUserKeyAsync(response.Key);
-            await _cryptoService.SetPrivateKeyAsync(response.PrivateKey);
+            await _cryptoService.SetUserPrivateKeyAsync(response.PrivateKey);
             await _cryptoService.SetOrgKeysAsync(response.Organizations);
             await _stateService.SetSecurityStampAsync(response.SecurityStamp);
             var organizations = response.Organizations.ToDictionary(o => o.Id, o => new OrganizationData(o));

--- a/src/Core/Services/SyncService.cs
+++ b/src/Core/Services/SyncService.cs
@@ -337,7 +337,7 @@ namespace Bit.Core.Services
             await _stateService.SetNameAsync(response.Name);
             await _stateService.SetPersonalPremiumAsync(response.Premium);
             await _stateService.SetAvatarColorAsync(response.AvatarColor);
-            await _keyConnectorService.SetUsesKeyConnector(response.UsesKeyConnector);
+            await _keyConnectorService.SetUsesKeyConnectorAsync(response.UsesKeyConnector);
         }
 
         private async Task SyncFoldersAsync(string userId, List<FolderResponse> response)

--- a/src/Core/Services/UserVerificationService.cs
+++ b/src/Core/Services/UserVerificationService.cs
@@ -44,7 +44,7 @@ namespace Bit.Core.Services
             }
             else
             {
-                var passwordValid = await _cryptoService.CompareAndUpdateKeyHashAsync(secret, null);
+                var passwordValid = await _cryptoService.CompareAndUpdatePasswordHashAsync(secret, null);
                 if (!passwordValid)
                 {
                     await InvalidSecretErrorAsync(verificationType);

--- a/src/Core/Services/UserVerificationService.cs
+++ b/src/Core/Services/UserVerificationService.cs
@@ -44,7 +44,7 @@ namespace Bit.Core.Services
             }
             else
             {
-                var passwordValid = await _cryptoService.CompareAndUpdatePasswordHashAsync(secret, null);
+                var passwordValid = await _cryptoService.CompareAndUpdateKeyHashAsync(secret, null);
                 if (!passwordValid)
                 {
                     await InvalidSecretErrorAsync(verificationType);

--- a/src/Core/Services/VaultTimeoutService.cs
+++ b/src/Core/Services/VaultTimeoutService.cs
@@ -179,7 +179,7 @@ namespace Bit.Core.Services
                 userId = await _stateService.GetActiveUserIdAsync();
             }
 
-            if (await _keyConnectorService.GetUsesKeyConnector())
+            if (await _keyConnectorService.GetUsesKeyConnectorAsync())
             {
                 var pinStatus = await GetPinLockTypeAsync(userId);
                 var ephemeralPinSet = await _stateService.GetPinKeyEncryptedUserKeyEphemeralAsync()

--- a/src/Core/Services/VaultTimeoutService.cs
+++ b/src/Core/Services/VaultTimeoutService.cs
@@ -221,7 +221,7 @@ namespace Bit.Core.Services
         {
             await _stateService.SetVaultTimeoutAsync(timeout);
             await _stateService.SetVaultTimeoutActionAsync(action);
-            await _cryptoService.ToggleKeysAsync();
+            await _cryptoService.RefreshKeysAsync();
             await _tokenService.ToggleTokensAsync();
         }
 

--- a/src/Core/Services/VaultTimeoutService.cs
+++ b/src/Core/Services/VaultTimeoutService.cs
@@ -61,7 +61,7 @@ namespace Bit.Core.Services
 
         public async Task<bool> IsLockedAsync(string userId = null)
         {
-            var hasKey = await _cryptoService.HasKeyAsync(userId);
+            var hasKey = await _cryptoService.HasUserKeyAsync(userId);
             if (hasKey)
             {
                 var biometricSet = await IsBiometricLockSetAsync(userId);
@@ -196,10 +196,10 @@ namespace Bit.Core.Services
                 }
             }
             await Task.WhenAll(
-                _cryptoService.ClearKeyAsync(userId),
+                _cryptoService.ClearUserKeyAsync(userId),
+                _cryptoService.ClearMasterKeyAsync(userId),
                 _cryptoService.ClearOrgKeysAsync(true, userId),
-                _cryptoService.ClearKeyPairAsync(true, userId),
-                _cryptoService.ClearEncKeyAsync(true, userId));
+                _cryptoService.ClearKeyPairAsync(true, userId));
 
             if (isActiveAccount)
             {
@@ -257,8 +257,7 @@ namespace Bit.Core.Services
 
         public async Task ClearAsync(string userId = null)
         {
-            await _stateService.SetPinProtectedKeyAsync(null, userId);
-            await _stateService.SetProtectedPinAsync(null, userId);
+            await _cryptoService.ClearPinKeysAsync(userId);
         }
 
         public async Task<int?> GetVaultTimeout(string userId = null)

--- a/src/Core/Services/VaultTimeoutService.cs
+++ b/src/Core/Services/VaultTimeoutService.cs
@@ -229,22 +229,19 @@ namespace Bit.Core.Services
         {
             // we can't depend on only the protected pin being set because old
             // versions only used it for MP on Restart
-            var pinIsEnabled = await _stateService.GetProtectedPinAsync(userId);
-            var userKeyPin = await _stateService.GetUserKeyPinAsync(userId);
-            var oldUserKeyPin = await _stateService.GetPinProtectedAsync(userId);
+            var isPinEnabled = await _stateService.GetProtectedPinAsync(userId) != null;
+            var hasUserKeyPin = await _stateService.GetUserKeyPinAsync(userId) != null;
+            var hasOldUserKeyPin = await _stateService.GetPinProtectedAsync(userId) != null;
 
-            if (userKeyPin != null || oldUserKeyPin != null)
+            if (hasUserKeyPin || hasOldUserKeyPin)
             {
                 return PinLockType.Persistent;
             }
-            else if (pinIsEnabled != null && userKeyPin == null && oldUserKeyPin == null)
+            else if (isPinEnabled && !hasUserKeyPin && !hasOldUserKeyPin)
             {
                 return PinLockType.Transient;
             }
-            else
-            {
-                return PinLockType.Disabled;
-            }
+            return PinLockType.Disabled;
         }
 
         public async Task<bool> IsBiometricLockSetAsync(string userId = null)

--- a/src/Core/Services/VaultTimeoutService.cs
+++ b/src/Core/Services/VaultTimeoutService.cs
@@ -214,7 +214,7 @@ namespace Bit.Core.Services
         {
             await _stateService.SetVaultTimeoutAsync(timeout);
             await _stateService.SetVaultTimeoutActionAsync(action);
-            await _cryptoService.ToggleKeyAsync();
+            await _cryptoService.ToggleKeysAsync();
             await _tokenService.ToggleTokensAsync();
         }
 

--- a/src/Core/Services/VaultTimeoutService.cs
+++ b/src/Core/Services/VaultTimeoutService.cs
@@ -1,13 +1,11 @@
 ﻿using System;
-using System.Linq;
 using System.Threading.Tasks;
 using Bit.Core.Abstractions;
 using Bit.Core.Enums;
-using Bit.Core.Models.Domain;
 
 namespace Bit.Core.Services
 {
-    public enum PinLockEnum
+    public enum PinLockType
     {
         Disabled,
         Persistent,
@@ -175,8 +173,8 @@ namespace Bit.Core.Services
                 var pinStatus = await IsPinLockSetAsync(userId);
                 var ephemeralPinSet = await _stateService.GetUserKeyPinEphemeralAsync()
                     ?? await _stateService.GetPinProtectedKeyAsync();
-                var pinEnabled = (pinStatus == PinLockEnum.Transient && ephemeralPinSet != null) ||
-                          pinStatus == PinLockEnum.Persistent;
+                var pinEnabled = (pinStatus == PinLockType.Transient && ephemeralPinSet != null) ||
+                          pinStatus == PinLockType.Persistent;
 
                 if (!pinEnabled && !await IsBiometricLockSetAsync())
                 {
@@ -227,7 +225,7 @@ namespace Bit.Core.Services
             await _tokenService.ToggleTokensAsync();
         }
 
-        public async Task<PinLockEnum> IsPinLockSetAsync(string userId = null)
+        public async Task<PinLockType> IsPinLockSetAsync(string userId = null)
         {
             // we can't depend on only the protected pin being set because old
             // versions only used it for MP on Restart
@@ -237,15 +235,15 @@ namespace Bit.Core.Services
 
             if (userKeyPin != null || oldUserKeyPin != null)
             {
-                return PinLockEnum.Persistent;
+                return PinLockType.Persistent;
             }
             else if (pinIsEnabled != null && userKeyPin == null && oldUserKeyPin == null)
             {
-                return PinLockEnum.Transient;
+                return PinLockType.Transient;
             }
             else
             {
-                return PinLockEnum.Disabled;
+                return PinLockType.Disabled;
             }
         }
 

--- a/src/Core/Services/VaultTimeoutService.cs
+++ b/src/Core/Services/VaultTimeoutService.cs
@@ -171,7 +171,7 @@ namespace Bit.Core.Services
             if (await _keyConnectorService.GetUsesKeyConnector())
             {
                 var pinStatus = await GetPinLockTypeAsync(userId);
-                var ephemeralPinSet = await _stateService.GetUserKeyPinEphemeralAsync()
+                var ephemeralPinSet = await _stateService.GetPinKeyEncryptedUserKeyEphemeralAsync()
                     ?? await _stateService.GetPinProtectedKeyAsync();
                 var pinEnabled = (pinStatus == PinLockType.Transient && ephemeralPinSet != null) ||
                           pinStatus == PinLockType.Persistent;
@@ -230,7 +230,7 @@ namespace Bit.Core.Services
             // we can't depend on only the protected pin being set because old
             // versions only used it for MP on Restart
             var isPinEnabled = await _stateService.GetProtectedPinAsync(userId) != null;
-            var hasUserKeyPin = await _stateService.GetUserKeyPinAsync(userId) != null;
+            var hasUserKeyPin = await _stateService.GetPinKeyEncryptedUserKeyAsync(userId) != null;
             var hasOldUserKeyPin = await _stateService.GetPinProtectedAsync(userId) != null;
 
             if (hasUserKeyPin || hasOldUserKeyPin)

--- a/src/Core/Services/VaultTimeoutService.cs
+++ b/src/Core/Services/VaultTimeoutService.cs
@@ -170,7 +170,7 @@ namespace Bit.Core.Services
 
             if (await _keyConnectorService.GetUsesKeyConnector())
             {
-                var pinStatus = await IsPinLockSetAsync(userId);
+                var pinStatus = await GetPinLockTypeAsync(userId);
                 var ephemeralPinSet = await _stateService.GetUserKeyPinEphemeralAsync()
                     ?? await _stateService.GetPinProtectedKeyAsync();
                 var pinEnabled = (pinStatus == PinLockType.Transient && ephemeralPinSet != null) ||
@@ -225,7 +225,7 @@ namespace Bit.Core.Services
             await _tokenService.ToggleTokensAsync();
         }
 
-        public async Task<PinLockType> IsPinLockSetAsync(string userId = null)
+        public async Task<PinLockType> GetPinLockTypeAsync(string userId = null)
         {
             // we can't depend on only the protected pin being set because old
             // versions only used it for MP on Restart

--- a/src/Core/Utilities/ServiceContainer.cs
+++ b/src/Core/Utilities/ServiceContainer.cs
@@ -79,7 +79,7 @@ namespace Bit.Core.Utilities
             var totpService = new TotpService(cryptoFunctionService);
             var authService = new AuthService(cryptoService, cryptoFunctionService, apiService, stateService,
                 tokenService, appIdService, i18nService, platformUtilsService, messagingService,
-                keyConnectorService, passwordGenerationService, policyService);
+                passwordGenerationService, policyService);
             var exportService = new ExportService(folderService, cipherService, cryptoService);
             var auditService = new AuditService(cryptoFunctionService, apiService);
             var environmentService = new EnvironmentService(apiService, stateService, conditionedRunner);

--- a/src/Core/Utilities/ServiceContainer.cs
+++ b/src/Core/Utilities/ServiceContainer.cs
@@ -79,7 +79,7 @@ namespace Bit.Core.Utilities
             var totpService = new TotpService(cryptoFunctionService);
             var authService = new AuthService(cryptoService, cryptoFunctionService, apiService, stateService,
                 tokenService, appIdService, i18nService, platformUtilsService, messagingService,
-                passwordGenerationService, policyService);
+                keyConnectorService, passwordGenerationService, policyService);
             var exportService = new ExportService(folderService, cipherService, cryptoService);
             var auditService = new AuditService(cryptoFunctionService, apiService);
             var environmentService = new EnvironmentService(apiService, stateService, conditionedRunner);

--- a/src/iOS.Core/Controllers/BaseLockPasswordViewController.cs
+++ b/src/iOS.Core/Controllers/BaseLockPasswordViewController.cs
@@ -112,7 +112,7 @@ namespace Bit.iOS.Core.Controllers
             {
                 _pinStatus = await _vaultTimeoutService.GetPinLockTypeAsync();
 
-                var ephemeralPinSet = await _stateService.GetUserKeyPinEphemeralAsync()
+                var ephemeralPinSet = await _stateService.GetPinKeyEncryptedUserKeyEphemeralAsync()
                     ?? await _stateService.GetPinProtectedKeyAsync();
                 _pinEnabled = (_pinStatus == PinLockType.Transient && ephemeralPinSet != null) ||
                     _pinStatus == PinLockType.Persistent;
@@ -259,13 +259,13 @@ namespace Bit.iOS.Core.Controllers
                         EncString oldPinProtected = null;
                         if (_pinStatus == PinLockType.Persistent)
                         {
-                            userKeyPin = await _stateService.GetUserKeyPinAsync();
+                            userKeyPin = await _stateService.GetPinKeyEncryptedUserKeyAsync();
                             var oldEncryptedKey = await _stateService.GetPinProtectedAsync();
                             oldPinProtected = oldEncryptedKey != null ? new EncString(oldEncryptedKey) : null;
                         }
                         else if (_pinStatus == PinLockType.Transient)
                         {
-                            userKeyPin = await _stateService.GetUserKeyPinEphemeralAsync();
+                            userKeyPin = await _stateService.GetPinKeyEncryptedUserKeyEphemeralAsync();
                             oldPinProtected = await _stateService.GetPinProtectedKeyAsync();
                         }
 

--- a/src/iOS.Core/Controllers/BaseLockPasswordViewController.cs
+++ b/src/iOS.Core/Controllers/BaseLockPasswordViewController.cs
@@ -110,7 +110,7 @@ namespace Bit.iOS.Core.Controllers
             }
             else
             {
-                _pinStatus = await _vaultTimeoutService.IsPinLockSetAsync();
+                _pinStatus = await _vaultTimeoutService.GetPinLockTypeAsync();
 
                 var ephemeralPinSet = await _stateService.GetUserKeyPinEphemeralAsync()
                     ?? await _stateService.GetPinProtectedKeyAsync();

--- a/src/iOS.Core/Controllers/BaseLockPasswordViewController.cs
+++ b/src/iOS.Core/Controllers/BaseLockPasswordViewController.cs
@@ -312,18 +312,18 @@ namespace Bit.iOS.Core.Controllers
                 {
                     var masterKey = await _cryptoService.MakeMasterKeyAsync(inputtedValue, email, kdfConfig);
 
-                    var storedPasswordHash = await _cryptoService.GetPasswordHashAsync();
+                    var storedPasswordHash = await _cryptoService.GetMasterKeyHashAsync();
                     if (storedPasswordHash == null)
                     {
                         var oldKey = await _secureStorageService.GetAsync<string>("oldKey");
                         if (masterKey.KeyB64 == oldKey)
                         {
-                            var localPasswordHash = await _cryptoService.HashPasswordAsync(inputtedValue, masterKey, HashPurpose.LocalAuthorization);
+                            var localPasswordHash = await _cryptoService.HashMasterKeyAsync(inputtedValue, masterKey, HashPurpose.LocalAuthorization);
                             await _secureStorageService.RemoveAsync("oldKey");
-                            await _cryptoService.SetPasswordHashAsync(localPasswordHash);
+                            await _cryptoService.SetMasterKeyHashAsync(localPasswordHash);
                         }
                     }
-                    var passwordValid = await _cryptoService.CompareAndUpdatePasswordHashAsync(inputtedValue, masterKey);
+                    var passwordValid = await _cryptoService.CompareAndUpdateKeyHashAsync(inputtedValue, masterKey);
                     if (passwordValid)
                     {
                         await AppHelpers.ResetInvalidUnlockAttemptsAsync();

--- a/src/iOS.Core/Controllers/BaseLockPasswordViewController.cs
+++ b/src/iOS.Core/Controllers/BaseLockPasswordViewController.cs
@@ -30,7 +30,7 @@ namespace Bit.iOS.Core.Controllers
         private IBiometricService _biometricService;
         private IKeyConnectorService _keyConnectorService;
         private IAccountsManager _accountManager;
-        private PinLockEnum _pinStatus;
+        private PinLockType _pinStatus;
         private bool _pinEnabled;
         private bool _biometricEnabled;
         private bool _biometricIntegrityValid = true;
@@ -104,7 +104,7 @@ namespace Bit.iOS.Core.Controllers
             if (autofillExtension && await _stateService.GetPasswordRepromptAutofillAsync())
             {
                 _passwordReprompt = true;
-                _pinStatus = PinLockEnum.Disabled;
+                _pinStatus = PinLockType.Disabled;
                 _pinEnabled = false;
                 _biometricEnabled = false;
             }
@@ -114,8 +114,8 @@ namespace Bit.iOS.Core.Controllers
 
                 var ephemeralPinSet = await _stateService.GetUserKeyPinEphemeralAsync()
                     ?? await _stateService.GetPinProtectedKeyAsync();
-                _pinEnabled = (_pinStatus == PinLockEnum.Transient && ephemeralPinSet != null) ||
-                    _pinStatus == PinLockEnum.Persistent;
+                _pinEnabled = (_pinStatus == PinLockType.Transient && ephemeralPinSet != null) ||
+                    _pinStatus == PinLockType.Persistent;
 
                 _biometricEnabled = await _vaultTimeoutService.IsBiometricLockSetAsync()
                     && await _cryptoService.HasEncryptedUserKeyAsync();
@@ -257,13 +257,13 @@ namespace Bit.iOS.Core.Controllers
                     {
                         EncString userKeyPin = null;
                         EncString oldPinProtected = null;
-                        if (_pinStatus == PinLockEnum.Persistent)
+                        if (_pinStatus == PinLockType.Persistent)
                         {
                             userKeyPin = await _stateService.GetUserKeyPinAsync();
                             var oldEncryptedKey = await _stateService.GetPinProtectedAsync();
                             oldPinProtected = oldEncryptedKey != null ? new EncString(oldEncryptedKey) : null;
                         }
-                        else if (_pinStatus == PinLockEnum.Transient)
+                        else if (_pinStatus == PinLockType.Transient)
                         {
                             userKeyPin = await _stateService.GetUserKeyPinEphemeralAsync();
                             oldPinProtected = await _stateService.GetPinProtectedKeyAsync();
@@ -273,7 +273,7 @@ namespace Bit.iOS.Core.Controllers
                         if (oldPinProtected != null)
                         {
                             userKey = await _cryptoService.DecryptAndMigrateOldPinKeyAsync(
-                                _pinStatus == PinLockEnum.Transient,
+                                _pinStatus == PinLockType.Transient,
                                 inputtedValue,
                                 email,
                                 kdfConfig,

--- a/src/iOS.Core/Controllers/BaseLockPasswordViewController.cs
+++ b/src/iOS.Core/Controllers/BaseLockPasswordViewController.cs
@@ -8,11 +8,13 @@ using Bit.App.Utilities;
 using Bit.Core.Abstractions;
 using Bit.Core.Enums;
 using Bit.Core.Models.Domain;
+using Bit.Core.Services;
 using Bit.Core.Utilities;
 using Bit.iOS.Core.Utilities;
 using Bit.iOS.Core.Views;
 using Foundation;
 using UIKit;
+using Xamarin.Essentials;
 using Xamarin.Forms;
 
 namespace Bit.iOS.Core.Controllers
@@ -28,10 +30,9 @@ namespace Bit.iOS.Core.Controllers
         private IBiometricService _biometricService;
         private IKeyConnectorService _keyConnectorService;
         private IAccountsManager _accountManager;
-        private bool _isPinProtected;
-        private bool _isPinProtectedWithKey;
-        private bool _pinLock;
-        private bool _biometricLock;
+        private PinLockEnum _pinStatus;
+        private bool _pinEnabled;
+        private bool _biometricEnabled;
         private bool _biometricIntegrityValid = true;
         private bool _passwordReprompt = false;
         private bool _usesKeyConnector;
@@ -85,7 +86,7 @@ namespace Bit.iOS.Core.Controllers
         }
 
         public abstract UITableView TableView { get; }
-        
+
         public override async void ViewDidLoad()
         {
             _vaultTimeoutService = ServiceContainer.Resolve<IVaultTimeoutService>("vaultTimeoutService");
@@ -103,25 +104,28 @@ namespace Bit.iOS.Core.Controllers
             if (autofillExtension && await _stateService.GetPasswordRepromptAutofillAsync())
             {
                 _passwordReprompt = true;
-                _isPinProtected = false;
-                _isPinProtectedWithKey = false;
-                _pinLock = false;
-                _biometricLock = false;
+                _pinStatus = PinLockEnum.Disabled;
+                _pinEnabled = false;
+                _biometricEnabled = false;
             }
             else
             {
-                (_isPinProtected, _isPinProtectedWithKey) = await _vaultTimeoutService.IsPinLockSetAsync();
-                _pinLock = (_isPinProtected && await _stateService.GetPinProtectedKeyAsync() != null) ||
-                           _isPinProtectedWithKey;
-                _biometricLock = await _vaultTimeoutService.IsBiometricLockSetAsync() &&
-                                 await _cryptoService.HasKeyAsync();
+                _pinStatus = await _vaultTimeoutService.IsPinLockSetAsync();
+
+                var ephemeralPinSet = await _stateService.GetUserKeyPinEphemeralAsync()
+                    ?? await _stateService.GetPinProtectedKeyAsync();
+                _pinEnabled = (_pinStatus == PinLockEnum.Transient && ephemeralPinSet != null) ||
+                    _pinStatus == PinLockEnum.Persistent;
+
+                _biometricEnabled = await _vaultTimeoutService.IsBiometricLockSetAsync()
+                    && await _cryptoService.HasEncryptedUserKeyAsync();
                 _biometricIntegrityValid =
                     await _platformUtilsService.IsBiometricIntegrityValidAsync(BiometricIntegritySourceKey);
                 _usesKeyConnector = await _keyConnectorService.GetUsesKeyConnector();
-                _biometricUnlockOnly = _usesKeyConnector && _biometricLock && !_pinLock;
+                _biometricUnlockOnly = _usesKeyConnector && _biometricEnabled && !_pinEnabled;
             }
 
-            if (_pinLock)
+            if (_pinEnabled)
             {
                 BaseNavItem.Title = AppResources.VerifyPIN;
             }
@@ -150,7 +154,7 @@ namespace Bit.iOS.Core.Controllers
 
             if (!_biometricUnlockOnly)
             {
-                MasterPasswordCell.Label.Text = _pinLock ? AppResources.PIN : AppResources.MasterPassword;
+                MasterPasswordCell.Label.Text = _pinEnabled ? AppResources.PIN : AppResources.MasterPassword;
                 MasterPasswordCell.TextField.SecureTextEntry = true;
                 MasterPasswordCell.TextField.ReturnKeyType = UIReturnKeyType.Go;
                 MasterPasswordCell.TextField.ShouldReturn += (UITextField tf) =>
@@ -158,7 +162,7 @@ namespace Bit.iOS.Core.Controllers
                     CheckPasswordAsync().FireAndForget();
                     return true;
                 };
-                if (_pinLock)
+                if (_pinEnabled)
                 {
                     MasterPasswordCell.TextField.KeyboardType = UIKeyboardType.NumberPad;
                 }
@@ -177,7 +181,7 @@ namespace Bit.iOS.Core.Controllers
 
             base.ViewDidLoad();
 
-            if (_biometricLock)
+            if (_biometricEnabled)
             {
                 if (!_biometricIntegrityValid)
                 {
@@ -198,18 +202,18 @@ namespace Bit.iOS.Core.Controllers
             // Users with key connector and without biometric or pin has no MP to unlock with
             if (_usesKeyConnector)
             {
-                if (!(_pinLock || _biometricLock) ||
-                    (_biometricLock && !_biometricIntegrityValid))
+                if (!(_pinEnabled || _biometricEnabled) ||
+                    (_biometricEnabled && !_biometricIntegrityValid))
                 {
                     PromptSSO();
                 }
             }
-            else if (!_biometricLock || !_biometricIntegrityValid)
+            else if (!_biometricEnabled || !_biometricIntegrityValid)
             {
                 MasterPasswordCell.TextField.BecomeFirstResponder();
             }
         }
-        
+
         protected async Task CheckPasswordAsync()
         {
             if (_checkingPassword)
@@ -224,7 +228,7 @@ namespace Bit.iOS.Core.Controllers
                 {
                     var alert = Dialogs.CreateAlert(AppResources.AnErrorHasOccurred,
                         string.Format(AppResources.ValidationFieldRequired,
-                            _pinLock ? AppResources.PIN : AppResources.MasterPassword),
+                            _pinEnabled ? AppResources.PIN : AppResources.MasterPassword),
                         AppResources.Ok);
                     PresentViewController(alert, true, null);
                     return;
@@ -246,33 +250,53 @@ namespace Bit.iOS.Core.Controllers
                     return;
                 }
 
-                if (_pinLock)
+                if (_pinEnabled)
                 {
                     var failed = true;
                     try
                     {
-                        if (_isPinProtected)
+                        EncString userKeyPin = null;
+                        EncString oldPinProtected = null;
+                        if (_pinStatus == PinLockEnum.Persistent)
                         {
-                            var key = await _cryptoService.MakeKeyFromPinAsync(inputtedValue, email,
+                            userKeyPin = await _stateService.GetUserKeyPinAsync();
+                            var oldEncryptedKey = await _stateService.GetPinProtectedAsync();
+                            oldPinProtected = oldEncryptedKey != null ? new EncString(oldEncryptedKey) : null;
+                        }
+                        else if (_pinStatus == PinLockEnum.Transient)
+                        {
+                            userKeyPin = await _stateService.GetUserKeyPinEphemeralAsync();
+                            oldPinProtected = await _stateService.GetPinProtectedKeyAsync();
+                        }
+
+                        UserKey userKey;
+                        if (oldPinProtected != null)
+                        {
+                            userKey = await _cryptoService.DecryptAndMigrateOldPinKeyAsync(
+                                _pinStatus == PinLockEnum.Transient,
+                                inputtedValue,
+                                email,
                                 kdfConfig,
-                                await _stateService.GetPinProtectedKeyAsync());
-                            var encKey = await _cryptoService.GetEncKeyAsync(key);
-                            var protectedPin = await _stateService.GetProtectedPinAsync();
-                            var decPin = await _cryptoService.DecryptToUtf8Async(new EncString(protectedPin), encKey);
-                            failed = decPin != inputtedValue;
-                            if (!failed)
-                            {
-                                await AppHelpers.ResetInvalidUnlockAttemptsAsync();
-                                await SetKeyAndContinueAsync(key);
-                            }
+                                oldPinProtected
+                            );
                         }
                         else
                         {
-                            var key2 = await _cryptoService.MakeKeyFromPinAsync(inputtedValue, email,
-                                kdfConfig);
-                            failed = false;
+                            userKey = await _cryptoService.DecryptUserKeyWithPinAsync(
+                                inputtedValue,
+                                email,
+                                kdfConfig,
+                                userKeyPin
+                            );
+                        }
+
+                        var protectedPin = await _stateService.GetProtectedPinAsync();
+                        var decryptedPin = await _cryptoService.DecryptToUtf8Async(new EncString(protectedPin), userKey);
+                        failed = decryptedPin != inputtedValue;
+                        if (!failed)
+                        {
                             await AppHelpers.ResetInvalidUnlockAttemptsAsync();
-                            await SetKeyAndContinueAsync(key2);
+                            await SetKeyAndContinueAsync(userKey);
                         }
                     }
                     catch
@@ -286,33 +310,27 @@ namespace Bit.iOS.Core.Controllers
                 }
                 else
                 {
-                    var key2 = await _cryptoService.MakeKeyAsync(inputtedValue, email, kdfConfig);
+                    var masterKey = await _cryptoService.MakeMasterKeyAsync(inputtedValue, email, kdfConfig);
 
-                    var storedKeyHash = await _cryptoService.GetKeyHashAsync();
-                    if (storedKeyHash == null)
+                    var storedPasswordHash = await _cryptoService.GetPasswordHashAsync();
+                    if (storedPasswordHash == null)
                     {
                         var oldKey = await _secureStorageService.GetAsync<string>("oldKey");
-                        if (key2.KeyB64 == oldKey)
+                        if (masterKey.KeyB64 == oldKey)
                         {
-                            var localKeyHash = await _cryptoService.HashPasswordAsync(inputtedValue, key2, HashPurpose.LocalAuthorization);
+                            var localPasswordHash = await _cryptoService.HashPasswordAsync(inputtedValue, masterKey, HashPurpose.LocalAuthorization);
                             await _secureStorageService.RemoveAsync("oldKey");
-                            await _cryptoService.SetKeyHashAsync(localKeyHash);
+                            await _cryptoService.SetPasswordHashAsync(localPasswordHash);
                         }
                     }
-                    var passwordValid = await _cryptoService.CompareAndUpdateKeyHashAsync(inputtedValue, key2);
+                    var passwordValid = await _cryptoService.CompareAndUpdatePasswordHashAsync(inputtedValue, masterKey);
                     if (passwordValid)
                     {
-                        if (_isPinProtected)
-                        {
-                            var protectedPin = await _stateService.GetProtectedPinAsync();
-                            var encKey = await _cryptoService.GetEncKeyAsync(key2);
-                            var decPin = await _cryptoService.DecryptToUtf8Async(new EncString(protectedPin), encKey);
-                            var pinKey = await _cryptoService.MakePinKeyAysnc(decPin, email,
-                                kdfConfig);
-                            await _stateService.SetPinProtectedKeyAsync(await _cryptoService.EncryptAsync(key2.Key, pinKey));
-                        }
                         await AppHelpers.ResetInvalidUnlockAttemptsAsync();
-                        await SetKeyAndContinueAsync(key2, true);
+
+                        var userKey = await _cryptoService.DecryptUserKeyWithMasterKeyAsync(masterKey);
+                        await _cryptoService.SetMasterKeyAsync(masterKey);
+                        await SetKeyAndContinueAsync(userKey, true);
                     }
                     else
                     {
@@ -339,12 +357,12 @@ namespace Bit.iOS.Core.Controllers
 
         public async Task PromptBiometricAsync()
         {
-            if (!_biometricLock || !_biometricIntegrityValid)
+            if (!_biometricEnabled || !_biometricIntegrityValid)
             {
                 return;
             }
             var success = await _platformUtilsService.AuthenticateBiometricAsync(null,
-                _pinLock ? AppResources.PIN : AppResources.MasterPassword,
+                _pinEnabled ? AppResources.PIN : AppResources.MasterPassword,
                 () => MasterPasswordCell.TextField.BecomeFirstResponder());
             await _stateService.SetBiometricLockedAsync(!success);
             if (success)
@@ -371,12 +389,12 @@ namespace Bit.iOS.Core.Controllers
             PresentViewController(loginController, true, null);
         }
 
-        private async Task SetKeyAndContinueAsync(SymmetricCryptoKey key, bool masterPassword = false)
+        private async Task SetKeyAndContinueAsync(UserKey userKey, bool masterPassword = false)
         {
-            var hasKey = await _cryptoService.HasKeyAsync();
+            var hasKey = await _cryptoService.HasUserKeyAsync();
             if (!hasKey)
             {
-                await _cryptoService.SetKeyAsync(key);
+                await _cryptoService.SetUserKeyAsync(userKey);
             }
             DoContinue(masterPassword);
         }
@@ -396,7 +414,7 @@ namespace Bit.iOS.Core.Controllers
         private async Task EnableBiometricsIfNeeded()
         {
             // Re-enable biometrics if initial use
-            if (_biometricLock & !_biometricIntegrityValid)
+            if (_biometricEnabled & !_biometricIntegrityValid)
             {
                 await _biometricService.SetupBiometricAsync(BiometricIntegritySourceKey);
             }
@@ -405,7 +423,7 @@ namespace Bit.iOS.Core.Controllers
         private void InvalidValue()
         {
             var alert = Dialogs.CreateAlert(AppResources.AnErrorHasOccurred,
-                string.Format(null, _pinLock ? AppResources.PIN : AppResources.InvalidMasterPassword),
+                string.Format(null, _pinEnabled ? AppResources.PIN : AppResources.InvalidMasterPassword),
                 AppResources.Ok, (a) =>
                 {
 
@@ -490,7 +508,7 @@ namespace Bit.iOS.Core.Controllers
                     return 0;
                 }
 
-                return (!controller._biometricUnlockOnly && controller._biometricLock) ||
+                return (!controller._biometricUnlockOnly && controller._biometricEnabled) ||
                     controller._passwordReprompt
                     ? 2
                     : 1;

--- a/src/iOS.Core/Controllers/LockPasswordViewController.cs
+++ b/src/iOS.Core/Controllers/LockPasswordViewController.cs
@@ -14,6 +14,7 @@ using Bit.Core.Enums;
 using Bit.App.Pages;
 using Bit.App.Models;
 using Xamarin.Forms;
+using Bit.Core.Services;
 
 namespace Bit.iOS.Core.Controllers
 {
@@ -29,10 +30,9 @@ namespace Bit.iOS.Core.Controllers
         private IPlatformUtilsService _platformUtilsService;
         private IBiometricService _biometricService;
         private IKeyConnectorService _keyConnectorService;
-        private bool _isPinProtected;
-        private bool _isPinProtectedWithKey;
-        private bool _pinLock;
-        private bool _biometricLock;
+        private PinLockEnum _pinStatus;
+        private bool _pinEnabled;
+        private bool _biometricEnabled;
         private bool _biometricIntegrityValid = true;
         private bool _passwordReprompt = false;
         private bool _usesKeyConnector;
@@ -96,25 +96,28 @@ namespace Bit.iOS.Core.Controllers
             if (autofillExtension && await _stateService.GetPasswordRepromptAutofillAsync())
             {
                 _passwordReprompt = true;
-                _isPinProtected = false;
-                _isPinProtectedWithKey = false;
-                _pinLock = false;
-                _biometricLock = false;
+                _pinStatus = PinLockEnum.Disabled;
+                _pinEnabled = false;
+                _biometricEnabled = false;
             }
             else
             {
-                (_isPinProtected, _isPinProtectedWithKey) = await _vaultTimeoutService.IsPinLockSetAsync();
-                _pinLock = (_isPinProtected && await _stateService.GetPinProtectedKeyAsync() != null) ||
-                           _isPinProtectedWithKey;
-                _biometricLock = await _vaultTimeoutService.IsBiometricLockSetAsync() &&
-                                 await _cryptoService.HasKeyAsync();
+                _pinStatus = await _vaultTimeoutService.IsPinLockSetAsync();
+
+                var ephemeralPinSet = await _stateService.GetUserKeyPinEphemeralAsync()
+                    ?? await _stateService.GetPinProtectedKeyAsync();
+                _pinEnabled = (_pinStatus == PinLockEnum.Transient && ephemeralPinSet != null) ||
+                    _pinStatus == PinLockEnum.Persistent;
+
+                _biometricEnabled = await _vaultTimeoutService.IsBiometricLockSetAsync()
+                    && await _cryptoService.HasEncryptedUserKeyAsync();
                 _biometricIntegrityValid =
                     await _platformUtilsService.IsBiometricIntegrityValidAsync(BiometricIntegritySourceKey);
                 _usesKeyConnector = await _keyConnectorService.GetUsesKeyConnector();
-                _biometricUnlockOnly = _usesKeyConnector && _biometricLock && !_pinLock;
+                _biometricUnlockOnly = _usesKeyConnector && _biometricEnabled && !_pinEnabled;
             }
 
-            if (_pinLock)
+            if (_pinEnabled)
             {
                 BaseNavItem.Title = AppResources.VerifyPIN;
             }
@@ -143,7 +146,7 @@ namespace Bit.iOS.Core.Controllers
 
             if (!_biometricUnlockOnly)
             {
-                MasterPasswordCell.Label.Text = _pinLock ? AppResources.PIN : AppResources.MasterPassword;
+                MasterPasswordCell.Label.Text = _pinEnabled ? AppResources.PIN : AppResources.MasterPassword;
                 MasterPasswordCell.TextField.SecureTextEntry = true;
                 MasterPasswordCell.TextField.ReturnKeyType = UIReturnKeyType.Go;
                 MasterPasswordCell.TextField.ShouldReturn += (UITextField tf) =>
@@ -151,7 +154,7 @@ namespace Bit.iOS.Core.Controllers
                     CheckPasswordAsync().GetAwaiter().GetResult();
                     return true;
                 };
-                if (_pinLock)
+                if (_pinEnabled)
                 {
                     MasterPasswordCell.TextField.KeyboardType = UIKeyboardType.NumberPad;
                 }
@@ -165,7 +168,7 @@ namespace Bit.iOS.Core.Controllers
 
             base.ViewDidLoad();
 
-            if (_biometricLock)
+            if (_biometricEnabled)
             {
                 if (!_biometricIntegrityValid)
                 {
@@ -186,13 +189,13 @@ namespace Bit.iOS.Core.Controllers
             // Users with key connector and without biometric or pin has no MP to unlock with
             if (_usesKeyConnector)
             {
-                if (!(_pinLock || _biometricLock) ||
-                    (_biometricLock && !_biometricIntegrityValid))
+                if (!(_pinEnabled || _biometricEnabled) ||
+                    (_biometricEnabled && !_biometricIntegrityValid))
                 {
                     PromptSSO();
                 }
             }
-            else if (!_biometricLock || !_biometricIntegrityValid)
+            else if (!_biometricEnabled || !_biometricIntegrityValid)
             {
                 MasterPasswordCell.TextField.BecomeFirstResponder();
             }
@@ -204,7 +207,7 @@ namespace Bit.iOS.Core.Controllers
             {
                 var alert = Dialogs.CreateAlert(AppResources.AnErrorHasOccurred,
                     string.Format(AppResources.ValidationFieldRequired,
-                        _pinLock ? AppResources.PIN : AppResources.MasterPassword),
+                        _pinEnabled ? AppResources.PIN : AppResources.MasterPassword),
                     AppResources.Ok);
                 PresentViewController(alert, true, null);
                 return;
@@ -214,33 +217,53 @@ namespace Bit.iOS.Core.Controllers
             var kdfConfig = await _stateService.GetActiveUserCustomDataAsync(a => new KdfConfig(a?.Profile));
             var inputtedValue = MasterPasswordCell.TextField.Text;
 
-            if (_pinLock)
+            if (_pinEnabled)
             {
                 var failed = true;
                 try
                 {
-                    if (_isPinProtected)
+                    EncString userKeyPin = null;
+                    EncString oldPinProtected = null;
+                    if (_pinStatus == PinLockEnum.Persistent)
                     {
-                        var key = await _cryptoService.MakeKeyFromPinAsync(inputtedValue, email,
+                        userKeyPin = await _stateService.GetUserKeyPinAsync();
+                        var oldEncryptedKey = await _stateService.GetPinProtectedAsync();
+                        oldPinProtected = oldEncryptedKey != null ? new EncString(oldEncryptedKey) : null;
+                    }
+                    else if (_pinStatus == PinLockEnum.Transient)
+                    {
+                        userKeyPin = await _stateService.GetUserKeyPinEphemeralAsync();
+                        oldPinProtected = await _stateService.GetPinProtectedKeyAsync();
+                    }
+
+                    UserKey userKey;
+                    if (oldPinProtected != null)
+                    {
+                        userKey = await _cryptoService.DecryptAndMigrateOldPinKeyAsync(
+                            _pinStatus == PinLockEnum.Transient,
+                            inputtedValue,
+                            email,
                             kdfConfig,
-                            await _stateService.GetPinProtectedKeyAsync());
-                        var encKey = await _cryptoService.GetEncKeyAsync(key);
-                        var protectedPin = await _stateService.GetProtectedPinAsync();
-                        var decPin = await _cryptoService.DecryptToUtf8Async(new EncString(protectedPin), encKey);
-                        failed = decPin != inputtedValue;
-                        if (!failed)
-                        {
-                            await AppHelpers.ResetInvalidUnlockAttemptsAsync();
-                            await SetKeyAndContinueAsync(key);
-                        }
+                            oldPinProtected
+                        );
                     }
                     else
                     {
-                        var key2 = await _cryptoService.MakeKeyFromPinAsync(inputtedValue, email,
-                            kdfConfig);
-                        failed = false;
+                        userKey = await _cryptoService.DecryptUserKeyWithPinAsync(
+                            inputtedValue,
+                            email,
+                            kdfConfig,
+                            userKeyPin
+                        );
+                    }
+
+                    var protectedPin = await _stateService.GetProtectedPinAsync();
+                    var decryptedPin = await _cryptoService.DecryptToUtf8Async(new EncString(protectedPin), userKey);
+                    failed = decryptedPin != inputtedValue;
+                    if (!failed)
+                    {
                         await AppHelpers.ResetInvalidUnlockAttemptsAsync();
-                        await SetKeyAndContinueAsync(key2);
+                        await SetKeyAndContinueAsync(userKey);
                     }
                 }
                 catch
@@ -260,33 +283,27 @@ namespace Bit.iOS.Core.Controllers
             }
             else
             {
-                var key2 = await _cryptoService.MakeKeyAsync(inputtedValue, email, kdfConfig);
+                var masterKey = await _cryptoService.MakeMasterKeyAsync(inputtedValue, email, kdfConfig);
                 
-                var storedKeyHash = await _cryptoService.GetKeyHashAsync();
-                if (storedKeyHash == null)
+                var storedPasswordHash = await _cryptoService.GetPasswordHashAsync();
+                if (storedPasswordHash == null)
                 {
                     var oldKey = await _secureStorageService.GetAsync<string>("oldKey");
-                    if (key2.KeyB64 == oldKey)
+                    if (masterKey.KeyB64 == oldKey)
                     {
-                        var localKeyHash = await _cryptoService.HashPasswordAsync(inputtedValue, key2, HashPurpose.LocalAuthorization);
+                        var localPasswordHash = await _cryptoService.HashPasswordAsync(inputtedValue, masterKey, HashPurpose.LocalAuthorization);
                         await _secureStorageService.RemoveAsync("oldKey");
-                        await _cryptoService.SetKeyHashAsync(localKeyHash);
+                        await _cryptoService.SetPasswordHashAsync(localPasswordHash);
                     }
                 }
-                var passwordValid = await _cryptoService.CompareAndUpdateKeyHashAsync(inputtedValue, key2);
+                var passwordValid = await _cryptoService.CompareAndUpdatePasswordHashAsync(inputtedValue, masterKey);
                 if (passwordValid)
                 {
-                    if (_isPinProtected)
-                    {
-                        var protectedPin = await _stateService.GetProtectedPinAsync();
-                        var encKey = await _cryptoService.GetEncKeyAsync(key2);
-                        var decPin = await _cryptoService.DecryptToUtf8Async(new EncString(protectedPin), encKey);
-                        var pinKey = await _cryptoService.MakePinKeyAysnc(decPin, email,
-                           kdfConfig);
-                        await _stateService.SetPinProtectedKeyAsync(await _cryptoService.EncryptAsync(key2.Key, pinKey));
-                    }
                     await AppHelpers.ResetInvalidUnlockAttemptsAsync();
-                    await SetKeyAndContinueAsync(key2, true);
+
+                    var userKey = await _cryptoService.DecryptUserKeyWithMasterKeyAsync(masterKey);
+                    await _cryptoService.SetMasterKeyAsync(masterKey);
+                    await SetKeyAndContinueAsync(userKey, true);
                 }
                 else
                 {
@@ -303,12 +320,12 @@ namespace Bit.iOS.Core.Controllers
 
         public async Task PromptBiometricAsync()
         {
-            if (!_biometricLock || !_biometricIntegrityValid)
+            if (!_biometricEnabled || !_biometricIntegrityValid)
             {
                 return;
             }
             var success = await _platformUtilsService.AuthenticateBiometricAsync(null,
-                _pinLock ? AppResources.PIN : AppResources.MasterPassword,
+                _pinEnabled ? AppResources.PIN : AppResources.MasterPassword,
                 () => MasterPasswordCell.TextField.BecomeFirstResponder());
             await _stateService.SetBiometricLockedAsync(!success);
             if (success)
@@ -335,12 +352,12 @@ namespace Bit.iOS.Core.Controllers
             PresentViewController(loginController, true, null);
         }
 
-        private async Task SetKeyAndContinueAsync(SymmetricCryptoKey key, bool masterPassword = false)
+        private async Task SetKeyAndContinueAsync(UserKey userKey, bool masterPassword = false)
         {
-            var hasKey = await _cryptoService.HasKeyAsync();
+            var hasKey = await _cryptoService.HasUserKeyAsync();
             if (!hasKey)
             {
-                await _cryptoService.SetKeyAsync(key);
+                await _cryptoService.SetUserKeyAsync(userKey);
             }
             DoContinue(masterPassword);
         }
@@ -360,7 +377,7 @@ namespace Bit.iOS.Core.Controllers
         private async Task EnableBiometricsIfNeeded()
         {
             // Re-enable biometrics if initial use
-            if (_biometricLock & !_biometricIntegrityValid)
+            if (_biometricEnabled & !_biometricIntegrityValid)
             {
                 await _biometricService.SetupBiometricAsync(BiometricIntegritySourceKey);
             }
@@ -369,7 +386,7 @@ namespace Bit.iOS.Core.Controllers
         private void InvalidValue()
         {
             var alert = Dialogs.CreateAlert(AppResources.AnErrorHasOccurred,
-                string.Format(null, _pinLock ? AppResources.PIN : AppResources.InvalidMasterPassword),
+                string.Format(null, _pinEnabled ? AppResources.PIN : AppResources.InvalidMasterPassword),
                 AppResources.Ok, (a) =>
                     {
 
@@ -444,7 +461,7 @@ namespace Bit.iOS.Core.Controllers
 
             public override nint NumberOfSections(UITableView tableView)
             {
-                return (!_controller._biometricUnlockOnly && _controller._biometricLock) ||
+                return (!_controller._biometricUnlockOnly && _controller._biometricEnabled) ||
                     _controller._passwordReprompt
                     ? 2
                     : 1;

--- a/src/iOS.Core/Controllers/LockPasswordViewController.cs
+++ b/src/iOS.Core/Controllers/LockPasswordViewController.cs
@@ -1,20 +1,20 @@
 ﻿using System;
-using UIKit;
-using Foundation;
-using Bit.iOS.Core.Views;
-using Bit.App.Resources;
-using Bit.iOS.Core.Utilities;
-using Bit.App.Abstractions;
-using Bit.Core.Abstractions;
-using Bit.Core.Utilities;
 using System.Threading.Tasks;
-using Bit.App.Utilities;
-using Bit.Core.Models.Domain;
-using Bit.Core.Enums;
-using Bit.App.Pages;
+using Bit.App.Abstractions;
 using Bit.App.Models;
-using Xamarin.Forms;
+using Bit.App.Pages;
+using Bit.App.Resources;
+using Bit.App.Utilities;
+using Bit.Core.Abstractions;
+using Bit.Core.Enums;
+using Bit.Core.Models.Domain;
 using Bit.Core.Services;
+using Bit.Core.Utilities;
+using Bit.iOS.Core.Utilities;
+using Bit.iOS.Core.Views;
+using Foundation;
+using UIKit;
+using Xamarin.Forms;
 
 namespace Bit.iOS.Core.Controllers
 {
@@ -30,7 +30,7 @@ namespace Bit.iOS.Core.Controllers
         private IPlatformUtilsService _platformUtilsService;
         private IBiometricService _biometricService;
         private IKeyConnectorService _keyConnectorService;
-        private PinLockEnum _pinStatus;
+        private PinLockType _pinStatus;
         private bool _pinEnabled;
         private bool _biometricEnabled;
         private bool _biometricIntegrityValid = true;
@@ -96,7 +96,7 @@ namespace Bit.iOS.Core.Controllers
             if (autofillExtension && await _stateService.GetPasswordRepromptAutofillAsync())
             {
                 _passwordReprompt = true;
-                _pinStatus = PinLockEnum.Disabled;
+                _pinStatus = PinLockType.Disabled;
                 _pinEnabled = false;
                 _biometricEnabled = false;
             }
@@ -106,8 +106,8 @@ namespace Bit.iOS.Core.Controllers
 
                 var ephemeralPinSet = await _stateService.GetUserKeyPinEphemeralAsync()
                     ?? await _stateService.GetPinProtectedKeyAsync();
-                _pinEnabled = (_pinStatus == PinLockEnum.Transient && ephemeralPinSet != null) ||
-                    _pinStatus == PinLockEnum.Persistent;
+                _pinEnabled = (_pinStatus == PinLockType.Transient && ephemeralPinSet != null) ||
+                    _pinStatus == PinLockType.Persistent;
 
                 _biometricEnabled = await _vaultTimeoutService.IsBiometricLockSetAsync()
                     && await _cryptoService.HasEncryptedUserKeyAsync();
@@ -129,7 +129,7 @@ namespace Bit.iOS.Core.Controllers
             {
                 BaseNavItem.Title = AppResources.VerifyMasterPassword;
             }
-            
+
             BaseCancelButton.Title = AppResources.Cancel;
 
             if (_biometricUnlockOnly)
@@ -224,13 +224,13 @@ namespace Bit.iOS.Core.Controllers
                 {
                     EncString userKeyPin = null;
                     EncString oldPinProtected = null;
-                    if (_pinStatus == PinLockEnum.Persistent)
+                    if (_pinStatus == PinLockType.Persistent)
                     {
                         userKeyPin = await _stateService.GetUserKeyPinAsync();
                         var oldEncryptedKey = await _stateService.GetPinProtectedAsync();
                         oldPinProtected = oldEncryptedKey != null ? new EncString(oldEncryptedKey) : null;
                     }
-                    else if (_pinStatus == PinLockEnum.Transient)
+                    else if (_pinStatus == PinLockType.Transient)
                     {
                         userKeyPin = await _stateService.GetUserKeyPinEphemeralAsync();
                         oldPinProtected = await _stateService.GetPinProtectedKeyAsync();
@@ -240,7 +240,7 @@ namespace Bit.iOS.Core.Controllers
                     if (oldPinProtected != null)
                     {
                         userKey = await _cryptoService.DecryptAndMigrateOldPinKeyAsync(
-                            _pinStatus == PinLockEnum.Transient,
+                            _pinStatus == PinLockType.Transient,
                             inputtedValue,
                             email,
                             kdfConfig,
@@ -284,7 +284,7 @@ namespace Bit.iOS.Core.Controllers
             else
             {
                 var masterKey = await _cryptoService.MakeMasterKeyAsync(inputtedValue, email, kdfConfig);
-                
+
                 var storedPasswordHash = await _cryptoService.GetMasterKeyHashAsync();
                 if (storedPasswordHash == null)
                 {
@@ -395,7 +395,7 @@ namespace Bit.iOS.Core.Controllers
                     });
             PresentViewController(alert, true, null);
         }
-        
+
         private async Task LogOutAsync()
         {
             await AppHelpers.LogOutAsync(await _stateService.GetActiveUserIdAsync());

--- a/src/iOS.Core/Controllers/LockPasswordViewController.cs
+++ b/src/iOS.Core/Controllers/LockPasswordViewController.cs
@@ -102,7 +102,7 @@ namespace Bit.iOS.Core.Controllers
             }
             else
             {
-                _pinStatus = await _vaultTimeoutService.IsPinLockSetAsync();
+                _pinStatus = await _vaultTimeoutService.GetPinLockTypeAsync();
 
                 var ephemeralPinSet = await _stateService.GetUserKeyPinEphemeralAsync()
                     ?? await _stateService.GetPinProtectedKeyAsync();

--- a/src/iOS.Core/Controllers/LockPasswordViewController.cs
+++ b/src/iOS.Core/Controllers/LockPasswordViewController.cs
@@ -285,18 +285,18 @@ namespace Bit.iOS.Core.Controllers
             {
                 var masterKey = await _cryptoService.MakeMasterKeyAsync(inputtedValue, email, kdfConfig);
                 
-                var storedPasswordHash = await _cryptoService.GetPasswordHashAsync();
+                var storedPasswordHash = await _cryptoService.GetMasterKeyHashAsync();
                 if (storedPasswordHash == null)
                 {
                     var oldKey = await _secureStorageService.GetAsync<string>("oldKey");
                     if (masterKey.KeyB64 == oldKey)
                     {
-                        var localPasswordHash = await _cryptoService.HashPasswordAsync(inputtedValue, masterKey, HashPurpose.LocalAuthorization);
+                        var localPasswordHash = await _cryptoService.HashMasterKeyAsync(inputtedValue, masterKey, HashPurpose.LocalAuthorization);
                         await _secureStorageService.RemoveAsync("oldKey");
-                        await _cryptoService.SetPasswordHashAsync(localPasswordHash);
+                        await _cryptoService.SetMasterKeyHashAsync(localPasswordHash);
                     }
                 }
-                var passwordValid = await _cryptoService.CompareAndUpdatePasswordHashAsync(inputtedValue, masterKey);
+                var passwordValid = await _cryptoService.CompareAndUpdateKeyHashAsync(inputtedValue, masterKey);
                 if (passwordValid)
                 {
                     await AppHelpers.ResetInvalidUnlockAttemptsAsync();

--- a/src/iOS.Core/Controllers/LockPasswordViewController.cs
+++ b/src/iOS.Core/Controllers/LockPasswordViewController.cs
@@ -104,7 +104,7 @@ namespace Bit.iOS.Core.Controllers
             {
                 _pinStatus = await _vaultTimeoutService.GetPinLockTypeAsync();
 
-                var ephemeralPinSet = await _stateService.GetUserKeyPinEphemeralAsync()
+                var ephemeralPinSet = await _stateService.GetPinKeyEncryptedUserKeyEphemeralAsync()
                     ?? await _stateService.GetPinProtectedKeyAsync();
                 _pinEnabled = (_pinStatus == PinLockType.Transient && ephemeralPinSet != null) ||
                     _pinStatus == PinLockType.Persistent;
@@ -226,13 +226,13 @@ namespace Bit.iOS.Core.Controllers
                     EncString oldPinProtected = null;
                     if (_pinStatus == PinLockType.Persistent)
                     {
-                        userKeyPin = await _stateService.GetUserKeyPinAsync();
+                        userKeyPin = await _stateService.GetPinKeyEncryptedUserKeyAsync();
                         var oldEncryptedKey = await _stateService.GetPinProtectedAsync();
                         oldPinProtected = oldEncryptedKey != null ? new EncString(oldEncryptedKey) : null;
                     }
                     else if (_pinStatus == PinLockType.Transient)
                     {
-                        userKeyPin = await _stateService.GetUserKeyPinEphemeralAsync();
+                        userKeyPin = await _stateService.GetPinKeyEncryptedUserKeyEphemeralAsync();
                         oldPinProtected = await _stateService.GetPinProtectedKeyAsync();
                     }
 

--- a/src/iOS.Core/Services/BiometricService.cs
+++ b/src/iOS.Core/Services/BiometricService.cs
@@ -1,20 +1,19 @@
 ﻿using System.Threading.Tasks;
+using Bit.App.Services;
 using Bit.Core.Abstractions;
 using Foundation;
 using LocalAuthentication;
 
 namespace Bit.iOS.Core.Services
 {
-    public class BiometricService : IBiometricService
+    public class BiometricService : BaseBiometricService
     {
-        private IStateService _stateService;
-
-        public BiometricService(IStateService stateService)
+        public BiometricService(IStateService stateService, ICryptoService cryptoService)
+            : base(stateService, cryptoService)
         {
-            _stateService = stateService;
         }
 
-        public async Task<bool> SetupBiometricAsync(string bioIntegritySrcKey = null)
+        public override async Task<bool> SetupBiometricAsync(string bioIntegritySrcKey = null)
         {
             if (bioIntegritySrcKey == null)
             {
@@ -30,7 +29,7 @@ namespace Bit.iOS.Core.Services
             return true;
         }
 
-        public async Task<bool> IsSystemBiometricIntegrityValidAsync(string bioIntegritySrcKey = null)
+        public override async Task<bool> IsSystemBiometricIntegrityValidAsync(string bioIntegritySrcKey = null)
         {
             var state = GetState();
             if (state == null)

--- a/src/iOS.Core/Utilities/iOSCoreHelpers.cs
+++ b/src/iOS.Core/Utilities/iOSCoreHelpers.cs
@@ -112,9 +112,9 @@ namespace Bit.iOS.Core.Utilities
             var clipboardService = new ClipboardService(stateService);
             var platformUtilsService = new MobilePlatformUtilsService(deviceActionService, clipboardService,
                 messagingService, broadcasterService);
-            var biometricService = new BiometricService(stateService);
             var cryptoFunctionService = new PclCryptoFunctionService(cryptoPrimitiveService);
             var cryptoService = new CryptoService(stateService, cryptoFunctionService);
+            var biometricService = new BiometricService(stateService, cryptoService);
             var passwordRepromptService = new MobilePasswordRepromptService(platformUtilsService, cryptoService);
 
             ServiceContainer.Register<ISynchronousStorageService>(preferencesStorage);

--- a/test/Core.Test/Services/CipherServiceTests.cs
+++ b/test/Core.Test/Services/CipherServiceTests.cs
@@ -29,7 +29,7 @@ namespace Bit.Core.Test.Services
                 .Returns(encFileName);
             sutProvider.GetDependency<ICryptoService>().EncryptToBytesAsync(data.Buffer, Arg.Any<SymmetricCryptoKey>())
                 .Returns(data);
-            sutProvider.GetDependency<ICryptoService>().MakeEncKeyAsync(Arg.Any<SymmetricCryptoKey>()).Returns(new Tuple<SymmetricCryptoKey, EncString>(null, encKey));
+            sutProvider.GetDependency<ICryptoService>().MakeDataEncKeyAsync(Arg.Any<UserKey>()).Returns(new Tuple<SymmetricCryptoKey, EncString>(null, encKey));
             sutProvider.GetDependency<IApiService>().PostCipherAttachmentAsync(cipher.Id, Arg.Any<AttachmentRequest>())
                 .Returns(uploadDataResponse);
 
@@ -50,7 +50,7 @@ namespace Bit.Core.Test.Services
                 .Returns(new EncString(fileName));
             sutProvider.GetDependency<ICryptoService>().EncryptToBytesAsync(data.Buffer, Arg.Any<SymmetricCryptoKey>())
                 .Returns(data);
-            sutProvider.GetDependency<ICryptoService>().MakeEncKeyAsync(Arg.Any<SymmetricCryptoKey>()).Returns(new Tuple<SymmetricCryptoKey, EncString>(null, encKey));
+            sutProvider.GetDependency<ICryptoService>().MakeDataEncKeyAsync(Arg.Any<UserKey>()).Returns(new Tuple<SymmetricCryptoKey, EncString>(null, encKey));
             sutProvider.GetDependency<IApiService>().PostCipherAttachmentAsync(cipher.Id, Arg.Any<AttachmentRequest>())
                 .Throws(new ApiException(new ErrorResponse { StatusCode = statusCode }));
             sutProvider.GetDependency<IApiService>().PostCipherAttachmentLegacyAsync(cipher.Id, Arg.Any<MultipartFormDataContent>())
@@ -70,7 +70,7 @@ namespace Bit.Core.Test.Services
                 .Returns(new EncString(fileName));
             sutProvider.GetDependency<ICryptoService>().EncryptToBytesAsync(data.Buffer, Arg.Any<SymmetricCryptoKey>())
                 .Returns(data);
-            sutProvider.GetDependency<ICryptoService>().MakeEncKeyAsync(Arg.Any<SymmetricCryptoKey>())
+            sutProvider.GetDependency<ICryptoService>().MakeDataEncKeyAsync(Arg.Any<UserKey>())
                 .Returns(new Tuple<SymmetricCryptoKey, EncString>(null, encKey));
             var expectedException = new ApiException(new ErrorResponse { StatusCode = HttpStatusCode.BadRequest });
             sutProvider.GetDependency<IApiService>().PostCipherAttachmentAsync(cipher.Id, Arg.Any<AttachmentRequest>())

--- a/test/Core.Test/Services/SendServiceTests.cs
+++ b/test/Core.Test/Services/SendServiceTests.cs
@@ -145,7 +145,7 @@ namespace Bit.Core.Test.Services
             return;
 
             var sendDataDict = sendDatas.ToDictionary(d => d.Id, d => d);
-            sutProvider.GetDependency<ICryptoService>().HasKeyAsync().Returns(true);
+            sutProvider.GetDependency<ICryptoService>().HasUserKeyAsync().Returns(true);
             ServiceContainer.Register("cryptoService", sutProvider.GetDependency<ICryptoService>());
             sutProvider.GetDependency<II18nService>().StringComparer.Returns(StringComparer.CurrentCulture);
             sutProvider.GetDependency<IStateService>().GetActiveUserIdAsync().Returns(userId);


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
See bitwarden/clients#5498 for motivation and background.
TDLR: We need to drop our dependency on always having a `MasterKey` present in our application in order to support various other authentication/decryption combinations.

This version is slightly less complex than the Clients PR due to the lack of a `BiometricKey` and `AutoKey`. The only key that needed migration from an encrypted state was the Pin key, both the MP on Reset enabled version and the disabled version.

Due to the change of how we handle the `UserKey`, I've also changed the logic to always set the encrypted version in storage. Previously this was only set when Vault Timeout was set to 'never' or we had biometrics set up. We will always need the encrypted version in storage so that when we unlock, we will have something to decrypt with the Master Password.

Various other changes mirror the clients repo:
- full refactor of CryptoService
- new classes for different keys (I think we're going to consider changing this to an enum later)
- more descriptive names for methods and keys


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **file.ext:** Description of what was changed and why

## Screenshots
<!--Required for any UI changes. Delete if not applicable-->



## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
