### PR TITLE
[PM-3096] Fix non discoverable passkey removal on moving to org

### DIFF
--- a/src/Core/Models/Domain/Fido2Key.cs
+++ b/src/Core/Models/Domain/Fido2Key.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Threading.Tasks;
 using Bit.Core.Models.Data;
 using Bit.Core.Models.View;
@@ -8,23 +7,25 @@ namespace Bit.Core.Models.Domain
 {
     public class Fido2Key : Domain
     {
+        public static HashSet<string> EncryptableProperties => new HashSet<string>
+        {
+            nameof(NonDiscoverableId),
+            nameof(KeyType),
+            nameof(KeyAlgorithm),
+            nameof(KeyCurve),
+            nameof(KeyValue),
+            nameof(RpId),
+            nameof(RpName),
+            nameof(UserHandle),
+            nameof(UserName),
+            nameof(Counter)
+        };
+
         public Fido2Key() { }
 
         public Fido2Key(Fido2KeyData data, bool alreadyEncrypted = false)
         {
-            BuildDomainModel(this, data, new HashSet<string>
-            {
-                nameof(NonDiscoverableId),
-                nameof(KeyType),
-                nameof(KeyAlgorithm),
-                nameof(KeyCurve),
-                nameof(KeyValue),
-                nameof(RpId),
-                nameof(RpName),
-                nameof(UserHandle),
-                nameof(UserName),
-                nameof(Counter)
-            }, alreadyEncrypted);
+            BuildDomainModel(this, data, EncryptableProperties, alreadyEncrypted);
         }
 
         public EncString NonDiscoverableId { get; set; }
@@ -40,37 +41,13 @@ namespace Bit.Core.Models.Domain
 
         public async Task<Fido2KeyView> DecryptAsync(string orgId)
         {
-            return await DecryptObjAsync(new Fido2KeyView(), this, new HashSet<string>
-            {
-                nameof(NonDiscoverableId),
-                nameof(KeyType),
-                nameof(KeyAlgorithm),
-                nameof(KeyCurve),
-                nameof(KeyValue),
-                nameof(RpId),
-                nameof(RpName),
-                nameof(UserHandle),
-                nameof(UserName),
-                nameof(Counter)
-            }, orgId);
+            return await DecryptObjAsync(new Fido2KeyView(), this, EncryptableProperties, orgId);
         }
 
         public Fido2KeyData ToFido2KeyData()
         {
             var data = new Fido2KeyData();
-            BuildDataModel(this, data, new HashSet<string>
-            {
-                nameof(NonDiscoverableId),
-                nameof(KeyType),
-                nameof(KeyAlgorithm),
-                nameof(KeyCurve),
-                nameof(KeyValue),
-                nameof(RpId),
-                nameof(RpName),
-                nameof(UserHandle),
-                nameof(UserName),
-                nameof(Counter)
-            });
+            BuildDataModel(this, data, EncryptableProperties);
             return data;
         }
     }

--- a/src/Core/Services/CipherService.cs
+++ b/src/Core/Services/CipherService.cs
@@ -1138,6 +1138,11 @@ namespace Bit.Core.Services
                             cipher.Login.Uris.Add(loginUri);
                         }
                     }
+                    if (model.Login.Fido2Key != null)
+                    {
+                        cipher.Login.Fido2Key = new Fido2Key();
+                        await EncryptObjPropertyAsync(model.Login.Fido2Key, cipher.Login.Fido2Key, Fido2Key.EncryptableProperties, key);
+                    }
                     break;
                 case CipherType.SecureNote:
                     cipher.SecureNote = new SecureNote
@@ -1183,19 +1188,7 @@ namespace Bit.Core.Services
                     break;
                 case CipherType.Fido2Key:
                     cipher.Fido2Key = new Fido2Key();
-                    await EncryptObjPropertyAsync(model.Fido2Key, cipher.Fido2Key, new HashSet<string>
-                    {
-                        nameof(Fido2Key.NonDiscoverableId),
-                        nameof(Fido2Key.KeyType),
-                        nameof(Fido2Key.KeyAlgorithm),
-                        nameof(Fido2Key.KeyCurve),
-                        nameof(Fido2Key.KeyValue),
-                        nameof(Fido2Key.RpId),
-                        nameof(Fido2Key.RpName),
-                        nameof(Fido2Key.UserHandle),
-                        nameof(Fido2Key.UserName),
-                        nameof(Fido2Key.Counter)
-                    }, key);
+                    await EncryptObjPropertyAsync(model.Fido2Key, cipher.Fido2Key, Fido2Key.EncryptableProperties, key);
                     break;
                 default:
                     throw new Exception("Unknown cipher type.");


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Fix when moving to org the non-discoverable passkey shouldn't be removed.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **Fido2Key:** Added `EncryptableProperties` to improve code reuse.
* **CipherService:** Replaced hashSet of properties with the new one in the `Fido2Key` and also added the non-discoverable passkey (`cipher.Login.Fido2Key`) to be taken into account when encrypting a cipher.

## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
