### PR TITLE
[PM-1280] TDE 2FA - approval options navigation

### DIFF
--- a/src/App/Pages/Accounts/LoginPasswordlessRequestViewModel.cs
+++ b/src/App/Pages/Accounts/LoginPasswordlessRequestViewModel.cs
@@ -306,7 +306,7 @@ namespace Bit.App.Pages
             await _deviceActionService.HideLoadingAsync();
         }
 
-        private async Task HandlePasswordlessLogin(PasswordlessLoginResponse response, bool createPendingAdminRequest )
+        private async Task HandlePasswordlessLogin(PasswordlessLoginResponse response, bool createPendingAdminRequest)
         {
             if (response == null)
             {

--- a/src/App/Pages/Accounts/TwoFactorPage.xaml.cs
+++ b/src/App/Pages/Accounts/TwoFactorPage.xaml.cs
@@ -37,6 +37,8 @@ namespace Bit.App.Pages
                 Device.BeginInvokeOnMainThread(async () => await TwoFactorAuthSuccessAsync());
             _vm.UpdateTempPasswordAction =
                 () => Device.BeginInvokeOnMainThread(async () => await UpdateTempPasswordAsync());
+            _vm.StartDeviceApprovalOptionsAction =
+                () => Device.BeginInvokeOnMainThread(async () => await StartDeviceApprovalOptionsAsync());
             _vm.CloseAction = async () => await Navigation.PopModalAsync();
             DuoWebView = _duoWebView;
             if (Device.RuntimePlatform == Device.Android)
@@ -177,6 +179,12 @@ namespace Bit.App.Pages
         private async Task UpdateTempPasswordAsync()
         {
             var page = new UpdateTempPasswordPage();
+            await Navigation.PushModalAsync(new NavigationPage(page));
+        }
+
+        private async Task StartDeviceApprovalOptionsAsync()
+        {
+            var page = new LoginApproveDevicePage();
             await Navigation.PushModalAsync(new NavigationPage(page));
         }
 

--- a/src/App/Pages/Accounts/TwoFactorPageViewModel.cs
+++ b/src/App/Pages/Accounts/TwoFactorPageViewModel.cs
@@ -330,7 +330,7 @@ namespace Bit.App.Pages
                 {
                     UpdateTempPasswordAction?.Invoke();
                 }
-                else if (decryptOptions.TrustedDeviceOption != null)
+                else if (decryptOptions?.TrustedDeviceOption != null)
                 {
                     // If user doesn't have a MP, but has reset password permission, they must set a MP
                     if (!decryptOptions.HasMasterPassword &&

--- a/src/App/Pages/Accounts/TwoFactorPageViewModel.cs
+++ b/src/App/Pages/Accounts/TwoFactorPageViewModel.cs
@@ -11,6 +11,7 @@ using Bit.Core.Abstractions;
 using Bit.Core.Enums;
 using Bit.Core.Exceptions;
 using Bit.Core.Models.Request;
+using Bit.Core.Services;
 using Bit.Core.Utilities;
 using Newtonsoft.Json;
 using Xamarin.CommunityToolkit.ObjectModel;
@@ -33,7 +34,7 @@ namespace Bit.App.Pages
         private readonly II18nService _i18nService;
         private readonly IAppIdService _appIdService;
         private readonly ILogger _logger;
-
+        private readonly IDeviceTrustCryptoService _deviceTrustCryptoService;
         private TwoFactorProviderType? _selectedProviderType;
         private string _totpInstruction;
         private string _webVaultUrl = "https://vault.bitwarden.com";
@@ -55,6 +56,7 @@ namespace Bit.App.Pages
             _i18nService = ServiceContainer.Resolve<II18nService>("i18nService");
             _appIdService = ServiceContainer.Resolve<IAppIdService>("appIdService");
             _logger = ServiceContainer.Resolve<ILogger>();
+            _deviceTrustCryptoService = ServiceContainer.Resolve<IDeviceTrustCryptoService>();
 
             PageTitle = AppResources.TwoStepLogin;
             SubmitCommand = new Command(async () => await SubmitAsync());
@@ -118,6 +120,7 @@ namespace Bit.App.Pages
         public Command SubmitCommand { get; }
         public ICommand MoreCommand { get; }
         public Action TwoFactorAuthSuccessAction { get; set; }
+        public Action StartDeviceApprovalOptionsAction { get; set; }
         public Action StartSetPasswordAction { get; set; }
         public Action CloseAction { get; set; }
         public Action UpdateTempPasswordAction { get; set; }
@@ -315,6 +318,7 @@ namespace Bit.App.Pages
 
                 var task = Task.Run(() => _syncService.FullSyncAsync(true));
                 await _deviceActionService.HideLoadingAsync();
+                var decryptOptions = await _stateService.GetAccountDecryptionOptions();
                 _messagingService.Send("listenYubiKeyOTP", false);
                 _broadcasterService.Unsubscribe(nameof(TwoFactorPage));
 
@@ -325,6 +329,27 @@ namespace Bit.App.Pages
                 else if (result.ForcePasswordReset)
                 {
                     UpdateTempPasswordAction?.Invoke();
+                }
+                else if (decryptOptions.TrustedDeviceOption != null)
+                {
+                    // If user doesn't have a MP, but has reset password permission, they must set a MP
+                    if (!decryptOptions.HasMasterPassword &&
+                        decryptOptions.TrustedDeviceOption.HasManageResetPasswordPermission)
+                    {
+                        StartSetPasswordAction?.Invoke();
+                    }
+                    else if (result.ForcePasswordReset)
+                    {
+                        UpdateTempPasswordAction?.Invoke();
+                    }
+                    else if (await _deviceTrustCryptoService.IsDeviceTrustedAsync())
+                    {
+                        TwoFactorAuthSuccessAction?.Invoke();
+                    }
+                    else
+                    {
+                        StartDeviceApprovalOptionsAction?.Invoke();
+                    }
                 }
                 else
                 {

--- a/src/iOS.Autofill/CredentialProviderViewController.cs
+++ b/src/iOS.Autofill/CredentialProviderViewController.cs
@@ -568,6 +568,7 @@ namespace Bit.iOS.Autofill
             {
                 vm.TwoFactorAuthSuccessAction = () => DismissLockAndContinue();
                 vm.StartSetPasswordAction = () => DismissViewController(false, () => LaunchSetPasswordFlow());
+                vm.StartDeviceApprovalOptionsAction = () => DismissViewController(false, () => LaunchDeviceApprovalOptionsFlow());
                 if (authingWithSso)
                 {
                     vm.CloseAction = () => DismissViewController(false, () => LaunchLoginSsoFlow());

--- a/src/iOS.Extension/LoadingViewController.cs
+++ b/src/iOS.Extension/LoadingViewController.cs
@@ -590,6 +590,7 @@ namespace Bit.iOS.Extension
             {
                 vm.TwoFactorAuthSuccessAction = () => DismissLockAndContinue();
                 vm.StartSetPasswordAction = () => DismissViewController(false, () => LaunchSetPasswordFlow());
+                vm.StartDeviceApprovalOptionsAction = () => DismissViewController(false, () => LaunchDeviceApprovalOptionsFlow());
                 if (authingWithSso)
                 {
                     vm.CloseAction = () => DismissViewController(false, () => LaunchLoginSsoFlow());

--- a/src/iOS.ShareExtension/LoadingViewController.cs
+++ b/src/iOS.ShareExtension/LoadingViewController.cs
@@ -390,6 +390,7 @@ namespace Bit.iOS.ShareExtension
             {
                 vm.TwoFactorAuthSuccessAction = () => DismissLockAndContinue();
                 vm.StartSetPasswordAction = () => DismissAndLaunch(() => LaunchSetPasswordFlow());
+                vm.StartDeviceApprovalOptionsAction = () => DismissViewController(false, () => LaunchDeviceApprovalOptionsFlow());
                 if (authingWithSso)
                 {
                     vm.CloseAction = () => DismissAndLaunch(() => LaunchLoginSsoFlow());


### PR DESCRIPTION
Merge after https://github.com/bitwarden/mobile/pull/2643
## Type of change
- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Navigate to device approval options after a successful 2FA authentication.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **src/App/Pages/Accounts/TwoFactorPageViewModel.cs:** Add logic for TDE flow and action to call when device approval options is needed.
* **iOS Extension:** Add missing action to navigate to device approval options screen.

## Screenshots
<!--Required for any UI changes. Delete if not applicable-->

https://github.com/bitwarden/mobile/assets/4648522/bb722b65-cb78-4d66-81d4-bd633ca4b46d


## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
