### PR TITLE
[PM-3227] Avoid clone on discoverable passkeys.

### DIFF
--- a/src/App/Pages/Vault/CipherDetailsPage.xaml.cs
+++ b/src/App/Pages/Vault/CipherDetailsPage.xaml.cs
@@ -204,7 +204,7 @@ namespace Bit.App.Pages
             }
         }
 
-        private async void More_Clicked(object sender, System.EventArgs e)
+        private async void More_Clicked(object sender, EventArgs e)
         {
             if (!DoOnce())
             {
@@ -214,7 +214,11 @@ namespace Bit.App.Pages
             var options = new List<string> { AppResources.Attachments };
             if (_vm.Cipher.OrganizationId == null)
             {
-                options.Add(AppResources.Clone);
+                if (_vm.CanClone)
+                {
+                    options.Add(AppResources.Clone);
+                }
+
                 options.Add(AppResources.MoveToOrganization);
             }
             else
@@ -288,13 +292,13 @@ namespace Bit.App.Pages
                 {
                     ToolbarItems.Remove(_collectionsItem);
                 }
-                if (_vm.Cipher.Type != Core.Enums.CipherType.Fido2Key && !ToolbarItems.Contains(_cloneItem))
+                if (_vm.CanClone && !ToolbarItems.Contains(_cloneItem))
                 {
                     ToolbarItems.Insert(1, _cloneItem);
                 }
                 if (!ToolbarItems.Contains(_shareItem))
                 {
-                    ToolbarItems.Insert(_vm.Cipher.Type == Core.Enums.CipherType.Fido2Key ? 1 : 2, _shareItem);
+                    ToolbarItems.Insert(_vm.CanClone ? 2 : 1, _shareItem);
                 }
             }
             else

--- a/src/App/Pages/Vault/CipherDetailsPageViewModel.cs
+++ b/src/App/Pages/Vault/CipherDetailsPageViewModel.cs
@@ -249,6 +249,7 @@ namespace Bit.App.Pages
         public double TotpProgress => string.IsNullOrEmpty(TotpSec) ? 0 : double.Parse(TotpSec) * 100 / _totpInterval;
         public bool IsDeleted => Cipher.IsDeleted;
         public bool CanEdit => !Cipher.IsDeleted;
+        public bool CanClone => Cipher.IsClonable;
 
         public async Task<bool> LoadAsync(Action finishedLoadingAction = null)
         {
@@ -707,6 +708,12 @@ namespace Bit.App.Pages
 
         private async Task<bool> CanCloneAsync()
         {
+            if (Cipher.Type == CipherType.Fido2Key)
+            {
+                await _platformUtilsService.ShowDialogAsync(AppResources.PasskeyWillNotBeCopied);
+                return false;
+            }
+
             if (Cipher.Type == CipherType.Login && Cipher.Login?.Fido2Key != null)
             {
                 return await _platformUtilsService.ShowDialogAsync(AppResources.ThePasskeyWillNotBeCopiedToTheClonedItemDoYouWantToContinueCloningThisItem, AppResources.PasskeyWillNotBeCopied, AppResources.Yes, AppResources.No);

--- a/src/Core/Models/View/CipherView.cs
+++ b/src/Core/Models/View/CipherView.cs
@@ -120,5 +120,7 @@ namespace Bit.Core.Models.View
         public bool CanLaunch => Login?.CanLaunch == true || Fido2Key?.CanLaunch == true;
 
         public string LaunchUri => Login?.LaunchUri ?? Fido2Key?.LaunchUri;
+
+        public bool IsClonable => OrganizationId is null && Type != CipherType.Fido2Key;
     }
 }


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Avoid ability to clone on discoverable passkeys.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **CipherDetailsPage.xaml.cs:** Remove "Clone" ability on the iOS menu when cipher is a discoverable passkey. Also, refactor a bit the code to be more clean and readable.
* **CipherDetailsPageViewModel:** Added `CanClone` to improve readability and have a centralized point for its logic. Also, added a safe check on the clone execution not to allow cloning a discoverable passkey in case something on the UI fails.
* **CipherView:** Added `IsClonable` to know whether the cipher can be cloned or not.

## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
