### PR TITLE
[PM-3379] Following key rotation, Mobile unable to log in with non-MP approval flow 

### DIFF
--- a/src/App/Pages/Accounts/LoginSsoPageViewModel.cs
+++ b/src/App/Pages/Accounts/LoginSsoPageViewModel.cs
@@ -226,8 +226,16 @@ namespace Bit.App.Pages
                     }
                     else if (await _deviceTrustCryptoService.IsDeviceTrustedAsync())
                     {
-                        _syncService.FullSyncAsync(true).FireAndForget();
-                        SsoAuthSuccessAction?.Invoke();
+                        if (decryptOptions.TrustedDeviceOption.EncryptedPrivateKey == null && decryptOptions.TrustedDeviceOption.EncryptedUserKey == null)
+                        {
+                            await _deviceTrustCryptoService.RemoveTrustedDeviceAsync();
+                            StartDeviceApprovalOptionsAction?.Invoke();
+                        }
+                        else
+                        {
+                            _syncService.FullSyncAsync(true).FireAndForget();
+                            SsoAuthSuccessAction?.Invoke();
+                        }
                     }
                     else if (pendingRequest != null)
                     {

--- a/src/App/Pages/Accounts/TwoFactorPageViewModel.cs
+++ b/src/App/Pages/Accounts/TwoFactorPageViewModel.cs
@@ -349,7 +349,15 @@ namespace Bit.App.Pages
                     }
                     else if (await _deviceTrustCryptoService.IsDeviceTrustedAsync())
                     {
-                        await TwoFactorAuthSuccessAsync();
+                        if (decryptOptions.TrustedDeviceOption.EncryptedPrivateKey == null && decryptOptions.TrustedDeviceOption.EncryptedUserKey == null)
+                        {
+                            await _deviceTrustCryptoService.RemoveTrustedDeviceAsync();
+                            StartDeviceApprovalOptionsAction?.Invoke();
+                        }
+                        else
+                        {
+                            await TwoFactorAuthSuccessAsync();
+                        }
                     }
                     else
                     {

--- a/src/Core/Abstractions/IDeviceTrustCryptoService.cs
+++ b/src/Core/Abstractions/IDeviceTrustCryptoService.cs
@@ -8,6 +8,7 @@ namespace Bit.Core.Abstractions
         Task<SymmetricCryptoKey> GetDeviceKeyAsync();
         Task<DeviceResponse> TrustDeviceAsync();
         Task<DeviceResponse> TrustDeviceIfNeededAsync();
+        Task RemoveTrustedDeviceAsync();
         Task<bool> GetShouldTrustDeviceAsync();
         Task SetShouldTrustDeviceAsync(bool value);
         Task<UserKey> DecryptUserKeyWithDeviceKeyAsync(string encryptedDevicePrivateKey, string encryptedUserKey);

--- a/src/Core/Services/AuthService.cs
+++ b/src/Core/Services/AuthService.cs
@@ -510,9 +510,12 @@ namespace Bit.Core.Services
                 // Trusted Device
                 var decryptOptions = await _stateService.GetAccountDecryptionOptions();
                 var hasUserKey = await _cryptoService.HasUserKeyAsync();
-                if (decryptOptions?.TrustedDeviceOption != null && !hasUserKey)
+                if (decryptOptions?.TrustedDeviceOption != null && !hasUserKey &&
+                    decryptOptions.TrustedDeviceOption.EncryptedPrivateKey != null &&
+                    decryptOptions.TrustedDeviceOption.EncryptedUserKey != null)
                 {
-                    var key = await _deviceTrustCryptoService.DecryptUserKeyWithDeviceKeyAsync(decryptOptions.TrustedDeviceOption.EncryptedPrivateKey, decryptOptions.TrustedDeviceOption.EncryptedUserKey);
+                    var key = await _deviceTrustCryptoService.DecryptUserKeyWithDeviceKeyAsync(decryptOptions.TrustedDeviceOption.EncryptedPrivateKey,
+                            decryptOptions.TrustedDeviceOption.EncryptedUserKey);
                     if (key != null)
                     {
                         await _cryptoService.SetUserKeyAsync(key);

--- a/src/Core/Services/DeviceTrustCryptoService.cs
+++ b/src/Core/Services/DeviceTrustCryptoService.cs
@@ -41,6 +41,11 @@ namespace Bit.Core.Services
             await _stateService.SetDeviceKeyAsync(deviceKey);
         }
 
+        public async Task RemoveTrustedDeviceAsync()
+        {
+            await SetDeviceKeyAsync(null);
+        }
+
         public async Task<DeviceResponse> TrustDeviceAsync()
         {
             // Attempt to get user key

--- a/src/Core/Services/StateService.cs
+++ b/src/Core/Services/StateService.cs
@@ -527,7 +527,7 @@ namespace Bit.Core.Services
         {
             var reconciledOptions = ReconcileOptions(new StorageOptions { UserId = userId },
                 await GetDefaultStorageOptionsAsync());
-            await _storageMediatorService.SaveAsync(Constants.DeviceKeyKey(reconciledOptions.UserId), value.KeyB64, true);
+            await _storageMediatorService.SaveAsync(Constants.DeviceKeyKey(reconciledOptions.UserId), value?.KeyB64, true);
         }
 
         public async Task<List<string>> GetAutofillBlacklistedUrisAsync(string userId = null)


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
After key rotation the user wasn't able to login using SSO.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->
When key rotation happens, decryption options come with null keys to the mobile client. If this happens we need to clear the trust device locally and redirect the user to the device approval options screen before entering the vault.

## Screenshots
<!--Required for any UI changes. Delete if not applicable-->

https://github.com/bitwarden/mobile/assets/4648522/90232a21-ea2b-49ab-a339-a0bf14935f0c




## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
