### PR TITLE
[PM-3426] Make cipher decryption faster by running in parallel

### DIFF
--- a/src/Core/Services/CipherService.cs
+++ b/src/Core/Services/CipherService.cs
@@ -262,14 +262,14 @@ namespace Bit.Core.Services
                         parallelQuery = parallelQuery.Where(filter);
                     }
     
-                    var decCiphers = parallelQuery
-                        .Select(cipher =>  
+                    var decCiphers = await Task.WhenAll(parallelQuery
+                        .Select(async cipher =>  
                         {
-                            return cipher.DecryptAsync().Result;
+                            return await cipher.DecryptAsync();
                         })
                         .ToList()
                         .OrderBy(c => c, new CipherLocaleComparer(_i18nService))
-                        .ToList();
+                        .ToList());
                     
                     if (filter == null)
                     {

--- a/src/Core/Services/CipherService.cs
+++ b/src/Core/Services/CipherService.cs
@@ -248,33 +248,36 @@ namespace Bit.Core.Services
             }
             async Task<List<CipherView>> doTask()
             {
-                var hashKey = await _cryptoService.HasKeyAsync();
-                if (!hashKey)
-                {
-                    throw new Exception("No key.");
-                }
-                
-                var parallelQuery = (await GetAllAsync()).AsParallel();
-                if (filter != null)
-                {
-                    parallelQuery = parallelQuery.Where(filter);
-                }
-
-                var decCiphers = parallelQuery
-                    .Select(cipher =>  
+                try {
+                    var hashKey = await _cryptoService.HasKeyAsync();
+                    if (!hashKey)
                     {
-                        return cipher.DecryptAsync().Result;
-                    })
-                    .ToList()
-                    .OrderBy(c => c, new CipherLocaleComparer(_i18nService))
-                    .ToList();
-                
-                if (filter == null)
-                {
-                    DecryptedCipherCache = decCiphers;
+                        throw new Exception("No key.");
+                    }
+                    
+                    var parallelQuery = (await GetAllAsync()).AsParallel();
+                    if (filter != null)
+                    {
+                        parallelQuery = parallelQuery.Where(filter);
+                    }
+    
+                    var decCiphers = parallelQuery
+                        .Select(cipher =>  
+                        {
+                            return cipher.DecryptAsync().Result;
+                        })
+                        .ToList()
+                        .OrderBy(c => c, new CipherLocaleComparer(_i18nService))
+                        .ToList();
+                    
+                    if (filter == null)
+                    {
+                        DecryptedCipherCache = decCiphers;
+                    }
+                    
+                    return decCiphers;
                 }
-                
-                return decCiphers;
+                finally {}
             }
             _getAllDecryptedTask = doTask();
             return await _getAllDecryptedTask;

--- a/src/Core/Services/CipherService.cs
+++ b/src/Core/Services/CipherService.cs
@@ -262,14 +262,14 @@ namespace Bit.Core.Services
                         parallelQuery = parallelQuery.Where(filter);
                     }
     
-                    var decCiphers = await Task.WhenAll(parallelQuery
-                        .Select(async cipher =>  
-                        {
-                            return await cipher.DecryptAsync();
-                        })
-                        .ToList()
-                        .OrderBy(c => c, new CipherLocaleComparer(_i18nService))
-                        .ToList());
+                     var decCiphers = (await Task.WhenAll(parallelQuery
+                         .Select(async cipher =>
+                         {
+                             return await cipher.DecryptAsync();
+                         })
+                         .ToList()))
+                         .OrderBy(c => c, new CipherLocaleComparer(_i18nService))
+                         .ToList();
                     
                     if (filter == null)
                     {

--- a/src/Core/Services/CipherService.cs
+++ b/src/Core/Services/CipherService.cs
@@ -248,7 +248,8 @@ namespace Bit.Core.Services
             }
             async Task<List<CipherView>> doTask()
             {
-                try {
+                try
+                {
                     var hashKey = await _cryptoService.HasKeyAsync();
                     if (!hashKey)
                     {
@@ -277,7 +278,7 @@ namespace Bit.Core.Services
                     
                     return decCiphers;
                 }
-                finally {}
+                finally { }
             }
             _getAllDecryptedTask = doTask();
             return await _getAllDecryptedTask;


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
With a lot of ciphers in the vault, opening the vault (unlock/login) takes quite long (~25 seconds for my 10k cipher test vault). One of the causes seems to be that the cipher decryption runs concurrently (through async await) but not in parallel.

This PR rewrites the cipher decryption logic a bit to be both more readable and to run in parallel. On my emulator device, this brought the decryption time down to ~15 seconds. (An improvement, but there might still be a bottleneck somewhere else, since not all CPU resources were fully utilized. On the other hand, the emulator might also hinder further parallelization).

Related:
https://github.com/bitwarden/mobile/issues/579

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- [CipherService.cs](https://github.com/bitwarden/mobile/compare/master...quexten:parallel-cipher-decryption?expand=1#diff-f8d20ac6245e78d9222fc49984a156e9a4e30278deb159d55744ee0962dfe220) use linq `.AsParallel()` to run the decryption in parallel

## Screenshots
<!--Required for any UI changes. Delete if not applicable-->



## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
