### PR TITLE
[PM-3394] Fix login with device for passwordless approvals

### DIFF
--- a/src/App/Pages/Accounts/LoginApproveDevicePage.xaml.cs
+++ b/src/App/Pages/Accounts/LoginApproveDevicePage.xaml.cs
@@ -50,13 +50,13 @@ namespace Bit.App.Pages
 
         private async Task StartLoginWithDeviceAsync()
         {
-            var page = new LoginPasswordlessRequestPage(_vm.Email, AuthRequestType.Unlock, _appOptions);
+            var page = new LoginPasswordlessRequestPage(_vm.Email, AuthRequestType.AuthenticateAndUnlock, _appOptions, true);
             await Navigation.PushModalAsync(new NavigationPage(page));
         }
 
         private async Task RequestAdminApprovalAsync()
         {
-            var page = new LoginPasswordlessRequestPage(_vm.Email, AuthRequestType.AdminApproval, _appOptions);
+            var page = new LoginPasswordlessRequestPage(_vm.Email, AuthRequestType.AdminApproval, _appOptions, true);
             await Navigation.PushModalAsync(new NavigationPage(page));
         }
     }

--- a/src/App/Pages/Accounts/LoginApproveDevicePage.xaml.cs
+++ b/src/App/Pages/Accounts/LoginApproveDevicePage.xaml.cs
@@ -50,7 +50,7 @@ namespace Bit.App.Pages
 
         private async Task StartLoginWithDeviceAsync()
         {
-            var page = new LoginPasswordlessRequestPage(_vm.Email, AuthRequestType.AuthenticateAndUnlock, _appOptions);
+            var page = new LoginPasswordlessRequestPage(_vm.Email, AuthRequestType.Unlock, _appOptions);
             await Navigation.PushModalAsync(new NavigationPage(page));
         }
 

--- a/src/App/Pages/Accounts/LoginPasswordlessRequestPage.xaml.cs
+++ b/src/App/Pages/Accounts/LoginPasswordlessRequestPage.xaml.cs
@@ -13,7 +13,7 @@ namespace Bit.App.Pages
         private LoginPasswordlessRequestViewModel _vm;
         private readonly AppOptions _appOptions;
 
-        public LoginPasswordlessRequestPage(string email, AuthRequestType authRequestType, AppOptions appOptions = null)
+        public LoginPasswordlessRequestPage(string email, AuthRequestType authRequestType, AppOptions appOptions = null, bool authingWithSso = false)
         {
             InitializeComponent();
             _appOptions = appOptions;
@@ -21,6 +21,7 @@ namespace Bit.App.Pages
             _vm.Page = this;
             _vm.Email = email;
             _vm.AuthRequestType = authRequestType;
+            _vm.AuthingWithSso = authingWithSso;
             _vm.StartTwoFactorAction = () => Device.BeginInvokeOnMainThread(async () => await StartTwoFactorAsync());
             _vm.LogInSuccessAction = () => Device.BeginInvokeOnMainThread(async () => await LogInSuccessAsync());
             _vm.UpdateTempPasswordAction = () => Device.BeginInvokeOnMainThread(async () => await UpdateTempPasswordAsync());

--- a/src/App/Pages/Accounts/LoginPasswordlessRequestViewModel.cs
+++ b/src/App/Pages/Accounts/LoginPasswordlessRequestViewModel.cs
@@ -243,7 +243,7 @@ namespace Bit.App.Pages
                     response = await _authService.GetPasswordlessLoginResquestAsync(_requestId, _requestAccessCode);
                 }
 
-                if (!response?.RequestApproved ?? true)
+                if (!response?.RequestApproved != true)
                 {
                     return;
                 }

--- a/src/App/Pages/Accounts/LoginPasswordlessRequestViewModel.cs
+++ b/src/App/Pages/Accounts/LoginPasswordlessRequestViewModel.cs
@@ -233,13 +233,13 @@ namespace Bit.App.Pages
             try
             {
                 PasswordlessLoginResponse response = null;
-                if (_authRequestType == AuthRequestType.AdminApproval)
-                {
-                    response = await _authService.GetPasswordlessLoginRequestByIdAsync(_requestId);
-                }
-                else if (_authRequestType == AuthRequestType.AuthenticateAndUnlock)
+                if (_authRequestType == AuthRequestType.AuthenticateAndUnlock)
                 {
                     response = await _authService.GetPasswordlessLoginResquestAsync(_requestId, _requestAccessCode);
+                }
+                else
+                {
+                    response = await _authService.GetPasswordlessLoginRequestByIdAsync(_requestId);
                 }
 
                 if (!(response?.RequestApproved ?? false))

--- a/src/App/Pages/Accounts/LoginPasswordlessRequestViewModel.cs
+++ b/src/App/Pages/Accounts/LoginPasswordlessRequestViewModel.cs
@@ -233,11 +233,11 @@ namespace Bit.App.Pages
             try
             {
                 PasswordlessLoginResponse response = null;
-                if (await _stateService.IsAuthenticatedAsync())
+                if (_authRequestType == AuthRequestType.AdminApproval)
                 {
                     response = await _authService.GetPasswordlessLoginRequestByIdAsync(_requestId);
                 }
-                else
+                else if (_authRequestType == AuthRequestType.AuthenticateAndUnlock)
                 {
                     response = await _authService.GetPasswordlessLoginResquestAsync(_requestId, _requestAccessCode);
                 }
@@ -249,7 +249,7 @@ namespace Bit.App.Pages
 
                 StopCheckLoginRequestStatus();
 
-                var authResult = await _authService.LogInPasswordlessAsync(Email, _requestAccessCode, _requestId, _requestKeyPair.Item2, response.Key, response.MasterPasswordHash);
+                var authResult = await _authService.LogInPasswordlessAsync(_authRequestType, Email, _requestAccessCode, _requestId, _requestKeyPair.Item2, response.Key, response.MasterPasswordHash);
                 await AppHelpers.ResetInvalidUnlockAttemptsAsync();
 
                 if (authResult == null && await _stateService.IsAuthenticatedAsync())

--- a/src/App/Pages/Accounts/LoginPasswordlessRequestViewModel.cs
+++ b/src/App/Pages/Accounts/LoginPasswordlessRequestViewModel.cs
@@ -242,7 +242,7 @@ namespace Bit.App.Pages
                     response = await _authService.GetPasswordlessLoginResquestAsync(_requestId, _requestAccessCode);
                 }
 
-                if (response.RequestApproved == null || !response.RequestApproved.Value)
+                if (response == null || response.RequestApproved == null || !response.RequestApproved.Value)
                 {
                     return;
                 }

--- a/src/App/Pages/Accounts/LoginPasswordlessRequestViewModel.cs
+++ b/src/App/Pages/Accounts/LoginPasswordlessRequestViewModel.cs
@@ -243,7 +243,7 @@ namespace Bit.App.Pages
                     response = await _authService.GetPasswordlessLoginResquestAsync(_requestId, _requestAccessCode);
                 }
 
-                if (!response?.RequestApproved != true)
+                if (response?.RequestApproved != true)
                 {
                     return;
                 }

--- a/src/App/Pages/Accounts/LoginPasswordlessRequestViewModel.cs
+++ b/src/App/Pages/Accounts/LoginPasswordlessRequestViewModel.cs
@@ -242,7 +242,7 @@ namespace Bit.App.Pages
                     response = await _authService.GetPasswordlessLoginResquestAsync(_requestId, _requestAccessCode);
                 }
 
-                if (response == null || response.RequestApproved == null || !response.RequestApproved.Value)
+                if (!(response?.RequestApproved ?? false))
                 {
                     return;
                 }

--- a/src/App/Pages/Accounts/LoginSsoPageViewModel.cs
+++ b/src/App/Pages/Accounts/LoginSsoPageViewModel.cs
@@ -240,7 +240,7 @@ namespace Bit.App.Pages
                     else if (pendingRequest != null)
                     {
                         var authRequest = await _authService.GetPasswordlessLoginRequestByIdAsync(pendingRequest.Id);
-                        if (authRequest?.RequestApproved ?? false)
+                        if (authRequest?.RequestApproved == true)
                         {
                             var authResult = await _authService.LogInPasswordlessAsync(true, await _stateService.GetActiveUserEmailAsync(), authRequest.RequestAccessCode, pendingRequest.Id, pendingRequest.PrivateKey, authRequest.Key, authRequest.MasterPasswordHash);
                             if (authResult == null && await _stateService.IsAuthenticatedAsync())

--- a/src/App/Pages/Accounts/LoginSsoPageViewModel.cs
+++ b/src/App/Pages/Accounts/LoginSsoPageViewModel.cs
@@ -242,7 +242,7 @@ namespace Bit.App.Pages
                         var authRequest = await _authService.GetPasswordlessLoginRequestByIdAsync(pendingRequest.Id);
                         if (authRequest != null && authRequest.RequestApproved != null && authRequest.RequestApproved.Value)
                         {
-                            var authResult = await _authService.LogInPasswordlessAsync(await _stateService.GetActiveUserEmailAsync(), authRequest.RequestAccessCode, pendingRequest.Id, pendingRequest.PrivateKey, authRequest.Key, authRequest.MasterPasswordHash);
+                            var authResult = await _authService.LogInPasswordlessAsync(AuthRequestType.AdminApproval, await _stateService.GetActiveUserEmailAsync(), authRequest.RequestAccessCode, pendingRequest.Id, pendingRequest.PrivateKey, authRequest.Key, authRequest.MasterPasswordHash);
                             if (authResult == null && await _stateService.IsAuthenticatedAsync())
                             {
                                 await Xamarin.Essentials.MainThread.InvokeOnMainThreadAsync(

--- a/src/App/Pages/Accounts/LoginSsoPageViewModel.cs
+++ b/src/App/Pages/Accounts/LoginSsoPageViewModel.cs
@@ -240,9 +240,9 @@ namespace Bit.App.Pages
                     else if (pendingRequest != null)
                     {
                         var authRequest = await _authService.GetPasswordlessLoginRequestByIdAsync(pendingRequest.Id);
-                        if (authRequest != null && authRequest.RequestApproved != null && authRequest.RequestApproved.Value)
+                        if (authRequest?.RequestApproved ?? false)
                         {
-                            var authResult = await _authService.LogInPasswordlessAsync(AuthRequestType.AdminApproval, await _stateService.GetActiveUserEmailAsync(), authRequest.RequestAccessCode, pendingRequest.Id, pendingRequest.PrivateKey, authRequest.Key, authRequest.MasterPasswordHash);
+                            var authResult = await _authService.LogInPasswordlessAsync(true, await _stateService.GetActiveUserEmailAsync(), authRequest.RequestAccessCode, pendingRequest.Id, pendingRequest.PrivateKey, authRequest.Key, authRequest.MasterPasswordHash);
                             if (authResult == null && await _stateService.IsAuthenticatedAsync())
                             {
                                 await Xamarin.Essentials.MainThread.InvokeOnMainThreadAsync(

--- a/src/App/Utilities/AccountManagement/AccountsManager.cs
+++ b/src/App/Utilities/AccountManagement/AccountsManager.cs
@@ -207,6 +207,7 @@ namespace Bit.App.Utilities.AccountManagement
         private async Task AddAccountAsync()
         {
             await AppHelpers.ClearServiceCacheAsync();
+            await _stateService.SetActiveUserAsync(null);
             await Device.InvokeOnMainThreadAsync(() =>
             {
                 Options.HideAccountSwitcher = false;

--- a/src/App/Utilities/AccountManagement/AccountsManager.cs
+++ b/src/App/Utilities/AccountManagement/AccountsManager.cs
@@ -207,7 +207,6 @@ namespace Bit.App.Utilities.AccountManagement
         private async Task AddAccountAsync()
         {
             await AppHelpers.ClearServiceCacheAsync();
-            await _stateService.SetActiveUserAsync(null);
             await Device.InvokeOnMainThreadAsync(() =>
             {
                 Options.HideAccountSwitcher = false;

--- a/src/Core/Abstractions/IAuthService.cs
+++ b/src/Core/Abstractions/IAuthService.cs
@@ -27,7 +27,7 @@ namespace Bit.Core.Abstractions
         Task<AuthResult> LogInSsoAsync(string code, string codeVerifier, string redirectUrl, string orgId);
         Task<AuthResult> LogInCompleteAsync(string email, string masterPassword, TwoFactorProviderType twoFactorProvider, string twoFactorToken, bool? remember = null);
         Task<AuthResult> LogInTwoFactorAsync(TwoFactorProviderType twoFactorProvider, string twoFactorToken, string captchaToken, bool? remember = null);
-        Task<AuthResult> LogInPasswordlessAsync(AuthRequestType authRequestType, string email, string accessCode, string authRequestId, byte[] decryptionKey, string userKeyCiphered, string localHashedPasswordCiphered);
+        Task<AuthResult> LogInPasswordlessAsync(bool authingWithSso, string email, string accessCode, string authRequestId, byte[] decryptionKey, string userKeyCiphered, string localHashedPasswordCiphered);
 
         Task<List<PasswordlessLoginResponse>> GetPasswordlessLoginRequestsAsync();
         Task<List<PasswordlessLoginResponse>> GetActivePasswordlessLoginRequestsAsync();

--- a/src/Core/Abstractions/IAuthService.cs
+++ b/src/Core/Abstractions/IAuthService.cs
@@ -27,7 +27,7 @@ namespace Bit.Core.Abstractions
         Task<AuthResult> LogInSsoAsync(string code, string codeVerifier, string redirectUrl, string orgId);
         Task<AuthResult> LogInCompleteAsync(string email, string masterPassword, TwoFactorProviderType twoFactorProvider, string twoFactorToken, bool? remember = null);
         Task<AuthResult> LogInTwoFactorAsync(TwoFactorProviderType twoFactorProvider, string twoFactorToken, string captchaToken, bool? remember = null);
-        Task<AuthResult> LogInPasswordlessAsync(string email, string accessCode, string authRequestId, byte[] decryptionKey, string userKeyCiphered, string localHashedPasswordCiphered);
+        Task<AuthResult> LogInPasswordlessAsync(AuthRequestType authRequestType, string email, string accessCode, string authRequestId, byte[] decryptionKey, string userKeyCiphered, string localHashedPasswordCiphered);
 
         Task<List<PasswordlessLoginResponse>> GetPasswordlessLoginRequestsAsync();
         Task<List<PasswordlessLoginResponse>> GetActivePasswordlessLoginRequestsAsync();

--- a/src/Core/Services/AuthService.cs
+++ b/src/Core/Services/AuthService.cs
@@ -222,10 +222,12 @@ namespace Bit.Core.Services
                 return null;
             }
 
+            // The approval device may not have a master key hash if it authenticated with a passwordless method
             if (string.IsNullOrEmpty(masterKeyHash) && decryptionKey != null)
             {
+                var authResult = await LogInHelperAsync(email, accessCode, null, null, null, null, null, null, null, null, null, authRequestId: authRequestId);
                 await _cryptoService.SetUserKeyAsync(new UserKey(decryptedKey));
-                return null;
+                return authResult;
             }
 
             var decKeyHash = await _cryptoService.RsaDecryptAsync(masterKeyHash, decryptionKey);

--- a/src/Core/Services/AuthService.cs
+++ b/src/Core/Services/AuthService.cs
@@ -226,6 +226,7 @@ namespace Bit.Core.Services
             if (string.IsNullOrEmpty(masterKeyHash) && decryptionKey != null)
             {
                 var authResult = await LogInHelperAsync(email, accessCode, null, null, null, null, null, null, null, null, null, authRequestId: authRequestId);
+                // Only set the user key after the login helper so we have a user id
                 await _cryptoService.SetUserKeyAsync(new UserKey(decryptedKey));
                 return authResult;
             }

--- a/src/Core/Services/AuthService.cs
+++ b/src/Core/Services/AuthService.cs
@@ -200,12 +200,13 @@ namespace Bit.Core.Services
             return !await _policyService.EvaluateMasterPassword(strength.Value, masterPassword, _masterPasswordPolicy);
         }
 
-        public async Task<AuthResult> LogInPasswordlessAsync(string email, string accessCode, string authRequestId, byte[] decryptionKey, string encryptedAuthRequestKey, string masterKeyHash)
+        public async Task<AuthResult> LogInPasswordlessAsync(AuthRequestType authRequestType, string email, string accessCode, string authRequestId, byte[] decryptionKey, string encryptedAuthRequestKey, string masterKeyHash)
         {
             var decryptedKey = await _cryptoService.RsaDecryptAsync(encryptedAuthRequestKey, decryptionKey);
 
-            // On SSO flow user is already AuthN
-            if (await _stateService.IsAuthenticatedAsync())
+            // If the user is already authenticated, we can just set the key
+            // Note: We can't check for the existance of an access token here because the active user id may not be null
+            if (authRequestType == AuthRequestType.AdminApproval)
             {
                 if (string.IsNullOrEmpty(masterKeyHash))
                 {

--- a/src/Core/Services/AuthService.cs
+++ b/src/Core/Services/AuthService.cs
@@ -200,13 +200,13 @@ namespace Bit.Core.Services
             return !await _policyService.EvaluateMasterPassword(strength.Value, masterPassword, _masterPasswordPolicy);
         }
 
-        public async Task<AuthResult> LogInPasswordlessAsync(AuthRequestType authRequestType, string email, string accessCode, string authRequestId, byte[] decryptionKey, string encryptedAuthRequestKey, string masterKeyHash)
+        public async Task<AuthResult> LogInPasswordlessAsync(bool authingWithSso, string email, string accessCode, string authRequestId, byte[] decryptionKey, string encryptedAuthRequestKey, string masterKeyHash)
         {
             var decryptedKey = await _cryptoService.RsaDecryptAsync(encryptedAuthRequestKey, decryptionKey);
 
             // If the user is already authenticated, we can just set the key
             // Note: We can't check for the existance of an access token here because the active user id may not be null
-            if (authRequestType == AuthRequestType.AdminApproval)
+            if (authingWithSso)
             {
                 if (string.IsNullOrEmpty(masterKeyHash))
                 {

--- a/src/Core/Services/CryptoService.cs
+++ b/src/Core/Services/CryptoService.cs
@@ -63,7 +63,7 @@ namespace Bit.Core.Services
 
         public async Task<UserKey> GetUserKeyWithLegacySupportAsync(string userId = null)
         {
-            var userKey = await GetUserKeyAsync();
+            var userKey = await GetUserKeyAsync(userId);
             if (userKey != null)
             {
                 return userKey;
@@ -71,7 +71,7 @@ namespace Bit.Core.Services
 
             // Legacy support: encryption used to be done with the master key (derived from master password).
             // Users who have not migrated will have a null user key and must use the master key instead.
-            return new UserKey((await GetMasterKeyAsync()).Key);
+            return new UserKey((await GetMasterKeyAsync(userId)).Key);
         }
 
         public async Task<bool> HasUserKeyAsync(string userId = null)

--- a/src/Core/Services/VaultTimeoutService.cs
+++ b/src/Core/Services/VaultTimeoutService.cs
@@ -74,14 +74,11 @@ namespace Bit.Core.Services
 
             if (!await _cryptoService.HasUserKeyAsync(userId))
             {
-                if (await _cryptoService.HasAutoUnlockKeyAsync(userId))
-                {
-                    await _cryptoService.SetUserKeyAsync(await _cryptoService.GetAutoUnlockKeyAsync(userId), userId);
-                }
-                else
+                if (!await _cryptoService.HasAutoUnlockKeyAsync(userId))
                 {
                     return true;
                 }
+                await _cryptoService.SetUserKeyAsync(await _cryptoService.GetAutoUnlockKeyAsync(userId), userId);
             }
 
             // Check again to verify auto key was set

--- a/src/Core/Services/VaultTimeoutService.cs
+++ b/src/Core/Services/VaultTimeoutService.cs
@@ -59,6 +59,13 @@ namespace Bit.Core.Services
 
         public async Task<bool> IsLockedAsync(string userId = null)
         {
+            // When checking if we need to lock inactive account, we don't want to
+            // set the key, so we only check if the account has an auto unlock key
+            if (userId != null && await _stateService.GetActiveUserIdAsync() != userId)
+            {
+                return await _cryptoService.HasAutoUnlockKeyAsync(userId);
+            }
+
             var biometricSet = await IsBiometricLockSetAsync(userId);
             if (biometricSet && await _stateService.GetBiometricLockedAsync(userId))
             {
@@ -69,7 +76,7 @@ namespace Bit.Core.Services
             {
                 if (await _cryptoService.HasAutoUnlockKeyAsync(userId))
                 {
-                    await _cryptoService.SetUserKeyAsync(await _cryptoService.GetAutoUnlockKeyAsync(userId));
+                    await _cryptoService.SetUserKeyAsync(await _cryptoService.GetAutoUnlockKeyAsync(userId), userId);
                 }
                 else
                 {

--- a/src/iOS.Autofill/CredentialProviderViewController.cs
+++ b/src/iOS.Autofill/CredentialProviderViewController.cs
@@ -511,11 +511,11 @@ namespace Bit.iOS.Autofill
             LogoutIfAuthed();
         }
 
-        private void LaunchLoginWithDevice(AuthRequestType authRequestType, string email = null)
+        private void LaunchLoginWithDevice(AuthRequestType authRequestType, string email = null, bool authingWithSso = false)
         {
             var appOptions = new AppOptions { IosExtension = true };
             var app = new App.App(appOptions);
-            var loginWithDevicePage = new LoginPasswordlessRequestPage(email, authRequestType, appOptions);
+            var loginWithDevicePage = new LoginPasswordlessRequestPage(email, authRequestType, appOptions, authingWithSso);
             ThemeManager.SetTheme(app.Resources);
             ThemeManager.ApplyResourcesTo(loginWithDevicePage);
             if (loginWithDevicePage.BindingContext is LoginPasswordlessRequestViewModel vm)
@@ -632,8 +632,8 @@ namespace Bit.iOS.Autofill
             if (loginApproveDevicePage.BindingContext is LoginApproveDeviceViewModel vm)
             {
                 vm.LogInWithMasterPasswordAction = () => DismissViewController(false, () => PerformSegue("lockPasswordSegue", this));
-                vm.RequestAdminApprovalAction = () => DismissViewController(false, () => LaunchLoginWithDevice(AuthRequestType.AdminApproval, vm.Email));
-                vm.LogInWithDeviceAction = () => DismissViewController(false, () => LaunchLoginWithDevice(AuthRequestType.AuthenticateAndUnlock, vm.Email));
+                vm.RequestAdminApprovalAction = () => DismissViewController(false, () => LaunchLoginWithDevice(AuthRequestType.AdminApproval, vm.Email, true));
+                vm.LogInWithDeviceAction = () => DismissViewController(false, () => LaunchLoginWithDevice(AuthRequestType.AuthenticateAndUnlock, vm.Email, true));
             }
 
             var navigationPage = new NavigationPage(loginApproveDevicePage);

--- a/src/iOS.Extension/LoadingViewController.cs
+++ b/src/iOS.Extension/LoadingViewController.cs
@@ -533,11 +533,11 @@ namespace Bit.iOS.Extension
             LogoutIfAuthed();
         }
 
-        private void LaunchLoginWithDevice(AuthRequestType authRequestType,string email = null)
+        private void LaunchLoginWithDevice(AuthRequestType authRequestType, string email = null, bool authingWithSso = false)
         {
             var appOptions = new AppOptions { IosExtension = true };
             var app = new App.App(appOptions);
-            var loginWithDevicePage = new LoginPasswordlessRequestPage(email, authRequestType, appOptions);
+            var loginWithDevicePage = new LoginPasswordlessRequestPage(email, authRequestType, appOptions, authingWithSso);
             ThemeManager.SetTheme(app.Resources);
             ThemeManager.ApplyResourcesTo(loginWithDevicePage);
             if (loginWithDevicePage.BindingContext is LoginPasswordlessRequestViewModel vm)
@@ -654,8 +654,8 @@ namespace Bit.iOS.Extension
             if (loginApproveDevicePage.BindingContext is LoginApproveDeviceViewModel vm)
             {
                 vm.LogInWithMasterPasswordAction = () => DismissViewController(false, () => PerformSegue("lockPasswordSegue", this));
-                vm.RequestAdminApprovalAction = () => DismissViewController(false, () => LaunchLoginWithDevice(AuthRequestType.AdminApproval, vm.Email));
-                vm.LogInWithDeviceAction = () => DismissViewController(false, () => LaunchLoginWithDevice(AuthRequestType.AuthenticateAndUnlock, vm.Email));
+                vm.RequestAdminApprovalAction = () => DismissViewController(false, () => LaunchLoginWithDevice(AuthRequestType.AdminApproval, vm.Email, true));
+                vm.LogInWithDeviceAction = () => DismissViewController(false, () => LaunchLoginWithDevice(AuthRequestType.AuthenticateAndUnlock, vm.Email, true));
             }
 
             var navigationPage = new NavigationPage(loginApproveDevicePage);

--- a/src/iOS.ShareExtension/LoadingViewController.cs
+++ b/src/iOS.ShareExtension/LoadingViewController.cs
@@ -348,9 +348,9 @@ namespace Bit.iOS.ShareExtension
             LogoutIfAuthed();
         }
 
-        private void LaunchLoginWithDevice(AuthRequestType authRequestType, string email = null)
+        private void LaunchLoginWithDevice(AuthRequestType authRequestType, string email = null, bool authingWithSso = false)
         {
-            var loginWithDevicePage = new LoginPasswordlessRequestPage(email, authRequestType, _appOptions.Value);
+            var loginWithDevicePage = new LoginPasswordlessRequestPage(email, authRequestType, _appOptions.Value, authingWithSso);
             SetupAppAndApplyResources(loginWithDevicePage);
             if (loginWithDevicePage.BindingContext is LoginPasswordlessRequestViewModel vm)
             {
@@ -438,8 +438,8 @@ namespace Bit.iOS.ShareExtension
             if (loginApproveDevicePage.BindingContext is LoginApproveDeviceViewModel vm)
             {
                 vm.LogInWithMasterPasswordAction = () => DismissViewController(false, () => PerformSegue("lockPasswordSegue", this));
-                vm.RequestAdminApprovalAction = () => DismissViewController(false, () => LaunchLoginWithDevice(AuthRequestType.AdminApproval, vm.Email));
-                vm.LogInWithDeviceAction = () => DismissViewController(false, () => LaunchLoginWithDevice(AuthRequestType.AuthenticateAndUnlock, vm.Email));
+                vm.RequestAdminApprovalAction = () => DismissViewController(false, () => LaunchLoginWithDevice(AuthRequestType.AdminApproval, vm.Email, true));
+                vm.LogInWithDeviceAction = () => DismissViewController(false, () => LaunchLoginWithDevice(AuthRequestType.AuthenticateAndUnlock, vm.Email, true));
             }
 
             var navigationPage = new NavigationPage(loginApproveDevicePage);


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
If the approving device doesn't have a master key, users should still be able to use Login with Device. This adds a token request in that instance, and sets the user key after.

While investigating this, I discovered that we're not clearing the active user id when adding a new account. This is problematic because `isAuthenticated` simply checks if the user id is `null`.
**Edit:** I originally fixed this by setting the active user Id to `null` but we can't do that for autofill purposes. Instead I am passing the `AuthRequestType` to any auth request logic so we know whether to use the Admin Approval logic or Unlock and Authenticate.

I also discovered that our background script to log out inactive accounts was attempting to set the user key if the vault timeout was set to 'never'. This change prevents that from happening as well, simply just returning if we have an auto key without using it.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **file.ext:** Description of what was changed and why

## Screenshots
<!--Required for any UI changes. Delete if not applicable-->



## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
