### PR TITLE
[PM-3385] Fix Master Password reprompt item level (TDE)

### DIFF
--- a/src/App/Abstractions/IPasswordRepromptService.cs
+++ b/src/App/Abstractions/IPasswordRepromptService.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading.Tasks;
+using Bit.Core.Enums;
 
 namespace Bit.App.Abstractions
 {
@@ -6,7 +7,7 @@ namespace Bit.App.Abstractions
     {
         string[] ProtectedFields { get; }
 
-        Task<bool> ShowPasswordPromptAsync();
+        Task<bool> PromptAndCheckPasswordIfNeededAsync(CipherRepromptType repromptType = CipherRepromptType.Password);
 
         Task<(string password, bool valid)> ShowPasswordPromptAndGetItAsync();
     }

--- a/src/App/Pages/Vault/AutofillCiphersPageViewModel.cs
+++ b/src/App/Pages/Vault/AutofillCiphersPageViewModel.cs
@@ -82,7 +82,7 @@ namespace Bit.App.Pages
                 return;
             }
 
-            if (cipher.Reprompt != CipherRepromptType.None && !await _passwordRepromptService.ShowPasswordPromptAsync())
+            if (!await _passwordRepromptService.PromptAndCheckPasswordIfNeededAsync(cipher.Reprompt))
             {
                 return;
             }

--- a/src/App/Pages/Vault/CipherDetailsPageViewModel.cs
+++ b/src/App/Pages/Vault/CipherDetailsPageViewModel.cs
@@ -698,12 +698,12 @@ namespace Bit.App.Pages
 
         public async Task<bool> PromptPasswordAsync()
         {
-            if (Cipher.Reprompt == CipherRepromptType.None || _passwordReprompted)
+            if (_passwordReprompted)
             {
                 return true;
             }
 
-            return _passwordReprompted = await _passwordRepromptService.ShowPasswordPromptAsync();
+            return _passwordReprompted = await _passwordRepromptService.PromptAndCheckPasswordIfNeededAsync(Cipher.Reprompt);
         }
 
         private async Task<bool> CanCloneAsync()

--- a/src/App/Pages/Vault/CiphersPageViewModel.cs
+++ b/src/App/Pages/Vault/CiphersPageViewModel.cs
@@ -191,7 +191,7 @@ namespace Bit.App.Pages
 
             if (_appOptions?.OtpData != null)
             {
-                if (cipher.Reprompt != CipherRepromptType.None && !await _passwordRepromptService.ShowPasswordPromptAsync())
+                if (!await _passwordRepromptService.PromptAndCheckPasswordIfNeededAsync(cipher.Reprompt))
                 {
                     return;
                 }
@@ -208,7 +208,7 @@ namespace Bit.App.Pages
             }
             else if (selection == AppResources.Autofill || selection == AppResources.AutofillAndSave)
             {
-                if (cipher.Reprompt != CipherRepromptType.None && !await _passwordRepromptService.ShowPasswordPromptAsync())
+                if (!await _passwordRepromptService.PromptAndCheckPasswordIfNeededAsync(cipher.Reprompt))
                 {
                     return;
                 }

--- a/src/App/Pages/Vault/OTPCipherSelectionPageViewModel.cs
+++ b/src/App/Pages/Vault/OTPCipherSelectionPageViewModel.cs
@@ -60,7 +60,7 @@ namespace Bit.App.Pages
 
             var cipher = listItem.Cipher;
 
-            if (cipher.Reprompt != CipherRepromptType.None && !await _passwordRepromptService.ShowPasswordPromptAsync())
+            if (!await _passwordRepromptService.PromptAndCheckPasswordIfNeededAsync(cipher.Reprompt))
             {
                 return;
             }

--- a/src/App/Services/MobilePasswordRepromptService.cs
+++ b/src/App/Services/MobilePasswordRepromptService.cs
@@ -2,6 +2,7 @@
 using Bit.App.Abstractions;
 using Bit.App.Resources;
 using Bit.Core.Abstractions;
+using Bit.Core.Enums;
 
 namespace Bit.App.Services
 {
@@ -18,8 +19,13 @@ namespace Bit.App.Services
 
         public string[] ProtectedFields { get; } = { "LoginTotp", "LoginPassword", "H_FieldValue", "CardNumber", "CardCode" };
 
-        public async Task<bool> ShowPasswordPromptAsync()
+        public async Task<bool> PromptAndCheckPasswordIfNeededAsync(CipherRepromptType repromptType = CipherRepromptType.Password)
         {
+            if (repromptType == CipherRepromptType.None || await ShouldByPassMasterPasswordRepromptAsync())
+            {
+                return true;
+            }
+
             return await _platformUtilsService.ShowPasswordDialogAsync(AppResources.PasswordConfirmation, AppResources.PasswordConfirmationDesc, ValidatePasswordAsync);
         }
 
@@ -37,6 +43,11 @@ namespace Bit.App.Services
             };
 
             return await _cryptoService.CompareAndUpdateKeyHashAsync(password, null);
+        }
+
+        private async Task<bool> ShouldByPassMasterPasswordRepromptAsync()
+        {
+            return await _cryptoService.GetMasterKeyHashAsync() is null;
         }
     }
 }

--- a/src/App/Utilities/AppHelpers.cs
+++ b/src/App/Utilities/AppHelpers.cs
@@ -99,60 +99,55 @@ namespace Bit.App.Utilities
             {
                 await page.Navigation.PushModalAsync(new NavigationPage(new CipherDetailsPage(cipher.Id)));
             }
-            else if (selection == AppResources.Edit)
+            else if (selection == AppResources.Edit
+                     &&
+                     await passwordRepromptService.PromptAndCheckPasswordIfNeededAsync(cipher.Reprompt))
             {
-                if (cipher.Reprompt == CipherRepromptType.None || await passwordRepromptService.ShowPasswordPromptAsync())
-                {
-                    await page.Navigation.PushModalAsync(new NavigationPage(new CipherAddEditPage(cipher.Id)));
-                }
+                await page.Navigation.PushModalAsync(new NavigationPage(new CipherAddEditPage(cipher.Id)));
             }
             else if (selection == AppResources.CopyUsername)
             {
                 await clipboardService.CopyTextAsync(cipher.Type == CipherType.Login ? cipher.Login.Username : cipher.Fido2Key.UserName);
                 platformUtilsService.ShowToastForCopiedValue(AppResources.Username);
             }
-            else if (selection == AppResources.CopyPassword)
+            else if (selection == AppResources.CopyPassword
+                     &&
+                     await passwordRepromptService.PromptAndCheckPasswordIfNeededAsync(cipher.Reprompt))
             {
-                if (cipher.Reprompt == CipherRepromptType.None || await passwordRepromptService.ShowPasswordPromptAsync())
-                {
-                    await clipboardService.CopyTextAsync(cipher.Login.Password);
-                    platformUtilsService.ShowToastForCopiedValue(AppResources.Password);
-                    var task = eventService.CollectAsync(Core.Enums.EventType.Cipher_ClientCopiedPassword, cipher.Id);
-                }
+                await clipboardService.CopyTextAsync(cipher.Login.Password);
+                platformUtilsService.ShowToastForCopiedValue(AppResources.Password);
+                var task = eventService.CollectAsync(Core.Enums.EventType.Cipher_ClientCopiedPassword, cipher.Id);
             }
-            else if (selection == AppResources.CopyTotp)
+            else if (selection == AppResources.CopyTotp
+                     &&
+                     await passwordRepromptService.PromptAndCheckPasswordIfNeededAsync(cipher.Reprompt))
             {
-                if (cipher.Reprompt == CipherRepromptType.None || await passwordRepromptService.ShowPasswordPromptAsync())
+                var totpService = ServiceContainer.Resolve<ITotpService>("totpService");
+                var totp = await totpService.GetCodeAsync(cipher.Login.Totp);
+                if (!string.IsNullOrWhiteSpace(totp))
                 {
-                    var totpService = ServiceContainer.Resolve<ITotpService>("totpService");
-                    var totp = await totpService.GetCodeAsync(cipher.Login.Totp);
-                    if (!string.IsNullOrWhiteSpace(totp))
-                    {
-                        await clipboardService.CopyTextAsync(totp);
-                        platformUtilsService.ShowToastForCopiedValue(AppResources.VerificationCodeTotp);
-                    }
+                    await clipboardService.CopyTextAsync(totp);
+                    platformUtilsService.ShowToastForCopiedValue(AppResources.VerificationCodeTotp);
                 }
             }
             else if (selection == AppResources.Launch && cipher.CanLaunch)
             {
                 platformUtilsService.LaunchUri(cipher.LaunchUri);
             }
-            else if (selection == AppResources.CopyNumber)
+            else if (selection == AppResources.CopyNumber
+                     &&
+                     await passwordRepromptService.PromptAndCheckPasswordIfNeededAsync(cipher.Reprompt))
             {
-                if (cipher.Reprompt == CipherRepromptType.None || await passwordRepromptService.ShowPasswordPromptAsync())
-                {
-                    await clipboardService.CopyTextAsync(cipher.Card.Number);
-                    platformUtilsService.ShowToastForCopiedValue(AppResources.Number);
-                }
+                await clipboardService.CopyTextAsync(cipher.Card.Number);
+                platformUtilsService.ShowToastForCopiedValue(AppResources.Number);
             }
-            else if (selection == AppResources.CopySecurityCode)
+            else if (selection == AppResources.CopySecurityCode
+                     &&
+                     await passwordRepromptService.PromptAndCheckPasswordIfNeededAsync(cipher.Reprompt))
             {
-                if (cipher.Reprompt == CipherRepromptType.None || await passwordRepromptService.ShowPasswordPromptAsync())
-                {
-                    await clipboardService.CopyTextAsync(cipher.Card.Code);
-                    platformUtilsService.ShowToastForCopiedValue(AppResources.SecurityCode);
-                    var task = eventService.CollectAsync(Core.Enums.EventType.Cipher_ClientCopiedCardCode, cipher.Id);
-                }
+                await clipboardService.CopyTextAsync(cipher.Card.Code);
+                platformUtilsService.ShowToastForCopiedValue(AppResources.SecurityCode);
+                eventService.CollectAsync(EventType.Cipher_ClientCopiedCardCode, cipher.Id).FireAndForget();
             }
             else if (selection == AppResources.CopyNotes)
             {

--- a/src/iOS.Autofill/CredentialProviderViewController.cs
+++ b/src/iOS.Autofill/CredentialProviderViewController.cs
@@ -313,7 +313,7 @@ namespace Bit.iOS.Autofill
                         // Add a timeout to resolve keyboard not always showing up.
                         await Task.Delay(250);
                         var passwordRepromptService = ServiceContainer.Resolve<IPasswordRepromptService>("passwordRepromptService");
-                        if (!await passwordRepromptService.ShowPasswordPromptAsync())
+                        if (!await passwordRepromptService.PromptAndCheckPasswordIfNeededAsync())
                         {
                             var err = new NSError(new NSString("ASExtensionErrorDomain"),
                                 Convert.ToInt32(ASExtensionErrorCode.UserCanceled), null);

--- a/src/iOS.Autofill/Utilities/AutofillHelpers.cs
+++ b/src/iOS.Autofill/Utilities/AutofillHelpers.cs
@@ -33,7 +33,7 @@ namespace Bit.iOS.Autofill.Utilities
                 return;
             }
 
-            if (item.Reprompt != Bit.Core.Enums.CipherRepromptType.None && !await passwordRepromptService.ShowPasswordPromptAsync())
+            if (!await passwordRepromptService.PromptAndCheckPasswordIfNeededAsync(item.Reprompt))
             {
                 return;
             }

--- a/src/iOS.Extension/LoginListViewController.cs
+++ b/src/iOS.Extension/LoginListViewController.cs
@@ -126,7 +126,7 @@ namespace Bit.iOS.Extension
                     return;
                 }
 
-                if (item.Reprompt != Bit.Core.Enums.CipherRepromptType.None && !await _controller.PasswordRepromptService.ShowPasswordPromptAsync())
+                if (!await _controller.PasswordRepromptService.PromptAndCheckPasswordIfNeededAsync(item.Reprompt))
                 {
                     return;
                 }


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Fix MP reprompt to be bypassed when no master hash is stored, like with TDE.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **MobilePasswordRepromptService.cs:** Added check of master password hash to bypass MP reprompt and also added the Cipher reprompt type check inside to be more maintainable.
* **Others:** Adapted code to new method


## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
