### PR TITLE
[PM-3386] Fix Master password vs OTP decision on TDE

### DIFF
--- a/src/Android/MainApplication.cs
+++ b/src/Android/MainApplication.cs
@@ -68,7 +68,6 @@ namespace Bit.Droid
                 ServiceContainer.Register<IDeleteAccountActionFlowExecutioner>("deleteAccountActionFlowExecutioner", deleteAccountActionFlowExecutioner);
 
                 var verificationActionsFlowHelper = new VerificationActionsFlowHelper(
-                    ServiceContainer.Resolve<IKeyConnectorService>("keyConnectorService"),
                     ServiceContainer.Resolve<IPasswordRepromptService>("passwordRepromptService"),
                     ServiceContainer.Resolve<ICryptoService>("cryptoService"),
                     ServiceContainer.Resolve<IUserVerificationService>());

--- a/src/App/Pages/Settings/ExportVaultPageViewModel.cs
+++ b/src/App/Pages/Settings/ExportVaultPageViewModel.cs
@@ -65,7 +65,7 @@ namespace Bit.App.Pages
             _initialized = true;
             FileFormatSelectedIndex = FileFormatOptions.FindIndex(k => k.Key == "json");
             DisablePrivateVaultPolicyEnabled = await _policyService.PolicyAppliesToUser(PolicyType.DisablePersonalVaultExport);
-            UseOTPVerification = !await _userVerificationService.HasMasterPasswordAsync();
+            UseOTPVerification = !await _userVerificationService.HasMasterPasswordAsync(true);
 
             if (UseOTPVerification)
             {
@@ -163,7 +163,7 @@ namespace Bit.App.Pages
                 return;
             }
 
-            var verificationType = await _userVerificationService.HasMasterPasswordAsync()
+            var verificationType = await _userVerificationService.HasMasterPasswordAsync(true)
                 ? VerificationType.MasterPassword
                 : VerificationType.OTP;
             if (!await _userVerificationService.VerifyUser(Secret, verificationType))

--- a/src/App/Utilities/VerificationActionsFlowHelper.cs
+++ b/src/App/Utilities/VerificationActionsFlowHelper.cs
@@ -60,7 +60,6 @@ namespace Bit.App.Utilities
     /// </summary>
     public class VerificationActionsFlowHelper : IVerificationActionsFlowHelper
     {
-        private readonly IKeyConnectorService _keyConnectorService;
         private readonly IPasswordRepromptService _passwordRepromptService;
         private readonly ICryptoService _cryptoService;
         private readonly IUserVerificationService _userVerificationService;
@@ -72,12 +71,11 @@ namespace Bit.App.Utilities
 
         private readonly Dictionary<VerificationFlowAction, IActionFlowExecutioner> _actionExecutionerDictionary = new Dictionary<VerificationFlowAction, IActionFlowExecutioner>();
 
-        public VerificationActionsFlowHelper(IKeyConnectorService keyConnectorService,
+        public VerificationActionsFlowHelper(
             IPasswordRepromptService passwordRepromptService,
             ICryptoService cryptoService,
             IUserVerificationService userVerificationService)
         {
-            _keyConnectorService = keyConnectorService;
             _passwordRepromptService = passwordRepromptService;
             _cryptoService = cryptoService;
             _userVerificationService = userVerificationService;
@@ -110,7 +108,7 @@ namespace Bit.App.Utilities
 
         public async Task ValidateAndExecuteAsync()
         {
-            var verificationType = await _userVerificationService.HasMasterPasswordAsync()
+            var verificationType = await _userVerificationService.HasMasterPasswordAsync(true)
                 ? VerificationType.MasterPassword
                 : VerificationType.OTP;
 

--- a/src/Core/Abstractions/IUserVerificationService.cs
+++ b/src/Core/Abstractions/IUserVerificationService.cs
@@ -6,6 +6,6 @@ namespace Bit.Core.Abstractions
     public interface IUserVerificationService
     {
         Task<bool> VerifyUser(string secret, VerificationType verificationType);
-        Task<bool> HasMasterPasswordAsync();
+        Task<bool> HasMasterPasswordAsync(bool checkMasterKeyHash = false);
     }
 }

--- a/src/Core/Services/UserVerificationService.cs
+++ b/src/Core/Services/UserVerificationService.cs
@@ -68,15 +68,20 @@ namespace Bit.Core.Services
             await _platformUtilsService.ShowDialogAsync(errorMessage);
         }
 
-        public async Task<bool> HasMasterPasswordAsync()
+        public async Task<bool> HasMasterPasswordAsync(bool checkMasterKeyHash = false)
         {
+            async Task<bool> CheckMasterKeyHashAsync()
+            {
+                return !checkMasterKeyHash && await _cryptoService.GetMasterKeyHashAsync() != null;
+            };
+
             var decryptOptions = await _stateService.GetAccountDecryptionOptions();
             if (decryptOptions != null)
             {
-                return decryptOptions.HasMasterPassword;
+                return decryptOptions.HasMasterPassword && await CheckMasterKeyHashAsync();
             }
 
-            return !await _keyConnectorService.GetUsesKeyConnectorAsync();
+            return !await _keyConnectorService.GetUsesKeyConnectorAsync() && await CheckMasterKeyHashAsync();
         }
     }
 }

--- a/src/iOS.Core/Utilities/iOSCoreHelpers.cs
+++ b/src/iOS.Core/Utilities/iOSCoreHelpers.cs
@@ -245,7 +245,6 @@ namespace Bit.iOS.Core.Utilities
             ServiceContainer.Register<IDeleteAccountActionFlowExecutioner>("deleteAccountActionFlowExecutioner", deleteAccountActionFlowExecutioner);
 
             var verificationActionsFlowHelper = new VerificationActionsFlowHelper(
-                ServiceContainer.Resolve<IKeyConnectorService>("keyConnectorService"),
                 ServiceContainer.Resolve<IPasswordRepromptService>("passwordRepromptService"),
                 ServiceContainer.Resolve<ICryptoService>("cryptoService"),
                 ServiceContainer.Resolve<IUserVerificationService>());


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Fix decision on whether to use MP reprompt or OTP on TDE (or when session doesn't have a master key hash.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **UserVerificationService:** Added check on master key hash and whether to check it on `HasMasterPasswordAsync`
* **ExportVaultPageViewModel, VerificationActionsFlowHelper:** Put check master key hash on `true`, so if user doesn't have a MP key hash then OTP is used.

## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
