### PR TITLE
[PM-3497] Dependency Updates

### DIFF
--- a/src/Android/Android.csproj
+++ b/src/Android/Android.csproj
@@ -77,21 +77,21 @@
     <PackageReference Include="Portable.BouncyCastle">
       <Version>1.9.0</Version>
     </PackageReference>
-    <PackageReference Include="Xamarin.AndroidX.AppCompat" Version="1.5.1.1" />
-    <PackageReference Include="Xamarin.AndroidX.AutoFill" Version="1.1.0.16" />
-    <PackageReference Include="Xamarin.AndroidX.CardView" Version="1.0.0.19" />
-    <PackageReference Include="Xamarin.AndroidX.Core" Version="1.10.0" />
-    <PackageReference Include="Xamarin.AndroidX.MediaRouter" Version="1.3.1.1" />
+    <PackageReference Include="Xamarin.AndroidX.AppCompat" Version="1.6.1.3" />
+    <PackageReference Include="Xamarin.AndroidX.AutoFill" Version="1.1.0.18" />
+    <PackageReference Include="Xamarin.AndroidX.CardView" Version="1.0.0.21" />
+    <PackageReference Include="Xamarin.AndroidX.Core" Version="1.10.1.2" />
+    <PackageReference Include="Xamarin.AndroidX.MediaRouter" Version="1.4.0.2" />
     <PackageReference Include="Xamarin.Essentials">
-      <Version>1.7.5</Version>
+      <Version>1.8.0</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Firebase.Messaging">
-      <Version>123.1.1.1</Version>
+      <Version>123.1.2.2</Version>
     </PackageReference>
-    <PackageReference Include="Xamarin.Google.Android.Material" Version="1.8.0" />
-    <PackageReference Include="Xamarin.Google.Dagger" Version="2.44.2.1" />
+    <PackageReference Include="Xamarin.Google.Android.Material" Version="1.9.0.2" />
+    <PackageReference Include="Xamarin.Google.Dagger" Version="2.46.1.2" />
     <PackageReference Include="Xamarin.GooglePlayServices.SafetyNet">
-      <Version>118.0.1.3</Version>
+      <Version>118.0.1.5</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/App/App.csproj
+++ b/src/App/App.csproj
@@ -16,9 +16,9 @@
     <PackageReference Include="Plugin.Fingerprint" Version="2.1.5" />
     <PackageReference Include="SkiaSharp.Views.Forms" Version="2.88.3" />
     <PackageReference Include="Xamarin.CommunityToolkit" Version="2.0.6" />
-    <PackageReference Include="Xamarin.Essentials" Version="1.7.5" />
+    <PackageReference Include="Xamarin.Essentials" Version="1.8.0" />
     <PackageReference Include="Xamarin.FFImageLoading.Forms" Version="2.4.11.982" />
-    <PackageReference Include="Xamarin.Forms" Version="5.0.0.2578" />
+    <PackageReference Include="Xamarin.Forms" Version="5.0.0.2612" />
     <PackageReference Include="ZXing.Net.Mobile" Version="2.4.1" />
     <PackageReference Include="ZXing.Net.Mobile.Forms" Version="2.4.1" />
     <PackageReference Include="MessagePack" Version="2.4.59" />

--- a/src/Core/Core.csproj
+++ b/src/Core/Core.csproj
@@ -30,11 +30,11 @@
 
   <ItemGroup>
     <PackageReference Include="CsvHelper" Version="30.0.1" />
-    <PackageReference Include="LiteDB" Version="5.0.16" />
+    <PackageReference Include="LiteDB" Version="5.0.17" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="PCLCrypto" Version="2.0.147" />
     <PackageReference Include="zxcvbn-core" Version="7.0.92" />
-    <PackageReference Include="Microsoft.AppCenter.Crashes" Version="5.0.1" />
+    <PackageReference Include="Microsoft.AppCenter.Crashes" Version="5.0.2" />
     <PackageReference Include="MessagePack" Version="2.4.59" />
     <PackageReference Include="MessagePack.MSBuild.Tasks" Version="2.4.59">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/iOS.Autofill/iOS.Autofill.csproj
+++ b/src/iOS.Autofill/iOS.Autofill.csproj
@@ -266,7 +266,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AppCenter.Crashes">
-      <Version>5.0.1</Version>
+      <Version>5.0.2</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/iOS.Extension/iOS.Extension.csproj
+++ b/src/iOS.Extension/iOS.Extension.csproj
@@ -242,7 +242,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AppCenter.Crashes">
-      <Version>5.0.1</Version>
+      <Version>5.0.2</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.AppExtension.CSharp.targets" />

--- a/src/iOS.ShareExtension/iOS.ShareExtension.csproj
+++ b/src/iOS.ShareExtension/iOS.ShareExtension.csproj
@@ -167,7 +167,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AppCenter.Crashes">
-      <Version>5.0.1</Version>
+      <Version>5.0.2</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/iOS/iOS.csproj
+++ b/src/iOS/iOS.csproj
@@ -195,7 +195,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Xamarin.Essentials">
-      <Version>1.7.5</Version>
+      <Version>1.8.0</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />

--- a/test/Common/Common.csproj
+++ b/test/Common/Common.csproj
@@ -8,14 +8,14 @@
 
     <ItemGroup>
     <PackageReference Include="NSubstitute" Version="5.0.0" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="xunit" Version="2.5.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <PackageReference Include="AutoFixture.Xunit2" Version="4.18.0" />
     <PackageReference Include="AutoFixture.AutoNSubstitute" Version="4.18.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.0" />
   </ItemGroup>
 
 </Project>

--- a/test/Core.Test/Core.Test.csproj
+++ b/test/Core.Test/Core.Test.csproj
@@ -7,10 +7,10 @@
   </PropertyGroup>
 
     <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.0" />
     <PackageReference Include="NSubstitute" Version="5.0.0" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="xunit" Version="2.5.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [ ] New feature development
- [X] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Another round of dependency updates made possible by the recent release of [Xamarin.Forms 5.0.0 SR-15](https://github.com/xamarin/Xamarin.Forms/releases/tag/release-5.0.0-sr15).

**_Note 1:_** `MessagePack*` will remain on its current version since it still breaks the Android build with the following error:

```
Xamarin.Android.Legacy.targets(317, 5): [XA2002] Can not resolve reference: `Microsoft.NET.StringTools`, referenced by `MessagePack`. Please add a NuGet package or assembly reference for `Microsoft.NET.StringTools`, or remove the reference to `MessagePack`.
```
The author states a [workaround](https://github.com/MessagePack-CSharp/MessagePack-CSharp/issues/1509#issuecomment-1554925920) was added in `2.5.94+` but we're still seeing this error with `2.5.124`.

**_Note 2:_** Continuing to leave `Google.Apis.AndroidPublisher.v3` untouched to prevent breaking the Github publishing automation (it's a big version jump so the likelihood of it bursting into flames is high)


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* ***.csproj:** Dependency version bumps


## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
