### PR TITLE
[PM 3513] Fix passwordless 2fa login with device on mobile

### DIFF
--- a/src/Core/Services/AuthService.cs
+++ b/src/Core/Services/AuthService.cs
@@ -33,11 +33,11 @@ namespace Bit.Core.Services
 
         private readonly LazyResolve<IWatchDeviceService> _watchDeviceService = new LazyResolve<IWatchDeviceService>();
         private MasterKey _masterKey;
+        private UserKey _userKey;
 
         private string _authedUserId;
         private MasterPasswordPolicyOptions _masterPasswordPolicy;
         private ForcePasswordResetReason? _2faForcePasswordResetReason;
-        private UserKey _userKey;
 
         public AuthService(
             ICryptoService cryptoService,


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
If a user had 2fa enabled on their account and requested device approval from a passwordless device, the user key wasn't being set on the account. This change stores the user key on the auth service so that a second auth request can set it if they are successfully authenticated


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **file.ext:** Description of what was changed and why

## Screenshots
<!--Required for any UI changes. Delete if not applicable-->



## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
