### PR TITLE
[PM-3512] Settings Appearance

### DIFF
--- a/src/Android/MainActivity.cs
+++ b/src/Android/MainActivity.cs
@@ -116,7 +116,7 @@ namespace Bit.Droid
                 {
                     ListenYubiKey((bool)message.Data);
                 }
-                else if (message.Command == "updatedTheme")
+                else if (message.Command is ThemeManager.UPDATED_THEME_MESSAGE_KEY)
                 {
                     Xamarin.Forms.Device.BeginInvokeOnMainThread(() => AppearanceAdjustments());
                 }

--- a/src/App/App.xaml.cs
+++ b/src/App/App.xaml.cs
@@ -365,7 +365,7 @@ namespace Bit.App
             await Device.InvokeOnMainThreadAsync(() =>
             {
                 ThemeManager.SetTheme(Current.Resources);
-                _messagingService.Send("updatedTheme");
+                _messagingService.Send(ThemeManager.UPDATED_THEME_MESSAGE_KEY);
             });
         }
 

--- a/src/App/Controls/Settings/SwitchItemView.xaml
+++ b/src/App/Controls/Settings/SwitchItemView.xaml
@@ -12,12 +12,8 @@
 
     <Switch
         x:Name="_switch"
-        Grid.Column="1"
-        Grid.RowSpan="2"
+        HeightRequest="20"
+        Scale="{OnPlatform iOS=0.8, Android=1}"
         IsToggled="{Binding IsToggled, Mode=TwoWay, Source={x:Reference _contentView}}"
-        HorizontalOptions="End"
-        VerticalOptions="Center"
-        AutomationId="{Binding SwitchAutomationId, Mode=OneWay, Source={x:Reference _contentView}}"
-        AutomationProperties.IsInAccessibleTree="True"
-        AutomationProperties.Name="{Binding Title, Mode=OneWay, Source={x:Reference _contentView}}"/>
+        AutomationId="{Binding SwitchAutomationId, Mode=OneWay, Source={x:Reference _contentView}}"/>
 </controls:BaseSettingItemView>

--- a/src/App/Pages/Accounts/HomePage.xaml.cs
+++ b/src/App/Pages/Accounts/HomePage.xaml.cs
@@ -64,7 +64,7 @@ namespace Bit.App.Pages
             }
             _broadcasterService.Subscribe(nameof(HomePage), (message) =>
             {
-                if (message.Command == "updatedTheme")
+                if (message.Command is ThemeManager.UPDATED_THEME_MESSAGE_KEY)
                 {
                     Device.BeginInvokeOnMainThread(() =>
                     {

--- a/src/App/Pages/Generator/GeneratorPage.xaml.cs
+++ b/src/App/Pages/Generator/GeneratorPage.xaml.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using Bit.App.Models;
 using Bit.App.Resources;
 using Bit.App.Styles;
+using Bit.App.Utilities;
 using Bit.Core.Abstractions;
 using Bit.Core.Utilities;
 using Xamarin.Forms;
@@ -79,7 +80,7 @@ namespace Bit.App.Pages
 
             _broadcasterService.Subscribe(nameof(GeneratorPage), (message) =>
             {
-                if (message.Command == "updatedTheme")
+                if (message.Command is ThemeManager.UPDATED_THEME_MESSAGE_KEY)
                 {
                     Device.BeginInvokeOnMainThread(() => _vm.RedrawPassword());
                 }

--- a/src/App/Pages/Settings/AboutSettingsPage.xaml
+++ b/src/App/Pages/Settings/AboutSettingsPage.xaml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="UTF-8" ?>
-<pages:BaseModalContentPage
+<pages:BaseContentPage
     xmlns="http://xamarin.com/schemas/2014/forms"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     xmlns:pages="clr-namespace:Bit.App.Pages"
@@ -14,15 +14,10 @@
         <pages:AboutSettingsPageViewModel />
     </ContentPage.BindingContext>
 
-    <ContentPage.ToolbarItems>
-        <ToolbarItem Text="{u:I18n Back}" Clicked="PopModal_Clicked" Order="Primary" Priority="-1" />
-    </ContentPage.ToolbarItems>
-
     <StackLayout>
         <controls:SwitchItemView
             Title="{u:I18n SubmitCrashLogs}"
             IsToggled="{Binding ShouldSubmitCrashLogs, Mode=TwoWay}"
-            HeightRequest="20"
             AutomationId="SubmitCrashLogsSwitch"
             StyleClass="settings-item-view"
             HorizontalOptions="FillAndExpand" />
@@ -68,7 +63,7 @@
             Orientation="Horizontal">
             <controls:CustomLabel
                 Text="{Binding AppInfo}"
-                MaxLines="0"
+                MaxLines="10"
                 StyleClass="box-footer-label"
                 HorizontalOptions="StartAndExpand"
                 LineBreakMode="TailTruncation" />
@@ -87,4 +82,4 @@
 
         </StackLayout>
     </StackLayout>
-</pages:BaseModalContentPage>
+</pages:BaseContentPage>

--- a/src/App/Pages/Settings/AboutSettingsPage.xaml.cs
+++ b/src/App/Pages/Settings/AboutSettingsPage.xaml.cs
@@ -1,6 +1,6 @@
 ﻿namespace Bit.App.Pages
 {
-    public partial class AboutSettingsPage : BaseModalContentPage
+    public partial class AboutSettingsPage : BaseContentPage
     {
         public AboutSettingsPage()
         {

--- a/src/App/Pages/Settings/AppearanceSettingsPage.xaml
+++ b/src/App/Pages/Settings/AppearanceSettingsPage.xaml
@@ -1,11 +1,10 @@
 ﻿<?xml version="1.0" encoding="UTF-8" ?>
-<pages:BaseModalContentPage
+<pages:BaseContentPage
     xmlns="http://xamarin.com/schemas/2014/forms"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     xmlns:pages="clr-namespace:Bit.App.Pages"
     x:DataType="pages:AppearanceSettingsPageViewModel"
     xmlns:controls="clr-namespace:Bit.App.Controls"
-    xmlns:core="clr-namespace:Bit.Core;assembly=BitwardenCore"
     xmlns:u="clr-namespace:Bit.App.Utilities"
     x:Class="Bit.App.Pages.AppearanceSettingsPage"
     Title="{u:I18n Appearance}">
@@ -14,7 +13,46 @@
         <pages:AppearanceSettingsPageViewModel />
     </ContentPage.BindingContext>
 
-    <ContentPage.ToolbarItems>
-        <ToolbarItem Text="{u:I18n Back}" Clicked="PopModal_Clicked" Order="Primary" Priority="-1" />
-    </ContentPage.ToolbarItems>
-</pages:BaseModalContentPage>
+    <ScrollView Padding="0, 0, 0, 20">
+        <StackLayout Padding="0" Spacing="5">
+            
+            <controls:SettingChooserItemView
+                Title="{u:I18n Language}"
+                Subtitle="{u:I18n LanguageChangeRequiresAppRestart}"
+                DisplayValue="{Binding LanguagePickerViewModel.SelectedValue}"
+                ChooseCommand="{Binding LanguagePickerViewModel.SelectOptionCommand}"
+                AutomationId="LanguageChooser"
+                StyleClass="settings-item-view"
+                HorizontalOptions="FillAndExpand"/>
+            
+            <controls:SettingChooserItemView
+                Title="{u:I18n Theme}"
+                Subtitle="{u:I18n ThemeDescription}"
+                DisplayValue="{Binding ThemePickerViewModel.SelectedValue}"
+                ChooseCommand="{Binding ThemePickerViewModel.SelectOptionCommand}"
+                AutomationId="ThemeChooser"
+                StyleClass="settings-item-view"
+                HorizontalOptions="FillAndExpand"/>
+
+            <controls:SettingChooserItemView
+                Title="{u:I18n DefaultDarkTheme}"
+                Subtitle="{u:I18n DefaultDarkThemeDescription}"
+                DisplayValue="{Binding DefaultDarkThemePickerViewModel.SelectedValue}"
+                ChooseCommand="{Binding DefaultDarkThemePickerViewModel.SelectOptionCommand}"
+                IsVisible="{Binding ShowDefaultDarkThemePicker}"
+                AutomationId="DefaultDarkThemeChooser"
+                StyleClass="settings-item-view"
+                HorizontalOptions="FillAndExpand"/>
+            
+            <controls:SwitchItemView
+                Title="{u:I18n ShowWebsiteIcons}"
+                Subtitle="{u:I18n ShowWebsiteIconsDescription}"
+                IsToggled="{Binding ShowWebsiteIcons}"
+                IsEnabled="{Binding IsShowWebsiteIconsEnabled}"
+                AutomationId="ShowWebsiteIconsSwitch"
+                StyleClass="settings-item-view"
+                HorizontalOptions="FillAndExpand" />
+
+        </StackLayout>
+    </ScrollView>
+</pages:BaseContentPage>

--- a/src/App/Pages/Settings/AppearanceSettingsPage.xaml.cs
+++ b/src/App/Pages/Settings/AppearanceSettingsPage.xaml.cs
@@ -1,12 +1,44 @@
-﻿namespace Bit.App.Pages
+﻿using System;
+using Bit.App.Resources;
+using Bit.Core.Abstractions;
+using Bit.Core.Services;
+using Bit.Core.Utilities;
+
+namespace Bit.App.Pages
 {
-    public partial class AppearanceSettingsPage : BaseModalContentPage
+    public partial class AppearanceSettingsPage : BaseContentPage
     {
+        private readonly AppearanceSettingsPageViewModel _vm;
+
         public AppearanceSettingsPage()
         {
             InitializeComponent();
-            var vm = BindingContext as AppearanceSettingsPageViewModel;
-            vm.Page = this;
+            _vm = BindingContext as AppearanceSettingsPageViewModel;
+            _vm.Page = this;
+        }
+
+        protected async override void OnAppearing()
+        {
+            base.OnAppearing();
+
+            try
+            {
+                _vm.SubscribeEvents();
+                await _vm.InitAsync();
+            }
+            catch (Exception ex)
+            {
+                LoggerHelper.LogEvenIfCantBeResolved(ex);
+                ServiceContainer.Resolve<IPlatformUtilsService>().ShowToast(null, null, AppResources.AnErrorHasOccurred);
+
+                Navigation.PopModalAsync().FireAndForget();
+            }
+        }
+
+        protected override void OnDisappearing()
+        {
+            base.OnDisappearing();
+            _vm.UnsubscribeEvents();
         }
     }
 }

--- a/src/App/Pages/Settings/AppearanceSettingsPageViewModel.cs
+++ b/src/App/Pages/Settings/AppearanceSettingsPageViewModel.cs
@@ -137,7 +137,7 @@ namespace Bit.App.Pages
             };
 
             var selectedKey = await _stateService.GetThemeAsync() ?? string.Empty;
-            
+
             ThemePickerViewModel.Init(options, selectedKey, string.Empty);
 
             TriggerPropertyChanged(nameof(ShowDefaultDarkThemePicker));

--- a/src/App/Pages/Settings/AppearanceSettingsPageViewModel.cs
+++ b/src/App/Pages/Settings/AppearanceSettingsPageViewModel.cs
@@ -1,11 +1,203 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Windows.Input;
+using Bit.App.Abstractions;
+using Bit.App.Resources;
+using Bit.App.Utilities;
+using Bit.Core.Abstractions;
+using Bit.Core.Utilities;
+using Xamarin.CommunityToolkit.ObjectModel;
+using Xamarin.Essentials;
+using Xamarin.Forms;
+
 namespace Bit.App.Pages
 {
     public class AppearanceSettingsPageViewModel : BaseViewModel
     {
+        private readonly IStateService _stateService;
+        private readonly ILogger _logger;
+        private readonly II18nService _i18nService;
+        private readonly IPlatformUtilsService _platformUtilsService;
+        private readonly IMessagingService _messagingService;
+
+        private bool _inited;
+        private bool _showWebsiteIcons;
+
         public AppearanceSettingsPageViewModel()
         {
+            _stateService = ServiceContainer.Resolve<IStateService>();
+            _logger = ServiceContainer.Resolve<ILogger>();
+            _i18nService = ServiceContainer.Resolve<II18nService>();
+            _platformUtilsService = ServiceContainer.Resolve<IPlatformUtilsService>();
+            _messagingService = ServiceContainer.Resolve<IMessagingService>();
+
+            var deviceActionService = ServiceContainer.Resolve<IDeviceActionService>();
+
+            LanguagePickerViewModel = new PickerViewModel<string>(
+                deviceActionService,
+                _logger,
+                OnLanguageChangingAsync,
+                AppResources.Language,
+                _ => _inited,
+                ex => HandleException(ex));
+
+            ThemePickerViewModel = new PickerViewModel<string>(
+                deviceActionService,
+                _logger,
+                key => OnThemeChangingAsync(key, DefaultDarkThemePickerViewModel.SelectedKey),
+                AppResources.Theme,
+                _ => _inited,
+                ex => HandleException(ex));
+            ThemePickerViewModel.SetAfterSelectionChanged(_ =>
+                MainThread.InvokeOnMainThreadAsync(() =>
+                {
+                    TriggerPropertyChanged(nameof(ShowDefaultDarkThemePicker));
+                }));
+
+            DefaultDarkThemePickerViewModel = new PickerViewModel<string>(
+                deviceActionService,
+                _logger,
+                key => OnThemeChangingAsync(ThemePickerViewModel.SelectedKey, key),
+                AppResources.DefaultDarkTheme,
+                _ => _inited,
+                ex => HandleException(ex));
+
+            ToggleShowWebsiteIconsCommand = CreateDefaultAsyncCommnad(ToggleShowWebsiteIconsAsync, _ => _inited);
+        }
+
+        public PickerViewModel<string> LanguagePickerViewModel { get; }
+        public PickerViewModel<string> ThemePickerViewModel { get; }
+        public PickerViewModel<string> DefaultDarkThemePickerViewModel { get; }
+
+        public bool ShowDefaultDarkThemePicker => ThemePickerViewModel.SelectedKey == string.Empty;
+
+        public bool ShowWebsiteIcons
+        {
+            get => _showWebsiteIcons;
+            set
+            {
+                if (SetProperty(ref _showWebsiteIcons, value))
+                {
+                    ((ICommand)ToggleShowWebsiteIconsCommand).Execute(null);
+                }
+            }
+        }
+
+        public bool IsShowWebsiteIconsEnabled => ToggleShowWebsiteIconsCommand.CanExecute(null);
+
+        public AsyncCommand ToggleShowWebsiteIconsCommand { get; }
+
+        public async Task InitAsync()
+        {
+            _showWebsiteIcons = !(await _stateService.GetDisableFaviconAsync() ?? false);
+            MainThread.BeginInvokeOnMainThread(() => TriggerPropertyChanged(nameof(ShowWebsiteIcons)));
+
+            InitLanguagePicker();
+            await InitThemePickerAsync();
+            await InitDefaultDarkThemePickerAsync();
+
+            _inited = true;
+
+            MainThread.BeginInvokeOnMainThread(() =>
+            {
+                ToggleShowWebsiteIconsCommand.RaiseCanExecuteChanged();
+                LanguagePickerViewModel.SelectOptionCommand.RaiseCanExecuteChanged();
+                ThemePickerViewModel.SelectOptionCommand.RaiseCanExecuteChanged();
+                DefaultDarkThemePickerViewModel.SelectOptionCommand.RaiseCanExecuteChanged();
+            });
+        }
+
+        private void InitLanguagePicker()
+        {
+            var options = new Dictionary<string, string>
+            {
+                [string.Empty] = AppResources.DefaultSystem
+            };
+            _i18nService.LocaleNames
+                .ToList()
+                .ForEach(pair => options[pair.Key] = pair.Value);
+
+            var selectedKey = _stateService.GetLocale() ?? string.Empty;
+
+            LanguagePickerViewModel.Init(options, selectedKey, string.Empty);
+        }
+
+        private async Task InitThemePickerAsync()
+        {
+            var options = new Dictionary<string, string>
+            {
+                [string.Empty] = AppResources.ThemeDefault,
+                [ThemeManager.Light] = AppResources.Light,
+                [ThemeManager.Dark] = AppResources.Dark,
+                [ThemeManager.Black] = AppResources.Black,
+                [ThemeManager.Nord] = AppResources.Nord,
+                [ThemeManager.SolarizedDark] = AppResources.SolarizedDark
+            };
+
+            var selectedKey = await _stateService.GetThemeAsync() ?? string.Empty;
+            
+            ThemePickerViewModel.Init(options, selectedKey, string.Empty);
+
+            TriggerPropertyChanged(nameof(ShowDefaultDarkThemePicker));
+        }
+
+        private async Task InitDefaultDarkThemePickerAsync()
+        {
+            var options = new Dictionary<string, string>
+            {
+                [ThemeManager.Dark] = AppResources.Dark,
+                [ThemeManager.Black] = AppResources.Black,
+                [ThemeManager.Nord] = AppResources.Nord,
+                [ThemeManager.SolarizedDark] = AppResources.SolarizedDark
+            };
+
+            var selectedKey = await _stateService.GetAutoDarkThemeAsync() ?? ThemeManager.Dark;
+
+            DefaultDarkThemePickerViewModel.Init(options, selectedKey, ThemeManager.Dark);
+        }
+
+        private async Task<bool> OnLanguageChangingAsync(string selectedLanguage)
+        {
+            _stateService.SetLocale(selectedLanguage == string.Empty ? (string)null : selectedLanguage);
+
+            await _platformUtilsService.ShowDialogAsync(string.Format(AppResources.LanguageChangeXDescription, LanguagePickerViewModel.SelectedValue), AppResources.Language, AppResources.Ok);
+            return true;
+        }
+
+        private async Task<bool> OnThemeChangingAsync(string selectedTheme, string selectedDefaultDarkTheme)
+        {
+            await _stateService.SetThemeAsync(selectedTheme == string.Empty ? (string)null : selectedTheme);
+            await _stateService.SetAutoDarkThemeAsync(selectedDefaultDarkTheme == string.Empty ? (string)null : selectedDefaultDarkTheme);
+
+            await MainThread.InvokeOnMainThreadAsync(() =>
+            {
+                ThemeManager.SetTheme(Application.Current.Resources);
+                _messagingService.Send(ThemeManager.UPDATED_THEME_MESSAGE_KEY);
+            });
+            return true;
+        }
+
+        private async Task ToggleShowWebsiteIconsAsync()
+        {
+            // TODO: [PS-961] Fix negative function names
+            await _stateService.SetDisableFaviconAsync(!ShowWebsiteIcons);
+        }
+
+        private void ToggleShowWebsiteIconsCommand_CanExecuteChanged(object sender, EventArgs e)
+        {
+            TriggerPropertyChanged(nameof(IsShowWebsiteIconsEnabled));
+        }
+
+        internal void SubscribeEvents()
+        {
+            ToggleShowWebsiteIconsCommand.CanExecuteChanged += ToggleShowWebsiteIconsCommand_CanExecuteChanged;
+        }
+
+        internal void UnsubscribeEvents()
+        {
+            ToggleShowWebsiteIconsCommand.CanExecuteChanged -= ToggleShowWebsiteIconsCommand_CanExecuteChanged;
         }
     }
 }
-

--- a/src/App/Pages/Settings/AutofillSettingsPage.xaml
+++ b/src/App/Pages/Settings/AutofillSettingsPage.xaml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="UTF-8" ?>
-<pages:BaseModalContentPage
+<pages:BaseContentPage
     xmlns="http://xamarin.com/schemas/2014/forms"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     xmlns:pages="clr-namespace:Bit.App.Pages"
@@ -13,8 +13,4 @@
     <ContentPage.BindingContext>
         <pages:AutofillSettingsPageViewModel />
     </ContentPage.BindingContext>
-
-    <ContentPage.ToolbarItems>
-        <ToolbarItem Text="{u:I18n Back}" Clicked="PopModal_Clicked" Order="Primary" Priority="-1" />
-    </ContentPage.ToolbarItems>
-</pages:BaseModalContentPage>
+</pages:BaseContentPage>

--- a/src/App/Pages/Settings/AutofillSettingsPage.xaml.cs
+++ b/src/App/Pages/Settings/AutofillSettingsPage.xaml.cs
@@ -1,6 +1,6 @@
 ﻿namespace Bit.App.Pages
 {
-    public partial class AutofillSettingsPage : BaseModalContentPage
+    public partial class AutofillSettingsPage : BaseContentPage
     {
         public AutofillSettingsPage()
         {

--- a/src/App/Pages/Settings/OptionsPageViewModel.cs
+++ b/src/App/Pages/Settings/OptionsPageViewModel.cs
@@ -264,7 +264,7 @@ namespace Bit.App.Pages
                 await _stateService.SetThemeAsync(ThemeOptions[ThemeSelectedIndex].Key);
                 await _stateService.SetAutoDarkThemeAsync(AutoDarkThemeOptions[AutoDarkThemeSelectedIndex].Key);
                 ThemeManager.SetTheme(Application.Current.Resources);
-                _messagingService.Send("updatedTheme");
+                _messagingService.Send(ThemeManager.UPDATED_THEME_MESSAGE_KEY);
             }
         }
 

--- a/src/App/Pages/Settings/OtherSettingsPage.xaml
+++ b/src/App/Pages/Settings/OtherSettingsPage.xaml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="UTF-8" ?>
-<pages:BaseModalContentPage
+<pages:BaseContentPage
     xmlns="http://xamarin.com/schemas/2014/forms"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     xmlns:pages="clr-namespace:Bit.App.Pages"
@@ -13,10 +13,6 @@
         <pages:OtherSettingsPageViewModel />
     </ContentPage.BindingContext>
 
-    <ContentPage.ToolbarItems>
-        <ToolbarItem Text="{u:I18n Back}" Clicked="PopModal_Clicked" Order="Primary" Priority="-1" />
-    </ContentPage.ToolbarItems>
-
     <ContentPage.Resources>
         <u:InverseBoolConverter x:Key="inverseBoolConverter" />
     </ContentPage.Resources>
@@ -27,7 +23,6 @@
                 Title="{u:I18n EnableSyncOnRefresh}"
                 IsToggled="{Binding EnableSyncOnRefresh}"
                 Subtitle="{u:I18n EnableSyncOnRefreshDescription}"
-                HeightRequest="20"
                 AutomationId="SubmitCrashLogsSwitch"
                 StyleClass="settings-item-view"
                 HorizontalOptions="FillAndExpand" />
@@ -56,7 +51,6 @@
                 Title="{u:I18n AllowScreenCapture}"
                 IsToggled="{Binding IsScreenCaptureAllowed}"
                 IsEnabled="{Binding CanToggleeScreenCaptureAllowed}"
-                HeightRequest="20"
                 AutomationId="SubmitCrashLogsSwitch"
                 StyleClass="settings-item-view"
                 HorizontalOptions="FillAndExpand" />
@@ -64,4 +58,4 @@
         </StackLayout>
     </ScrollView>
 
-</pages:BaseModalContentPage>
+</pages:BaseContentPage>

--- a/src/App/Pages/Settings/OtherSettingsPage.xaml.cs
+++ b/src/App/Pages/Settings/OtherSettingsPage.xaml.cs
@@ -6,7 +6,7 @@ using Bit.Core.Utilities;
 
 namespace Bit.App.Pages
 {
-    public partial class OtherSettingsPage : BaseModalContentPage
+    public partial class OtherSettingsPage : BaseContentPage
     {
         private OtherSettingsPageViewModel _vm;
 

--- a/src/App/Pages/Settings/OtherSettingsPageViewModel.cs
+++ b/src/App/Pages/Settings/OtherSettingsPageViewModel.cs
@@ -42,7 +42,8 @@ namespace Bit.App.Pages
 
             ClearClipboardPickerViewModel = new PickerViewModel<int>(
                 _deviceActionService,
-                OnClearClipboardChangedAsync,
+                _logger,
+                OnClearClipboardChangingAsync,
                 AppResources.ClearClipboard,
                 _ => _inited,
                 ex => HandleException(ex));
@@ -120,11 +121,6 @@ namespace Bit.App.Pages
             }
 
             var clearClipboard = await _stateService.GetClearClipboardAsync() ?? CLEAR_CLIPBOARD_NEVER_OPTION;
-            if (!clearClipboardOptions.ContainsKey(clearClipboard))
-            {
-                _logger.Error("There is no clear clipboard options for key: " + clearClipboard);
-                clearClipboard = CLEAR_CLIPBOARD_NEVER_OPTION;
-            }
 
             ClearClipboardPickerViewModel.Init(clearClipboardOptions, clearClipboard, CLEAR_CLIPBOARD_NEVER_OPTION);
         }
@@ -175,7 +171,7 @@ namespace Bit.App.Pages
             _platformUtilsService.ShowToast("success", null, AppResources.SyncingComplete);
         }
 
-        private async Task<bool> OnClearClipboardChangedAsync(int optionKey)
+        private async Task<bool> OnClearClipboardChangingAsync(int optionKey)
         {
             await _stateService.SetClearClipboardAsync(optionKey == CLEAR_CLIPBOARD_NEVER_OPTION ? (int?)null : optionKey);
             return true;

--- a/src/App/Pages/Settings/SecuritySettingsPage.xaml
+++ b/src/App/Pages/Settings/SecuritySettingsPage.xaml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="UTF-8" ?>
-<pages:BaseModalContentPage
+<pages:BaseContentPage
     xmlns="http://xamarin.com/schemas/2014/forms"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     xmlns:pages="clr-namespace:Bit.App.Pages"
@@ -13,8 +13,4 @@
     <ContentPage.BindingContext>
         <pages:SecuritySettingsPageViewModel />
     </ContentPage.BindingContext>
-
-    <ContentPage.ToolbarItems>
-        <ToolbarItem Text="{u:I18n Back}" Clicked="PopModal_Clicked" Order="Primary" Priority="-1" />
-    </ContentPage.ToolbarItems>
-</pages:BaseModalContentPage>
+</pages:BaseContentPage>

--- a/src/App/Pages/Settings/SecuritySettingsPage.xaml.cs
+++ b/src/App/Pages/Settings/SecuritySettingsPage.xaml.cs
@@ -1,6 +1,6 @@
 ﻿namespace Bit.App.Pages
 {
-    public partial class SecuritySettingsPage : BaseModalContentPage
+    public partial class SecuritySettingsPage : BaseContentPage
     {
         public SecuritySettingsPage()
         {

--- a/src/App/Pages/Settings/SettingsPage/SettingsPageViewModel.cs
+++ b/src/App/Pages/Settings/SettingsPage/SettingsPageViewModel.cs
@@ -39,7 +39,7 @@ namespace Bit.App.Pages
 
         private async Task NavigateToAsync(Page page)
         {
-            await Page.Navigation.PushModalAsync(new NavigationPage(page));
+            await Page.Navigation.PushAsync(page);
         }
     }
 

--- a/src/App/Pages/Settings/VaultSettingsPage.xaml
+++ b/src/App/Pages/Settings/VaultSettingsPage.xaml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="UTF-8" ?>
-<pages:BaseModalContentPage
+<pages:BaseContentPage
     xmlns="http://xamarin.com/schemas/2014/forms"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     xmlns:pages="clr-namespace:Bit.App.Pages"
@@ -12,10 +12,6 @@
     <ContentPage.BindingContext>
         <pages:VaultSettingsPageViewModel />
     </ContentPage.BindingContext>
-
-    <ContentPage.ToolbarItems>
-        <ToolbarItem Text="{u:I18n Back}" Clicked="PopModal_Clicked" Order="Primary" Priority="-1" />
-    </ContentPage.ToolbarItems>
 
     <StackLayout>
         <controls:CustomLabel
@@ -48,5 +44,5 @@
 
     </StackLayout>
 
-</pages:BaseModalContentPage>
+</pages:BaseContentPage>
 

--- a/src/App/Pages/Settings/VaultSettingsPage.xaml.cs
+++ b/src/App/Pages/Settings/VaultSettingsPage.xaml.cs
@@ -1,6 +1,6 @@
 ﻿namespace Bit.App.Pages
 {
-    public partial class VaultSettingsPage : BaseModalContentPage
+    public partial class VaultSettingsPage : BaseContentPage
     {
         public VaultSettingsPage()
         {

--- a/src/App/Pages/TabsPage.cs
+++ b/src/App/Pages/TabsPage.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using Bit.App.Effects;
 using Bit.App.Models;
 using Bit.App.Resources;
+using Bit.App.Utilities;
 using Bit.Core;
 using Bit.Core.Abstractions;
 using Bit.Core.Models.Data;
@@ -137,7 +138,7 @@ namespace Bit.App.Pages
                     await groupingsPage.HideAccountSwitchingOverlayAsync();
                 }
 
-                _messagingService.Send("updatedTheme");
+                _messagingService.Send(ThemeManager.UPDATED_THEME_MESSAGE_KEY);
                 if (navPage.RootPage is GroupingsPage)
                 {
                     // Load something?

--- a/src/App/Styles/ControlTemplates.xaml
+++ b/src/App/Styles/ControlTemplates.xaml
@@ -9,16 +9,19 @@
 
     <ControlTemplate x:Key="SettingControlTemplate">
         <Grid
-            RowDefinitions="Auto,Auto"
-            ColumnDefinitions="*,Auto">
+            RowDefinitions="Auto,*"
+            ColumnDefinitions="*,Auto"
+            ColumnSpacing="10">
             <controls:CustomLabel
+                Grid.Row="0"
+                Grid.Column="0"
                 Text="{TemplateBinding Title}"
                 HorizontalOptions="StartAndExpand"
                 LineBreakMode="TailTruncation" />
 
             <ContentPresenter
                 Grid.Column="1"
-                Grid.RowSpan="2" 
+                Grid.RowSpan="2"
                 HorizontalOptions="End"
                 VerticalOptions="Center" />
 

--- a/src/App/Utilities/ThemeManager.cs
+++ b/src/App/Utilities/ThemeManager.cs
@@ -12,6 +12,8 @@ namespace Bit.App.Utilities
 {
     public static class ThemeManager
     {
+        public const string UPDATED_THEME_MESSAGE_KEY = "updatedTheme";
+
         public static bool UsingLightTheme = true;
         public static Func<ResourceDictionary> Resources = () => null;
 
@@ -63,7 +65,7 @@ namespace Bit.App.Utilities
                 // Platform styles
                 if (Device.RuntimePlatform == Device.Android)
                 {
-                    resources.MergedDictionaries.Add(new Android());
+                    resources.MergedDictionaries.Add(new Styles.Android());
                 }
                 else if (Device.RuntimePlatform == Device.iOS)
                 {

--- a/src/iOS.Core/Renderers/CustomTabbedRenderer.cs
+++ b/src/iOS.Core/Renderers/CustomTabbedRenderer.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using Bit.App.Abstractions;
 using Bit.App.Pages;
+using Bit.App.Utilities;
 using Bit.Core.Abstractions;
 using Bit.Core.Utilities;
 using Bit.iOS.Core.Renderers;
@@ -23,7 +24,7 @@ namespace Bit.iOS.Core.Renderers
             _broadcasterService = ServiceContainer.Resolve<IBroadcasterService>("broadcasterService");
             _broadcasterService.Subscribe(nameof(CustomTabbedRenderer), (message) =>
             {
-                if (message.Command == "updatedTheme")
+                if (message.Command is ThemeManager.UPDATED_THEME_MESSAGE_KEY)
                 {
                     Device.BeginInvokeOnMainThread(() =>
                     {

--- a/src/iOS/AppDelegate.cs
+++ b/src/iOS/AppDelegate.cs
@@ -75,7 +75,7 @@ namespace Bit.iOS
                     {
                         var task = StopEventTimerAsync();
                     }
-                    else if (message.Command == "updatedTheme")
+                    else if (message.Command is ThemeManager.UPDATED_THEME_MESSAGE_KEY)
                     {
                         Device.BeginInvokeOnMainThread(() =>
                         {


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Implemented new view for settings: Appearance.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **PickerViewModel:** Improved it to reuse code and also added `afterSelectionChangedAsync` to be able to perform actions after the picker selected value has been set.
* **AppearanceSettingsPage/ViewModel:** Implemented new Appearance view with new `PickerViewModel` approach.
* **Other settings views:** Made the navigation to not be modal, removed the toolbar item for the back button given that the default is being used and changed the base class to be `BaseContentPage` instead the modal one.
* **Other:** Moved `updatedTheme` to a constant and updated everywhere to used that constant

## Screenshots
<!--Required for any UI changes. Delete if not applicable-->

### Android Appearance Light
<img width="314" alt="Android Appearance Light" src="https://github.com/bitwarden/mobile/assets/15682323/7e1abe08-5190-4a0c-887e-19958783cf01">

### Android Appearance Dark
<img width="314" alt="Android Appearance Dark" src="https://github.com/bitwarden/mobile/assets/15682323/024df571-3643-4172-aad0-a003c23fc4b2">

### iOS Appearance Light
<img width="314" alt="iOS Appearance Light" src="https://github.com/bitwarden/mobile/assets/15682323/b409926e-1bc6-4e89-8522-da0fbc2a0d7e">

### iOS Appearance Dark
<img width="314" alt="iOS Appearance Dark" src="https://github.com/bitwarden/mobile/assets/15682323/eb9e8624-a898-4d17-9b48-83b265054c59">


## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
