### PR TITLE
[PM-3556] Change anonaddy to addy io

### DIFF
--- a/src/App/Pages/Generator/GeneratorPage.xaml
+++ b/src/App/Pages/Generator/GeneratorPage.xaml
@@ -269,15 +269,15 @@
                                 Grid.Column="1"
                                 AutomationId="ShowForwardedEmailApiSecretButton" />
                         </Grid>
-                        <Label IsVisible="{Binding ForwardedEmailServiceSelected, Converter={StaticResource enumToBool}, ConverterParameter={x:Static enums:ForwardedEmailServiceType.AnonAddy}}"
+                        <Label IsVisible="{Binding ForwardedEmailServiceSelected, Converter={StaticResource enumToBool}, ConverterParameter={x:Static enums:ForwardedEmailServiceType.AddyIo}}"
                             Text="{u:I18n DomainNameRequiredParenthesis}"
                             StyleClass="box-label"
                             Margin="0,10,0,0"/>
-                        <Entry IsVisible="{Binding ForwardedEmailServiceSelected, Converter={StaticResource enumToBool}, ConverterParameter={x:Static enums:ForwardedEmailServiceType.AnonAddy}}"
-                            x:Name="_anonAddyDomainNameEntry"
-                            Text="{Binding AnonAddyDomainName}"
+                        <Entry IsVisible="{Binding ForwardedEmailServiceSelected, Converter={StaticResource enumToBool}, ConverterParameter={x:Static enums:ForwardedEmailServiceType.AddyIo}}"
+                            x:Name="_addyIoDomainNameEntry"
+                            Text="{Binding AddyIoDomainName}"
                             StyleClass="box-value"
-                            AutomationId="AnonAddyDomainNameEntry" />
+                            AutomationId="AddyIoDomainNameEntry" />
                     </StackLayout>                    
                     <!--RANDOM WORD OPTIONS-->
                     <Grid IsVisible="{Binding UsernameTypeSelected, Converter={StaticResource enumToBool}, ConverterParameter={x:Static enums:UsernameType.RandomWord}}">

--- a/src/App/Pages/Generator/GeneratorPage.xaml
+++ b/src/App/Pages/Generator/GeneratorPage.xaml
@@ -269,15 +269,15 @@
                                 Grid.Column="1"
                                 AutomationId="ShowForwardedEmailApiSecretButton" />
                         </Grid>
-                        <Label IsVisible="{Binding ForwardedEmailServiceSelected, Converter={StaticResource enumToBool}, ConverterParameter={x:Static enums:ForwardedEmailServiceType.AddyIo}}"
+                        <Label IsVisible="{Binding ForwardedEmailServiceSelected, Converter={StaticResource enumToBool}, ConverterParameter={x:Static enums:ForwardedEmailServiceType.AnonAddy}}"
                             Text="{u:I18n DomainNameRequiredParenthesis}"
                             StyleClass="box-label"
                             Margin="0,10,0,0"/>
-                        <Entry IsVisible="{Binding ForwardedEmailServiceSelected, Converter={StaticResource enumToBool}, ConverterParameter={x:Static enums:ForwardedEmailServiceType.AddyIo}}"
-                            x:Name="_addyIoDomainNameEntry"
+                        <Entry IsVisible="{Binding ForwardedEmailServiceSelected, Converter={StaticResource enumToBool}, ConverterParameter={x:Static enums:ForwardedEmailServiceType.AnonAddy}}"
+                            x:Name="_anonAddyDomainNameEntry"
                             Text="{Binding AddyIoDomainName}"
                             StyleClass="box-value"
-                            AutomationId="AddyIoDomainNameEntry" />
+                            AutomationId="AnonAddyDomainNameEntry" />
                     </StackLayout>                    
                     <!--RANDOM WORD OPTIONS-->
                     <Grid IsVisible="{Binding UsernameTypeSelected, Converter={StaticResource enumToBool}, ConverterParameter={x:Static enums:UsernameType.RandomWord}}">

--- a/src/App/Pages/Generator/GeneratorPageViewModel.cs
+++ b/src/App/Pages/Generator/GeneratorPageViewModel.cs
@@ -77,7 +77,7 @@ namespace Bit.App.Pages
             };
 
             ForwardedEmailServiceTypeOptions = new List<ForwardedEmailServiceType> {
-                ForwardedEmailServiceType.AddyIo,
+                ForwardedEmailServiceType.AnonAddy,
                 ForwardedEmailServiceType.DuckDuckGo,
                 ForwardedEmailServiceType.Fastmail,
                 ForwardedEmailServiceType.FirefoxRelay,
@@ -451,8 +451,8 @@ namespace Bit.App.Pages
             {
                 switch (ForwardedEmailServiceSelected)
                 {
-                    case ForwardedEmailServiceType.AddyIo:
-                        return _usernameOptions.AddyIoApiAccessToken;
+                    case ForwardedEmailServiceType.AnonAddy:
+                        return _usernameOptions.AnonAddyApiAccessToken;
                     case ForwardedEmailServiceType.DuckDuckGo:
                         return _usernameOptions.DuckDuckGoApiKey;
                     case ForwardedEmailServiceType.Fastmail:
@@ -470,10 +470,10 @@ namespace Bit.App.Pages
                 bool changed = false;
                 switch (ForwardedEmailServiceSelected)
                 {
-                    case ForwardedEmailServiceType.AddyIo:
-                        if (_usernameOptions.AddyIoApiAccessToken != value)
+                    case ForwardedEmailServiceType.AnonAddy:
+                        if (_usernameOptions.AnonAddyApiAccessToken != value)
                         {
-                            _usernameOptions.AddyIoApiAccessToken = value;
+                            _usernameOptions.AnonAddyApiAccessToken = value;
                             changed = true;
                         }
                         break;
@@ -523,7 +523,7 @@ namespace Bit.App.Pages
             {
                 switch (ForwardedEmailServiceSelected)
                 {
-                    case ForwardedEmailServiceType.AddyIo:
+                    case ForwardedEmailServiceType.AnonAddy:
                     case ForwardedEmailServiceType.FirefoxRelay:
                         return AppResources.APIAccessToken;
                     case ForwardedEmailServiceType.DuckDuckGo:
@@ -547,12 +547,12 @@ namespace Bit.App.Pages
 
         public string AddyIoDomainName
         {
-            get => _usernameOptions.AddyIoDomainName;
+            get => _usernameOptions.AnonAddyDomainName;
             set
             {
-                if (_usernameOptions.AddyIoDomainName != value)
+                if (_usernameOptions.AnonAddyDomainName != value)
                 {
-                    _usernameOptions.AddyIoDomainName = value;
+                    _usernameOptions.AnonAddyDomainName = value;
                     TriggerPropertyChanged(nameof(AddyIoDomainName));
                     SaveUsernameOptionsAsync(false).FireAndForget();
                 }
@@ -832,7 +832,7 @@ namespace Bit.App.Pages
             {
                 if (ex is ForwardedEmailInvalidSecretException)
                 {
-                    message = ForwardedEmailServiceSelected == ForwardedEmailServiceType.AddyIo || ForwardedEmailServiceSelected == ForwardedEmailServiceType.FirefoxRelay
+                    message = ForwardedEmailServiceSelected == ForwardedEmailServiceType.AnonAddy || ForwardedEmailServiceSelected == ForwardedEmailServiceType.FirefoxRelay
                                 ? AppResources.InvalidAPIToken
                                 : AppResources.InvalidAPIKey;
                 }

--- a/src/App/Pages/Generator/GeneratorPageViewModel.cs
+++ b/src/App/Pages/Generator/GeneratorPageViewModel.cs
@@ -77,7 +77,7 @@ namespace Bit.App.Pages
             };
 
             ForwardedEmailServiceTypeOptions = new List<ForwardedEmailServiceType> {
-                ForwardedEmailServiceType.AnonAddy,
+                ForwardedEmailServiceType.AddyIo,
                 ForwardedEmailServiceType.DuckDuckGo,
                 ForwardedEmailServiceType.Fastmail,
                 ForwardedEmailServiceType.FirefoxRelay,
@@ -451,8 +451,8 @@ namespace Bit.App.Pages
             {
                 switch (ForwardedEmailServiceSelected)
                 {
-                    case ForwardedEmailServiceType.AnonAddy:
-                        return _usernameOptions.AnonAddyApiAccessToken;
+                    case ForwardedEmailServiceType.AddyIo:
+                        return _usernameOptions.AddyIoApiAccessToken;
                     case ForwardedEmailServiceType.DuckDuckGo:
                         return _usernameOptions.DuckDuckGoApiKey;
                     case ForwardedEmailServiceType.Fastmail:
@@ -470,10 +470,10 @@ namespace Bit.App.Pages
                 bool changed = false;
                 switch (ForwardedEmailServiceSelected)
                 {
-                    case ForwardedEmailServiceType.AnonAddy:
-                        if (_usernameOptions.AnonAddyApiAccessToken != value)
+                    case ForwardedEmailServiceType.AddyIo:
+                        if (_usernameOptions.AddyIoApiAccessToken != value)
                         {
-                            _usernameOptions.AnonAddyApiAccessToken = value;
+                            _usernameOptions.AddyIoApiAccessToken = value;
                             changed = true;
                         }
                         break;
@@ -523,7 +523,7 @@ namespace Bit.App.Pages
             {
                 switch (ForwardedEmailServiceSelected)
                 {
-                    case ForwardedEmailServiceType.AnonAddy:
+                    case ForwardedEmailServiceType.AddyIo:
                     case ForwardedEmailServiceType.FirefoxRelay:
                         return AppResources.APIAccessToken;
                     case ForwardedEmailServiceType.DuckDuckGo:
@@ -545,15 +545,15 @@ namespace Bit.App.Pages
             set => SetProperty(ref _showForwardedEmailApiSecret, value);
         }
 
-        public string AnonAddyDomainName
+        public string AddyIoDomainName
         {
-            get => _usernameOptions.AnonAddyDomainName;
+            get => _usernameOptions.AddyIoDomainName;
             set
             {
-                if (_usernameOptions.AnonAddyDomainName != value)
+                if (_usernameOptions.AddyIoDomainName != value)
                 {
-                    _usernameOptions.AnonAddyDomainName = value;
-                    TriggerPropertyChanged(nameof(AnonAddyDomainName));
+                    _usernameOptions.AddyIoDomainName = value;
+                    TriggerPropertyChanged(nameof(AddyIoDomainName));
                     SaveUsernameOptionsAsync(false).FireAndForget();
                 }
             }
@@ -793,7 +793,7 @@ namespace Bit.App.Pages
             TriggerPropertyChanged(nameof(CapitalizeRandomWordUsername));
             TriggerPropertyChanged(nameof(ForwardedEmailApiSecret));
             TriggerPropertyChanged(nameof(ForwardedEmailApiSecretLabel));
-            TriggerPropertyChanged(nameof(AnonAddyDomainName));
+            TriggerPropertyChanged(nameof(AddyIoDomainName));
             TriggerPropertyChanged(nameof(CatchAllEmailDomain));
             TriggerPropertyChanged(nameof(ForwardedEmailServiceSelected));
             TriggerPropertyChanged(nameof(UsernameTypeSelected));
@@ -832,7 +832,7 @@ namespace Bit.App.Pages
             {
                 if (ex is ForwardedEmailInvalidSecretException)
                 {
-                    message = ForwardedEmailServiceSelected == ForwardedEmailServiceType.AnonAddy || ForwardedEmailServiceSelected == ForwardedEmailServiceType.FirefoxRelay
+                    message = ForwardedEmailServiceSelected == ForwardedEmailServiceType.AddyIo || ForwardedEmailServiceSelected == ForwardedEmailServiceType.FirefoxRelay
                                 ? AppResources.InvalidAPIToken
                                 : AppResources.InvalidAPIKey;
                 }

--- a/src/App/Resources/AppResources.Designer.cs
+++ b/src/App/Resources/AppResources.Designer.cs
@@ -509,11 +509,11 @@ namespace Bit.App.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to AnonAddy.
+        ///   Looks up a localized string similar to addy.io.
         /// </summary>
-        public static string AnonAddy {
+        public static string AddyIo {
             get {
-                return ResourceManager.GetString("AnonAddy", resourceCulture);
+                return ResourceManager.GetString("AddyIo", resourceCulture);
             }
         }
         

--- a/src/App/Resources/AppResources.af.resx
+++ b/src/App/Resources/AppResources.af.resx
@@ -2414,8 +2414,8 @@ kies u Voeg TOTP toe om die sleutel veilig te bewaar</value>
     <value>Diens</value>
   </data>
   <data name="AnonAddy" xml:space="preserve">
-    <value>AnonAddy</value>
-    <comment>"AnonAddy" is the product name and should not be translated.</comment>
+    <value>addy.io</value>
+    <comment>"addy.io" is the product name and should not be translated.</comment>
   </data>
   <data name="FirefoxRelay" xml:space="preserve">
     <value>Firefox Relay</value>

--- a/src/App/Resources/AppResources.af.resx
+++ b/src/App/Resources/AppResources.af.resx
@@ -2413,7 +2413,7 @@ kies u Voeg TOTP toe om die sleutel veilig te bewaar</value>
   <data name="Service" xml:space="preserve">
     <value>Diens</value>
   </data>
-  <data name="AnonAddy" xml:space="preserve">
+  <data name="AddyIo" xml:space="preserve">
     <value>addy.io</value>
     <comment>"addy.io" is the product name and should not be translated.</comment>
   </data>

--- a/src/App/Resources/AppResources.ar.resx
+++ b/src/App/Resources/AppResources.ar.resx
@@ -2414,9 +2414,9 @@
   <data name="Service" xml:space="preserve">
     <value>الخدمة</value>
   </data>
-  <data name="AnonAddy" xml:space="preserve">
-    <value>AnonAddy</value>
-    <comment>"AnonAddy" is the product name and should not be translated.</comment>
+  <data name="AddyIo" xml:space="preserve">
+    <value>addy.io</value>
+    <comment>"addy.io" is the product name and should not be translated.</comment>
   </data>
   <data name="FirefoxRelay" xml:space="preserve">
     <value>FirefoxRelay</value>

--- a/src/App/Resources/AppResources.az.resx
+++ b/src/App/Resources/AppResources.az.resx
@@ -2412,9 +2412,9 @@ Skan prosesi avtomatik baş tutacaq.</value>
   <data name="Service" xml:space="preserve">
     <value>Xidmət</value>
   </data>
-  <data name="AnonAddy" xml:space="preserve">
-    <value>AnonAddy</value>
-    <comment>"AnonAddy" is the product name and should not be translated.</comment>
+  <data name="AddyIo" xml:space="preserve">
+    <value>addy.io</value>
+    <comment>"addy.io" is the product name and should not be translated.</comment>
   </data>
   <data name="FirefoxRelay" xml:space="preserve">
     <value>Firefox Relay</value>

--- a/src/App/Resources/AppResources.be.resx
+++ b/src/App/Resources/AppResources.be.resx
@@ -2413,9 +2413,9 @@
   <data name="Service" xml:space="preserve">
     <value>Сэрвіс</value>
   </data>
-  <data name="AnonAddy" xml:space="preserve">
-    <value>AnonAddy</value>
-    <comment>"AnonAddy" is the product name and should not be translated.</comment>
+  <data name="AddyIo" xml:space="preserve">
+    <value>addy.io</value>
+    <comment>"addy.io" is the product name and should not be translated.</comment>
   </data>
   <data name="FirefoxRelay" xml:space="preserve">
     <value>Firefox Relay</value>

--- a/src/App/Resources/AppResources.bg.resx
+++ b/src/App/Resources/AppResources.bg.resx
@@ -2413,9 +2413,9 @@ select Add TOTP to store the key safely</value>
   <data name="Service" xml:space="preserve">
     <value>Услуга</value>
   </data>
-  <data name="AnonAddy" xml:space="preserve">
-    <value>AnonAddy</value>
-    <comment>"AnonAddy" is the product name and should not be translated.</comment>
+  <data name="AddyIo" xml:space="preserve">
+    <value>addy.io</value>
+    <comment>"addy.io" is the product name and should not be translated.</comment>
   </data>
   <data name="FirefoxRelay" xml:space="preserve">
     <value>Firefox Relay</value>

--- a/src/App/Resources/AppResources.bn.resx
+++ b/src/App/Resources/AppResources.bn.resx
@@ -2414,9 +2414,9 @@ select Add TOTP to store the key safely</value>
   <data name="Service" xml:space="preserve">
     <value>Service</value>
   </data>
-  <data name="AnonAddy" xml:space="preserve">
-    <value>AnonAddy</value>
-    <comment>"AnonAddy" is the product name and should not be translated.</comment>
+  <data name="AddyIo" xml:space="preserve">
+    <value>addy.io</value>
+    <comment>"addy.io" is the product name and should not be translated.</comment>
   </data>
   <data name="FirefoxRelay" xml:space="preserve">
     <value>Firefox Relay</value>

--- a/src/App/Resources/AppResources.bs.resx
+++ b/src/App/Resources/AppResources.bs.resx
@@ -2412,9 +2412,9 @@ Skeniranje će biti izvršeno automatski.</value>
   <data name="Service" xml:space="preserve">
     <value>Service</value>
   </data>
-  <data name="AnonAddy" xml:space="preserve">
-    <value>AnonAddy</value>
-    <comment>"AnonAddy" is the product name and should not be translated.</comment>
+  <data name="AddyIo" xml:space="preserve">
+    <value>addy.io</value>
+    <comment>"addy.io" is the product name and should not be translated.</comment>
   </data>
   <data name="FirefoxRelay" xml:space="preserve">
     <value>Firefox Relay</value>

--- a/src/App/Resources/AppResources.ca.resx
+++ b/src/App/Resources/AppResources.ca.resx
@@ -2413,9 +2413,9 @@ seleccioneu Afegeix TOTP per emmagatzemar la clau de manera segura</value>
   <data name="Service" xml:space="preserve">
     <value>Servei</value>
   </data>
-  <data name="AnonAddy" xml:space="preserve">
-    <value>AnonAddy</value>
-    <comment>"AnonAddy" is the product name and should not be translated.</comment>
+  <data name="AddyIo" xml:space="preserve">
+    <value>addy.io</value>
+    <comment>"addy.io" is the product name and should not be translated.</comment>
   </data>
   <data name="FirefoxRelay" xml:space="preserve">
     <value>Firefox Relay</value>

--- a/src/App/Resources/AppResources.cs.resx
+++ b/src/App/Resources/AppResources.cs.resx
@@ -2412,9 +2412,9 @@ Načtení proběhne automaticky.</value>
   <data name="Service" xml:space="preserve">
     <value>Služba</value>
   </data>
-  <data name="AnonAddy" xml:space="preserve">
-    <value>AnonAddy</value>
-    <comment>"AnonAddy" is the product name and should not be translated.</comment>
+  <data name="AddyIo" xml:space="preserve">
+    <value>addy.io</value>
+    <comment>"addy.io" is the product name and should not be translated.</comment>
   </data>
   <data name="FirefoxRelay" xml:space="preserve">
     <value>Firefox Relay</value>

--- a/src/App/Resources/AppResources.cy.resx
+++ b/src/App/Resources/AppResources.cy.resx
@@ -2414,9 +2414,9 @@ select Add TOTP to store the key safely</value>
   <data name="Service" xml:space="preserve">
     <value>Service</value>
   </data>
-  <data name="AnonAddy" xml:space="preserve">
-    <value>AnonAddy</value>
-    <comment>"AnonAddy" is the product name and should not be translated.</comment>
+  <data name="AddyIo" xml:space="preserve">
+    <value>addy.io</value>
+    <comment>"addy.io" is the product name and should not be translated.</comment>
   </data>
   <data name="FirefoxRelay" xml:space="preserve">
     <value>Firefox Relay</value>

--- a/src/App/Resources/AppResources.da.resx
+++ b/src/App/Resources/AppResources.da.resx
@@ -2413,9 +2413,9 @@ vælg Tilføj TOTP for at gemme nøglen sikkert</value>
   <data name="Service" xml:space="preserve">
     <value>Tjeneste</value>
   </data>
-  <data name="AnonAddy" xml:space="preserve">
-    <value>AnonAddy</value>
-    <comment>"AnonAddy" is the product name and should not be translated.</comment>
+  <data name="AddyIo" xml:space="preserve">
+    <value>addy.io</value>
+    <comment>"addy.io" is the product name and should not be translated.</comment>
   </data>
   <data name="FirefoxRelay" xml:space="preserve">
     <value>Firefox Relay</value>

--- a/src/App/Resources/AppResources.de.resx
+++ b/src/App/Resources/AppResources.de.resx
@@ -2412,9 +2412,9 @@ Das Scannen erfolgt automatisch.</value>
   <data name="Service" xml:space="preserve">
     <value>Dienst</value>
   </data>
-  <data name="AnonAddy" xml:space="preserve">
-    <value>AnonAddy</value>
-    <comment>"AnonAddy" is the product name and should not be translated.</comment>
+  <data name="AddyIo" xml:space="preserve">
+    <value>addy.io</value>
+    <comment>"addy.io" is the product name and should not be translated.</comment>
   </data>
   <data name="FirefoxRelay" xml:space="preserve">
     <value>Firefox Relay</value>

--- a/src/App/Resources/AppResources.el.resx
+++ b/src/App/Resources/AppResources.el.resx
@@ -2413,9 +2413,9 @@
   <data name="Service" xml:space="preserve">
     <value>Υπηρεσία</value>
   </data>
-  <data name="AnonAddy" xml:space="preserve">
-    <value>AnonAddy</value>
-    <comment>"AnonAddy" is the product name and should not be translated.</comment>
+  <data name="AddyIo" xml:space="preserve">
+    <value>addy.io</value>
+    <comment>"addy.io" is the product name and should not be translated.</comment>
   </data>
   <data name="FirefoxRelay" xml:space="preserve">
     <value>Firefox Relay</value>

--- a/src/App/Resources/AppResources.en-GB.resx
+++ b/src/App/Resources/AppResources.en-GB.resx
@@ -2413,9 +2413,9 @@ select Add TOTP to store the key safely</value>
   <data name="Service" xml:space="preserve">
     <value>Service</value>
   </data>
-  <data name="AnonAddy" xml:space="preserve">
-    <value>AnonAddy</value>
-    <comment>"AnonAddy" is the product name and should not be translated.</comment>
+  <data name="AddyIo" xml:space="preserve">
+    <value>addy.io</value>
+    <comment>"addy.io" is the product name and should not be translated.</comment>
   </data>
   <data name="FirefoxRelay" xml:space="preserve">
     <value>Firefox Relay</value>

--- a/src/App/Resources/AppResources.en-IN.resx
+++ b/src/App/Resources/AppResources.en-IN.resx
@@ -2427,9 +2427,9 @@ select Add TOTP to store the key safely</value>
   <data name="Service" xml:space="preserve">
     <value>Service</value>
   </data>
-  <data name="AnonAddy" xml:space="preserve">
-    <value>AnonAddy</value>
-    <comment>"AnonAddy" is the product name and should not be translated.</comment>
+  <data name="AddyIo" xml:space="preserve">
+    <value>addy.io</value>
+    <comment>"addy.io" is the product name and should not be translated.</comment>
   </data>
   <data name="FirefoxRelay" xml:space="preserve">
     <value>Firefox Relay</value>

--- a/src/App/Resources/AppResources.es.resx
+++ b/src/App/Resources/AppResources.es.resx
@@ -2414,9 +2414,9 @@ seleccione Agregar TOTP para almacenar la clave de forma segura</value>
   <data name="Service" xml:space="preserve">
     <value>Servicio</value>
   </data>
-  <data name="AnonAddy" xml:space="preserve">
-    <value>AnonAddy</value>
-    <comment>"AnonAddy" is the product name and should not be translated.</comment>
+  <data name="AddyIo" xml:space="preserve">
+    <value>addy.io</value>
+    <comment>"addy.io" is the product name and should not be translated.</comment>
   </data>
   <data name="FirefoxRelay" xml:space="preserve">
     <value>Firefox Relay</value>

--- a/src/App/Resources/AppResources.et.resx
+++ b/src/App/Resources/AppResources.et.resx
@@ -2413,9 +2413,9 @@ Skaneerimine toimub automaatselt.</value>
   <data name="Service" xml:space="preserve">
     <value>Teenus</value>
   </data>
-  <data name="AnonAddy" xml:space="preserve">
-    <value>AnonAddy</value>
-    <comment>"AnonAddy" is the product name and should not be translated.</comment>
+  <data name="AddyIo" xml:space="preserve">
+    <value>addy.io</value>
+    <comment>"addy.io" is the product name and should not be translated.</comment>
   </data>
   <data name="FirefoxRelay" xml:space="preserve">
     <value>Firefox Relay</value>

--- a/src/App/Resources/AppResources.eu.resx
+++ b/src/App/Resources/AppResources.eu.resx
@@ -2412,9 +2412,9 @@
   <data name="Service" xml:space="preserve">
     <value>Zerbitzua</value>
   </data>
-  <data name="AnonAddy" xml:space="preserve">
-    <value>AnonAddy</value>
-    <comment>"AnonAddy" is the product name and should not be translated.</comment>
+  <data name="AddyIo" xml:space="preserve">
+    <value>addy.io</value>
+    <comment>"addy.io" is the product name and should not be translated.</comment>
   </data>
   <data name="FirefoxRelay" xml:space="preserve">
     <value>Firefox Relay</value>

--- a/src/App/Resources/AppResources.fa.resx
+++ b/src/App/Resources/AppResources.fa.resx
@@ -2414,9 +2414,9 @@
   <data name="Service" xml:space="preserve">
     <value>سرویس</value>
   </data>
-  <data name="AnonAddy" xml:space="preserve">
-    <value>AnonAddy</value>
-    <comment>"AnonAddy" is the product name and should not be translated.</comment>
+  <data name="AddyIo" xml:space="preserve">
+    <value>addy.io</value>
+    <comment>"addy.io" is the product name and should not be translated.</comment>
   </data>
   <data name="FirefoxRelay" xml:space="preserve">
     <value>رله فایرفاکس</value>

--- a/src/App/Resources/AppResources.fi.resx
+++ b/src/App/Resources/AppResources.fi.resx
@@ -2414,9 +2414,9 @@ turvallisesti valitsemalla "Lisää TOTP"</value>
   <data name="Service" xml:space="preserve">
     <value>Palvelu</value>
   </data>
-  <data name="AnonAddy" xml:space="preserve">
-    <value>AnonAddy</value>
-    <comment>"AnonAddy" is the product name and should not be translated.</comment>
+  <data name="AddyIo" xml:space="preserve">
+    <value>addy.io</value>
+    <comment>"addy.io" is the product name and should not be translated.</comment>
   </data>
   <data name="FirefoxRelay" xml:space="preserve">
     <value>Firefox Relay</value>

--- a/src/App/Resources/AppResources.fil.resx
+++ b/src/App/Resources/AppResources.fil.resx
@@ -2414,9 +2414,9 @@ pindutin ang Magdagdag ng TOTP para ligtas na mai-store ang key</value>
   <data name="Service" xml:space="preserve">
     <value>Serbisyo</value>
   </data>
-  <data name="AnonAddy" xml:space="preserve">
-    <value>AnonAddy</value>
-    <comment>"AnonAddy" is the product name and should not be translated.</comment>
+  <data name="AddyIo" xml:space="preserve">
+    <value>addy.io</value>
+    <comment>"addy.io" is the product name and should not be translated.</comment>
   </data>
   <data name="FirefoxRelay" xml:space="preserve">
     <value>Firefox Relay</value>

--- a/src/App/Resources/AppResources.fr.resx
+++ b/src/App/Resources/AppResources.fr.resx
@@ -2414,9 +2414,9 @@ sélectionnez Ajouter TOTP pour stocker la clé en toute sécurité</value>
   <data name="Service" xml:space="preserve">
     <value>Service</value>
   </data>
-  <data name="AnonAddy" xml:space="preserve">
-    <value>AnonAddy</value>
-    <comment>"AnonAddy" is the product name and should not be translated.</comment>
+  <data name="AddyIo" xml:space="preserve">
+    <value>addy.io</value>
+    <comment>"addy.io" is the product name and should not be translated.</comment>
   </data>
   <data name="FirefoxRelay" xml:space="preserve">
     <value>Firefox Relay</value>

--- a/src/App/Resources/AppResources.gl.resx
+++ b/src/App/Resources/AppResources.gl.resx
@@ -2414,9 +2414,9 @@ select Add TOTP to store the key safely</value>
   <data name="Service" xml:space="preserve">
     <value>Service</value>
   </data>
-  <data name="AnonAddy" xml:space="preserve">
-    <value>AnonAddy</value>
-    <comment>"AnonAddy" is the product name and should not be translated.</comment>
+  <data name="AddyIo" xml:space="preserve">
+    <value>addy.io</value>
+    <comment>"addy.io" is the product name and should not be translated.</comment>
   </data>
   <data name="FirefoxRelay" xml:space="preserve">
     <value>Firefox Relay</value>

--- a/src/App/Resources/AppResources.he.resx
+++ b/src/App/Resources/AppResources.he.resx
@@ -2416,9 +2416,9 @@ select Add TOTP to store the key safely</value>
   <data name="Service" xml:space="preserve">
     <value>Service</value>
   </data>
-  <data name="AnonAddy" xml:space="preserve">
-    <value>AnonAddy</value>
-    <comment>"AnonAddy" is the product name and should not be translated.</comment>
+  <data name="AddyIo" xml:space="preserve">
+    <value>addy.io</value>
+    <comment>"addy.io" is the product name and should not be translated.</comment>
   </data>
   <data name="FirefoxRelay" xml:space="preserve">
     <value>Firefox Relay</value>

--- a/src/App/Resources/AppResources.hi.resx
+++ b/src/App/Resources/AppResources.hi.resx
@@ -2414,9 +2414,9 @@ select Add TOTP to store the key safely</value>
   <data name="Service" xml:space="preserve">
     <value>सेवा</value>
   </data>
-  <data name="AnonAddy" xml:space="preserve">
+  <data name="AddyIo" xml:space="preserve">
     <value>एननऐडी</value>
-    <comment>"AnonAddy" is the product name and should not be translated.</comment>
+    <comment>"addy.io" is the product name and should not be translated.</comment>
   </data>
   <data name="FirefoxRelay" xml:space="preserve">
     <value>फायरफॉक्स रीले</value>

--- a/src/App/Resources/AppResources.hr.resx
+++ b/src/App/Resources/AppResources.hr.resx
@@ -2411,9 +2411,9 @@
   <data name="Service" xml:space="preserve">
     <value>Usluga</value>
   </data>
-  <data name="AnonAddy" xml:space="preserve">
-    <value>AnonAddy</value>
-    <comment>"AnonAddy" is the product name and should not be translated.</comment>
+  <data name="AddyIo" xml:space="preserve">
+    <value>addy.io</value>
+    <comment>"addy.io" is the product name and should not be translated.</comment>
   </data>
   <data name="FirefoxRelay" xml:space="preserve">
     <value>Firefox Relay</value>

--- a/src/App/Resources/AppResources.hu.resx
+++ b/src/App/Resources/AppResources.hu.resx
@@ -2412,9 +2412,9 @@ TOTP hozzáadása a kulcs biztonságos tárolásához lehetőséget.</value>
   <data name="Service" xml:space="preserve">
     <value>Szolgáltatás</value>
   </data>
-  <data name="AnonAddy" xml:space="preserve">
-    <value>AnonAddy</value>
-    <comment>"AnonAddy" is the product name and should not be translated.</comment>
+  <data name="AddyIo" xml:space="preserve">
+    <value>addy.io</value>
+    <comment>"addy.io" is the product name and should not be translated.</comment>
   </data>
   <data name="FirefoxRelay" xml:space="preserve">
     <value>Firefox Relay</value>

--- a/src/App/Resources/AppResources.id.resx
+++ b/src/App/Resources/AppResources.id.resx
@@ -2413,9 +2413,9 @@ select Add TOTP to store the key safely</value>
   <data name="Service" xml:space="preserve">
     <value>Service</value>
   </data>
-  <data name="AnonAddy" xml:space="preserve">
-    <value>AnonAddy</value>
-    <comment>"AnonAddy" is the product name and should not be translated.</comment>
+  <data name="AddyIo" xml:space="preserve">
+    <value>addy.io</value>
+    <comment>"addy.io" is the product name and should not be translated.</comment>
   </data>
   <data name="FirefoxRelay" xml:space="preserve">
     <value>Firefox Relay</value>

--- a/src/App/Resources/AppResources.it.resx
+++ b/src/App/Resources/AppResources.it.resx
@@ -2413,9 +2413,9 @@ clicca Aggiungi TOTP per salvare la chiave in modo sicuro</value>
   <data name="Service" xml:space="preserve">
     <value>Servizio</value>
   </data>
-  <data name="AnonAddy" xml:space="preserve">
-    <value>AnonAddy</value>
-    <comment>"AnonAddy" is the product name and should not be translated.</comment>
+  <data name="AddyIo" xml:space="preserve">
+    <value>addy.io</value>
+    <comment>"addy.io" is the product name and should not be translated.</comment>
   </data>
   <data name="FirefoxRelay" xml:space="preserve">
     <value>FirefoxRelay</value>

--- a/src/App/Resources/AppResources.ja.resx
+++ b/src/App/Resources/AppResources.ja.resx
@@ -2413,9 +2413,9 @@
   <data name="Service" xml:space="preserve">
     <value>サービス</value>
   </data>
-  <data name="AnonAddy" xml:space="preserve">
-    <value>AnonAddy</value>
-    <comment>"AnonAddy" is the product name and should not be translated.</comment>
+  <data name="AddyIo" xml:space="preserve">
+    <value>addy.io</value>
+    <comment>"addy.io" is the product name and should not be translated.</comment>
   </data>
   <data name="FirefoxRelay" xml:space="preserve">
     <value>Firefox Relay</value>

--- a/src/App/Resources/AppResources.ka.resx
+++ b/src/App/Resources/AppResources.ka.resx
@@ -2414,9 +2414,9 @@ select Add TOTP to store the key safely</value>
   <data name="Service" xml:space="preserve">
     <value>Service</value>
   </data>
-  <data name="AnonAddy" xml:space="preserve">
-    <value>AnonAddy</value>
-    <comment>"AnonAddy" is the product name and should not be translated.</comment>
+  <data name="AddyIo" xml:space="preserve">
+    <value>addy.io</value>
+    <comment>"addy.io" is the product name and should not be translated.</comment>
   </data>
   <data name="FirefoxRelay" xml:space="preserve">
     <value>Firefox Relay</value>

--- a/src/App/Resources/AppResources.kn.resx
+++ b/src/App/Resources/AppResources.kn.resx
@@ -2414,9 +2414,9 @@ select Add TOTP to store the key safely</value>
   <data name="Service" xml:space="preserve">
     <value>Service</value>
   </data>
-  <data name="AnonAddy" xml:space="preserve">
-    <value>AnonAddy</value>
-    <comment>"AnonAddy" is the product name and should not be translated.</comment>
+  <data name="AddyIo" xml:space="preserve">
+    <value>addy.io</value>
+    <comment>"addy.io" is the product name and should not be translated.</comment>
   </data>
   <data name="FirefoxRelay" xml:space="preserve">
     <value>Firefox Relay</value>

--- a/src/App/Resources/AppResources.ko.resx
+++ b/src/App/Resources/AppResources.ko.resx
@@ -2413,9 +2413,9 @@
   <data name="Service" xml:space="preserve">
     <value>서비스</value>
   </data>
-  <data name="AnonAddy" xml:space="preserve">
-    <value>AnonAddy</value>
-    <comment>"AnonAddy" is the product name and should not be translated.</comment>
+  <data name="AddyIo" xml:space="preserve">
+    <value>addy.io</value>
+    <comment>"addy.io" is the product name and should not be translated.</comment>
   </data>
   <data name="FirefoxRelay" xml:space="preserve">
     <value>Firefox Relay</value>

--- a/src/App/Resources/AppResources.lt.resx
+++ b/src/App/Resources/AppResources.lt.resx
@@ -2414,9 +2414,9 @@ pasirinkite Pridėti TOTP, kad raktas būtų saugiai išsaugotas</value>
   <data name="Service" xml:space="preserve">
     <value>Paslauga</value>
   </data>
-  <data name="AnonAddy" xml:space="preserve">
-    <value>AnonAddy</value>
-    <comment>"AnonAddy" is the product name and should not be translated.</comment>
+  <data name="AddyIo" xml:space="preserve">
+    <value>addy.io</value>
+    <comment>"addy.io" is the product name and should not be translated.</comment>
   </data>
   <data name="FirefoxRelay" xml:space="preserve">
     <value>Firefox Relay</value>

--- a/src/App/Resources/AppResources.lv.resx
+++ b/src/App/Resources/AppResources.lv.resx
@@ -2413,9 +2413,9 @@ jāizvēlas "Pievienot TOTP", lai droši glabātu atslēgu.</value>
   <data name="Service" xml:space="preserve">
     <value>Pakalpojums</value>
   </data>
-  <data name="AnonAddy" xml:space="preserve">
-    <value>AnonAddy</value>
-    <comment>"AnonAddy" is the product name and should not be translated.</comment>
+  <data name="AddyIo" xml:space="preserve">
+    <value>addy.io</value>
+    <comment>"addy.io" is the product name and should not be translated.</comment>
   </data>
   <data name="FirefoxRelay" xml:space="preserve">
     <value>Firefox Relay</value>

--- a/src/App/Resources/AppResources.ml.resx
+++ b/src/App/Resources/AppResources.ml.resx
@@ -2413,9 +2413,9 @@ select Add TOTP to store the key safely</value>
   <data name="Service" xml:space="preserve">
     <value>Service</value>
   </data>
-  <data name="AnonAddy" xml:space="preserve">
-    <value>AnonAddy</value>
-    <comment>"AnonAddy" is the product name and should not be translated.</comment>
+  <data name="AddyIo" xml:space="preserve">
+    <value>addy.io</value>
+    <comment>"addy.io" is the product name and should not be translated.</comment>
   </data>
   <data name="FirefoxRelay" xml:space="preserve">
     <value>Firefox Relay</value>

--- a/src/App/Resources/AppResources.mr.resx
+++ b/src/App/Resources/AppResources.mr.resx
@@ -2414,9 +2414,9 @@ select Add TOTP to store the key safely</value>
   <data name="Service" xml:space="preserve">
     <value>Service</value>
   </data>
-  <data name="AnonAddy" xml:space="preserve">
-    <value>AnonAddy</value>
-    <comment>"AnonAddy" is the product name and should not be translated.</comment>
+  <data name="AddyIo" xml:space="preserve">
+    <value>addy.io</value>
+    <comment>"addy.io" is the product name and should not be translated.</comment>
   </data>
   <data name="FirefoxRelay" xml:space="preserve">
     <value>Firefox Relay</value>

--- a/src/App/Resources/AppResources.my.resx
+++ b/src/App/Resources/AppResources.my.resx
@@ -2414,9 +2414,9 @@ select Add TOTP to store the key safely</value>
   <data name="Service" xml:space="preserve">
     <value>Service</value>
   </data>
-  <data name="AnonAddy" xml:space="preserve">
-    <value>AnonAddy</value>
-    <comment>"AnonAddy" is the product name and should not be translated.</comment>
+  <data name="AddyIo" xml:space="preserve">
+    <value>addy.io</value>
+    <comment>"addy.io" is the product name and should not be translated.</comment>
   </data>
   <data name="FirefoxRelay" xml:space="preserve">
     <value>Firefox Relay</value>

--- a/src/App/Resources/AppResources.nb.resx
+++ b/src/App/Resources/AppResources.nb.resx
@@ -2414,9 +2414,9 @@ velg Legg til TOTP for å lagre nøkkelen sikkert</value>
   <data name="Service" xml:space="preserve">
     <value>Tjeneste</value>
   </data>
-  <data name="AnonAddy" xml:space="preserve">
-    <value>AnonAddy</value>
-    <comment>"AnonAddy" is the product name and should not be translated.</comment>
+  <data name="AddyIo" xml:space="preserve">
+    <value>addy.io</value>
+    <comment>"addy.io" is the product name and should not be translated.</comment>
   </data>
   <data name="FirefoxRelay" xml:space="preserve">
     <value>Firefox Relay</value>

--- a/src/App/Resources/AppResources.ne.resx
+++ b/src/App/Resources/AppResources.ne.resx
@@ -2414,9 +2414,9 @@ select Add TOTP to store the key safely</value>
   <data name="Service" xml:space="preserve">
     <value>Service</value>
   </data>
-  <data name="AnonAddy" xml:space="preserve">
-    <value>AnonAddy</value>
-    <comment>"AnonAddy" is the product name and should not be translated.</comment>
+  <data name="AddyIo" xml:space="preserve">
+    <value>addy.io</value>
+    <comment>"addy.io" is the product name and should not be translated.</comment>
   </data>
   <data name="FirefoxRelay" xml:space="preserve">
     <value>Firefox Relay</value>

--- a/src/App/Resources/AppResources.nl.resx
+++ b/src/App/Resources/AppResources.nl.resx
@@ -2413,9 +2413,9 @@ kies je TOTP toevoegen om de sleutel veilig op te slaan</value>
   <data name="Service" xml:space="preserve">
     <value>Dienst</value>
   </data>
-  <data name="AnonAddy" xml:space="preserve">
-    <value>AnonAddy</value>
-    <comment>"AnonAddy" is the product name and should not be translated.</comment>
+  <data name="AddyIo" xml:space="preserve">
+    <value>addy.io</value>
+    <comment>"addy.io" is the product name and should not be translated.</comment>
   </data>
   <data name="FirefoxRelay" xml:space="preserve">
     <value>Firefox Relay</value>

--- a/src/App/Resources/AppResources.nn.resx
+++ b/src/App/Resources/AppResources.nn.resx
@@ -2414,9 +2414,9 @@ select Add TOTP to store the key safely</value>
   <data name="Service" xml:space="preserve">
     <value>Service</value>
   </data>
-  <data name="AnonAddy" xml:space="preserve">
-    <value>AnonAddy</value>
-    <comment>"AnonAddy" is the product name and should not be translated.</comment>
+  <data name="AddyIo" xml:space="preserve">
+    <value>addy.io</value>
+    <comment>"addy.io" is the product name and should not be translated.</comment>
   </data>
   <data name="FirefoxRelay" xml:space="preserve">
     <value>Firefox Relay</value>

--- a/src/App/Resources/AppResources.or.resx
+++ b/src/App/Resources/AppResources.or.resx
@@ -2414,9 +2414,9 @@ select Add TOTP to store the key safely</value>
   <data name="Service" xml:space="preserve">
     <value>Service</value>
   </data>
-  <data name="AnonAddy" xml:space="preserve">
-    <value>AnonAddy</value>
-    <comment>"AnonAddy" is the product name and should not be translated.</comment>
+  <data name="AddyIo" xml:space="preserve">
+    <value>addy.io</value>
+    <comment>"addy.io" is the product name and should not be translated.</comment>
   </data>
   <data name="FirefoxRelay" xml:space="preserve">
     <value>Firefox Relay</value>

--- a/src/App/Resources/AppResources.pl.resx
+++ b/src/App/Resources/AppResources.pl.resx
@@ -2413,9 +2413,9 @@ wybierz Dodaj TOTP, aby bezpiecznie przechowywać klucz</value>
   <data name="Service" xml:space="preserve">
     <value>Usługa</value>
   </data>
-  <data name="AnonAddy" xml:space="preserve">
-    <value>AnonAddy</value>
-    <comment>"AnonAddy" is the product name and should not be translated.</comment>
+  <data name="AddyIo" xml:space="preserve">
+    <value>addy.io</value>
+    <comment>"addy.io" is the product name and should not be translated.</comment>
   </data>
   <data name="FirefoxRelay" xml:space="preserve">
     <value>Firefox Relay</value>

--- a/src/App/Resources/AppResources.pt-BR.resx
+++ b/src/App/Resources/AppResources.pt-BR.resx
@@ -2414,9 +2414,9 @@ selecione Adicionar TOTP para armazenar a chave de forma segura</value>
   <data name="Service" xml:space="preserve">
     <value>Serviço</value>
   </data>
-  <data name="AnonAddy" xml:space="preserve">
-    <value>AnonAddy</value>
-    <comment>"AnonAddy" is the product name and should not be translated.</comment>
+  <data name="AddyIo" xml:space="preserve">
+    <value>addy.io</value>
+    <comment>"addy.io" is the product name and should not be translated.</comment>
   </data>
   <data name="FirefoxRelay" xml:space="preserve">
     <value>Firefox Relay</value>

--- a/src/App/Resources/AppResources.pt-PT.resx
+++ b/src/App/Resources/AppResources.pt-PT.resx
@@ -2412,9 +2412,9 @@ A leitura será efetuada automaticamente.</value>
   <data name="Service" xml:space="preserve">
     <value>Serviço</value>
   </data>
-  <data name="AnonAddy" xml:space="preserve">
-    <value>AnonAddy</value>
-    <comment>"AnonAddy" is the product name and should not be translated.</comment>
+  <data name="AddyIo" xml:space="preserve">
+    <value>addy.io</value>
+    <comment>"addy.io" is the product name and should not be translated.</comment>
   </data>
   <data name="FirefoxRelay" xml:space="preserve">
     <value>Firefox Relay</value>

--- a/src/App/Resources/AppResources.resx
+++ b/src/App/Resources/AppResources.resx
@@ -2414,9 +2414,9 @@ select Add TOTP to store the key safely</value>
   <data name="Service" xml:space="preserve">
     <value>Service</value>
   </data>
-  <data name="AnonAddy" xml:space="preserve">
-    <value>AnonAddy</value>
-    <comment>"AnonAddy" is the product name and should not be translated.</comment>
+  <data name="AddyIo" xml:space="preserve">
+    <value>addy.io</value>
+    <comment>"addy.io" is the product name and should not be translated.</comment>
   </data>
   <data name="FirefoxRelay" xml:space="preserve">
     <value>Firefox Relay</value>

--- a/src/App/Resources/AppResources.ro.resx
+++ b/src/App/Resources/AppResources.ro.resx
@@ -2413,9 +2413,9 @@ selectați „Adăugare TOTP” pentru a stoca cheia în siguranță</value>
   <data name="Service" xml:space="preserve">
     <value>Serviciu</value>
   </data>
-  <data name="AnonAddy" xml:space="preserve">
-    <value>AnonAddy</value>
-    <comment>"AnonAddy" is the product name and should not be translated.</comment>
+  <data name="AddyIo" xml:space="preserve">
+    <value>addy.io</value>
+    <comment>"addy.io" is the product name and should not be translated.</comment>
   </data>
   <data name="FirefoxRelay" xml:space="preserve">
     <value>Firefox Relay</value>

--- a/src/App/Resources/AppResources.ru.resx
+++ b/src/App/Resources/AppResources.ru.resx
@@ -2413,9 +2413,9 @@
   <data name="Service" xml:space="preserve">
     <value>Служба</value>
   </data>
-  <data name="AnonAddy" xml:space="preserve">
-    <value>AnonAddy</value>
-    <comment>"AnonAddy" is the product name and should not be translated.</comment>
+  <data name="AddyIo" xml:space="preserve">
+    <value>addy.io</value>
+    <comment>"addy.io" is the product name and should not be translated.</comment>
   </data>
   <data name="FirefoxRelay" xml:space="preserve">
     <value>Firefox Relay</value>

--- a/src/App/Resources/AppResources.si.resx
+++ b/src/App/Resources/AppResources.si.resx
@@ -2414,9 +2414,9 @@ select Add TOTP to store the key safely</value>
   <data name="Service" xml:space="preserve">
     <value>Service</value>
   </data>
-  <data name="AnonAddy" xml:space="preserve">
-    <value>AnonAddy</value>
-    <comment>"AnonAddy" is the product name and should not be translated.</comment>
+  <data name="AddyIo" xml:space="preserve">
+    <value>addy.io</value>
+    <comment>"addy.io" is the product name and should not be translated.</comment>
   </data>
   <data name="FirefoxRelay" xml:space="preserve">
     <value>Firefox Relay</value>

--- a/src/App/Resources/AppResources.sk.resx
+++ b/src/App/Resources/AppResources.sk.resx
@@ -2413,9 +2413,9 @@ Pridať TOTP, aby ste kľúč bezpečne uložili</value>
   <data name="Service" xml:space="preserve">
     <value>Služba</value>
   </data>
-  <data name="AnonAddy" xml:space="preserve">
-    <value>AnonAddy</value>
-    <comment>"AnonAddy" is the product name and should not be translated.</comment>
+  <data name="AddyIo" xml:space="preserve">
+    <value>addy.io</value>
+    <comment>"addy.io" is the product name and should not be translated.</comment>
   </data>
   <data name="FirefoxRelay" xml:space="preserve">
     <value>Firefox Relay</value>

--- a/src/App/Resources/AppResources.sl.resx
+++ b/src/App/Resources/AppResources.sl.resx
@@ -2413,9 +2413,9 @@ select Add TOTP to store the key safely</value>
   <data name="Service" xml:space="preserve">
     <value>Service</value>
   </data>
-  <data name="AnonAddy" xml:space="preserve">
-    <value>AnonAddy</value>
-    <comment>"AnonAddy" is the product name and should not be translated.</comment>
+  <data name="AddyIo" xml:space="preserve">
+    <value>addy.io</value>
+    <comment>"addy.io" is the product name and should not be translated.</comment>
   </data>
   <data name="FirefoxRelay" xml:space="preserve">
     <value>Firefox Relay</value>

--- a/src/App/Resources/AppResources.sr.resx
+++ b/src/App/Resources/AppResources.sr.resx
@@ -2415,9 +2415,9 @@
   <data name="Service" xml:space="preserve">
     <value>Сервис</value>
   </data>
-  <data name="AnonAddy" xml:space="preserve">
-    <value>AnonAddy</value>
-    <comment>"AnonAddy" is the product name and should not be translated.</comment>
+  <data name="AddyIo" xml:space="preserve">
+    <value>addy.io</value>
+    <comment>"addy.io" is the product name and should not be translated.</comment>
   </data>
   <data name="FirefoxRelay" xml:space="preserve">
     <value>Firefox Relay</value>

--- a/src/App/Resources/AppResources.sv.resx
+++ b/src/App/Resources/AppResources.sv.resx
@@ -2415,9 +2415,9 @@ välj Lägg till TOTP för att lagra nyckeln på ett säkert sätt</value>
   <data name="Service" xml:space="preserve">
     <value>Tjänst</value>
   </data>
-  <data name="AnonAddy" xml:space="preserve">
-    <value>AnonAddy</value>
-    <comment>"AnonAddy" is the product name and should not be translated.</comment>
+  <data name="AddyIo" xml:space="preserve">
+    <value>addy.io</value>
+    <comment>"addy.io" is the product name and should not be translated.</comment>
   </data>
   <data name="FirefoxRelay" xml:space="preserve">
     <value>Firefox Relay</value>

--- a/src/App/Resources/AppResources.ta.resx
+++ b/src/App/Resources/AppResources.ta.resx
@@ -2414,9 +2414,9 @@
   <data name="Service" xml:space="preserve">
     <value>சேவை</value>
   </data>
-  <data name="AnonAddy" xml:space="preserve">
-    <value>AnonAddy</value>
-    <comment>"AnonAddy" is the product name and should not be translated.</comment>
+  <data name="AddyIo" xml:space="preserve">
+    <value>addy.io</value>
+    <comment>"addy.io" is the product name and should not be translated.</comment>
   </data>
   <data name="FirefoxRelay" xml:space="preserve">
     <value>Firefox Relay</value>

--- a/src/App/Resources/AppResources.te.resx
+++ b/src/App/Resources/AppResources.te.resx
@@ -2414,9 +2414,9 @@ select Add TOTP to store the key safely</value>
   <data name="Service" xml:space="preserve">
     <value>Service</value>
   </data>
-  <data name="AnonAddy" xml:space="preserve">
-    <value>AnonAddy</value>
-    <comment>"AnonAddy" is the product name and should not be translated.</comment>
+  <data name="AddyIo" xml:space="preserve">
+    <value>addy.io</value>
+    <comment>"addy.io" is the product name and should not be translated.</comment>
   </data>
   <data name="FirefoxRelay" xml:space="preserve">
     <value>Firefox Relay</value>

--- a/src/App/Resources/AppResources.th.resx
+++ b/src/App/Resources/AppResources.th.resx
@@ -2421,9 +2421,9 @@ select Add TOTP to store the key safely</value>
   <data name="Service" xml:space="preserve">
     <value>Service</value>
   </data>
-  <data name="AnonAddy" xml:space="preserve">
-    <value>AnonAddy</value>
-    <comment>"AnonAddy" is the product name and should not be translated.</comment>
+  <data name="AddyIo" xml:space="preserve">
+    <value>addy.io</value>
+    <comment>"addy.io" is the product name and should not be translated.</comment>
   </data>
   <data name="FirefoxRelay" xml:space="preserve">
     <value>Firefox Relay</value>

--- a/src/App/Resources/AppResources.tr.resx
+++ b/src/App/Resources/AppResources.tr.resx
@@ -2412,9 +2412,9 @@ Kod otomatik olarak taranacaktır.</value>
   <data name="Service" xml:space="preserve">
     <value>Servis</value>
   </data>
-  <data name="AnonAddy" xml:space="preserve">
-    <value>AnonAddy</value>
-    <comment>"AnonAddy" is the product name and should not be translated.</comment>
+  <data name="AddyIo" xml:space="preserve">
+    <value>addy.io</value>
+    <comment>"addy.io" is the product name and should not be translated.</comment>
   </data>
   <data name="FirefoxRelay" xml:space="preserve">
     <value>Firefox Relay</value>

--- a/src/App/Resources/AppResources.uk.resx
+++ b/src/App/Resources/AppResources.uk.resx
@@ -2413,9 +2413,9 @@
   <data name="Service" xml:space="preserve">
     <value>Послуга</value>
   </data>
-  <data name="AnonAddy" xml:space="preserve">
-    <value>AnonAddy</value>
-    <comment>"AnonAddy" is the product name and should not be translated.</comment>
+  <data name="AddyIo" xml:space="preserve">
+    <value>addy.io</value>
+    <comment>"addy.io" is the product name and should not be translated.</comment>
   </data>
   <data name="FirefoxRelay" xml:space="preserve">
     <value>Firefox Relay</value>

--- a/src/App/Resources/AppResources.vi.resx
+++ b/src/App/Resources/AppResources.vi.resx
@@ -2413,9 +2413,9 @@ chọn Thêm TOTP để lưu khóa an toàn</value>
   <data name="Service" xml:space="preserve">
     <value>Dịch vụ</value>
   </data>
-  <data name="AnonAddy" xml:space="preserve">
-    <value>AnonAddy</value>
-    <comment>"AnonAddy" is the product name and should not be translated.</comment>
+  <data name="AddyIo" xml:space="preserve">
+    <value>addy.io</value>
+    <comment>"addy.io" is the product name and should not be translated.</comment>
   </data>
   <data name="FirefoxRelay" xml:space="preserve">
     <value>Firefox Relay</value>

--- a/src/App/Resources/AppResources.zh-Hans.resx
+++ b/src/App/Resources/AppResources.zh-Hans.resx
@@ -2413,9 +2413,9 @@
   <data name="Service" xml:space="preserve">
     <value>服务</value>
   </data>
-  <data name="AnonAddy" xml:space="preserve">
-    <value>AnonAddy</value>
-    <comment>"AnonAddy" is the product name and should not be translated.</comment>
+  <data name="AddyIo" xml:space="preserve">
+    <value>addy.io</value>
+    <comment>"addy.io" is the product name and should not be translated.</comment>
   </data>
   <data name="FirefoxRelay" xml:space="preserve">
     <value>Firefox Relay</value>

--- a/src/App/Resources/AppResources.zh-Hant.resx
+++ b/src/App/Resources/AppResources.zh-Hant.resx
@@ -2413,9 +2413,9 @@
   <data name="Service" xml:space="preserve">
     <value>服務</value>
   </data>
-  <data name="AnonAddy" xml:space="preserve">
-    <value>AnonAddy</value>
-    <comment>"AnonAddy" is the product name and should not be translated.</comment>
+  <data name="AddyIo" xml:space="preserve">
+    <value>addy.io</value>
+    <comment>"addy.io" is the product name and should not be translated.</comment>
   </data>
   <data name="FirefoxRelay" xml:space="preserve">
     <value>Firefox Relay</value>

--- a/src/Core/Enums/ForwardedEmailServiceType.cs
+++ b/src/Core/Enums/ForwardedEmailServiceType.cs
@@ -6,7 +6,7 @@ namespace Bit.Core.Enums
     {
         None = -1,
         [LocalizableEnum("AddyIo")]
-        AddyIo = 0,
+        AnonAddy = 0,
         [LocalizableEnum("FirefoxRelay")]
         FirefoxRelay = 1,
         [LocalizableEnum("SimpleLogin")]

--- a/src/Core/Enums/ForwardedEmailServiceType.cs
+++ b/src/Core/Enums/ForwardedEmailServiceType.cs
@@ -5,8 +5,8 @@ namespace Bit.Core.Enums
     public enum ForwardedEmailServiceType
     {
         None = -1,
-        [LocalizableEnum("AnonAddy")]
-        AnonAddy = 0,
+        [LocalizableEnum("AddyIo")]
+        AddyIo = 0,
         [LocalizableEnum("FirefoxRelay")]
         FirefoxRelay = 1,
         [LocalizableEnum("SimpleLogin")]

--- a/src/Core/Models/Domain/UsernameGenerationOptions.cs
+++ b/src/Core/Models/Domain/UsernameGenerationOptions.cs
@@ -22,8 +22,8 @@ namespace Bit.Core.Models.Domain
         public string SimpleLoginApiKey { get; set; }
         public string DuckDuckGoApiKey { get; set; }
         public string FastMailApiKey { get; set; }
-        public string AddyIoApiAccessToken { get; set; }
-        public string AddyIoDomainName { get; set; }
+        public string AnonAddyApiAccessToken { get; set; }
+        public string AnonAddyDomainName { get; set; }
         public string EmailWebsite { get; set; }
 
         public ForwarderOptions GetForwarderOptions()
@@ -35,11 +35,11 @@ namespace Bit.Core.Models.Domain
 
             switch (ServiceType)
             {
-                case ForwardedEmailServiceType.AddyIo:
-                    return new AddyIoForwarderOptions
+                case ForwardedEmailServiceType.AnonAddy:
+                    return new AnonAddyForwarderOptions
                     {
-                        ApiKey = AddyIoApiAccessToken,
-                        DomainName = AddyIoDomainName
+                        ApiKey = AnonAddyApiAccessToken,
+                        DomainName = AnonAddyDomainName
                     };
                 case ForwardedEmailServiceType.DuckDuckGo:
                     return new ForwarderOptions { ApiKey = DuckDuckGoApiKey };

--- a/src/Core/Models/Domain/UsernameGenerationOptions.cs
+++ b/src/Core/Models/Domain/UsernameGenerationOptions.cs
@@ -22,8 +22,8 @@ namespace Bit.Core.Models.Domain
         public string SimpleLoginApiKey { get; set; }
         public string DuckDuckGoApiKey { get; set; }
         public string FastMailApiKey { get; set; }
-        public string AnonAddyApiAccessToken { get; set; }
-        public string AnonAddyDomainName { get; set; }
+        public string AddyIoApiAccessToken { get; set; }
+        public string AddyIoDomainName { get; set; }
         public string EmailWebsite { get; set; }
 
         public ForwarderOptions GetForwarderOptions()
@@ -35,11 +35,11 @@ namespace Bit.Core.Models.Domain
 
             switch (ServiceType)
             {
-                case ForwardedEmailServiceType.AnonAddy:
-                    return new AnonAddyForwarderOptions
+                case ForwardedEmailServiceType.AddyIo:
+                    return new AddyIoForwarderOptions
                     {
-                        ApiKey = AnonAddyApiAccessToken,
-                        DomainName = AnonAddyDomainName
+                        ApiKey = AddyIoApiAccessToken,
+                        DomainName = AddyIoDomainName
                     };
                 case ForwardedEmailServiceType.DuckDuckGo:
                     return new ForwarderOptions { ApiKey = DuckDuckGoApiKey };

--- a/src/Core/Services/EmailForwarders/AddyIoForwarder.cs
+++ b/src/Core/Services/EmailForwarders/AddyIoForwarder.cs
@@ -7,26 +7,26 @@ using Newtonsoft.Json.Linq;
 
 namespace Bit.Core.Services.EmailForwarders
 {
-    public class AnonAddyForwarderOptions : ForwarderOptions
+    public class AddyIoForwarderOptions : ForwarderOptions
     {
         public string DomainName { get; set; }
     }
 
-    public class AnonAddyForwarder : BaseForwarder<AnonAddyForwarderOptions>
+    public class AddyIoForwarder : BaseForwarder<AddyIoForwarderOptions>
     {
-        protected override string RequestUri => "https://app.anonaddy.com/api/v1/aliases";
+        protected override string RequestUri => "https://app.addy.io/api/v1/aliases";
 
-        protected override bool CanGenerate(AnonAddyForwarderOptions options)
+        protected override bool CanGenerate(AddyIoForwarderOptions options)
         {
             return !string.IsNullOrWhiteSpace(options.ApiKey) && !string.IsNullOrWhiteSpace(options.DomainName);
         }
 
-        protected override void ConfigureHeaders(HttpRequestHeaders headers, AnonAddyForwarderOptions options)
+        protected override void ConfigureHeaders(HttpRequestHeaders headers, AddyIoForwarderOptions options)
         {
             headers.Add("Authorization", $"Bearer {options.ApiKey}");
         }
 
-        protected override Task<HttpContent> GetContentAsync(IApiService apiService, AnonAddyForwarderOptions options)
+        protected override Task<HttpContent> GetContentAsync(IApiService apiService, AddyIoForwarderOptions options)
         {
             return Task.FromResult<HttpContent>(new FormUrlEncodedContent(new Dictionary<string, string>
             {

--- a/src/Core/Services/EmailForwarders/AnonAddyForwarder.cs
+++ b/src/Core/Services/EmailForwarders/AnonAddyForwarder.cs
@@ -7,26 +7,26 @@ using Newtonsoft.Json.Linq;
 
 namespace Bit.Core.Services.EmailForwarders
 {
-    public class AddyIoForwarderOptions : ForwarderOptions
+    public class AnonAddyForwarderOptions : ForwarderOptions
     {
         public string DomainName { get; set; }
     }
 
-    public class AddyIoForwarder : BaseForwarder<AddyIoForwarderOptions>
+    public class AnonAddyForwarder : BaseForwarder<AnonAddyForwarderOptions>
     {
         protected override string RequestUri => "https://app.addy.io/api/v1/aliases";
 
-        protected override bool CanGenerate(AddyIoForwarderOptions options)
+        protected override bool CanGenerate(AnonAddyForwarderOptions options)
         {
             return !string.IsNullOrWhiteSpace(options.ApiKey) && !string.IsNullOrWhiteSpace(options.DomainName);
         }
 
-        protected override void ConfigureHeaders(HttpRequestHeaders headers, AddyIoForwarderOptions options)
+        protected override void ConfigureHeaders(HttpRequestHeaders headers, AnonAddyForwarderOptions options)
         {
             headers.Add("Authorization", $"Bearer {options.ApiKey}");
         }
 
-        protected override Task<HttpContent> GetContentAsync(IApiService apiService, AddyIoForwarderOptions options)
+        protected override Task<HttpContent> GetContentAsync(IApiService apiService, AnonAddyForwarderOptions options)
         {
             return Task.FromResult<HttpContent>(new FormUrlEncodedContent(new Dictionary<string, string>
             {

--- a/src/Core/Services/UsernameGenerationService.cs
+++ b/src/Core/Services/UsernameGenerationService.cs
@@ -135,10 +135,10 @@ namespace Bit.Core.Services
 
         private async Task<string> GenerateForwardedEmailAliasAsync(UsernameGenerationOptions options)
         {
-            if (options.ServiceType == ForwardedEmailServiceType.AnonAddy)
+            if (options.ServiceType == ForwardedEmailServiceType.AddyIo)
             {
-                return await new AnonAddyForwarder()
-                                    .GenerateAsync(_apiService, (AnonAddyForwarderOptions)options.GetForwarderOptions());
+                return await new AddyIoForwarder()
+                                    .GenerateAsync(_apiService, (AddyIoForwarderOptions)options.GetForwarderOptions());
             }
 
             BaseForwarder<ForwarderOptions> simpleForwarder = null;

--- a/src/Core/Services/UsernameGenerationService.cs
+++ b/src/Core/Services/UsernameGenerationService.cs
@@ -135,10 +135,10 @@ namespace Bit.Core.Services
 
         private async Task<string> GenerateForwardedEmailAliasAsync(UsernameGenerationOptions options)
         {
-            if (options.ServiceType == ForwardedEmailServiceType.AddyIo)
+            if (options.ServiceType == ForwardedEmailServiceType.AnonAddy)
             {
-                return await new AddyIoForwarder()
-                                    .GenerateAsync(_apiService, (AddyIoForwarderOptions)options.GetForwarderOptions());
+                return await new AnonAddyForwarder()
+                                    .GenerateAsync(_apiService, (AnonAddyForwarderOptions)options.GetForwarderOptions());
             }
 
             BaseForwarder<ForwarderOptions> simpleForwarder = null;


### PR DESCRIPTION
## Type of change

```
- [ ] Bug fix
- [ ] New feature development
- [] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [X] Other
```

## Objective

To use the new API URL for addy.io and update the name after the rebrand - [https://addy.io/blog/anonaddy-has-rebranded-as-addy-io/](https://addy.io/blog/anonaddy-has-rebranded-as-addy-io/).

## Code changes

- Updated API URL to `https://app.addy.io/api/v1/aliases`.
- Updated translations and references to from `AnonAddy` to `AddyIo`.

The only translation value I haven't updated is the Hindi one as I'm not sure how you translated it - https://github.com/bitwarden/mobile/blob/master/src/App/Resources/AppResources.hi.resx#L2418

I have not built and tested these changes myself.