### PR TITLE
fix for TDE pref naming collision

### DIFF
--- a/src/Core/Constants.cs
+++ b/src/Core/Constants.cs
@@ -86,8 +86,8 @@ namespace Bit.Core
         public static string VaultTimeoutKey(string userId) => $"vaultTimeout_{userId}";
         public static string VaultTimeoutActionKey(string userId) => $"vaultTimeoutAction_{userId}";
         public static string MasterKeyEncryptedUserKeyKey(string userId) => $"masterKeyEncryptedUserKey_{userId}";
-        public static string UserKeyAutoUnlockKey(string userId) => $"autoUnlock_{userId}";
-        public static string UserKeyBiometricUnlockKey(string userId) => $"biometricUnlock_{userId}";
+        public static string UserKeyAutoUnlockKey(string userId) => $"userKeyAutoUnlock_{userId}";
+        public static string UserKeyBiometricUnlockKey(string userId) => $"UserKeyBiometricUnlock_{userId}";
         public static string CiphersKey(string userId) => $"ciphers_{userId}";
         public static string FoldersKey(string userId) => $"folders_{userId}";
         public static string CollectionsKey(string userId) => $"collections_{userId}";

--- a/src/Core/Constants.cs
+++ b/src/Core/Constants.cs
@@ -87,7 +87,7 @@ namespace Bit.Core
         public static string VaultTimeoutActionKey(string userId) => $"vaultTimeoutAction_{userId}";
         public static string MasterKeyEncryptedUserKeyKey(string userId) => $"masterKeyEncryptedUserKey_{userId}";
         public static string UserKeyAutoUnlockKey(string userId) => $"userKeyAutoUnlock_{userId}";
-        public static string UserKeyBiometricUnlockKey(string userId) => $"UserKeyBiometricUnlock_{userId}";
+        public static string UserKeyBiometricUnlockKey(string userId) => $"userKeyBiometricUnlock_{userId}";
         public static string CiphersKey(string userId) => $"ciphers_{userId}";
         public static string FoldersKey(string userId) => $"folders_{userId}";
         public static string CollectionsKey(string userId) => $"collections_{userId}";


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
`UserKeyBiometricUnlockKey` was defined as `biometricUnlock_{userId}` which was already used for `BiometricUnlockKey`.  It has been changed to `userKeyBiometricUnlock_{userId}`.  For sanity `UserKeyAutoUnlockKey` was also changed to `userKeyAutoUnlock_{userId}`.

**Note:** I did not add migration as this feature has not shipped yet.  QA should clear app data before resuming testing.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **Constants.cs:** Fixed values described above

## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
