### PR TITLE
[PM-3593] Autofill: user with no MP not able to biometrics

### DIFF
--- a/src/iOS.Core/Controllers/BaseLockPasswordViewController.cs
+++ b/src/iOS.Core/Controllers/BaseLockPasswordViewController.cs
@@ -118,11 +118,15 @@ namespace Bit.iOS.Core.Controllers
                     _pinStatus == PinLockType.Persistent;
 
                 _biometricEnabled = await _vaultTimeoutService.IsBiometricLockSetAsync()
-                    && await _cryptoService.HasEncryptedUserKeyAsync();
-                _biometricIntegrityValid =
-                    await _platformUtilsService.IsBiometricIntegrityValidAsync(BiometricIntegritySourceKey);
+                    && await _biometricService.CanUseBiometricsUnlockAsync();
                 _hasMasterPassword = await _userVerificationService.HasMasterPasswordAsync();
                 _biometricUnlockOnly = !_hasMasterPassword && _biometricEnabled && !_pinEnabled;
+
+                if (_biometricUnlockOnly)
+                {
+                    await EnableBiometricsIfNeeded();
+                }
+                _biometricIntegrityValid = await _platformUtilsService.IsBiometricIntegrityValidAsync(BiometricIntegritySourceKey);
             }
 
             if (_pinEnabled)


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
When a user with no MP and biometrics enabled attempts to autofill, the user is prompted to log in via SSO instead of biometrics.

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->
Start the enable biometrics on iOS extension when biometric is the only login method besides SSO.

## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
