### PR TITLE
[PM-3551] Expired SSO token cached

### DIFF
--- a/src/App/Pages/Accounts/LoginSsoPageViewModel.cs
+++ b/src/App/Pages/Accounts/LoginSsoPageViewModel.cs
@@ -34,7 +34,7 @@ namespace Bit.App.Pages
         private readonly ICryptoService _cryptoService;
 
         private string _orgIdentifier;
-        private bool _useEphemeralWebBrowserSession = false;
+        private bool _useEphemeralWebBrowserSession;
 
         public LoginSsoPageViewModel()
         {

--- a/src/App/Pages/Accounts/LoginSsoPageViewModel.cs
+++ b/src/App/Pages/Accounts/LoginSsoPageViewModel.cs
@@ -34,6 +34,7 @@ namespace Bit.App.Pages
         private readonly ICryptoService _cryptoService;
 
         private string _orgIdentifier;
+        private bool _useEphemeralWebBrowserSession = false;
 
         public LoginSsoPageViewModel()
         {
@@ -145,9 +146,12 @@ namespace Bit.App.Pages
                           "ssoToken=" + Uri.EscapeDataString(ssoToken);
 
                 WebAuthenticatorResult authResult = null;
-
-                authResult = await WebAuthenticator.AuthenticateAsync(new Uri(url),
-                    new Uri(REDIRECT_URI));
+                authResult = await WebAuthenticator.AuthenticateAsync(new WebAuthenticatorOptions()
+                {
+                    CallbackUrl = new Uri(REDIRECT_URI),
+                    Url = new Uri(url),
+                    PrefersEphemeralWebBrowserSession = _useEphemeralWebBrowserSession,
+                });
 
                 var code = GetResultCode(authResult, state);
                 if (!string.IsNullOrEmpty(code))
@@ -172,6 +176,8 @@ namespace Bit.App.Pages
             {
                 // user canceled
                 await _deviceActionService.HideLoadingAsync();
+                // Workaroung for cached expired sso token PM-3551 
+                _useEphemeralWebBrowserSession = true;
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Fix bug where an expired sso token is cached by the mobile browser and the user cannot continue the sso login flow.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->
When a user cancels the modal, we will start a cached cleared browser session to login.

## Screenshots
<!--Required for any UI changes. Delete if not applicable-->



## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
