### PR TITLE
[PM-3382] User cannot select Email as a secondary 2FA option following SSO

### DIFF
--- a/src/App/Pages/Accounts/TwoFactorPageViewModel.cs
+++ b/src/App/Pages/Accounts/TwoFactorPageViewModel.cs
@@ -466,7 +466,8 @@ namespace Bit.App.Pages
                 {
                     Email = _authService.Email,
                     MasterPasswordHash = _authService.MasterPasswordHash,
-                    DeviceIdentifier = await _appIdService.GetAppIdAsync()
+                    DeviceIdentifier = await _appIdService.GetAppIdAsync(),
+                    SsoEmail2FaSessionToken =  _authService.SsoEmail2FaSessionToken
                 };
                 await _apiService.PostTwoFactorEmailAsync(request);
                 if (showLoading)

--- a/src/Core/Abstractions/IAuthService.cs
+++ b/src/Core/Abstractions/IAuthService.cs
@@ -15,6 +15,7 @@ namespace Bit.Core.Abstractions
         string Code { get; set; }
         string CodeVerifier { get; set; }
         string SsoRedirectUrl { get; set; }
+        string SsoEmail2FaSessionToken { get; set; }
         TwoFactorProviderType? SelectedTwoFactorProviderType { get; set; }
         Dictionary<TwoFactorProviderType, TwoFactorProvider> TwoFactorProviders { get; set; }
         Dictionary<TwoFactorProviderType, Dictionary<string, object>> TwoFactorProvidersData { get; set; }

--- a/src/Core/Models/Request/TwoFactorEmailRequest.cs
+++ b/src/Core/Models/Request/TwoFactorEmailRequest.cs
@@ -5,5 +5,6 @@
         public string Email { get; set; }
         public string MasterPasswordHash { get; set; }
         public string DeviceIdentifier { get; set; }
+        public string SsoEmail2FaSessionToken { get; set; }
     }
 }

--- a/src/Core/Models/Response/IdentityTwoFactorResponse.cs
+++ b/src/Core/Models/Response/IdentityTwoFactorResponse.cs
@@ -12,5 +12,7 @@ namespace Bit.Core.Models.Response
         public MasterPasswordPolicyOptions MasterPasswordPolicy { get; set; }
         [JsonProperty("CaptchaBypassToken")]
         public string CaptchaToken { get; set; }
+        public string SsoEmail2faSessionToken { get; set; }
+        public string Email { get; set; }
     }
 }

--- a/src/Core/Services/AuthService.cs
+++ b/src/Core/Services/AuthService.cs
@@ -124,6 +124,7 @@ namespace Bit.Core.Services
         public string Code { get; set; }
         public string CodeVerifier { get; set; }
         public string SsoRedirectUrl { get; set; }
+        public string SsoEmail2FaSessionToken { get; set; }
         public Dictionary<TwoFactorProviderType, TwoFactorProvider> TwoFactorProviders { get; set; }
         public Dictionary<TwoFactorProviderType, Dictionary<string, object>> TwoFactorProvidersData { get; set; }
         public TwoFactorProviderType? SelectedTwoFactorProviderType { get; set; }
@@ -457,13 +458,14 @@ namespace Bit.Core.Services
             if (result.TwoFactor)
             {
                 // Two factor required.
-                Email = email;
+                Email = response.TwoFactorResponse.Email;
                 MasterPasswordHash = hashedPassword;
                 LocalMasterPasswordHash = localHashedPassword;
                 AuthRequestId = authRequestId;
                 Code = code;
                 CodeVerifier = codeVerifier;
                 SsoRedirectUrl = redirectUrl;
+                SsoEmail2FaSessionToken = response.TwoFactorResponse.SsoEmail2faSessionToken;
                 _masterKey = _setCryptoKeys ? masterKey : null;
                 _userKey = userKey2FA;
                 TwoFactorProvidersData = response.TwoFactorResponse.TwoFactorProviders2;


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Fix send 2FA code email on mobile client by updating it to receive and use new identity property SsoEmail2faSessionToken.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->
Get new field from identity response and use it in the request for 2FA code email.

## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
