### PR TITLE
[PM-3640] don't clear key needed for bio/auto migration in pin migration

### DIFF
--- a/src/Core/Services/CryptoService.cs
+++ b/src/Core/Services/CryptoService.cs
@@ -1011,6 +1011,10 @@ namespace Bit.Core.Services
             // Decrypt
             var masterKey = new MasterKey(Convert.FromBase64String(oldKey));
             var encryptedUserKey = await _stateService.GetEncKeyEncryptedAsync(userId);
+            if (encryptedUserKey == null)
+            {
+                return;
+            }
             var userKey = await DecryptUserKeyWithMasterKeyAsync(
                 masterKey,
                 new EncString(encryptedUserKey),
@@ -1070,8 +1074,11 @@ namespace Bit.Core.Services
                 var encPin = await EncryptAsync(pin, userKey);
                 await _stateService.SetProtectedPinAsync(encPin.EncryptedString);
             }
-            // Clear old key
-            await _stateService.SetEncKeyEncryptedAsync(null);
+            // Clear old key only if not needed for bio/auto migration
+            if (await _stateService.GetKeyEncryptedAsync() != null)
+            {
+                await _stateService.SetEncKeyEncryptedAsync(null);
+            }
             return userKey;
         }
 


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
When migrating the pin, we were clearing the old encryption key. Unfortunately, this key is needed for the bio/auto migration that could still happen later.

This fix checks for the existence of an old encrypted master key inside the pin migration, indicating that the bio/auto migration is still needed, and doesn't clear the old encryption key if so. I have also added a null check to the bio/auto migration.

This will need to be picked to `rc`


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **file.ext:** Description of what was changed and why

## Screenshots
<!--Required for any UI changes. Delete if not applicable-->



## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
