### PR TITLE
[PM-3664] Modern (like on browser) mobile UI

### DIFF
--- a/src/App/App.csproj
+++ b/src/App/App.csproj
@@ -19,6 +19,7 @@
     <PackageReference Include="Xamarin.Essentials" Version="1.8.0" />
     <PackageReference Include="Xamarin.FFImageLoading.Forms" Version="2.4.11.982" />
     <PackageReference Include="Xamarin.Forms" Version="5.0.0.2612" />
+    <PackageReference Include="Xamarin.Forms.PancakeView" Version="2.3.0.759" />
     <PackageReference Include="ZXing.Net.Mobile" Version="2.4.1" />
     <PackageReference Include="ZXing.Net.Mobile.Forms" Version="2.4.1" />
     <PackageReference Include="MessagePack" Version="2.4.59" />

--- a/src/App/Controls/AuthenticatorViewCell/AuthenticatorViewCell.xaml
+++ b/src/App/Controls/AuthenticatorViewCell/AuthenticatorViewCell.xaml
@@ -7,121 +7,123 @@
                        xmlns:u="clr-namespace:Bit.App.Utilities"
                        xmlns:ff="clr-namespace:FFImageLoading.Forms;assembly=FFImageLoading.Forms"
                        xmlns:core="clr-namespace:Bit.Core;assembly=BitwardenCore"
+                       xmlns:yummy="clr-namespace:Xamarin.Forms.PancakeView;assembly=Xamarin.Forms.PancakeView"
                        StyleClass="list-row, list-row-platform"
                        HorizontalOptions="FillAndExpand"
                        x:DataType="pages:GroupingsPageTOTPListItem"
-                       ColumnDefinitions="40,*,40,Auto,40"
-                       RowSpacing="0"
-                       Padding="0,10,0,0"
-                       RowDefinitions="*,*">
+                       >
 
     <Grid.Resources>
         <u:IconGlyphConverter x:Key="iconGlyphConverter" />
         <u:InverseBoolConverter x:Key="inverseBool" />
     </Grid.Resources>
 
-    <controls:IconLabel
-        Grid.Column="0"
-        HorizontalOptions="Center"
-        VerticalOptions="Center"
-        StyleClass="list-icon, list-icon-platform"
-        Grid.RowSpan="2"
-        IsVisible="{Binding ShowIconImage, Converter={StaticResource inverseBool}}"
-        Text="{Binding Cipher, Converter={StaticResource iconGlyphConverter}}"
-        AutomationProperties.IsInAccessibleTree="False" />
+    <yummy:PancakeView StyleClass="round-card" Margin="10,2.5,10,2.5" Padding="0,10,0,10">
+        <Grid RowSpacing="0" ColumnSpacing="0" ColumnDefinitions="40,*,40,Auto,40" RowDefinitions="*,*">
+            <controls:IconLabel
+                Grid.Column="0"
+                HorizontalOptions="Center"
+                VerticalOptions="Center"
+                StyleClass="list-icon, list-icon-platform"
+                Grid.RowSpan="2"
+                IsVisible="{Binding ShowIconImage, Converter={StaticResource inverseBool}}"
+                Text="{Binding Cipher, Converter={StaticResource iconGlyphConverter}}"
+                AutomationProperties.IsInAccessibleTree="False" />
 
-    <ff:CachedImage
-        Grid.Column="0"
-        BitmapOptimizations="True"
-        ErrorPlaceholder="login.png"
-        LoadingPlaceholder="login.png"
-        HorizontalOptions="Center"
-        VerticalOptions="Center"
-        WidthRequest="22"
-        HeightRequest="22"
-        Grid.RowSpan="2"
-        IsVisible="{Binding ShowIconImage}"
-        Source="{Binding IconImageSource, Mode=OneTime}"
-        AutomationProperties.IsInAccessibleTree="False" />
+            <ff:CachedImage
+                Grid.Column="0"
+                BitmapOptimizations="True"
+                ErrorPlaceholder="login.png"
+                LoadingPlaceholder="login.png"
+                HorizontalOptions="Center"
+                VerticalOptions="Center"
+                WidthRequest="22"
+                HeightRequest="22"
+                Grid.RowSpan="2"
+                IsVisible="{Binding ShowIconImage}"
+                Source="{Binding IconImageSource, Mode=OneTime}"
+                AutomationProperties.IsInAccessibleTree="False" />
 
-    <Label
-        LineBreakMode="TailTruncation"
-        Grid.Column="1"
-        Grid.Row="0"
-        VerticalTextAlignment="Center"
-        VerticalOptions="Fill"
-        StyleClass="list-title, list-title-platform"
-        Text="{Binding Cipher.Name}" />
+            <Label
+                LineBreakMode="TailTruncation"
+                Grid.Column="1"
+                Grid.Row="0"
+                VerticalTextAlignment="Center"
+                VerticalOptions="Fill"
+                StyleClass="list-title, list-title-platform"
+                Text="{Binding Cipher.Name}" />
 
-    <Label
-        LineBreakMode="TailTruncation"
-        Grid.Column="1"
-        Grid.Row="1"
-        VerticalTextAlignment="Center"
-        VerticalOptions="Fill"
-        StyleClass="list-subtitle, list-subtitle-platform"
-        Text="{Binding Cipher.SubTitle}" />
+            <Label
+                LineBreakMode="TailTruncation"
+                Grid.Column="1"
+                Grid.Row="1"
+                VerticalTextAlignment="Center"
+                VerticalOptions="Fill"
+                StyleClass="list-subtitle, list-subtitle-platform"
+                Text="{Binding Cipher.SubTitle}" />
 
-    <controls:CircularProgressbarView
-        Progress="{Binding Progress}"
-        Grid.Row="0"
-        Grid.Column="2"
-        Grid.RowSpan="2"
-        HorizontalOptions="Fill"
-        VerticalOptions="CenterAndExpand" />
+            <controls:CircularProgressbarView
+                Progress="{Binding Progress}"
+                Grid.Row="0"
+                Grid.Column="2"
+                Grid.RowSpan="2"
+                HorizontalOptions="Fill"
+                VerticalOptions="CenterAndExpand" />
 
-    <Label
-        Text="{Binding TotpSec, Mode=OneWay}"
-        Style="{DynamicResource textTotp}"
-        Grid.Row="0"
-        Grid.Column="2"
-        Grid.RowSpan="2"
-        StyleClass="text-sm"
-        HorizontalTextAlignment="Center"
-        HorizontalOptions="Fill"
-        VerticalTextAlignment="Center"
-        VerticalOptions="Fill" />
-    
-    <StackLayout
-        Grid.Row="0"
-        Grid.Column="3"
-        Margin="3,0,2,0"
-        Spacing="5"
-        Grid.RowSpan="2"
-        Orientation="Horizontal"
-        HorizontalOptions="Fill"
-        VerticalOptions="Fill">
+            <Label
+                Text="{Binding TotpSec, Mode=OneWay}"
+                Style="{DynamicResource textTotp}"
+                Grid.Row="0"
+                Grid.Column="2"
+                Grid.RowSpan="2"
+                StyleClass="text-sm"
+                HorizontalTextAlignment="Center"
+                HorizontalOptions="Fill"
+                VerticalTextAlignment="Center"
+                VerticalOptions="Fill" />
+            
+            <StackLayout
+                Grid.Row="0"
+                Grid.Column="3"
+                Margin="3,0,2,0"
+                Spacing="5"
+                Grid.RowSpan="2"
+                Orientation="Horizontal"
+                HorizontalOptions="Fill"
+                VerticalOptions="Fill">
 
-        <controls:MonoLabel
-            Text="{Binding TotpCodeFormattedStart, Mode=OneWay}"
-            Style="{DynamicResource textTotp}"
-            StyleClass="text-lg"
-            HorizontalTextAlignment="Center"
-            VerticalTextAlignment="Center"
-            HorizontalOptions="Center"
-            VerticalOptions="FillAndExpand" />
-        
-        <controls:MonoLabel
-            Text="{Binding TotpCodeFormattedEnd, Mode=OneWay}"
-            Style="{DynamicResource textTotp}"
-            StyleClass="text-lg"
-            HorizontalTextAlignment="Center"
-            VerticalTextAlignment="Center"
-            HorizontalOptions="Center"
-            VerticalOptions="FillAndExpand" />
-    </StackLayout>
+                <controls:MonoLabel
+                    Text="{Binding TotpCodeFormattedStart, Mode=OneWay}"
+                    Style="{DynamicResource textTotp}"
+                    StyleClass="text-lg"
+                    HorizontalTextAlignment="Center"
+                    VerticalTextAlignment="Center"
+                    HorizontalOptions="Center"
+                    VerticalOptions="FillAndExpand" />
+                
+                <controls:MonoLabel
+                    Text="{Binding TotpCodeFormattedEnd, Mode=OneWay}"
+                    Style="{DynamicResource textTotp}"
+                    StyleClass="text-lg"
+                    HorizontalTextAlignment="Center"
+                    VerticalTextAlignment="Center"
+                    HorizontalOptions="Center"
+                    VerticalOptions="FillAndExpand" />
+            </StackLayout>
 
-    <controls:IconButton
-        StyleClass="box-row-button, box-row-button-platform"
-        Text="{Binding Source={x:Static core:BitwardenIcons.Clone}}"
-        Command="{Binding CopyCommand}"
-        CommandParameter="LoginTotp"
-        Grid.Row="0"
-        Grid.Column="4"
-        Grid.RowSpan="2"
-        Padding="0,0,1,0"
-        HorizontalOptions="Center"
-        VerticalOptions="Center"
-        AutomationProperties.IsInAccessibleTree="True"
-        AutomationProperties.Name="{u:I18n CopyTotp}" />
+            <controls:IconButton
+                StyleClass="box-row-button, box-row-button-platform"
+                Text="{Binding Source={x:Static core:BitwardenIcons.Clone}}"
+                Command="{Binding CopyCommand}"
+                CommandParameter="LoginTotp"
+                Grid.Row="0"
+                Grid.Column="4"
+                Grid.RowSpan="2"
+                Padding="0,0,1,0"
+                HorizontalOptions="Center"
+                VerticalOptions="Center"
+                AutomationProperties.IsInAccessibleTree="True"
+                AutomationProperties.Name="{u:I18n CopyTotp}" />
+        </Grid>
+    </yummy:PancakeView>
 </controls:ExtendedGrid>

--- a/src/App/Controls/CipherViewCell/CipherViewCell.xaml
+++ b/src/App/Controls/CipherViewCell/CipherViewCell.xaml
@@ -6,122 +6,126 @@
     xmlns:u="clr-namespace:Bit.App.Utilities"
     xmlns:ff="clr-namespace:FFImageLoading.Forms;assembly=FFImageLoading.Forms"
     xmlns:core="clr-namespace:Bit.Core;assembly=BitwardenCore"
+    xmlns:yummy="clr-namespace:Xamarin.Forms.PancakeView;assembly=Xamarin.Forms.PancakeView"
     StyleClass="list-row, list-row-platform"
     RowSpacing="0"
     ColumnSpacing="0"
     x:DataType="controls:CipherViewCellViewModel"
     AutomationId="CipherCell">
 
-    <Grid.Resources>
-        <u:IconGlyphConverter x:Key="iconGlyphConverter"/>
-        <u:IconImageConverter x:Key="iconImageConverter"/>
-        <u:InverseBoolConverter x:Key="inverseBool" />
-        <u:StringHasValueConverter x:Key="stringHasValueConverter" />
-    </Grid.Resources>
+    <yummy:PancakeView StyleClass="round-card" Margin="10,5,10,5">
+        <Grid RowSpacing="0" ColumnSpacing="0">
+            <Grid.Resources>
+                <u:IconGlyphConverter x:Key="iconGlyphConverter"/>
+                <u:IconImageConverter x:Key="iconImageConverter"/>
+                <u:InverseBoolConverter x:Key="inverseBool" />
+                <u:StringHasValueConverter x:Key="stringHasValueConverter" />
+            </Grid.Resources>
 
-    <Grid.RowDefinitions>
-        <RowDefinition Height="Auto" />
-    </Grid.RowDefinitions>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+            </Grid.RowDefinitions>
 
-    <Grid.ColumnDefinitions>
-        <ColumnDefinition Width="40" x:Name="_iconColumn" />
-        <ColumnDefinition Width="*" />
-        <ColumnDefinition Width="60" />
-    </Grid.ColumnDefinitions>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="40" x:Name="_iconColumn" />
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="60" />
+            </Grid.ColumnDefinitions>
 
-    <controls:IconLabel
-        Grid.Column="0"
-        HorizontalOptions="Center"
-        VerticalOptions="Center"
-        StyleClass="list-icon, list-icon-platform"
-        IsVisible="{Binding ShowIconImage, Converter={StaticResource inverseBool}}"
-        Text="{Binding Cipher, Converter={StaticResource iconGlyphConverter}}"
-        ShouldUpdateFontSizeDynamicallyForAccesibility="True"
-        AutomationProperties.IsInAccessibleTree="False"
-        AutomationId="CipherTypeIcon" />
+            <controls:IconLabel
+                Grid.Column="0"
+                HorizontalOptions="Center"
+                VerticalOptions="Center"
+                StyleClass="list-icon, list-icon-platform"
+                IsVisible="{Binding ShowIconImage, Converter={StaticResource inverseBool}}"
+                Text="{Binding Cipher, Converter={StaticResource iconGlyphConverter}}"
+                ShouldUpdateFontSizeDynamicallyForAccesibility="True"
+                AutomationProperties.IsInAccessibleTree="False"
+                AutomationId="CipherTypeIcon" />
 
-    <ff:CachedImage
-        x:Name="_iconImage"
-        Grid.Column="0"
-        BitmapOptimizations="True"
-        ErrorPlaceholder="login.png"
-        LoadingPlaceholder="login.png"
-        HorizontalOptions="CenterAndExpand"
-        VerticalOptions="CenterAndExpand"
-        Margin="9"
-        WidthRequest="22"
-        HeightRequest="22"
-        Aspect="AspectFit"
-        IsVisible="{Binding ShowIconImage}"
-        Source="{Binding IconImageSource, Mode=OneTime}"
-        AutomationProperties.IsInAccessibleTree="False"
-        AutomationId="CipherWebsiteIcon" />
+            <ff:CachedImage
+                x:Name="_iconImage"
+                Grid.Column="0"
+                BitmapOptimizations="True"
+                ErrorPlaceholder="login.png"
+                LoadingPlaceholder="login.png"
+                HorizontalOptions="CenterAndExpand"
+                VerticalOptions="CenterAndExpand"
+                Margin="9"
+                WidthRequest="22"
+                HeightRequest="22"
+                Aspect="AspectFit"
+                IsVisible="{Binding ShowIconImage}"
+                Source="{Binding IconImageSource, Mode=OneTime}"
+                AutomationProperties.IsInAccessibleTree="False"
+                AutomationId="CipherWebsiteIcon" />
 
-    <Grid RowSpacing="0" ColumnSpacing="0" Grid.Row="0" Grid.Column="1" VerticalOptions="Center" Padding="0, 7">
-        <Grid.RowDefinitions>
-            <RowDefinition Height="Auto" />
-            <RowDefinition Height="Auto" />
-        </Grid.RowDefinitions>
+            <Grid RowSpacing="0" ColumnSpacing="0" Grid.Row="0" Grid.Column="1" VerticalOptions="Center" Padding="0, 7">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="Auto" />
+                </Grid.RowDefinitions>
 
-        <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="Auto" />
-            <ColumnDefinition Width="Auto" />
-            <ColumnDefinition Width="*" />
-        </Grid.ColumnDefinitions>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition Width="*" />
+                </Grid.ColumnDefinitions>
 
-        <Label 
-            LineBreakMode="TailTruncation"
-            Grid.Column="0"
-            Grid.Row="0"
-            StyleClass="list-title, list-title-platform"
-            Text="{Binding Cipher.Name}"
-            AutomationId="CipherNameLabel" />
-        <Label
-            LineBreakMode="TailTruncation"
-            Grid.Column="0"
-            Grid.Row="1"
-            Grid.ColumnSpan="3"
-            StyleClass="list-subtitle, list-subtitle-platform"
-            Text="{Binding Cipher.SubTitle}"
-            IsVisible="{Binding Source={RelativeSource Self}, Path=Text,
-                        Converter={StaticResource stringHasValueConverter}}"
-            AutomationId="CipherSubTitleLabel" />
-        <controls:IconLabel
-            Grid.Column="1"
-            Grid.Row="0"
-            HorizontalOptions="Start"
-            VerticalOptions="Center"
-            StyleClass="list-title-icon"
-            Margin="5, 0, 0, 0"
-            Text="{Binding Source={x:Static core:BitwardenIcons.Collection}}"
-            IsVisible="{Binding Cipher.Shared, Mode=OneTime}"
-            AutomationProperties.IsInAccessibleTree="True"
-            AutomationProperties.Name="{u:I18n Shared}"
-            AutomationId="CipherInCollectionIcon" />
-        <controls:IconLabel
-            Grid.Column="2"
-            Grid.Row="0"
-            HorizontalOptions="Start"
-            VerticalOptions="Center"
-            StyleClass="list-title-icon"
-            Margin="5, 0, 0, 0"
-            Text="{Binding Source={x:Static core:BitwardenIcons.Paperclip}}"
-            IsVisible="{Binding Cipher.HasAttachments, Mode=OneTime}"
-            AutomationProperties.IsInAccessibleTree="True"
-            AutomationProperties.Name="{u:I18n Attachments}"
-            AutomationId="CipherWithAttachmentsIcon" />
-    </Grid>
+                <Label 
+                    LineBreakMode="TailTruncation"
+                    Grid.Column="0"
+                    Grid.Row="0"
+                    StyleClass="list-title, list-title-platform"
+                    Text="{Binding Cipher.Name}"
+                    AutomationId="CipherNameLabel" />
+                <Label
+                    LineBreakMode="TailTruncation"
+                    Grid.Column="0"
+                    Grid.Row="1"
+                    Grid.ColumnSpan="3"
+                    StyleClass="list-subtitle, list-subtitle-platform"
+                    Text="{Binding Cipher.SubTitle}"
+                    IsVisible="{Binding Source={RelativeSource Self}, Path=Text,
+                                Converter={StaticResource stringHasValueConverter}}"
+                    AutomationId="CipherSubTitleLabel" />
+                <controls:IconLabel
+                    Grid.Column="1"
+                    Grid.Row="0"
+                    HorizontalOptions="Start"
+                    VerticalOptions="Center"
+                    StyleClass="list-title-icon"
+                    Margin="5, 0, 0, 0"
+                    Text="{Binding Source={x:Static core:BitwardenIcons.Collection}}"
+                    IsVisible="{Binding Cipher.Shared, Mode=OneTime}"
+                    AutomationProperties.IsInAccessibleTree="True"
+                    AutomationProperties.Name="{u:I18n Shared}"
+                    AutomationId="CipherInCollectionIcon" />
+                <controls:IconLabel
+                    Grid.Column="2"
+                    Grid.Row="0"
+                    HorizontalOptions="Start"
+                    VerticalOptions="Center"
+                    StyleClass="list-title-icon"
+                    Margin="5, 0, 0, 0"
+                    Text="{Binding Source={x:Static core:BitwardenIcons.Paperclip}}"
+                    IsVisible="{Binding Cipher.HasAttachments, Mode=OneTime}"
+                    AutomationProperties.IsInAccessibleTree="True"
+                    AutomationProperties.Name="{u:I18n Attachments}"
+                    AutomationId="CipherWithAttachmentsIcon" />
+            </Grid>
 
-    <controls:MiButton
-        Grid.Row="0"
-        Grid.Column="2"
-        Text="{Binding Source={x:Static core:BitwardenIcons.ViewCellMenu}}"
-        StyleClass="list-row-button, list-row-button-platform, btn-disabled"
-        Clicked="MoreButton_Clicked"
-        VerticalOptions="CenterAndExpand"
-        HorizontalOptions="EndAndExpand"
-        AutomationProperties.IsInAccessibleTree="True"
-        AutomationProperties.Name="{u:I18n Options}"
-        AutomationId="CipherOptionsButton" />
-
+            <controls:MiButton
+                Grid.Row="0"
+                Grid.Column="2"
+                Text="{Binding Source={x:Static core:BitwardenIcons.ViewCellMenu}}"
+                StyleClass="list-row-button, list-row-button-platform, btn-disabled"
+                Clicked="MoreButton_Clicked"
+                VerticalOptions="CenterAndExpand"
+                HorizontalOptions="EndAndExpand"
+                AutomationProperties.IsInAccessibleTree="True"
+                AutomationProperties.Name="{u:I18n Options}"
+                AutomationId="CipherOptionsButton" />
+        </Grid>
+    </yummy:PancakeView>
 </controls:ExtendedGrid>

--- a/src/App/Controls/CipherViewCell/CipherViewCell.xaml
+++ b/src/App/Controls/CipherViewCell/CipherViewCell.xaml
@@ -13,7 +13,7 @@
     x:DataType="controls:CipherViewCellViewModel"
     AutomationId="CipherCell">
 
-    <yummy:PancakeView StyleClass="round-card" Margin="10,5,10,5">
+    <yummy:PancakeView StyleClass="round-card" Margin="10,2.5,10,2.5">
         <Grid RowSpacing="0" ColumnSpacing="0">
             <Grid.Resources>
                 <u:IconGlyphConverter x:Key="iconGlyphConverter"/>

--- a/src/App/Lists/ItemLayouts/CustomFields/BooleanCustomFieldItemLayout.xaml
+++ b/src/App/Lists/ItemLayouts/CustomFields/BooleanCustomFieldItemLayout.xaml
@@ -7,6 +7,7 @@
     xmlns:controls="clr-namespace:Bit.App.Controls"
     xmlns:cfvm="clr-namespace:Bit.App.Lists.ItemViewModels.CustomFields"
     xmlns:core="clr-namespace:Bit.Core;assembly=BitwardenCore"
+    xmlns:yummy="clr-namespace:Xamarin.Forms.PancakeView;assembly=Xamarin.Forms.PancakeView"
     x:DataType="cfvm:BooleanCustomFieldItemViewModel"
     Spacing="0" Padding="0">
     <StackLayout.Resources>
@@ -16,59 +17,60 @@
             <u:BooleanToBoxRowInputPaddingConverter x:Key="booleanToBoxRowInputPaddingConverter" />
         </ResourceDictionary>
     </StackLayout.Resources>
-    <Grid
-        StyleClass="box-row"
-        Padding="{Binding IsEditing, Converter={StaticResource booleanToBoxRowInputPaddingConverter}}">
-        <Grid.RowDefinitions>
-            <RowDefinition Height="Auto" />
-            <RowDefinition Height="*" />
-        </Grid.RowDefinitions>
-        <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="*" />
-            <ColumnDefinition Width="Auto" />
-            <ColumnDefinition Width="Auto" />
-        </Grid.ColumnDefinitions>
-        <Label
-            Text="{Binding Field.Name, Mode=OneWay}"
-            StyleClass="box-label"
-            Grid.Row="0"
-            Grid.Column="0"
-            IsVisible="{Binding IsEditing, Mode=OneWay, Converter={StaticResource inverseBool}}"
-            AutomationId="BooleanCustomFieldNameLabel" />
-        <Label
-            Text="{Binding Field.Name, Mode=OneWay}"
-            IsVisible="{Binding IsEditing}"
-            StyleClass="box-value"
-            VerticalOptions="FillAndExpand"
-            VerticalTextAlignment="Center"
-            Grid.Row="0"
-            Grid.Column="0"
-            Grid.RowSpan="2" />
-        <controls:IconLabel
-            Text="{Binding BooleanValue, Mode=OneWay, Converter={StaticResource iconGlyphConverter}, ConverterParameter={x:Static u:BooleanGlyphType.Checkbox}}"
-            StyleClass="box-value"
-            Grid.Row="1"
-            Grid.Column="0"
-            Margin="0, 5, 0, 0"
-            IsVisible="{Binding IsEditing, Mode=OneWay, Converter={StaticResource inverseBool}}"
-            AutomationId="BooleanCustomFieldValueLabel" />
-        <Switch
-            IsToggled="{Binding BooleanValue}"
-            IsVisible="{Binding IsEditing}"
-            Grid.Row="0"
-            Grid.Column="1"
-            Grid.RowSpan="2"
-            AutomationId="BooleanCustomFieldValueToggle" />
-        <controls:IconButton 
-            StyleClass="box-row-button, box-row-button-platform"
-            Text="{Binding Source={x:Static core:BitwardenIcons.Cog}}"
-            Command="{Binding FieldOptionsCommand}"
-            IsVisible="{Binding IsEditing}"
-            Grid.Row="0"
-            Grid.Column="2"
-            Grid.RowSpan="2"
-            AutomationProperties.IsInAccessibleTree="True"
-            AutomationProperties.Name="{u:I18n Options}" />
-    </Grid>
-    <BoxView StyleClass="box-row-separator" />
+    <yummy:PancakeView StyleClass="round-card">
+        <Grid
+            StyleClass="box-row"
+            Padding="{Binding IsEditing, Converter={StaticResource booleanToBoxRowInputPaddingConverter}}">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="*" />
+            </Grid.RowDefinitions>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="Auto" />
+            </Grid.ColumnDefinitions>
+            <Label
+                Text="{Binding Field.Name, Mode=OneWay}"
+                StyleClass="box-label"
+                Grid.Row="0"
+                Grid.Column="0"
+                IsVisible="{Binding IsEditing, Mode=OneWay, Converter={StaticResource inverseBool}}"
+                AutomationId="BooleanCustomFieldNameLabel" />
+            <Label
+                Text="{Binding Field.Name, Mode=OneWay}"
+                IsVisible="{Binding IsEditing}"
+                StyleClass="box-value"
+                VerticalOptions="FillAndExpand"
+                VerticalTextAlignment="Center"
+                Grid.Row="0"
+                Grid.Column="0"
+                Grid.RowSpan="2" />
+            <controls:IconLabel
+                Text="{Binding BooleanValue, Mode=OneWay, Converter={StaticResource iconGlyphConverter}, ConverterParameter={x:Static u:BooleanGlyphType.Checkbox}}"
+                StyleClass="box-value"
+                Grid.Row="1"
+                Grid.Column="0"
+                Margin="0, 5, 0, 0"
+                IsVisible="{Binding IsEditing, Mode=OneWay, Converter={StaticResource inverseBool}}"
+                AutomationId="BooleanCustomFieldValueLabel" />
+            <Switch
+                IsToggled="{Binding BooleanValue}"
+                IsVisible="{Binding IsEditing}"
+                Grid.Row="0"
+                Grid.Column="1"
+                Grid.RowSpan="2"
+                AutomationId="BooleanCustomFieldValueToggle" />
+            <controls:IconButton 
+                StyleClass="box-row-button, box-row-button-platform"
+                Text="{Binding Source={x:Static core:BitwardenIcons.Cog}}"
+                Command="{Binding FieldOptionsCommand}"
+                IsVisible="{Binding IsEditing}"
+                Grid.Row="0"
+                Grid.Column="2"
+                Grid.RowSpan="2"
+                AutomationProperties.IsInAccessibleTree="True"
+                AutomationProperties.Name="{u:I18n Options}" />
+        </Grid>
+    </yummy:PancakeView>
 </StackLayout>

--- a/src/App/Lists/ItemLayouts/CustomFields/HiddenCustomFieldItemLayout.xaml
+++ b/src/App/Lists/ItemLayouts/CustomFields/HiddenCustomFieldItemLayout.xaml
@@ -6,6 +6,7 @@
     xmlns:u="clr-namespace:Bit.App.Utilities"
     xmlns:cfvm="clr-namespace:Bit.App.Lists.ItemViewModels.CustomFields"
     xmlns:core="clr-namespace:Bit.Core;assembly=BitwardenCore"
+    xmlns:yummy="clr-namespace:Xamarin.Forms.PancakeView;assembly=Xamarin.Forms.PancakeView"
     x:DataType="cfvm:HiddenCustomFieldItemViewModel"
     Spacing="0" Padding="0">
     <StackLayout.Resources>
@@ -15,90 +16,91 @@
             <u:BooleanToBoxRowInputPaddingConverter x:Key="booleanToBoxRowInputPaddingConverter" />
         </ResourceDictionary>
     </StackLayout.Resources>
-    <Grid
-        StyleClass="box-row"
-        Padding="{Binding IsEditing, Converter={StaticResource booleanToBoxRowInputPaddingConverter}}">
-        <Grid.RowDefinitions>
-            <RowDefinition Height="Auto" />
-            <RowDefinition Height="*" />
-        </Grid.RowDefinitions>
-        <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="*" />
-            <ColumnDefinition Width="Auto" />
-            <ColumnDefinition Width="Auto" />
-        </Grid.ColumnDefinitions>
-        <Label
-            Text="{Binding Field.Name, Mode=OneWay}"
-            StyleClass="box-label"
-            Grid.Row="0"
-            Grid.Column="0"
-            AutomationId="HiddenCustomFieldNameLabel" />
-        <StackLayout
-            Grid.Row="1"
-            Grid.Column="0"
-            IsVisible="{Binding IsEditing, Converter={StaticResource inverseBool}}">
-            <controls:MonoLabel
-                Text="{Binding ValueText, Mode=OneWay}"
+    <yummy:PancakeView StyleClass="round-card">
+        <Grid
+            StyleClass="box-row"
+            Padding="{Binding IsEditing, Converter={StaticResource booleanToBoxRowInputPaddingConverter}}">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="*" />
+            </Grid.RowDefinitions>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="Auto" />
+            </Grid.ColumnDefinitions>
+            <Label
+                Text="{Binding Field.Name, Mode=OneWay}"
+                StyleClass="box-label"
+                Grid.Row="0"
+                Grid.Column="0"
+                AutomationId="HiddenCustomFieldNameLabel" />
+            <StackLayout
+                Grid.Row="1"
+                Grid.Column="0"
+                IsVisible="{Binding IsEditing, Converter={StaticResource inverseBool}}">
+                <controls:MonoLabel
+                    Text="{Binding ValueText, Mode=OneWay}"
+                    StyleClass="box-value"
+                    IsVisible="{Binding ShowHiddenValue}"
+                    AutomationId="HiddenCustomFieldValueLabel" />
+                <controls:MonoLabel
+                    Text="{Binding Field.MaskedValue, Mode=OneWay}"
+                    StyleClass="box-value"
+                    IsVisible="{Binding ShowHiddenValue, Converter={StaticResource inverseBool}}" />
+            </StackLayout>
+            <controls:MonoEntry
+                Text="{Binding Field.Value}"
                 StyleClass="box-value"
-                IsVisible="{Binding ShowHiddenValue}"
-                AutomationId="HiddenCustomFieldValueLabel" />
-            <controls:MonoLabel
-                Text="{Binding Field.MaskedValue, Mode=OneWay}"
-                StyleClass="box-value"
-                IsVisible="{Binding ShowHiddenValue, Converter={StaticResource inverseBool}}" />
-        </StackLayout>
-        <controls:MonoEntry
-            Text="{Binding Field.Value}"
-            StyleClass="box-value"
-            Grid.Row="1"
-            Grid.Column="0"
-            IsVisible="{Binding IsEditing}"
-            IsPassword="{Binding ShowHiddenValue, Converter={StaticResource inverseBool}}"
-            IsEnabled="{Binding ShowViewHidden}"
-            IsSpellCheckEnabled="False"
-            IsTextPredictionEnabled="False"
-            AutomationProperties.IsInAccessibleTree="True"
-            AutomationProperties.Name="{Binding Field.Name}"
-            AutomationId="HiddenCustomFieldValueEntry">
-            <Entry.Keyboard>
-                <Keyboard x:FactoryMethod="Create">
-                    <x:Arguments>
-                        <KeyboardFlags>None</KeyboardFlags>
-                    </x:Arguments>
-                </Keyboard>
-            </Entry.Keyboard>
-        </controls:MonoEntry>
-        <controls:IconButton 
-            StyleClass="box-row-button, box-row-button-platform"
-            Text="{Binding ShowHiddenValue, Converter={StaticResource iconGlyphConverter}, ConverterParameter={x:Static u:BooleanGlyphType.Eye}}"
-            Command="{Binding ToggleHiddenValueCommand}"
-            IsVisible="{Binding ShowViewHidden}"
-            Grid.Row="0"
-            Grid.Column="1"
-            Grid.RowSpan="2"
-            AutomationProperties.IsInAccessibleTree="True"
-            AutomationProperties.Name="{u:I18n ToggleVisibility}"
-            AutomationId="HiddenCustomFieldShowValueButton" />
-        <controls:IconButton
-            StyleClass="box-row-button, box-row-button-platform"
-            Text="{Binding Source={x:Static core:BitwardenIcons.Clone}}"
-            Command="{Binding CopyFieldCommand}"
-            IsVisible="{Binding ShowCopyButton}"
-            Grid.Row="0"
-            Grid.Column="2"
-            Grid.RowSpan="2"
-            AutomationProperties.IsInAccessibleTree="True"
-            AutomationProperties.Name="{u:I18n Copy}" />
-        <controls:IconButton 
-            StyleClass="box-row-button, box-row-button-platform"
-            Text="{Binding Source={x:Static core:BitwardenIcons.Cog}}"
-            Command="{Binding FieldOptionsCommand}"
-            IsVisible="{Binding IsEditing}"
-            Grid.Row="0"
-            Grid.Column="2"
-            Grid.RowSpan="2"
-            AutomationProperties.IsInAccessibleTree="True"
-            AutomationProperties.Name="{u:I18n Options}" />
-    </Grid>
-    <BoxView StyleClass="box-row-separator" IsVisible="{Binding IsEditing, Mode=OneWay, Converter={StaticResource inverseBool}}" />
+                Grid.Row="1"
+                Grid.Column="0"
+                IsVisible="{Binding IsEditing}"
+                IsPassword="{Binding ShowHiddenValue, Converter={StaticResource inverseBool}}"
+                IsEnabled="{Binding ShowViewHidden}"
+                IsSpellCheckEnabled="False"
+                IsTextPredictionEnabled="False"
+                AutomationProperties.IsInAccessibleTree="True"
+                AutomationProperties.Name="{Binding Field.Name}"
+                AutomationId="HiddenCustomFieldValueEntry">
+                <Entry.Keyboard>
+                    <Keyboard x:FactoryMethod="Create">
+                        <x:Arguments>
+                            <KeyboardFlags>None</KeyboardFlags>
+                        </x:Arguments>
+                    </Keyboard>
+                </Entry.Keyboard>
+            </controls:MonoEntry>
+            <controls:IconButton 
+                StyleClass="box-row-button, box-row-button-platform"
+                Text="{Binding ShowHiddenValue, Converter={StaticResource iconGlyphConverter}, ConverterParameter={x:Static u:BooleanGlyphType.Eye}}"
+                Command="{Binding ToggleHiddenValueCommand}"
+                IsVisible="{Binding ShowViewHidden}"
+                Grid.Row="0"
+                Grid.Column="1"
+                Grid.RowSpan="2"
+                AutomationProperties.IsInAccessibleTree="True"
+                AutomationProperties.Name="{u:I18n ToggleVisibility}"
+                AutomationId="HiddenCustomFieldShowValueButton" />
+            <controls:IconButton
+                StyleClass="box-row-button, box-row-button-platform"
+                Text="{Binding Source={x:Static core:BitwardenIcons.Clone}}"
+                Command="{Binding CopyFieldCommand}"
+                IsVisible="{Binding ShowCopyButton}"
+                Grid.Row="0"
+                Grid.Column="2"
+                Grid.RowSpan="2"
+                AutomationProperties.IsInAccessibleTree="True"
+                AutomationProperties.Name="{u:I18n Copy}" />
+            <controls:IconButton 
+                StyleClass="box-row-button, box-row-button-platform"
+                Text="{Binding Source={x:Static core:BitwardenIcons.Cog}}"
+                Command="{Binding FieldOptionsCommand}"
+                IsVisible="{Binding IsEditing}"
+                Grid.Row="0"
+                Grid.Column="2"
+                Grid.RowSpan="2"
+                AutomationProperties.IsInAccessibleTree="True"
+                AutomationProperties.Name="{u:I18n Options}" />
+        </Grid>
+    </yummy:PancakeView>
 </StackLayout>

--- a/src/App/Lists/ItemLayouts/CustomFields/LinkedCustomFieldItemLayout.xaml
+++ b/src/App/Lists/ItemLayouts/CustomFields/LinkedCustomFieldItemLayout.xaml
@@ -6,6 +6,7 @@
     xmlns:u="clr-namespace:Bit.App.Utilities"
     xmlns:cfvm="clr-namespace:Bit.App.Lists.ItemViewModels.CustomFields"
     xmlns:core="clr-namespace:Bit.Core;assembly=BitwardenCore"
+    xmlns:yummy="clr-namespace:Xamarin.Forms.PancakeView;assembly=Xamarin.Forms.PancakeView"
     x:DataType="cfvm:LinkedCustomFieldItemViewModel"
     Spacing="0" Padding="0">
     <StackLayout.Resources>
@@ -14,52 +15,53 @@
             <u:BooleanToBoxRowInputPaddingConverter x:Key="booleanToBoxRowInputPaddingConverter" />
         </ResourceDictionary>
     </StackLayout.Resources>
-    <Grid
-        StyleClass="box-row"
-        Padding="{Binding IsEditing, Converter={StaticResource booleanToBoxRowInputPaddingConverter}}">
-        <Grid.RowDefinitions>
-            <RowDefinition Height="Auto" />
-            <RowDefinition Height="*" />
-        </Grid.RowDefinitions>
-        <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="*" />
-            <ColumnDefinition Width="Auto" />
-        </Grid.ColumnDefinitions>
-        <Label
-            Text="{Binding Field.Name, Mode=OneWay}"
-            StyleClass="box-label"
-            Grid.Row="0"
-            Grid.Column="0"
-            AutomationId="LinkedCustomFieldNameLabel" />
-        <controls:IconLabel
-            Text="{Binding ValueText, Mode=OneWay}"
-            StyleClass="box-value"
-            Grid.Row="1"
-            Grid.Column="0"
-            IsVisible="{Binding IsEditing, Mode=OneWay, Converter={StaticResource inverseBool}}"
-            AutomationId="LinkedCustomFieldValueLabel" />
-        <StackLayout
-            StyleClass="box-row, box-row-input"
-            IsVisible="{Binding IsEditing}">
-            <Picker
-                x:Name="_linkedFieldOptionPicker"
-                ItemsSource="{Binding LinkedFieldOptions, Mode=OneTime}"
-                SelectedIndex="{Binding LinkedFieldOptionSelectedIndex}"
-                ItemDisplayBinding="{Binding Key}"
+    <yummy:PancakeView StyleClass="round-card">
+        <Grid
+            StyleClass="box-row"
+            Padding="{Binding IsEditing, Converter={StaticResource booleanToBoxRowInputPaddingConverter}}">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="*" />
+            </Grid.RowDefinitions>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="Auto" />
+            </Grid.ColumnDefinitions>
+            <Label
+                Text="{Binding Field.Name, Mode=OneWay}"
+                StyleClass="box-label"
+                Grid.Row="0"
+                Grid.Column="0"
+                AutomationId="LinkedCustomFieldNameLabel" />
+            <controls:IconLabel
+                Text="{Binding ValueText, Mode=OneWay}"
                 StyleClass="box-value"
-                AutomationId="LinkedCustomFieldValuePicker" />
-        </StackLayout>
-        <controls:IconButton 
-            StyleClass="box-row-button, box-row-button-platform"
-            Text="{Binding Source={x:Static core:BitwardenIcons.Cog}}"
-            Command="{Binding FieldOptionsCommand}"
-            IsVisible="{Binding IsEditing}"
-            Grid.Row="0"
-            Grid.Column="1"
-            Grid.RowSpan="2"
-            AutomationProperties.IsInAccessibleTree="True"
-            AutomationProperties.Name="{u:I18n Options}"
-            AutomationId="LinkedCustomFieldOptionsButton" />
-    </Grid>
-    <BoxView StyleClass="box-row-separator" IsVisible="{Binding IsEditing, Mode=OneWay, Converter={StaticResource inverseBool}}" />
+                Grid.Row="1"
+                Grid.Column="0"
+                IsVisible="{Binding IsEditing, Mode=OneWay, Converter={StaticResource inverseBool}}"
+                AutomationId="LinkedCustomFieldValueLabel" />
+            <StackLayout
+                StyleClass="box-row, box-row-input"
+                IsVisible="{Binding IsEditing}">
+                <Picker
+                    x:Name="_linkedFieldOptionPicker"
+                    ItemsSource="{Binding LinkedFieldOptions, Mode=OneTime}"
+                    SelectedIndex="{Binding LinkedFieldOptionSelectedIndex}"
+                    ItemDisplayBinding="{Binding Key}"
+                    StyleClass="box-value"
+                    AutomationId="LinkedCustomFieldValuePicker" />
+            </StackLayout>
+            <controls:IconButton 
+                StyleClass="box-row-button, box-row-button-platform"
+                Text="{Binding Source={x:Static core:BitwardenIcons.Cog}}"
+                Command="{Binding FieldOptionsCommand}"
+                IsVisible="{Binding IsEditing}"
+                Grid.Row="0"
+                Grid.Column="1"
+                Grid.RowSpan="2"
+                AutomationProperties.IsInAccessibleTree="True"
+                AutomationProperties.Name="{u:I18n Options}"
+                AutomationId="LinkedCustomFieldOptionsButton" />
+        </Grid>
+    </yummy:PancakeView>
 </StackLayout>

--- a/src/App/Lists/ItemLayouts/CustomFields/TextCustomFieldItemLayout.xaml
+++ b/src/App/Lists/ItemLayouts/CustomFields/TextCustomFieldItemLayout.xaml
@@ -6,6 +6,7 @@
     xmlns:u="clr-namespace:Bit.App.Utilities"
     xmlns:cfvm="clr-namespace:Bit.App.Lists.ItemViewModels.CustomFields"
     xmlns:core="clr-namespace:Bit.Core;assembly=BitwardenCore"
+    xmlns:yummy="clr-namespace:Xamarin.Forms.PancakeView;assembly=Xamarin.Forms.PancakeView"
     x:DataType="cfvm:TextCustomFieldItemViewModel"
     Spacing="0" Padding="0">
     <StackLayout.Resources>
@@ -14,61 +15,62 @@
             <u:BooleanToBoxRowInputPaddingConverter x:Key="booleanToBoxRowInputPaddingConverter" />
         </ResourceDictionary>
     </StackLayout.Resources>
-    <Grid
-        StyleClass="box-row"
-        Padding="{Binding IsEditing, Converter={StaticResource booleanToBoxRowInputPaddingConverter}}">
-        <Grid.RowDefinitions>
-            <RowDefinition Height="Auto" />
-            <RowDefinition Height="*" />
-        </Grid.RowDefinitions>
-        <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="*" />
-            <ColumnDefinition Width="Auto" />
-        </Grid.ColumnDefinitions>
-        <Label
-            Text="{Binding Field.Name, Mode=OneWay}"
-            StyleClass="box-label"
-            Grid.Row="0"
-            Grid.Column="0"
-            AutomationId="TextCustomFieldNameLabel" />
-        <Label
-            Text="{Binding ValueText, Mode=OneWay}"
-            StyleClass="box-value"
-            Grid.Row="1"
-            Grid.Column="0"
-            IsVisible="{Binding IsEditing, Mode=OneWay, Converter={StaticResource inverseBool}}"
-            AutomationId="TextCustomFieldValueLabel" />
-        <Entry
-            Text="{Binding Field.Value}"
-            StyleClass="box-value"
-            Grid.Row="1"
-            Grid.Column="0"
-            IsVisible="{Binding IsEditing}"
-            AutomationProperties.IsInAccessibleTree="True"
-            AutomationProperties.Name="{Binding Field.Name}"
-            AutomationId="TextCustomFieldValueEntry" />
-        <controls:IconButton
-            StyleClass="box-row-button, box-row-button-platform"
-            Text="{Binding Source={x:Static core:BitwardenIcons.Clone}}"
-            Command="{Binding CopyFieldCommand}"
-            IsVisible="{Binding ShowCopyButton}"
-            Grid.Row="0"
-            Grid.Column="1"
-            Grid.RowSpan="2"
-            AutomationProperties.IsInAccessibleTree="True"
-            AutomationProperties.Name="{u:I18n Copy}"
-            AutomationId="TextCustomFieldCopyValue" />
-        <controls:IconButton 
-            StyleClass="box-row-button, box-row-button-platform"
-            Text="{Binding Source={x:Static core:BitwardenIcons.Cog}}"
-            Command="{Binding FieldOptionsCommand}"
-            IsVisible="{Binding IsEditing}"
-            Grid.Row="0"
-            Grid.Column="1"
-            Grid.RowSpan="2"
-            AutomationProperties.IsInAccessibleTree="True"
-            AutomationProperties.Name="{u:I18n Options}"
-            AutomationId="TextCustomFieldOptionsButton" />
-    </Grid>
-    <BoxView StyleClass="box-row-separator" IsVisible="{Binding IsEditing, Mode=OneWay, Converter={StaticResource inverseBool}}" />
+    <yummy:PancakeView StyleClass="round-card">
+        <Grid
+            StyleClass="box-row"
+            Padding="{Binding IsEditing, Converter={StaticResource booleanToBoxRowInputPaddingConverter}}">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="*" />
+            </Grid.RowDefinitions>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="Auto" />
+            </Grid.ColumnDefinitions>
+            <Label
+                Text="{Binding Field.Name, Mode=OneWay}"
+                StyleClass="box-label"
+                Grid.Row="0"
+                Grid.Column="0"
+                AutomationId="TextCustomFieldNameLabel" />
+            <Label
+                Text="{Binding ValueText, Mode=OneWay}"
+                StyleClass="box-value"
+                Grid.Row="1"
+                Grid.Column="0"
+                IsVisible="{Binding IsEditing, Mode=OneWay, Converter={StaticResource inverseBool}}"
+                AutomationId="TextCustomFieldValueLabel" />
+            <Entry
+                Text="{Binding Field.Value}"
+                StyleClass="box-value"
+                Grid.Row="1"
+                Grid.Column="0"
+                IsVisible="{Binding IsEditing}"
+                AutomationProperties.IsInAccessibleTree="True"
+                AutomationProperties.Name="{Binding Field.Name}"
+                AutomationId="TextCustomFieldValueEntry" />
+            <controls:IconButton
+                StyleClass="box-row-button, box-row-button-platform"
+                Text="{Binding Source={x:Static core:BitwardenIcons.Clone}}"
+                Command="{Binding CopyFieldCommand}"
+                IsVisible="{Binding ShowCopyButton}"
+                Grid.Row="0"
+                Grid.Column="1"
+                Grid.RowSpan="2"
+                AutomationProperties.IsInAccessibleTree="True"
+                AutomationProperties.Name="{u:I18n Copy}"
+                AutomationId="TextCustomFieldCopyValue" />
+            <controls:IconButton 
+                StyleClass="box-row-button, box-row-button-platform"
+                Text="{Binding Source={x:Static core:BitwardenIcons.Cog}}"
+                Command="{Binding FieldOptionsCommand}"
+                IsVisible="{Binding IsEditing}"
+                Grid.Row="0"
+                Grid.Column="1"
+                Grid.RowSpan="2"
+                AutomationProperties.IsInAccessibleTree="True"
+                AutomationProperties.Name="{u:I18n Options}"
+                AutomationId="TextCustomFieldOptionsButton" />
+        </Grid>
+    </yummy:PancakeView>
 </StackLayout>

--- a/src/App/Pages/Vault/CipherAddEditPage.xaml
+++ b/src/App/Pages/Vault/CipherAddEditPage.xaml
@@ -12,6 +12,7 @@
     xmlns:dts="clr-namespace:Bit.App.Lists.DataTemplateSelectors"
     xmlns:il="clr-namespace:Bit.App.Lists.ItemLayouts.CustomFields"
     xmlns:core="clr-namespace:Bit.Core;assembly=BitwardenCore"
+    xmlns:yummy="clr-namespace:Xamarin.Forms.PancakeView;assembly=Xamarin.Forms.PancakeView"
     x:DataType="pages:CipherAddEditPageViewModel"
     x:Name="_page"
     Title="{Binding PageTitle}">
@@ -120,108 +121,114 @@
                         StyleClass="box-value"
                         AutomationId="ItemTypePicker" />
                 </StackLayout>
-                <StackLayout StyleClass="box-row, box-row-input">
-                    <Label
-                        Text="{u:I18n Name}"
-                        StyleClass="box-label" />
-                    <Entry
-                        x:Name="_nameEntry"
-                        Text="{Binding Cipher.Name}"
-                        StyleClass="box-value"
-                        AutomationProperties.IsInAccessibleTree="True"
-                        AutomationProperties.Name="{u:I18n Name}"
-                        AutomationId="ItemNameEntry" />
-                </StackLayout>
-                <StackLayout IsVisible="{Binding IsLogin}" Spacing="0" Padding="0">
-                    <Grid StyleClass="box-row, box-row-input"
-                        RowDefinitions="Auto,*"
-                        ColumnDefinitions="*,Auto">
-                         <Label
-                            Text="{u:I18n Username}"
-                            StyleClass="box-label"/>
-                        <Entry
-                            x:Name="_loginUsernameEntry"
-                            Text="{Binding Cipher.Login.Username}"
-                            StyleClass="box-value" 
-                            Grid.Row="1"
-                            AutomationProperties.IsInAccessibleTree="True"
-                            AutomationProperties.Name="{u:I18n Username}"
-                            AutomationId="LoginUsernameEntry" />
-                        <controls:IconButton 
-                            StyleClass="box-row-button, box-row-button-platform"
-                            Text="{Binding Source={x:Static core:BitwardenIcons.Generate}}"
-                            Command="{Binding GenerateUsernameCommand}"
-                            Grid.Column="1"
-                            Grid.RowSpan="2"
-                            AutomationProperties.IsInAccessibleTree="True"
-                            AutomationProperties.Name="{u:I18n GenerateUsername}"
-                            AutomationId="GenerateUsernameButton" />
-                    </Grid>
-                    <Grid StyleClass="box-row, box-row-input">
-                        <Grid.RowDefinitions>
-                            <RowDefinition Height="Auto" />
-                            <RowDefinition Height="*" />
-                        </Grid.RowDefinitions>
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="*" />
-                            <ColumnDefinition Width="Auto" />
-                            <ColumnDefinition Width="Auto" />
-                            <ColumnDefinition Width="Auto" />
-                        </Grid.ColumnDefinitions>
+                <yummy:PancakeView StyleClass="round-card">
+                    <StackLayout StyleClass="box-row, box-row-input">
                         <Label
-                            Text="{u:I18n Password}"
-                            StyleClass="box-label"
-                            Grid.Row="0"
-                            Grid.Column="0" />
-                        <controls:MonoEntry
-                            x:Name="_loginPasswordEntry"
-                            Text="{Binding Cipher.Login.Password}"
+                            Text="{u:I18n Name}"
+                            StyleClass="box-label" />
+                        <Entry
+                            x:Name="_nameEntry"
+                            Text="{Binding Cipher.Name}"
                             StyleClass="box-value"
-                            Grid.Row="1"
-                            Grid.Column="0"
-                            Grid.ColumnSpan="{Binding PasswordFieldColSpan}"
-                            IsPassword="{Binding ShowPassword, Converter={StaticResource inverseBool}}"
-                            IsSpellCheckEnabled="False"
-                            IsTextPredictionEnabled="False"
-                            IsEnabled="{Binding Cipher.ViewPassword}"
                             AutomationProperties.IsInAccessibleTree="True"
-                            AutomationProperties.Name="{u:I18n Password}"
-                            AutomationId="LoginPasswordEntry" />
-                        <controls:IconButton 
-                            StyleClass="box-row-button, box-row-button-platform"
-                            Text="{Binding Source={x:Static core:BitwardenIcons.CheckCircle}}"
-                            Command="{Binding CheckPasswordCommand}"
-                            Grid.Row="0"
-                            Grid.Column="1"
-                            Grid.RowSpan="2"
-                            AutomationProperties.IsInAccessibleTree="True"
-                            AutomationProperties.Name="{u:I18n CheckPassword}"
-                            IsVisible="{Binding Cipher.ViewPassword}"
-                            AutomationId="CheckPasswordButton" />
-                        <controls:IconButton 
-                            StyleClass="box-row-button, box-row-button-platform"
-                            Text="{Binding ShowPasswordIcon}"
-                            Command="{Binding TogglePasswordCommand}"
-                            Grid.Row="0"
-                            Grid.Column="2"
-                            Grid.RowSpan="2"
-                            AutomationProperties.IsInAccessibleTree="True"
-                            AutomationProperties.Name="{u:I18n ToggleVisibility}"
-                            AutomationProperties.HelpText="{Binding PasswordVisibilityAccessibilityText}"
-                            IsVisible="{Binding Cipher.ViewPassword}"
-                            AutomationId="ViewPasswordButton" />
-                        <controls:IconButton 
-                            StyleClass="box-row-button, box-row-button-platform"
-                            Text="{Binding Source={x:Static core:BitwardenIcons.Generate}}"
-                            Command="{Binding GeneratePasswordCommand}"
-                            Grid.Row="0"
-                            Grid.Column="3"
-                            Grid.RowSpan="2"
-                            AutomationProperties.IsInAccessibleTree="True"
-                            AutomationProperties.Name="{u:I18n GeneratePassword}"
-                            IsVisible="{Binding Cipher.ViewPassword}"
-                            AutomationId="RegeneratePasswordButton" />
-                    </Grid>
+                            AutomationProperties.Name="{u:I18n Name}"
+                            AutomationId="ItemNameEntry" />
+                    </StackLayout>
+                </yummy:PancakeView>
+                <StackLayout IsVisible="{Binding IsLogin}" Spacing="0" Padding="0">
+                    <yummy:PancakeView StyleClass="round-card">
+                        <Grid StyleClass="box-row, box-row-input"
+                            RowDefinitions="Auto,*"
+                            ColumnDefinitions="*,Auto">
+                            <Label
+                                Text="{u:I18n Username}"
+                                StyleClass="box-label"/>
+                            <Entry
+                                x:Name="_loginUsernameEntry"
+                                Text="{Binding Cipher.Login.Username}"
+                                StyleClass="box-value" 
+                                Grid.Row="1"
+                                AutomationProperties.IsInAccessibleTree="True"
+                                AutomationProperties.Name="{u:I18n Username}"
+                                AutomationId="LoginUsernameEntry" />
+                            <controls:IconButton 
+                                StyleClass="box-row-button, box-row-button-platform"
+                                Text="{Binding Source={x:Static core:BitwardenIcons.Generate}}"
+                                Command="{Binding GenerateUsernameCommand}"
+                                Grid.Column="1"
+                                Grid.RowSpan="2"
+                                AutomationProperties.IsInAccessibleTree="True"
+                                AutomationProperties.Name="{u:I18n GenerateUsername}"
+                                AutomationId="GenerateUsernameButton" />
+                        </Grid>
+                    </yummy:PancakeView>
+                    <yummy:PancakeView StyleClass="round-card">
+                        <Grid StyleClass="box-row, box-row-input">
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="Auto" />
+                                <RowDefinition Height="*" />
+                            </Grid.RowDefinitions>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*" />
+                                <ColumnDefinition Width="Auto" />
+                                <ColumnDefinition Width="Auto" />
+                                <ColumnDefinition Width="Auto" />
+                            </Grid.ColumnDefinitions>
+                            <Label
+                                Text="{u:I18n Password}"
+                                StyleClass="box-label"
+                                Grid.Row="0"
+                                Grid.Column="0" />
+                            <controls:MonoEntry
+                                x:Name="_loginPasswordEntry"
+                                Text="{Binding Cipher.Login.Password}"
+                                StyleClass="box-value"
+                                Grid.Row="1"
+                                Grid.Column="0"
+                                Grid.ColumnSpan="{Binding PasswordFieldColSpan}"
+                                IsPassword="{Binding ShowPassword, Converter={StaticResource inverseBool}}"
+                                IsSpellCheckEnabled="False"
+                                IsTextPredictionEnabled="False"
+                                IsEnabled="{Binding Cipher.ViewPassword}"
+                                AutomationProperties.IsInAccessibleTree="True"
+                                AutomationProperties.Name="{u:I18n Password}"
+                                AutomationId="LoginPasswordEntry" />
+                            <controls:IconButton 
+                                StyleClass="box-row-button, box-row-button-platform"
+                                Text="{Binding Source={x:Static core:BitwardenIcons.CheckCircle}}"
+                                Command="{Binding CheckPasswordCommand}"
+                                Grid.Row="0"
+                                Grid.Column="1"
+                                Grid.RowSpan="2"
+                                AutomationProperties.IsInAccessibleTree="True"
+                                AutomationProperties.Name="{u:I18n CheckPassword}"
+                                IsVisible="{Binding Cipher.ViewPassword}"
+                                AutomationId="CheckPasswordButton" />
+                            <controls:IconButton 
+                                StyleClass="box-row-button, box-row-button-platform"
+                                Text="{Binding ShowPasswordIcon}"
+                                Command="{Binding TogglePasswordCommand}"
+                                Grid.Row="0"
+                                Grid.Column="2"
+                                Grid.RowSpan="2"
+                                AutomationProperties.IsInAccessibleTree="True"
+                                AutomationProperties.Name="{u:I18n ToggleVisibility}"
+                                AutomationProperties.HelpText="{Binding PasswordVisibilityAccessibilityText}"
+                                IsVisible="{Binding Cipher.ViewPassword}"
+                                AutomationId="ViewPasswordButton" />
+                            <controls:IconButton 
+                                StyleClass="box-row-button, box-row-button-platform"
+                                Text="{Binding Source={x:Static core:BitwardenIcons.Generate}}"
+                                Command="{Binding GeneratePasswordCommand}"
+                                Grid.Row="0"
+                                Grid.Column="3"
+                                Grid.RowSpan="2"
+                                AutomationProperties.IsInAccessibleTree="True"
+                                AutomationProperties.Name="{u:I18n GeneratePassword}"
+                                IsVisible="{Binding Cipher.ViewPassword}"
+                                AutomationId="RegeneratePasswordButton" />
+                        </Grid>
+                    </yummy:PancakeView>
 
                     <Label
                         Text="{u:I18n Passkey}"
@@ -234,202 +241,216 @@
                         StyleClass="box-value,text-muted"
                         IsVisible="{Binding ShowPasskeyInfo}" />
 
-                    <Grid StyleClass="box-row, box-row-input">
-                        <Grid.RowDefinitions>
-                            <RowDefinition Height="Auto" />
-                            <RowDefinition Height="*" />
-                        </Grid.RowDefinitions>
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="*" />
-                            <ColumnDefinition Width="Auto" />
-                            <ColumnDefinition Width="Auto" />
-                        </Grid.ColumnDefinitions>
-                        <Label
-                            Text="{u:I18n AuthenticatorKey}"
-                            StyleClass="box-label"
-                            Grid.Row="0"
-                            Grid.Column="0" />
-                        <Frame 
-                            IsVisible="{Binding HasTotpValue, Converter={StaticResource inverseBool}}" 
-                            Margin="0,5,0,0"
-                            StyleClass="btn-icon-row"
-                            HorizontalOptions="FillAndExpand"
-                            VerticalOptions="FillAndExpand"
-                            Padding="0"
-                            Grid.Row="1"
-                            Grid.Column="0"
-                            Grid.ColumnSpan="3">
-                            <Frame.GestureRecognizers>
-                                <TapGestureRecognizer Tapped="ScanTotp_Clicked" />
-                            </Frame.GestureRecognizers>
-                            <controls:IconLabel 
-                                Text="{Binding SetupTotpText}" 
-                                Padding="0,15"
-                                HorizontalOptions="Center"
+                    <yummy:PancakeView StyleClass="round-card">
+                        <Grid StyleClass="box-row, box-row-input">
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="Auto" />
+                                <RowDefinition Height="*" />
+                            </Grid.RowDefinitions>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*" />
+                                <ColumnDefinition Width="Auto" />
+                                <ColumnDefinition Width="Auto" />
+                            </Grid.ColumnDefinitions>
+                            <Label
+                                Text="{u:I18n AuthenticatorKey}"
+                                StyleClass="box-label"
+                                Grid.Row="0"
+                                Grid.Column="0" />
+                            <Frame 
+                                IsVisible="{Binding HasTotpValue, Converter={StaticResource inverseBool}}" 
+                                Margin="0,5,0,0"
+                                StyleClass="btn-icon-row"
+                                HorizontalOptions="FillAndExpand"
                                 VerticalOptions="FillAndExpand"
-                                VerticalTextAlignment="Center"
-                                AutomationId="SetupTotpButton" />
-                        </Frame>
-                        <controls:MonoEntry
-                            x:Name="_loginTotpEntry"
-                            Text="{Binding Cipher.Login.Totp}"
-                            IsSpellCheckEnabled="False"
-                            IsTextPredictionEnabled="False"
-                            IsVisible="{Binding HasTotpValue}"
-                            IsPassword="{Binding Cipher.ViewPassword, Converter={StaticResource inverseBool}}"
-                            IsEnabled="{Binding Cipher.ViewPassword}"
-                            StyleClass="box-value"
-                            Grid.Row="1"
-                            Grid.Column="0"
-                            Grid.ColumnSpan="{Binding TotpColumnSpan}"
-                            AutomationProperties.IsInAccessibleTree="True"
-                            AutomationProperties.Name="{u:I18n AuthenticatorKey}"
-                            AutomationId="LoginTotpEntry" />
-                        <controls:IconButton 
-                            StyleClass="box-row-button, box-row-button-platform"
-                            Text="{Binding Source={x:Static core:BitwardenIcons.Clone}}"
-                            Command="{Binding CopyCommand}"
-                            IsVisible="{Binding HasTotpValue}"
-                            Grid.Row="0"
-                            Grid.Column="1"
-                            Grid.RowSpan="2"
-                            AutomationProperties.IsInAccessibleTree="True"
-                            AutomationProperties.Name="{u:I18n CopyTotp}"
-                            AutomationId="CopyTotpValueButton" />
-                        <controls:IconButton 
-                            StyleClass="box-row-button, box-row-button-platform"
-                            Text="{Binding Source={x:Static core:BitwardenIcons.Camera}}"
-                            Clicked="ScanTotp_Clicked"
-                            Grid.Row="0"
-                            Grid.Column="2"
-                            Grid.RowSpan="2"
-                            IsVisible="{Binding HasTotpValue}"
-                            AutomationProperties.IsInAccessibleTree="True"
-                            AutomationProperties.Name="{u:I18n ScanQrTitle}"
-                            />
-                    </Grid>
+                                Padding="0"
+                                Grid.Row="1"
+                                Grid.Column="0"
+                                Grid.ColumnSpan="3">
+                                <Frame.GestureRecognizers>
+                                    <TapGestureRecognizer Tapped="ScanTotp_Clicked" />
+                                </Frame.GestureRecognizers>
+                                <controls:IconLabel 
+                                    Text="{Binding SetupTotpText}" 
+                                    Padding="0,15"
+                                    HorizontalOptions="Center"
+                                    VerticalOptions="FillAndExpand"
+                                    VerticalTextAlignment="Center"
+                                    AutomationId="SetupTotpButton" />
+                            </Frame>
+                            <controls:MonoEntry
+                                x:Name="_loginTotpEntry"
+                                Text="{Binding Cipher.Login.Totp}"
+                                IsSpellCheckEnabled="False"
+                                IsTextPredictionEnabled="False"
+                                IsVisible="{Binding HasTotpValue}"
+                                IsPassword="{Binding Cipher.ViewPassword, Converter={StaticResource inverseBool}}"
+                                IsEnabled="{Binding Cipher.ViewPassword}"
+                                StyleClass="box-value"
+                                Grid.Row="1"
+                                Grid.Column="0"
+                                Grid.ColumnSpan="{Binding TotpColumnSpan}"
+                                AutomationProperties.IsInAccessibleTree="True"
+                                AutomationProperties.Name="{u:I18n AuthenticatorKey}"
+                                AutomationId="LoginTotpEntry" />
+                            <controls:IconButton 
+                                StyleClass="box-row-button, box-row-button-platform"
+                                Text="{Binding Source={x:Static core:BitwardenIcons.Clone}}"
+                                Command="{Binding CopyCommand}"
+                                IsVisible="{Binding HasTotpValue}"
+                                Grid.Row="0"
+                                Grid.Column="1"
+                                Grid.RowSpan="2"
+                                AutomationProperties.IsInAccessibleTree="True"
+                                AutomationProperties.Name="{u:I18n CopyTotp}"
+                                AutomationId="CopyTotpValueButton" />
+                            <controls:IconButton 
+                                StyleClass="box-row-button, box-row-button-platform"
+                                Text="{Binding Source={x:Static core:BitwardenIcons.Camera}}"
+                                Clicked="ScanTotp_Clicked"
+                                Grid.Row="0"
+                                Grid.Column="2"
+                                Grid.RowSpan="2"
+                                IsVisible="{Binding HasTotpValue}"
+                                AutomationProperties.IsInAccessibleTree="True"
+                                AutomationProperties.Name="{u:I18n ScanQrTitle}"
+                                />
+                        </Grid>
+                    </yummy:PancakeView>
                 </StackLayout>
                 <StackLayout IsVisible="{Binding IsCard}" Spacing="0" Padding="0">
-                    <StackLayout StyleClass="box-row, box-row-input">
-                        <Label
-                            Text="{u:I18n CardholderName}"
-                            StyleClass="box-label" />
-                        <Entry
-                            x:Name="_cardholderNameEntry"
-                            Text="{Binding Cipher.Card.CardholderName}"
-                            StyleClass="box-value"
-                            AutomationId="CardholderNameEntry" />
-                    </StackLayout>
-                    <Grid StyleClass="box-row, box-row-input">
-                        <Grid.RowDefinitions>
-                            <RowDefinition Height="Auto" />
-                            <RowDefinition Height="*" />
-                        </Grid.RowDefinitions>
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="*" />
-                            <ColumnDefinition Width="Auto" />
-                        </Grid.ColumnDefinitions>
-                        <Label
-                            Text="{u:I18n Number}"
-                            StyleClass="box-label"
-                            Grid.Row="0"
-                            Grid.Column="0" />
-                        <controls:MonoEntry
-                            x:Name="_cardNumberEntry"
-                            Text="{Binding Cipher.Card.Number}"
-                            StyleClass="box-value"
-                            Grid.Row="1"
-                            Grid.Column="0"
-                            IsPassword="{Binding ShowCardNumber, Converter={StaticResource inverseBool}}"
-                            IsSpellCheckEnabled="False"
-                            IsTextPredictionEnabled="False"
-                            AutomationProperties.IsInAccessibleTree="True"
-                            AutomationProperties.Name="{u:I18n Number}"
-                            AutomationId="CardNumberEntry" />
-                        <controls:IconButton 
-                            StyleClass="box-row-button, box-row-button-platform"
-                            Text="{Binding ShowCardNumberIcon}"
-                            Command="{Binding ToggleCardNumberCommand}"
-                            Grid.Row="0"
-                            Grid.Column="1"
-                            Grid.RowSpan="2"
-                            AutomationProperties.IsInAccessibleTree="True"
-                            AutomationProperties.Name="{u:I18n ToggleVisibility}"
-                            AutomationId="ShowCardNumberButton" />
-                    </Grid>
-                    <StackLayout StyleClass="box-row, box-row-input">
-                        <Label
-                            Text="{u:I18n Brand}"
-                            StyleClass="box-label" />
-                        <Picker
-                            x:Name="_cardBrandPicker"
-                            ItemsSource="{Binding CardBrandOptions, Mode=OneTime}"
-                            SelectedIndex="{Binding CardBrandSelectedIndex}"
-                            StyleClass="box-value"
-                            AutomationId="CardBrandPicker" />
-                    </StackLayout>
-                    <StackLayout StyleClass="box-row, box-row-input">
-                        <Label
-                            Text="{u:I18n ExpirationMonth}"
-                            StyleClass="box-label" />
-                        <Picker
-                            x:Name="_cardExpMonthPicker"
-                            ItemsSource="{Binding CardExpMonthOptions, Mode=OneTime}"
-                            SelectedIndex="{Binding CardExpMonthSelectedIndex}"
-                            StyleClass="box-value"
-                            AutomationId="CardExpirationMonthPicker" />
-                    </StackLayout>
-                    <StackLayout StyleClass="box-row, box-row-input">
-                        <Label
-                            Text="{u:I18n ExpirationYear}"
-                            StyleClass="box-label" />
-                        <Entry
-                            x:Name="_cardExpYearEntry"
-                            Text="{Binding Cipher.Card.ExpYear}"
-                            StyleClass="box-value"
-                            Keyboard="Numeric"
-                            AutomationProperties.IsInAccessibleTree="True"
-                            AutomationProperties.Name="{u:I18n ExpirationYear}"
-                            AutomationId="CardExpirationYearEntry" />
-                    </StackLayout>
-                    <Grid StyleClass="box-row, box-row-input">
-                        <Grid.RowDefinitions>
-                            <RowDefinition Height="Auto" />
-                            <RowDefinition Height="*" />
-                        </Grid.RowDefinitions>
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="*" />
-                            <ColumnDefinition Width="Auto" />
-                        </Grid.ColumnDefinitions>
-                        <Label
-                            Text="{u:I18n SecurityCode}"
-                            StyleClass="box-label"
-                            Grid.Row="0"
-                            Grid.Column="0" />
-                        <controls:MonoEntry
-                            x:Name="_cardCodeEntry"
-                            Text="{Binding Cipher.Card.Code}"
-                            StyleClass="box-value"
-                            Grid.Row="1"
-                            Grid.Column="0"
-                            Keyboard="Numeric"
-                            IsPassword="{Binding ShowCardCode, Converter={StaticResource inverseBool}}"
-                            IsSpellCheckEnabled="False"
-                            IsTextPredictionEnabled="False"
-                            AutomationProperties.IsInAccessibleTree="True"
-                            AutomationProperties.Name="{u:I18n SecurityCode}"
-                            AutomationId="CardSecurityCodeEntry" />
-                        <controls:IconButton 
-                            StyleClass="box-row-button, box-row-button-platform"
-                            Text="{Binding ShowCardCodeIcon}"
-                            Command="{Binding ToggleCardCodeCommand}"
-                            Grid.Row="0"
-                            Grid.Column="1"
-                            Grid.RowSpan="2"
-                            AutomationProperties.IsInAccessibleTree="True"
-                            AutomationProperties.Name="{u:I18n ToggleVisibility}"
-                            AutomationId="CardShowSecurityCodeButton" />
-                    </Grid>
+                    <yummy:PancakeView StyleClass="round-card">
+                        <StackLayout StyleClass="box-row, box-row-input">
+                            <Label
+                                Text="{u:I18n CardholderName}"
+                                StyleClass="box-label" />
+                            <Entry
+                                x:Name="_cardholderNameEntry"
+                                Text="{Binding Cipher.Card.CardholderName}"
+                                StyleClass="box-value"
+                                AutomationId="CardholderNameEntry" />
+                        </StackLayout>
+                    </yummy:PancakeView>
+                    <yummy:PancakeView StyleClass="round-card">
+                        <Grid StyleClass="box-row, box-row-input">
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="Auto" />
+                                <RowDefinition Height="*" />
+                            </Grid.RowDefinitions>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*" />
+                                <ColumnDefinition Width="Auto" />
+                            </Grid.ColumnDefinitions>
+                            <Label
+                                Text="{u:I18n Number}"
+                                StyleClass="box-label"
+                                Grid.Row="0"
+                                Grid.Column="0" />
+                            <controls:MonoEntry
+                                x:Name="_cardNumberEntry"
+                                Text="{Binding Cipher.Card.Number}"
+                                StyleClass="box-value"
+                                Grid.Row="1"
+                                Grid.Column="0"
+                                IsPassword="{Binding ShowCardNumber, Converter={StaticResource inverseBool}}"
+                                IsSpellCheckEnabled="False"
+                                IsTextPredictionEnabled="False"
+                                AutomationProperties.IsInAccessibleTree="True"
+                                AutomationProperties.Name="{u:I18n Number}"
+                                AutomationId="CardNumberEntry" />
+                            <controls:IconButton 
+                                StyleClass="box-row-button, box-row-button-platform"
+                                Text="{Binding ShowCardNumberIcon}"
+                                Command="{Binding ToggleCardNumberCommand}"
+                                Grid.Row="0"
+                                Grid.Column="1"
+                                Grid.RowSpan="2"
+                                AutomationProperties.IsInAccessibleTree="True"
+                                AutomationProperties.Name="{u:I18n ToggleVisibility}"
+                                AutomationId="ShowCardNumberButton" />
+                        </Grid>
+                    </yummy:PancakeView>
+                    <yummy:PancakeView StyleClass="round-card">
+                        <StackLayout StyleClass="box-row, box-row-input">
+                            <Label
+                                Text="{u:I18n Brand}"
+                                StyleClass="box-label" />
+                            <Picker
+                                x:Name="_cardBrandPicker"
+                                ItemsSource="{Binding CardBrandOptions, Mode=OneTime}"
+                                SelectedIndex="{Binding CardBrandSelectedIndex}"
+                                StyleClass="box-value"
+                                AutomationId="CardBrandPicker" />
+                        </StackLayout>
+                    </yummy:PancakeView>
+                    <yummy:PancakeView StyleClass="round-card">
+                        <StackLayout StyleClass="box-row, box-row-input">
+                            <Label
+                                Text="{u:I18n ExpirationMonth}"
+                                StyleClass="box-label" />
+                            <Picker
+                                x:Name="_cardExpMonthPicker"
+                                ItemsSource="{Binding CardExpMonthOptions, Mode=OneTime}"
+                                SelectedIndex="{Binding CardExpMonthSelectedIndex}"
+                                StyleClass="box-value"
+                                AutomationId="CardExpirationMonthPicker" />
+                        </StackLayout>
+                    </yummy:PancakeView>
+                    <yummy:PancakeView StyleClass="round-card">
+                        <StackLayout StyleClass="box-row, box-row-input">
+                            <Label
+                                Text="{u:I18n ExpirationYear}"
+                                StyleClass="box-label" />
+                            <Entry
+                                x:Name="_cardExpYearEntry"
+                                Text="{Binding Cipher.Card.ExpYear}"
+                                StyleClass="box-value"
+                                Keyboard="Numeric"
+                                AutomationProperties.IsInAccessibleTree="True"
+                                AutomationProperties.Name="{u:I18n ExpirationYear}"
+                                AutomationId="CardExpirationYearEntry" />
+                        </StackLayout>
+                    </yummy:PancakeView>
+                    <yummy:PancakeView StyleClass="round-card">
+                        <Grid StyleClass="box-row, box-row-input">
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="Auto" />
+                                <RowDefinition Height="*" />
+                            </Grid.RowDefinitions>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*" />
+                                <ColumnDefinition Width="Auto" />
+                            </Grid.ColumnDefinitions>
+                            <Label
+                                Text="{u:I18n SecurityCode}"
+                                StyleClass="box-label"
+                                Grid.Row="0"
+                                Grid.Column="0" />
+                            <controls:MonoEntry
+                                x:Name="_cardCodeEntry"
+                                Text="{Binding Cipher.Card.Code}"
+                                StyleClass="box-value"
+                                Grid.Row="1"
+                                Grid.Column="0"
+                                Keyboard="Numeric"
+                                IsPassword="{Binding ShowCardCode, Converter={StaticResource inverseBool}}"
+                                IsSpellCheckEnabled="False"
+                                IsTextPredictionEnabled="False"
+                                AutomationProperties.IsInAccessibleTree="True"
+                                AutomationProperties.Name="{u:I18n SecurityCode}"
+                                AutomationId="CardSecurityCodeEntry" />
+                            <controls:IconButton 
+                                StyleClass="box-row-button, box-row-button-platform"
+                                Text="{Binding ShowCardCodeIcon}"
+                                Command="{Binding ToggleCardCodeCommand}"
+                                Grid.Row="0"
+                                Grid.Column="1"
+                                Grid.RowSpan="2"
+                                AutomationProperties.IsInAccessibleTree="True"
+                                AutomationProperties.Name="{u:I18n ToggleVisibility}"
+                                AutomationId="CardShowSecurityCodeButton" />
+                        </Grid>
+                    </yummy:PancakeView>
                 </StackLayout>
                 <StackLayout IsVisible="{Binding IsIdentity}" Spacing="0" Padding="0">
                     <StackLayout StyleClass="box-row, box-row-input">
@@ -443,188 +464,218 @@
                             StyleClass="box-value"
                             AutomationId="IdentityTitlePicker" />
                     </StackLayout>
-                    <StackLayout StyleClass="box-row, box-row-input">
-                        <Label
-                            Text="{u:I18n FirstName}"
-                            StyleClass="box-label" />
-                        <Entry
-                            x:Name="_identityFirstNameEntry"
-                            Text="{Binding Cipher.Identity.FirstName}"
-                            StyleClass="box-value,capitalize-word-input"
-                            AutomationProperties.IsInAccessibleTree="True"
-                            AutomationProperties.Name="{u:I18n FirstName}"
-                            AutomationId="IdentityFirstNameEntry" />
+                    <yummy:PancakeView StyleClass="round-card">
+                        <StackLayout StyleClass="box-row, box-row-input">
+                            <Label
+                                Text="{u:I18n FirstName}"
+                                StyleClass="box-label" />
+                            <Entry
+                                x:Name="_identityFirstNameEntry"
+                                Text="{Binding Cipher.Identity.FirstName}"
+                                StyleClass="box-value,capitalize-word-input"
+                                AutomationProperties.IsInAccessibleTree="True"
+                                AutomationProperties.Name="{u:I18n FirstName}"
+                                AutomationId="IdentityFirstNameEntry" />
+                        </StackLayout>
+                    </yummy:PancakeView>
+                    <yummy:PancakeView StyleClass="round-card">
+                        <StackLayout StyleClass="box-row, box-row-input">
+                            <Label
+                                Text="{u:I18n MiddleName}"
+                                StyleClass="box-label" />
+                            <Entry
+                                x:Name="_identityMiddleNameEntry"
+                                Text="{Binding Cipher.Identity.MiddleName}"
+                                StyleClass="box-value,capitalize-word-input"
+                                AutomationProperties.IsInAccessibleTree="True"
+                                AutomationProperties.Name="{u:I18n MiddleName}"
+                                AutomationId="IdentityMiddleNameEntry" />
+                        </StackLayout>
+                    </yummy:PancakeView>
+                    <yummy:PancakeView StyleClass="round-card">
+                        <StackLayout StyleClass="box-row, box-row-input">
+                            <Label
+                                Text="{u:I18n LastName}"
+                                StyleClass="box-label" />
+                            <Entry
+                                x:Name="_identityLastNameEntry"
+                                Text="{Binding Cipher.Identity.LastName}"
+                                StyleClass="box-value,capitalize-word-input"
+                                AutomationProperties.IsInAccessibleTree="True"
+                                AutomationProperties.Name="{u:I18n LastName}"
+                                AutomationId="IdentityLastNameEntry" />
+                        </StackLayout>
+                    </yummy:PancakeView>
+                    <yummy:PancakeView StyleClass="round-card">
+                        <StackLayout StyleClass="box-row, box-row-input">
+                            <Label
+                                Text="{u:I18n Username}"
+                                StyleClass="box-label" />
+                            <Entry
+                                x:Name="_identityUsernameEntry"
+                                Text="{Binding Cipher.Identity.Username}"
+                                StyleClass="box-value"
+                                AutomationProperties.IsInAccessibleTree="True"
+                                AutomationProperties.Name="{u:I18n Username}"
+                                AutomationId="IdentityUsernameEntry" />
+                        </StackLayout>
+                    </yummy:PancakeView>
+                    <yummy:PancakeView StyleClass="round-card">
+                        <StackLayout StyleClass="box-row, box-row-input">
+                            <Label
+                                Text="{u:I18n Company}"
+                                StyleClass="box-label" />
+                            <Entry
+                                x:Name="_identityCompanyEntry"
+                                Text="{Binding Cipher.Identity.Company}"
+                                StyleClass="box-value" 
+                                AutomationProperties.IsInAccessibleTree="True"
+                                AutomationProperties.Name="{u:I18n Company}"
+                                AutomationId="IdentityCompanyEntry" />
                     </StackLayout>
-                    <StackLayout StyleClass="box-row, box-row-input">
-                        <Label
-                            Text="{u:I18n MiddleName}"
-                            StyleClass="box-label" />
-                        <Entry
-                            x:Name="_identityMiddleNameEntry"
-                            Text="{Binding Cipher.Identity.MiddleName}"
-                            StyleClass="box-value,capitalize-word-input"
-                            AutomationProperties.IsInAccessibleTree="True"
-                            AutomationProperties.Name="{u:I18n MiddleName}"
-                            AutomationId="IdentityMiddleNameEntry" />
-                    </StackLayout>
-                    <StackLayout StyleClass="box-row, box-row-input">
-                        <Label
-                            Text="{u:I18n LastName}"
-                            StyleClass="box-label" />
-                        <Entry
-                            x:Name="_identityLastNameEntry"
-                            Text="{Binding Cipher.Identity.LastName}"
-                            StyleClass="box-value,capitalize-word-input"
-                            AutomationProperties.IsInAccessibleTree="True"
-                            AutomationProperties.Name="{u:I18n LastName}"
-                            AutomationId="IdentityLastNameEntry" />
-                    </StackLayout>
-                    <StackLayout StyleClass="box-row, box-row-input">
-                        <Label
-                            Text="{u:I18n Username}"
-                            StyleClass="box-label" />
-                        <Entry
-                            x:Name="_identityUsernameEntry"
-                            Text="{Binding Cipher.Identity.Username}"
-                            StyleClass="box-value"
-                            AutomationProperties.IsInAccessibleTree="True"
-                            AutomationProperties.Name="{u:I18n Username}"
-                            AutomationId="IdentityUsernameEntry" />
-                    </StackLayout>
-                    <StackLayout StyleClass="box-row, box-row-input">
-                        <Label
-                            Text="{u:I18n Company}"
-                            StyleClass="box-label" />
-                        <Entry
-                            x:Name="_identityCompanyEntry"
-                            Text="{Binding Cipher.Identity.Company}"
-                            StyleClass="box-value" 
-                            AutomationProperties.IsInAccessibleTree="True"
-                            AutomationProperties.Name="{u:I18n Company}"
-                            AutomationId="IdentityCompanyEntry" />
-                    </StackLayout>
-                    <StackLayout StyleClass="box-row, box-row-input">
-                        <Label
-                            Text="{u:I18n SSN}"
-                            StyleClass="box-label" />
-                        <Entry
-                            x:Name="_identitySsnEntry"
-                            Text="{Binding Cipher.Identity.SSN}"
-                            StyleClass="box-value" 
-                            AutomationProperties.IsInAccessibleTree="True"
-                            AutomationProperties.Name="{u:I18n SSN}"
-                            AutomationId="IdentitySsnEntry" />
-                    </StackLayout>
-                    <StackLayout StyleClass="box-row, box-row-input">
-                        <Label
-                            Text="{u:I18n PassportNumber}"
-                            StyleClass="box-label" />
-                        <Entry
-                            x:Name="_identityPassportNumberEntry"
-                            Text="{Binding Cipher.Identity.PassportNumber}"
-                            StyleClass="box-value" 
-                            AutomationProperties.IsInAccessibleTree="True"
-                            AutomationProperties.Name="{u:I18n PassportNumber}"
-                            AutomationId="IdentityPassportNumberEntry" />
-                    </StackLayout>
-                    <StackLayout StyleClass="box-row, box-row-input">
-                        <Label
-                            Text="{u:I18n LicenseNumber}"
-                            StyleClass="box-label" />
-                        <Entry
-                            x:Name="_identityLicenseNumberEntry"
-                            Text="{Binding Cipher.Identity.LicenseNumber}"
-                            StyleClass="box-value"
-                            AutomationProperties.IsInAccessibleTree="True"
-                            AutomationProperties.Name="{u:I18n LicenseNumber}"
-                            AutomationId="IdentityLicenseNumberEntry" />
-                    </StackLayout>
-                    <StackLayout StyleClass="box-row, box-row-input">
-                        <Label
-                            Text="{u:I18n Email}"
-                            StyleClass="box-label" />
-                        <Entry
-                            x:Name="_identityEmailEntry"
-                            Keyboard="Email"
-                            Text="{Binding Cipher.Identity.Email}"
-                            StyleClass="box-value" 
-                            AutomationProperties.IsInAccessibleTree="True"
-                            AutomationProperties.Name="{u:I18n Email}"
-                            AutomationId="IdentityEmailEntry" />
-                    </StackLayout>
-                    <StackLayout StyleClass="box-row, box-row-input">
-                        <Label
-                            Text="{u:I18n Phone}"
-                            StyleClass="box-label" />
-                        <Entry
-                            x:Name="_identityPhoneEntry"
-                            Text="{Binding Cipher.Identity.Phone}"
-                            Keyboard="Telephone"
-                            StyleClass="box-value"
-                            AutomationProperties.IsInAccessibleTree="True"
-                            AutomationProperties.Name="{u:I18n Phone}"
-                            AutomationId="IdentityPhoneEntry" />
-                    </StackLayout>
-                    <StackLayout StyleClass="box-row, box-row-input">
-                        <Label
-                            Text="{u:I18n Address1}"
-                            StyleClass="box-label" />
-                        <Entry
-                            x:Name="_identityAddress1Entry"
-                            Text="{Binding Cipher.Identity.Address1}"
-                            StyleClass="box-value" 
-                            AutomationProperties.IsInAccessibleTree="True"
-                            AutomationProperties.Name="{u:I18n Address1}"
-                            AutomationId="IdentityAddressOneEntry" />
-                    </StackLayout>
-                    <StackLayout StyleClass="box-row, box-row-input">
-                        <Label
-                            Text="{u:I18n Address2}"
-                            StyleClass="box-label" />
-                        <Entry
-                            x:Name="_identityAddress2Entry"
-                            Text="{Binding Cipher.Identity.Address2}"
-                            StyleClass="box-value"
-                            AutomationProperties.IsInAccessibleTree="True"
-                            AutomationProperties.Name="{u:I18n Address2}"
-                            AutomationId="IdentityAddressTwoEntry" />
-                    </StackLayout>
-                    <StackLayout StyleClass="box-row, box-row-input">
-                        <Label
-                            Text="{u:I18n Address3}"
-                            StyleClass="box-label" />
-                        <Entry
-                            x:Name="_identityAddress3Entry"
-                            Text="{Binding Cipher.Identity.Address3}"
-                            StyleClass="box-value"
-                            AutomationProperties.IsInAccessibleTree="True"
-                            AutomationProperties.Name="{u:I18n Address3}"
-                            AutomationId="IdentityAddressThreeEntry" />
-                    </StackLayout>
-                    <StackLayout StyleClass="box-row, box-row-input">
-                        <Label
-                            Text="{u:I18n CityTown}"
-                            StyleClass="box-label" />
-                        <Entry
-                            x:Name="_identityCityEntry"
-                            Text="{Binding Cipher.Identity.City}"
-                            StyleClass="box-value,capitalize-sentence-input"
-                            AutomationProperties.IsInAccessibleTree="True"
-                            AutomationProperties.Name="{u:I18n CityTown}"
-                            AutomationId="IdentityCityEntry" />
-                    </StackLayout>
-                    <StackLayout StyleClass="box-row, box-row-input">
-                        <Label
-                            Text="{u:I18n StateProvince}"
-                            StyleClass="box-label" />
-                        <Entry
-                            x:Name="_identityStateEntry"
-                            Text="{Binding Cipher.Identity.State}"
-                            StyleClass="box-value,capitalize-sentence-input"
-                            AutomationProperties.IsInAccessibleTree="True"
-                            AutomationProperties.Name="{u:I18n StateProvince}"
-                            AutomationId="IdentityStateEntry" />
-                    </StackLayout>
+                    </yummy:PancakeView>                                                            <yummy:PancakeView StyleClass="round-card">
+                        <StackLayout StyleClass="box-row, box-row-input">
+                            <Label
+                                Text="{u:I18n SSN}"
+                                StyleClass="box-label" />
+                            <Entry
+                                x:Name="_identitySsnEntry"
+                                Text="{Binding Cipher.Identity.SSN}"
+                                StyleClass="box-value" 
+                                AutomationProperties.IsInAccessibleTree="True"
+                                AutomationProperties.Name="{u:I18n SSN}"
+                                AutomationId="IdentitySsnEntry" />
+                        </StackLayout>
+                    </yummy:PancakeView>
+                    <yummy:PancakeView StyleClass="round-card">
+                        <StackLayout StyleClass="box-row, box-row-input">
+                            <Label
+                                Text="{u:I18n PassportNumber}"
+                                StyleClass="box-label" />
+                            <Entry
+                                x:Name="_identityPassportNumberEntry"
+                                Text="{Binding Cipher.Identity.PassportNumber}"
+                                StyleClass="box-value" 
+                                AutomationProperties.IsInAccessibleTree="True"
+                                AutomationProperties.Name="{u:I18n PassportNumber}"
+                                AutomationId="IdentityPassportNumberEntry" />
+                        </StackLayout>
+                    </yummy:PancakeView>
+                    <yummy:PancakeView StyleClass="round-card">
+                        <StackLayout StyleClass="box-row, box-row-input">
+                            <Label
+                                Text="{u:I18n LicenseNumber}"
+                                StyleClass="box-label" />
+                            <Entry
+                                x:Name="_identityLicenseNumberEntry"
+                                Text="{Binding Cipher.Identity.LicenseNumber}"
+                                StyleClass="box-value"
+                                AutomationProperties.IsInAccessibleTree="True"
+                                AutomationProperties.Name="{u:I18n LicenseNumber}"
+                                AutomationId="IdentityLicenseNumberEntry" />
+                        </StackLayout>
+                    </yummy:PancakeView>
+                    <yummy:PancakeView StyleClass="round-card">
+                        <StackLayout StyleClass="box-row, box-row-input">
+                            <Label
+                                Text="{u:I18n Email}"
+                                StyleClass="box-label" />
+                            <Entry
+                                x:Name="_identityEmailEntry"
+                                Keyboard="Email"
+                                Text="{Binding Cipher.Identity.Email}"
+                                StyleClass="box-value" 
+                                AutomationProperties.IsInAccessibleTree="True"
+                                AutomationProperties.Name="{u:I18n Email}"
+                                AutomationId="IdentityEmailEntry" />
+                        </StackLayout>
+                    </yummy:PancakeView>
+                    <yummy:PancakeView StyleClass="round-card">
+                        <StackLayout StyleClass="box-row, box-row-input">
+                            <Label
+                                Text="{u:I18n Phone}"
+                                StyleClass="box-label" />
+                            <Entry
+                                x:Name="_identityPhoneEntry"
+                                Text="{Binding Cipher.Identity.Phone}"
+                                Keyboard="Telephone"
+                                StyleClass="box-value"
+                                AutomationProperties.IsInAccessibleTree="True"
+                                AutomationProperties.Name="{u:I18n Phone}"
+                                AutomationId="IdentityPhoneEntry" />
+                        </StackLayout>
+                    </yummy:PancakeView>
+                    <yummy:PancakeView StyleClass="round-card">
+                        <StackLayout StyleClass="box-row, box-row-input">
+                            <Label
+                                Text="{u:I18n Address1}"
+                                StyleClass="box-label" />
+                            <Entry
+                                x:Name="_identityAddress1Entry"
+                                Text="{Binding Cipher.Identity.Address1}"
+                                StyleClass="box-value" 
+                                AutomationProperties.IsInAccessibleTree="True"
+                                AutomationProperties.Name="{u:I18n Address1}"
+                                AutomationId="IdentityAddressOneEntry" />
+                        </StackLayout>
+                    </yummy:PancakeView>
+                    <yummy:PancakeView StyleClass="round-card">
+                        <StackLayout StyleClass="box-row, box-row-input">
+                            <Label
+                                Text="{u:I18n Address2}"
+                                StyleClass="box-label" />
+                            <Entry
+                                x:Name="_identityAddress2Entry"
+                                Text="{Binding Cipher.Identity.Address2}"
+                                StyleClass="box-value"
+                                AutomationProperties.IsInAccessibleTree="True"
+                                AutomationProperties.Name="{u:I18n Address2}"
+                                AutomationId="IdentityAddressTwoEntry" />
+                        </StackLayout>
+                    </yummy:PancakeView>
+                    <yummy:PancakeView StyleClass="round-card">
+                        <StackLayout StyleClass="box-row, box-row-input">
+                            <Label
+                                Text="{u:I18n Address3}"
+                                StyleClass="box-label" />
+                            <Entry
+                                x:Name="_identityAddress3Entry"
+                                Text="{Binding Cipher.Identity.Address3}"
+                                StyleClass="box-value"
+                                AutomationProperties.IsInAccessibleTree="True"
+                                AutomationProperties.Name="{u:I18n Address3}"
+                                AutomationId="IdentityAddressThreeEntry" />
+                        </StackLayout>
+                    </yummy:PancakeView>
+                    <yummy:PancakeView StyleClass="round-card">
+                        <StackLayout StyleClass="box-row, box-row-input">
+                            <Label
+                                Text="{u:I18n CityTown}"
+                                StyleClass="box-label" />
+                            <Entry
+                                x:Name="_identityCityEntry"
+                                Text="{Binding Cipher.Identity.City}"
+                                StyleClass="box-value,capitalize-sentence-input"
+                                AutomationProperties.IsInAccessibleTree="True"
+                                AutomationProperties.Name="{u:I18n CityTown}"
+                                AutomationId="IdentityCityEntry" />
+                        </StackLayout>
+                    </yummy:PancakeView>
+                    <yummy:PancakeView StyleClass="round-card">
+                        <StackLayout StyleClass="box-row, box-row-input">
+                            <Label
+                                Text="{u:I18n StateProvince}"
+                                StyleClass="box-label" />
+                            <Entry
+                                x:Name="_identityStateEntry"
+                                Text="{Binding Cipher.Identity.State}"
+                                StyleClass="box-value,capitalize-sentence-input"
+                                AutomationProperties.IsInAccessibleTree="True"
+                                AutomationProperties.Name="{u:I18n StateProvince}"
+                                AutomationId="IdentityStateEntry" />
+                        </StackLayout>
+                    </yummy:PancakeView>
+                    <yummy:PancakeView StyleClass="round-card">
                     <StackLayout StyleClass="box-row, box-row-input">
                         <Label
                             Text="{u:I18n ZipPostalCode}"
@@ -637,6 +688,8 @@
                             AutomationProperties.Name="{u:I18n ZipPostalCode}"
                             AutomationId="IdentityPostalCodeEntry" />
                     </StackLayout>
+                    </yummy:PancakeView>
+                                                            <yummy:PancakeView StyleClass="round-card">
                     <StackLayout StyleClass="box-row, box-row-input">
                         <Label
                             Text="{u:I18n Country}"
@@ -649,6 +702,7 @@
                             AutomationProperties.Name="{u:I18n Country}"
                             AutomationId="IdentityCountryEntry" />
                     </StackLayout>
+                    </yummy:PancakeView>
                 </StackLayout>
 
                 <StackLayout IsVisible="{Binding IsFido2Key}" Spacing="0" Padding="0">
@@ -691,6 +745,7 @@
                 <controls:RepeaterView ItemsSource="{Binding Uris}">
                     <controls:RepeaterView.ItemTemplate>
                         <DataTemplate x:DataType="views:LoginUriView">
+                            <yummy:PancakeView StyleClass="round-card">
                             <Grid StyleClass="box-row, box-row-input" AutomationId="UriListGrid" >
                                 <Grid.RowDefinitions>
                                     <RowDefinition Height="Auto" />
@@ -726,6 +781,7 @@
                                     AutomationProperties.Name="{u:I18n Options}"
                                     AutomationId="LoginUriOptionsButton" />
                             </Grid>
+                            </yummy:PancakeView>
                         </DataTemplate>
                     </controls:RepeaterView.ItemTemplate>
                 </controls:RepeaterView>
@@ -738,17 +794,19 @@
                     <Label Text="{u:I18n Miscellaneous, Header=True}"
                            StyleClass="box-header, box-header-platform" />
                 </StackLayout>
-                <StackLayout StyleClass="box-row, box-row-input">
-                    <Label
-                        Text="{u:I18n Folder}"
-                        StyleClass="box-label" />
-                    <Picker
-                        x:Name="_folderPicker"
-                        ItemsSource="{Binding FolderOptions, Mode=OneTime}"
-                        SelectedIndex="{Binding FolderSelectedIndex}"
-                        StyleClass="box-value"
-                        AutomationId="FolderPicker" />
-                </StackLayout>
+                <yummy:PancakeView StyleClass="round-card">
+                    <StackLayout StyleClass="box-row, box-row-input">
+                        <Label
+                            Text="{u:I18n Folder}"
+                            StyleClass="box-label" />
+                        <Picker
+                            x:Name="_folderPicker"
+                            ItemsSource="{Binding FolderOptions, Mode=OneTime}"
+                            SelectedIndex="{Binding FolderSelectedIndex}"
+                            StyleClass="box-value"
+                            AutomationId="FolderPicker" />
+                    </StackLayout>
+                </yummy:PancakeView>
                 <StackLayout StyleClass="box-row, box-row-switch">
                     <Label
                         Text="{u:I18n Favorite}"
@@ -779,31 +837,32 @@
                         HorizontalOptions="End"
                         AutomationId="MasterPasswordRepromptToggle" />
                 </StackLayout>
-                <BoxView StyleClass="box-row-separator" />
             </StackLayout>
             <StackLayout StyleClass="box">
                 <StackLayout StyleClass="box-row-header">
                     <Label Text="{u:I18n Notes, Header=True}"
                            StyleClass="box-header, box-header-platform" />
                 </StackLayout>
-                <StackLayout StyleClass="box-row, box-row-input">
-                    <Editor
-                        x:Name="_notesEditor"
-                        AutoSize="TextChanges"
-                        StyleClass="box-value"
-                        effects:ScrollEnabledEffect.IsScrollEnabled="false"
-                        Text="{Binding Cipher.Notes}"
-                        AutomationProperties.IsInAccessibleTree="True"
-                        AutomationProperties.Name="{u:I18n Notes}"
-                        AutomationId="ItemNotesEntry">
-                        <Editor.Behaviors>
-                            <behaviors:EditorPreventAutoBottomScrollingOnFocusedBehavior ParentScrollView="{x:Reference _scrollView}" />
-                        </Editor.Behaviors>
-                        <Editor.Effects>
-                            <effects:ScrollEnabledEffect />
-                        </Editor.Effects>
-                    </Editor>
-                </StackLayout>
+                <yummy:PancakeView StyleClass="round-card">
+                    <StackLayout StyleClass="box-row, box-row-input">
+                        <Editor
+                            x:Name="_notesEditor"
+                            AutoSize="TextChanges"
+                            StyleClass="box-value"
+                            effects:ScrollEnabledEffect.IsScrollEnabled="false"
+                            Text="{Binding Cipher.Notes}"
+                            AutomationProperties.IsInAccessibleTree="True"
+                            AutomationProperties.Name="{u:I18n Notes}"
+                            AutomationId="ItemNotesEntry">
+                            <Editor.Behaviors>
+                                <behaviors:EditorPreventAutoBottomScrollingOnFocusedBehavior ParentScrollView="{x:Reference _scrollView}" />
+                            </Editor.Behaviors>
+                            <Editor.Effects>
+                                <effects:ScrollEnabledEffect />
+                            </Editor.Effects>
+                        </Editor>
+                    </StackLayout>
+                </yummy:PancakeView>
                 <BoxView StyleClass="box-row-separator" IsVisible="{Binding ShowNotesSeparator}" />
             </StackLayout>
             <StackLayout StyleClass="box">

--- a/src/App/Pages/Vault/CipherDetailsPage.xaml
+++ b/src/App/Pages/Vault/CipherDetailsPage.xaml
@@ -11,6 +11,7 @@
     xmlns:dts="clr-namespace:Bit.App.Lists.DataTemplateSelectors"
     xmlns:il="clr-namespace:Bit.App.Lists.ItemLayouts.CustomFields"
     xmlns:core="clr-namespace:Bit.Core;assembly=BitwardenCore"
+    xmlns:yummy="clr-namespace:Xamarin.Forms.PancakeView;assembly=Xamarin.Forms.PancakeView"
     x:DataType="pages:CipherDetailsPageViewModel"
     x:Name="_page"
     Title="{Binding PageTitle}">
@@ -70,131 +71,119 @@
             <ScrollView x:Key="scrollView" x:Name="_scrollView">
                 <StackLayout Spacing="20" x:Name="_mainLayout">
                     <StackLayout StyleClass="box" AutomationId="ItemInformationSection">
-                        <StackLayout StyleClass="box-row-header">
-                            <Label Text="{u:I18n ItemInformation, Header=True}"
-                                   StyleClass="box-header, box-header-platform" />
-                        </StackLayout>
-                        <StackLayout StyleClass="box-row" AutomationId="ItemRow">
-                            <Label
-                                Text="{u:I18n Name}"
-                                StyleClass="box-label"
-                                AutomationId="ItemName" />
-                            <Label
-                                Text="{Binding Cipher.Name, Mode=OneWay}"
-                                StyleClass="box-value"
-                                AutomationId="ItemValue" />
-                        </StackLayout>
-                        <BoxView StyleClass="box-row-separator" />
+                        <Label 
+                           Text="{Binding Cipher.Name, Mode=OneWay}"
+                           FontSize="30"
+                           Margin="0,15,0,5"
+                           />
                         <StackLayout IsVisible="{Binding IsLogin}" Spacing="0" Padding="0">
-                            <Grid StyleClass="box-row"
-                                  IsVisible="{Binding Cipher.Login.Username, Converter={StaticResource stringHasValue}}"
+                            <yummy:PancakeView StyleClass="round-card" IsVisible="{Binding Cipher.Login.Username, Converter={StaticResource stringHasValue}}">
+                                <Grid StyleClass="box-row"
+                                    AutomationId="ItemRow">
+                                    <Grid.RowDefinitions>
+                                        <RowDefinition Height="Auto" />
+                                        <RowDefinition Height="*" />
+                                    </Grid.RowDefinitions>
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="*" />
+                                        <ColumnDefinition Width="Auto" />
+                                    </Grid.ColumnDefinitions>
+                                    <Label
+                                        Text="{u:I18n Username}"
+                                        StyleClass="box-label"
+                                        Grid.Row="0"
+                                        Grid.Column="0"
+                                        AutomationId="ItemName" />
+                                    <Label
+                                        Text="{Binding Cipher.Login.Username, Mode=OneWay}"
+                                        StyleClass="box-value"
+                                        Grid.Row="1"
+                                        Grid.Column="0"
+                                        AutomationId="ItemValue" />
+                                    <controls:IconButton
+                                        StyleClass="box-row-button, box-row-button-platform"
+                                        Text="{Binding Source={x:Static core:BitwardenIcons.Clone}}"
+                                        Command="{Binding CopyCommand}"
+                                        CommandParameter="LoginUsername"
+                                        Grid.Row="0"
+                                        Grid.Column="1"
+                                        Grid.RowSpan="2"
+                                        AutomationProperties.IsInAccessibleTree="True"
+                                        AutomationProperties.Name="{u:I18n CopyUsername}"
+                                        AutomationId="CopyValueButton" />
+                                </Grid>
+                            </yummy:PancakeView>
+                            <yummy:PancakeView StyleClass="round-card" IsVisible="{Binding Cipher.Login.Password, Converter={StaticResource stringHasValue}}">
+                                <Grid StyleClass="box-row"
                                   AutomationId="ItemRow">
-                                <Grid.RowDefinitions>
-                                    <RowDefinition Height="Auto" />
-                                    <RowDefinition Height="*" />
-                                </Grid.RowDefinitions>
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="*" />
-                                    <ColumnDefinition Width="Auto" />
-                                </Grid.ColumnDefinitions>
-                                <Label
-                                    Text="{u:I18n Username}"
-                                    StyleClass="box-label"
-                                    Grid.Row="0"
-                                    Grid.Column="0"
-                                    AutomationId="ItemName" />
-                                <Label
-                                    Text="{Binding Cipher.Login.Username, Mode=OneWay}"
-                                    StyleClass="box-value"
-                                    Grid.Row="1"
-                                    Grid.Column="0"
-                                    AutomationId="ItemValue" />
-                                <controls:IconButton
-                                    StyleClass="box-row-button, box-row-button-platform"
-                                    Text="{Binding Source={x:Static core:BitwardenIcons.Clone}}"
-                                    Command="{Binding CopyCommand}"
-                                    CommandParameter="LoginUsername"
-                                    Grid.Row="0"
-                                    Grid.Column="1"
-                                    Grid.RowSpan="2"
-                                    AutomationProperties.IsInAccessibleTree="True"
-                                    AutomationProperties.Name="{u:I18n CopyUsername}"
-                                    AutomationId="CopyValueButton" />
-                            </Grid>
-                            <BoxView StyleClass="box-row-separator"
-                                     IsVisible="{Binding Cipher.Login.Username, Converter={StaticResource stringHasValue}}" />
-                            <Grid StyleClass="box-row"
-                                  IsVisible="{Binding Cipher.Login.Password, Converter={StaticResource stringHasValue}}"
-                                  AutomationId="ItemRow">
-                                <Grid.RowDefinitions>
-                                    <RowDefinition Height="Auto" />
-                                    <RowDefinition Height="*" />
-                                </Grid.RowDefinitions>
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="*" />
-                                    <ColumnDefinition Width="Auto" />
-                                    <ColumnDefinition Width="Auto" />
-                                    <ColumnDefinition Width="Auto" />
-                                </Grid.ColumnDefinitions>
-                                <Label
-                                    Text="{u:I18n Password}"
-                                    StyleClass="box-label"
-                                    Grid.Row="0"
-                                    Grid.Column="0"
-                                    AutomationId="ItemName" />
-                                <controls:MonoLabel
-                                    Text="{Binding Cipher.Login.MaskedPassword, Mode=OneWay}"
-                                    StyleClass="box-value"
-                                    Grid.Row="1"
-                                    Grid.Column="0"
-                                    IsVisible="{Binding ShowPassword, Converter={StaticResource inverseBool}}"
-                                    AutomationId="ItemValue" />
-                                <controls:MonoLabel
-                                    Text="{Binding ColoredPassword, Mode=OneWay}"
-                                    StyleClass="box-value, text-html"
-                                    Grid.Row="1"
-                                    Grid.Column="0"
-                                    LineBreakMode="CharacterWrap"
-                                    IsVisible="{Binding ShowPassword}"
-                                    AutomationId="ItemValue" />
-                                <controls:IconButton
-                                    StyleClass="box-row-button, box-row-button-platform"
-                                    Text="{Binding Source={x:Static core:BitwardenIcons.CheckCircle}}"
-                                    Command="{Binding CheckPasswordCommand}"
-                                    Grid.Row="0"
-                                    Grid.Column="1"
-                                    Grid.RowSpan="2"
-                                    AutomationProperties.IsInAccessibleTree="True"
-                                    AutomationProperties.Name="{u:I18n CheckPassword}"
-                                    IsVisible="{Binding Cipher.ViewPassword}"
-                                    AutomationId="CheckPasswordButton" />
-                                <controls:IconButton
-                                    StyleClass="box-row-button, box-row-button-platform"
-                                    Text="{Binding ShowPasswordIcon}"
-                                    Command="{Binding TogglePasswordCommand}"
-                                    Grid.Row="0"
-                                    Grid.Column="2"
-                                    Grid.RowSpan="2"
-                                    AutomationProperties.IsInAccessibleTree="True"
-                                    AutomationProperties.Name="{u:I18n ToggleVisibility}"
-                                    AutomationProperties.HelpText="{Binding PasswordVisibilityAccessibilityText}"
-                                    IsVisible="{Binding Cipher.ViewPassword}"
-                                    AutomationId="ShowValueButton" />
-                                <controls:IconButton
-                                    StyleClass="box-row-button, box-row-button-platform"
-                                    Text="{Binding Source={x:Static core:BitwardenIcons.Clone}}"
-                                    Command="{Binding CopyCommand}"
-                                    CommandParameter="LoginPassword"
-                                    Grid.Row="0"
-                                    Grid.Column="3"
-                                    Grid.RowSpan="2"
-                                    AutomationProperties.IsInAccessibleTree="True"
-                                    AutomationProperties.Name="{u:I18n CopyPassword}"
-                                    IsVisible="{Binding Cipher.ViewPassword}"
-                                    AutomationId="CopyValueButton" />
-                            </Grid>
-                            <BoxView StyleClass="box-row-separator"
-                                     IsVisible="{Binding Cipher.Login.Password, Converter={StaticResource stringHasValue}}" />
+                                    <Grid.RowDefinitions>
+                                        <RowDefinition Height="Auto" />
+                                        <RowDefinition Height="*" />
+                                    </Grid.RowDefinitions>
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="*" />
+                                        <ColumnDefinition Width="Auto" />
+                                        <ColumnDefinition Width="Auto" />
+                                        <ColumnDefinition Width="Auto" />
+                                    </Grid.ColumnDefinitions>
+                                    <Label
+                                        Text="{u:I18n Password}"
+                                        StyleClass="box-label"
+                                        Grid.Row="0"
+                                        Grid.Column="0"
+                                        AutomationId="ItemName" />
+                                    <controls:MonoLabel
+                                        Text="{Binding Cipher.Login.MaskedPassword, Mode=OneWay}"
+                                        StyleClass="box-value"
+                                        Grid.Row="1"
+                                        Grid.Column="0"
+                                        IsVisible="{Binding ShowPassword, Converter={StaticResource inverseBool}}"
+                                        AutomationId="ItemValue" />
+                                    <controls:MonoLabel
+                                        Text="{Binding ColoredPassword, Mode=OneWay}"
+                                        StyleClass="box-value, text-html"
+                                        Grid.Row="1"
+                                        Grid.Column="0"
+                                        LineBreakMode="CharacterWrap"
+                                        IsVisible="{Binding ShowPassword}"
+                                        AutomationId="ItemValue" />
+                                    <controls:IconButton
+                                        StyleClass="box-row-button, box-row-button-platform"
+                                        Text="{Binding Source={x:Static core:BitwardenIcons.CheckCircle}}"
+                                        Command="{Binding CheckPasswordCommand}"
+                                        Grid.Row="0"
+                                        Grid.Column="1"
+                                        Grid.RowSpan="2"
+                                        AutomationProperties.IsInAccessibleTree="True"
+                                        AutomationProperties.Name="{u:I18n CheckPassword}"
+                                        IsVisible="{Binding Cipher.ViewPassword}"
+                                        AutomationId="CheckPasswordButton" />
+                                    <controls:IconButton
+                                        StyleClass="box-row-button, box-row-button-platform"
+                                        Text="{Binding ShowPasswordIcon}"
+                                        Command="{Binding TogglePasswordCommand}"
+                                        Grid.Row="0"
+                                        Grid.Column="2"
+                                        Grid.RowSpan="2"
+                                        AutomationProperties.IsInAccessibleTree="True"
+                                        AutomationProperties.Name="{u:I18n ToggleVisibility}"
+                                        AutomationProperties.HelpText="{Binding PasswordVisibilityAccessibilityText}"
+                                        IsVisible="{Binding Cipher.ViewPassword}"
+                                        AutomationId="ShowValueButton" />
+                                    <controls:IconButton
+                                        StyleClass="box-row-button, box-row-button-platform"
+                                        Text="{Binding Source={x:Static core:BitwardenIcons.Clone}}"
+                                        Command="{Binding CopyCommand}"
+                                        CommandParameter="LoginPassword"
+                                        Grid.Row="0"
+                                        Grid.Column="3"
+                                        Grid.RowSpan="2"
+                                        AutomationProperties.IsInAccessibleTree="True"
+                                        AutomationProperties.Name="{u:I18n CopyPassword}"
+                                        IsVisible="{Binding Cipher.ViewPassword}"
+                                        AutomationId="CopyValueButton" />
+                                </Grid>
+                            </yummy:PancakeView>
                             <Label
                                 Text="{u:I18n Passkey}"
                                 StyleClass="box-label"
@@ -205,379 +194,373 @@
                                 IsEnabled="False"
                                 StyleClass="box-value,text-muted"
                                 IsVisible="{Binding Cipher.Login.Fido2Key, Converter={StaticResource notNull}}" />
-                            <Grid StyleClass="box-row"
-                                  IsVisible="{Binding ShowTotp}"
+                            <yummy:PancakeView StyleClass="round-card" IsVisible="{Binding ShowTotp}">
+                                <Grid StyleClass="box-row"
                                   AutomationId="ItemRow">
-                                <Grid.RowDefinitions>
-                                    <RowDefinition Height="Auto" />
-                                    <RowDefinition Height="*" />
-                                    <RowDefinition Height="Auto" />
-                                </Grid.RowDefinitions>
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="*" />
-                                    <ColumnDefinition Width="40" />
-                                    <ColumnDefinition Width="Auto" />
-                                </Grid.ColumnDefinitions>
-                                <Label
-                                    Text="{u:I18n VerificationCodeTotp}"
-                                    StyleClass="box-label"
-                                    Grid.Row="0"
-                                    Grid.Column="0"
-                                    AutomationId="ItemName" />
-                                <controls:MonoLabel
-                                    Text="{Binding TotpCodeFormatted, Mode=OneWay}"
-                                    IsVisible="{Binding ShowUpgradePremiumTotpText, Converter={StaticResource inverseBool}}"
-                                    StyleClass="box-value"
-                                    Grid.Row="1"
-                                    Grid.Column="0"
-                                    VerticalTextAlignment="Start"
-                                    VerticalOptions="Start"
-                                    AutomationId="ItemValue" />
-                                <controls:CircularProgressbarView
-                                    Progress="{Binding TotpProgress}"
-                                    Grid.Row="0"
-                                    Grid.Column="1"
-                                    Grid.RowSpan="2"
-                                    HorizontalOptions="FillAndExpand"
-                                    VerticalOptions="FillAndExpand"
-                                    AutomationId="LoginTotpProgressBar" />
-                                <Label
-                                    Text="{Binding TotpSec, Mode=OneWay}"
-                                    Style="{DynamicResource textTotp}"
-                                    Grid.Row="0"
-                                    Grid.Column="1"
-                                    Grid.RowSpan="2"
-                                    StyleClass="text-sm"
-                                    VerticalTextAlignment="Center"
-                                    HorizontalTextAlignment="Center"
-                                    HorizontalOptions="FillAndExpand"
-                                    VerticalOptions="FillAndExpand" />
-                                <controls:IconButton
-                                    StyleClass="box-row-button, box-row-button-platform"
-                                    Text="{Binding Source={x:Static core:BitwardenIcons.Clone}}"
-                                    Command="{Binding CopyCommand}"
-                                    IsVisible="{Binding CanAccessPremium}"
-                                    CommandParameter="LoginTotp"
-                                    Grid.Row="0"
-                                    Grid.Column="2"
-                                    Grid.RowSpan="2"
-                                    AutomationProperties.IsInAccessibleTree="True"
-                                    AutomationProperties.Name="{u:I18n CopyTotp}"
-                                    AutomationId="CopyValueButton" />
-                                <Label
-                                    Text="{u:I18n PremiumSubscriptionRequired}"
-                                    StyleClass="box-footer-label"
-                                    IsVisible="{Binding ShowUpgradePremiumTotpText}"
-                                    Margin="0,5,0,2"
-                                    Grid.Column="0"
-                                    Grid.Row="1"
-                                    HorizontalOptions="FillAndExpand"
-                                    AutomationId="ShowUpgradePremiumTotpLabel" />
-                            </Grid>
-                            <BoxView StyleClass="box-row-separator" IsVisible="{Binding ShowTotp}" />
+                                    <Grid.RowDefinitions>
+                                        <RowDefinition Height="Auto" />
+                                        <RowDefinition Height="*" />
+                                        <RowDefinition Height="Auto" />
+                                    </Grid.RowDefinitions>
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="*" />
+                                        <ColumnDefinition Width="40" />
+                                        <ColumnDefinition Width="Auto" />
+                                    </Grid.ColumnDefinitions>
+                                    <Label
+                                        Text="{u:I18n VerificationCodeTotp}"
+                                        StyleClass="box-label"
+                                        Grid.Row="0"
+                                        Grid.Column="0"
+                                        AutomationId="ItemName" />
+                                    <controls:MonoLabel
+                                        Text="{Binding TotpCodeFormatted, Mode=OneWay}"
+                                        IsVisible="{Binding ShowUpgradePremiumTotpText, Converter={StaticResource inverseBool}}"
+                                        StyleClass="box-value"
+                                        Grid.Row="1"
+                                        Grid.Column="0"
+                                        VerticalTextAlignment="Start"
+                                        VerticalOptions="Start"
+                                        AutomationId="ItemValue" />
+                                    <controls:CircularProgressbarView
+                                        Progress="{Binding TotpProgress}"
+                                        Grid.Row="0"
+                                        Grid.Column="1"
+                                        Grid.RowSpan="2"
+                                        HorizontalOptions="FillAndExpand"
+                                        VerticalOptions="FillAndExpand"
+                                        AutomationId="LoginTotpProgressBar" />
+                                    <Label
+                                        Text="{Binding TotpSec, Mode=OneWay}"
+                                        Style="{DynamicResource textTotp}"
+                                        Grid.Row="0"
+                                        Grid.Column="1"
+                                        Grid.RowSpan="2"
+                                        StyleClass="text-sm"
+                                        VerticalTextAlignment="Center"
+                                        HorizontalTextAlignment="Center"
+                                        HorizontalOptions="FillAndExpand"
+                                        VerticalOptions="FillAndExpand" />
+                                    <controls:IconButton
+                                        StyleClass="box-row-button, box-row-button-platform"
+                                        Text="{Binding Source={x:Static core:BitwardenIcons.Clone}}"
+                                        Command="{Binding CopyCommand}"
+                                        IsVisible="{Binding CanAccessPremium}"
+                                        CommandParameter="LoginTotp"
+                                        Grid.Row="0"
+                                        Grid.Column="2"
+                                        Grid.RowSpan="2"
+                                        AutomationProperties.IsInAccessibleTree="True"
+                                        AutomationProperties.Name="{u:I18n CopyTotp}"
+                                        AutomationId="CopyValueButton" />
+                                    <Label
+                                        Text="{u:I18n PremiumSubscriptionRequired}"
+                                        StyleClass="box-footer-label"
+                                        IsVisible="{Binding ShowUpgradePremiumTotpText}"
+                                        Margin="0,5,0,2"
+                                        Grid.Column="0"
+                                        Grid.Row="1"
+                                        HorizontalOptions="FillAndExpand"
+                                        AutomationId="ShowUpgradePremiumTotpLabel" />
+                                </Grid>
+                            </yummy:PancakeView>
                         </StackLayout>
                         <StackLayout IsVisible="{Binding IsCard}" Spacing="0" Padding="0">
-                            <StackLayout StyleClass="box-row"
-                                         IsVisible="{Binding Cipher.Card.CardholderName, Converter={StaticResource stringHasValue}}"
-                                         AutomationId="ItemRow">
-                                <Label
-                                    Text="{u:I18n CardholderName}"
-                                    StyleClass="box-label"
-                                    AutomationId="ItemName" />
-                                <Label
-                                    Text="{Binding Cipher.Card.CardholderName, Mode=OneWay}"
-                                    StyleClass="box-value"
-                                    AutomationId="ItemValue" />
-                            </StackLayout>
-                            <BoxView StyleClass="box-row-separator"
-                                     IsVisible="{Binding Cipher.Card.CardholderName, Converter={StaticResource stringHasValue}}" />
-                            <Grid StyleClass="box-row"
-                                  IsVisible="{Binding Cipher.Card.Number, Converter={StaticResource stringHasValue}}"
-                                  AutomationId="ItemRow">
-                                <Grid.RowDefinitions>
-                                    <RowDefinition Height="Auto" />
-                                    <RowDefinition Height="*" />
-                                </Grid.RowDefinitions>
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="*" />
-                                    <ColumnDefinition Width="Auto" />
-                                    <ColumnDefinition Width="Auto" />
-                                </Grid.ColumnDefinitions>
-                                <Label
-                                    Text="{u:I18n Number}"
-                                    StyleClass="box-label"
-                                    Grid.Row="0"
-                                    Grid.Column="0"
-                                    AutomationId="ItemName" />
-                                <controls:MonoLabel
-                                    Text="{Binding Cipher.Card.MaskedNumber, Mode=OneWay}"
-                                    StyleClass="box-value"
-                                    Grid.Row="1"
-                                    Grid.Column="0"
-                                    IsVisible="{Binding ShowCardNumber, Converter={StaticResource inverseBool}}"
-                                    AutomationId="ItemValue" />
-                                <controls:MonoLabel
-                                    Text="{Binding Cipher.Card.Number, Mode=OneWay}"
-                                    StyleClass="box-value"
-                                    Grid.Row="1"
-                                    Grid.Column="0"
-                                    IsVisible="{Binding ShowCardNumber}"
-                                    AutomationId="ItemValue" />
-                                <controls:IconButton
-                                    StyleClass="box-row-button, box-row-button-platform"
-                                    Text="{Binding ShowCardNumberIcon}"
-                                    Command="{Binding ToggleCardNumberCommand}"
-                                    Grid.Row="0"
-                                    Grid.Column="1"
-                                    Grid.RowSpan="2"
-                                    AutomationProperties.IsInAccessibleTree="True"
-                                    AutomationProperties.Name="{u:I18n ToggleVisibility}"
-                                    AutomationId="ShowValueButton" />
-                                <controls:IconButton
-                                    StyleClass="box-row-button, box-row-button-platform"
-                                    Text="{Binding Source={x:Static core:BitwardenIcons.Clone}}"
-                                    Command="{Binding CopyCommand}"
-                                    CommandParameter="CardNumber"
-                                    Grid.Row="0"
-                                    Grid.Column="2"
-                                    Grid.RowSpan="2"
-                                    AutomationProperties.IsInAccessibleTree="True"
-                                    AutomationProperties.Name="{u:I18n CopyNumber}"
-                                    AutomationId="CopyValueButton" />
-                            </Grid>
-                            <BoxView StyleClass="box-row-separator"
-                                     IsVisible="{Binding Cipher.Card.Number, Converter={StaticResource stringHasValue}}" />
-                            <StackLayout StyleClass="box-row"
-                                         IsVisible="{Binding Cipher.Card.Brand, Converter={StaticResource stringHasValue}}"
-                                         AutomationId="ItemRow">
-                                <Label
-                                    Text="{u:I18n Brand}"
-                                    StyleClass="box-label"
-                                    AutomationId="ItemName" />
-                                <Label
-                                    Text="{Binding Cipher.Card.Brand, Mode=OneWay}"
-                                    StyleClass="box-value"
-                                    AutomationId="ItemValue" />
-                            </StackLayout>
-                            <BoxView StyleClass="box-row-separator"
-                                     IsVisible="{Binding Cipher.Card.Brand, Converter={StaticResource stringHasValue}}" />
-                            <StackLayout StyleClass="box-row"
-                                         IsVisible="{Binding Cipher.Card.Expiration, Converter={StaticResource stringHasValue}}"
-                                         AutomationId="ItemRow">
-                                <Label
-                                    Text="{u:I18n Expiration}"
-                                    StyleClass="box-label"
-                                    AutomationId="ItemName" />
-                                <Label
-                                    Text="{Binding Cipher.Card.Expiration, Mode=OneWay}"
-                                    StyleClass="box-value"
-                                    AutomationId="ItemValue" />
-                            </StackLayout>
-                            <BoxView StyleClass="box-row-separator"
-                                     IsVisible="{Binding Cipher.Card.Expiration, Converter={StaticResource stringHasValue}}" />
-                            <Grid StyleClass="box-row"
-                                  IsVisible="{Binding Cipher.Card.Code, Converter={StaticResource stringHasValue}}"
-                                  AutomationId="ItemRow">
-                                <Grid.RowDefinitions>
-                                    <RowDefinition Height="Auto" />
-                                    <RowDefinition Height="*" />
-                                </Grid.RowDefinitions>
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="*" />
-                                    <ColumnDefinition Width="Auto" />
-                                    <ColumnDefinition Width="Auto" />
-                                </Grid.ColumnDefinitions>
-                                <Label
-                                    Text="{u:I18n SecurityCode}"
-                                    StyleClass="box-label"
-                                    Grid.Row="0"
-                                    Grid.Column="0"
-                                    AutomationId="ItemName" />
-                                <controls:MonoLabel
-                                    Text="{Binding Cipher.Card.MaskedCode, Mode=OneWay}"
-                                    StyleClass="box-value"
-                                    Grid.Row="1"
-                                    Grid.Column="0"
-                                    IsVisible="{Binding ShowCardCode, Converter={StaticResource inverseBool}}"
-                                    AutomationId="ItemValue" />
-                                <controls:MonoLabel
-                                    Text="{Binding Cipher.Card.Code, Mode=OneWay}"
-                                    StyleClass="box-value"
-                                    Grid.Row="1"
-                                    Grid.Column="0"
-                                    IsVisible="{Binding ShowCardCode}"
-                                    AutomationId="ItemValue" />
-                                <controls:IconButton
-                                    StyleClass="box-row-button, box-row-button-platform"
-                                    Text="{Binding ShowCardCodeIcon}"
-                                    Command="{Binding ToggleCardCodeCommand}"
-                                    Grid.Row="0"
-                                    Grid.Column="1"
-                                    Grid.RowSpan="2"
-                                    AutomationProperties.IsInAccessibleTree="True"
-                                    AutomationProperties.Name="{u:I18n ToggleVisibility}"
-                                    AutomationId="ShowValueButton" />
-                                <controls:IconButton
-                                    StyleClass="box-row-button, box-row-button-platform"
-                                    Text="{Binding Source={x:Static core:BitwardenIcons.Clone}}"
-                                    Command="{Binding CopyCommand}"
-                                    CommandParameter="CardCode"
-                                    Grid.Row="0"
-                                    Grid.Column="2"
-                                    Grid.RowSpan="2"
-                                    AutomationProperties.IsInAccessibleTree="True"
-                                    AutomationProperties.Name="{u:I18n CopySecurityCode}"
-                                    AutomationId="CopyValueButton" />
-                            </Grid>
-                            <BoxView StyleClass="box-row-separator"
-                                     IsVisible="{Binding Cipher.Card.Code, Converter={StaticResource stringHasValue}}" />
+                            <yummy:PancakeView StyleClass="round-card" IsVisible="{Binding Cipher.Card.CardholderName, Converter={StaticResource stringHasValue}}">
+                                <StackLayout StyleClass="box-row"
+                                            IsVisible="{Binding Cipher.Card.CardholderName, Converter={StaticResource stringHasValue}}"
+                                            AutomationId="ItemRow">
+                                    <Label
+                                        Text="{u:I18n CardholderName}"
+                                        StyleClass="box-label"
+                                        AutomationId="ItemName" />
+                                    <Label
+                                        Text="{Binding Cipher.Card.CardholderName, Mode=OneWay}"
+                                        StyleClass="box-value"
+                                        AutomationId="ItemValue" />
+                                </StackLayout>
+                            </yummy:PancakeView>
+                            <yummy:PancakeView StyleClass="round-card" IsVisible="{Binding Cipher.Card.Number, Converter={StaticResource stringHasValue}}">
+                                <Grid StyleClass="box-row"
+                                    AutomationId="ItemRow">
+                                    <Grid.RowDefinitions>
+                                        <RowDefinition Height="Auto" />
+                                        <RowDefinition Height="*" />
+                                    </Grid.RowDefinitions>
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="*" />
+                                        <ColumnDefinition Width="Auto" />
+                                        <ColumnDefinition Width="Auto" />
+                                    </Grid.ColumnDefinitions>
+                                    <Label
+                                        Text="{u:I18n Number}"
+                                        StyleClass="box-label"
+                                        Grid.Row="0"
+                                        Grid.Column="0"
+                                        AutomationId="ItemName" />
+                                    <controls:MonoLabel
+                                        Text="{Binding Cipher.Card.MaskedNumber, Mode=OneWay}"
+                                        StyleClass="box-value"
+                                        Grid.Row="1"
+                                        Grid.Column="0"
+                                        IsVisible="{Binding ShowCardNumber, Converter={StaticResource inverseBool}}"
+                                        AutomationId="ItemValue" />
+                                    <controls:MonoLabel
+                                        Text="{Binding Cipher.Card.Number, Mode=OneWay}"
+                                        StyleClass="box-value"
+                                        Grid.Row="1"
+                                        Grid.Column="0"
+                                        IsVisible="{Binding ShowCardNumber}"
+                                        AutomationId="ItemValue" />
+                                    <controls:IconButton
+                                        StyleClass="box-row-button, box-row-button-platform"
+                                        Text="{Binding ShowCardNumberIcon}"
+                                        Command="{Binding ToggleCardNumberCommand}"
+                                        Grid.Row="0"
+                                        Grid.Column="1"
+                                        Grid.RowSpan="2"
+                                        AutomationProperties.IsInAccessibleTree="True"
+                                        AutomationProperties.Name="{u:I18n ToggleVisibility}"
+                                        AutomationId="ShowValueButton" />
+                                    <controls:IconButton
+                                        StyleClass="box-row-button, box-row-button-platform"
+                                        Text="{Binding Source={x:Static core:BitwardenIcons.Clone}}"
+                                        Command="{Binding CopyCommand}"
+                                        CommandParameter="CardNumber"
+                                        Grid.Row="0"
+                                        Grid.Column="2"
+                                        Grid.RowSpan="2"
+                                        AutomationProperties.IsInAccessibleTree="True"
+                                        AutomationProperties.Name="{u:I18n CopyNumber}"
+                                        AutomationId="CopyValueButton" />
+                                </Grid>
+                            </yummy:PancakeView>
+                            <yummy:PancakeView StyleClass="round-card" IsVisible="{Binding Cipher.Card.Brand, Converter={StaticResource stringHasValue}}">
+                                <StackLayout StyleClass="box-row"
+                                            IsVisible="{Binding Cipher.Card.Brand, Converter={StaticResource stringHasValue}}"
+                                            AutomationId="ItemRow">
+                                    <Label
+                                        Text="{u:I18n Brand}"
+                                        StyleClass="box-label"
+                                        AutomationId="ItemName" />
+                                    <Label
+                                        Text="{Binding Cipher.Card.Brand, Mode=OneWay}"
+                                        StyleClass="box-value"
+                                        AutomationId="ItemValue" />
+                                </StackLayout>
+                            </yummy:PancakeView>
+                            <yummy:PancakeView StyleClass="round-card" IsVisible="{Binding Cipher.Card.Expiration, Converter={StaticResource stringHasValue}}">
+                                <StackLayout StyleClass="box-row"
+                                            IsVisible="{Binding Cipher.Card.Expiration, Converter={StaticResource stringHasValue}}"
+                                            AutomationId="ItemRow">
+                                    <Label
+                                        Text="{u:I18n Expiration}"
+                                        StyleClass="box-label"
+                                        AutomationId="ItemName" />
+                                    <Label
+                                        Text="{Binding Cipher.Card.Expiration, Mode=OneWay}"
+                                        StyleClass="box-value"
+                                        AutomationId="ItemValue" />
+                                </StackLayout>
+                            </yummy:PancakeView>
+                            <yummy:PancakeView StyleClass="round-card" IsVisible="{Binding Cipher.Card.Code, Converter={StaticResource stringHasValue}}">
+                                <Grid StyleClass="box-row"
+                                    AutomationId="ItemRow">
+                                    <Grid.RowDefinitions>
+                                        <RowDefinition Height="Auto" />
+                                        <RowDefinition Height="*" />
+                                    </Grid.RowDefinitions>
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="*" />
+                                        <ColumnDefinition Width="Auto" />
+                                        <ColumnDefinition Width="Auto" />
+                                    </Grid.ColumnDefinitions>
+                                    <Label
+                                        Text="{u:I18n SecurityCode}"
+                                        StyleClass="box-label"
+                                        Grid.Row="0"
+                                        Grid.Column="0"
+                                        AutomationId="ItemName" />
+                                    <controls:MonoLabel
+                                        Text="{Binding Cipher.Card.MaskedCode, Mode=OneWay}"
+                                        StyleClass="box-value"
+                                        Grid.Row="1"
+                                        Grid.Column="0"
+                                        IsVisible="{Binding ShowCardCode, Converter={StaticResource inverseBool}}"
+                                        AutomationId="ItemValue" />
+                                    <controls:MonoLabel
+                                        Text="{Binding Cipher.Card.Code, Mode=OneWay}"
+                                        StyleClass="box-value"
+                                        Grid.Row="1"
+                                        Grid.Column="0"
+                                        IsVisible="{Binding ShowCardCode}"
+                                        AutomationId="ItemValue" />
+                                    <controls:IconButton
+                                        StyleClass="box-row-button, box-row-button-platform"
+                                        Text="{Binding ShowCardCodeIcon}"
+                                        Command="{Binding ToggleCardCodeCommand}"
+                                        Grid.Row="0"
+                                        Grid.Column="1"
+                                        Grid.RowSpan="2"
+                                        AutomationProperties.IsInAccessibleTree="True"
+                                        AutomationProperties.Name="{u:I18n ToggleVisibility}"
+                                        AutomationId="ShowValueButton" />
+                                    <controls:IconButton
+                                        StyleClass="box-row-button, box-row-button-platform"
+                                        Text="{Binding Source={x:Static core:BitwardenIcons.Clone}}"
+                                        Command="{Binding CopyCommand}"
+                                        CommandParameter="CardCode"
+                                        Grid.Row="0"
+                                        Grid.Column="2"
+                                        Grid.RowSpan="2"
+                                        AutomationProperties.IsInAccessibleTree="True"
+                                        AutomationProperties.Name="{u:I18n CopySecurityCode}"
+                                        AutomationId="CopyValueButton" />
+                                </Grid>
+                            </yummy:PancakeView>
                         </StackLayout>
                         <StackLayout IsVisible="{Binding IsIdentity}" Spacing="0" Padding="0">
-                            <StackLayout StyleClass="box-row"
-                                         IsVisible="{Binding Cipher.Identity.FullName, Converter={StaticResource stringHasValue}}"
-                                         AutomationId="ItemRow">
-                                <Label
-                                    Text="{u:I18n IdentityName}"
-                                    StyleClass="box-label"
-                                    AutomationId="ItemName" />
-                                <Label
-                                    Text="{Binding Cipher.Identity.FullName, Mode=OneWay}"
-                                    StyleClass="box-value"
-                                    AutomationId="ItemValue" />
-                            </StackLayout>
-                            <BoxView StyleClass="box-row-separator"
-                                     IsVisible="{Binding Cipher.Identity.FullName, Converter={StaticResource stringHasValue}}" />
-                            <StackLayout StyleClass="box-row"
-                                         IsVisible="{Binding Cipher.Identity.Username, Converter={StaticResource stringHasValue}}"
-                                         AutomationId="ItemRow">
-                                <Label
-                                    Text="{u:I18n Username}"
-                                    StyleClass="box-label"
-                                    AutomationId="ItemName" />
-                                <Label
-                                    Text="{Binding Cipher.Identity.Username, Mode=OneWay}"
-                                    StyleClass="box-value"
-                                    AutomationId="ItemValue" />
-                            </StackLayout>
-                            <BoxView StyleClass="box-row-separator"
-                                     IsVisible="{Binding Cipher.Identity.Username, Converter={StaticResource stringHasValue}}" />
-                            <StackLayout StyleClass="box-row"
-                                         IsVisible="{Binding Cipher.Identity.Company, Converter={StaticResource stringHasValue}}"
-                                         AutomationId="ItemRow">
-                                <Label
-                                    Text="{u:I18n Company}"
-                                    StyleClass="box-label"
-                                    AutomationId="ItemName" />
-                                <Label
-                                    Text="{Binding Cipher.Identity.Company, Mode=OneWay}"
-                                    StyleClass="box-value"
-                                    AutomationId="ItemValue" />
-                            </StackLayout>
-                            <BoxView StyleClass="box-row-separator"
-                                     IsVisible="{Binding Cipher.Identity.Company, Converter={StaticResource stringHasValue}}" />
-                            <StackLayout StyleClass="box-row"
-                                         IsVisible="{Binding Cipher.Identity.SSN, Converter={StaticResource stringHasValue}}"
-                                         AutomationId="ItemRow">
-                                <Label
-                                    Text="{u:I18n SSN}"
-                                    StyleClass="box-label"
-                                    AutomationId="ItemName" />
-                                <Label
-                                    Text="{Binding Cipher.Identity.SSN, Mode=OneWay}"
-                                    StyleClass="box-value"
-                                    AutomationId="ItemValue" />
-                            </StackLayout>
-                            <BoxView StyleClass="box-row-separator"
-                                     IsVisible="{Binding Cipher.Identity.SSN, Converter={StaticResource stringHasValue}}" />
-                            <StackLayout StyleClass="box-row"
-                                         IsVisible="{Binding Cipher.Identity.PassportNumber, Converter={StaticResource stringHasValue}}"
-                                         AutomationId="ItemRow">
-                                <Label
-                                    Text="{u:I18n PassportNumber}"
-                                    StyleClass="box-label"
-                                    AutomationId="ItemName" />
-                                <Label
-                                    Text="{Binding Cipher.Identity.PassportNumber, Mode=OneWay}"
-                                    StyleClass="box-value"
-                                    AutomationId="ItemValue" />
-                            </StackLayout>
-                            <BoxView StyleClass="box-row-separator"
-                                     IsVisible="{Binding Cipher.Identity.PassportNumber, Converter={StaticResource stringHasValue}}" />
-                            <StackLayout StyleClass="box-row"
-                                         IsVisible="{Binding Cipher.Identity.LicenseNumber, Converter={StaticResource stringHasValue}}"
-                                         AutomationId="ItemRow">
-                                <Label
-                                    Text="{u:I18n LicenseNumber}"
-                                    StyleClass="box-label"
-                                    AutomationId="ItemName" />
-                                <Label
-                                    Text="{Binding Cipher.Identity.LicenseNumber, Mode=OneWay}"
-                                    StyleClass="box-value"
-                                    AutomationId="ItemValue" />
-                            </StackLayout>
-                            <BoxView StyleClass="box-row-separator"
-                                     IsVisible="{Binding Cipher.Identity.LicenseNumber, Converter={StaticResource stringHasValue}}" />
-                            <StackLayout StyleClass="box-row"
-                                         IsVisible="{Binding Cipher.Identity.Email, Converter={StaticResource stringHasValue}}"
-                                         AutomationId="ItemRow">
-                                <Label
-                                    Text="{u:I18n Email}"
-                                    StyleClass="box-label"
-                                    AutomationId="ItemName" />
-                                <Label
-                                    Text="{Binding Cipher.Identity.Email, Mode=OneWay}"
-                                    StyleClass="box-value"
-                                    AutomationId="ItemValue" />
-                            </StackLayout>
-                            <BoxView StyleClass="box-row-separator"
-                                     IsVisible="{Binding Cipher.Identity.Email, Converter={StaticResource stringHasValue}}" />
-                            <StackLayout StyleClass="box-row"
-                                         IsVisible="{Binding Cipher.Identity.Phone, Converter={StaticResource stringHasValue}}"
-                                         AutomationId="ItemRow" >
-                                <Label
-                                    Text="{u:I18n Phone}"
-                                    StyleClass="box-label"
-                                    AutomationId="ItemName" />
-                                <Label
-                                    Text="{Binding Cipher.Identity.Phone, Mode=OneWay}"
-                                    StyleClass="box-value"
-                                    AutomationId="ItemValue" />
-                            </StackLayout>
-                            <BoxView StyleClass="box-row-separator"
-                                     IsVisible="{Binding Cipher.Identity.Phone, Converter={StaticResource stringHasValue}}" />
-                            <StackLayout StyleClass="box-row" IsVisible="{Binding ShowIdentityAddress}"
-                                         AutomationId="ItemRow">
-                                <Label
-                                    Text="{u:I18n Address}"
-                                    StyleClass="box-label"
-                                    AutomationId="ItemName" />
-                                <Label
-                                    Text="{Binding Cipher.Identity.Address1, Mode=OneWay}"
-                                    IsVisible="{Binding Cipher.Identity.Address1, Converter={StaticResource stringHasValue}}"
-                                    StyleClass="box-value"
-                                    AutomationId="IdentityAddressOneLabel" />
-                                <Label
-                                    Text="{Binding Cipher.Identity.Address2, Mode=OneWay}"
-                                    IsVisible="{Binding Cipher.Identity.Address2, Converter={StaticResource stringHasValue}}"
-                                    StyleClass="box-value"
-                                    AutomationId="IdentityAddressTwoLabel" />
-                                <Label
-                                    Text="{Binding Cipher.Identity.Address3, Mode=OneWay}"
-                                    IsVisible="{Binding Cipher.Identity.Address3, Converter={StaticResource stringHasValue}}"
-                                    StyleClass="box-value"
-                                    AutomationId="IdentityAddressThreeLabel" />
-                                <Label
-                                    Text="{Binding Cipher.Identity.FullAddressPart2, Mode=OneWay}"
-                                    IsVisible="{Binding Cipher.Identity.FullAddressPart2, Converter={StaticResource stringHasValue}}"
-                                    StyleClass="box-value"
-                                    AutomationId="IdentityFullAddressPartTwoLabel" />
-                                <Label
-                                    Text="{Binding Cipher.Identity.Country, Mode=OneWay}"
-                                    IsVisible="{Binding Cipher.Identity.Country, Converter={StaticResource stringHasValue}}"
-                                    StyleClass="box-value"
-                                    AutomationId="IdentityCountryLabel" />
-                            </StackLayout>
-                            <BoxView StyleClass="box-row-separator" IsVisible="{Binding ShowIdentityAddress}" />
+                            <yummy:PancakeView StyleClass="round-card" IsVisible="{Binding Cipher.Identity.FullName, Converter={StaticResource stringHasValue}}">
+                                <StackLayout StyleClass="box-row"
+                                            IsVisible="{Binding Cipher.Identity.FullName, Converter={StaticResource stringHasValue}}"
+                                            AutomationId="ItemRow">
+                                    <Label
+                                        Text="{u:I18n IdentityName}"
+                                        StyleClass="box-label"
+                                        AutomationId="ItemName" />
+                                    <Label
+                                        Text="{Binding Cipher.Identity.FullName, Mode=OneWay}"
+                                        StyleClass="box-value"
+                                        AutomationId="ItemValue" />
+                                </StackLayout>
+                            </yummy:PancakeView>
+                            <yummy:PancakeView StyleClass="round-card" IsVisible="{Binding Cipher.Identity.Username, Converter={StaticResource stringHasValue}}">
+                                <StackLayout StyleClass="box-row"
+                                            IsVisible="{Binding Cipher.Identity.Username, Converter={StaticResource stringHasValue}}"
+                                            AutomationId="ItemRow">
+                                    <Label
+                                        Text="{u:I18n Username}"
+                                        StyleClass="box-label"
+                                        AutomationId="ItemName" />
+                                    <Label
+                                        Text="{Binding Cipher.Identity.Username, Mode=OneWay}"
+                                        StyleClass="box-value"
+                                        AutomationId="ItemValue" />
+                                </StackLayout>
+                            </yummy:PancakeView>
+                            <yummy:PancakeView StyleClass="round-card" IsVisible="{Binding Cipher.Identity.Company, Converter={StaticResource stringHasValue}}">
+                                <StackLayout StyleClass="box-row"
+                                            AutomationId="ItemRow">
+                                    <Label
+                                        Text="{u:I18n Company}"
+                                        StyleClass="box-label"
+                                        AutomationId="ItemName" />
+                                    <Label
+                                        Text="{Binding Cipher.Identity.Company, Mode=OneWay}"
+                                        StyleClass="box-value"
+                                        AutomationId="ItemValue" />
+                                </StackLayout>
+                            </yummy:PancakeView>
+                            <yummy:PancakeView StyleClass="round-card" IsVisible="{Binding Cipher.Identity.SSN, Converter={StaticResource stringHasValue}}">
+                                <StackLayout StyleClass="box-row"
+                                            IsVisible="{Binding Cipher.Identity.SSN, Converter={StaticResource stringHasValue}}"
+                                            AutomationId="ItemRow">
+                                    <Label
+                                        Text="{u:I18n SSN}"
+                                        StyleClass="box-label"
+                                        AutomationId="ItemName" />
+                                    <Label
+                                        Text="{Binding Cipher.Identity.SSN, Mode=OneWay}"
+                                        StyleClass="box-value"
+                                        AutomationId="ItemValue" />
+                                </StackLayout>
+                            </yummy:PancakeView>
+                            <yummy:PancakeView StyleClass="round-card" IsVisible="{Binding Cipher.Identity.PassportNumber, Converter={StaticResource stringHasValue}}">
+                                <StackLayout StyleClass="box-row"
+                                            AutomationId="ItemRow">
+                                    <Label
+                                        Text="{u:I18n PassportNumber}"
+                                        StyleClass="box-label"
+                                        AutomationId="ItemName" />
+                                    <Label
+                                        Text="{Binding Cipher.Identity.PassportNumber, Mode=OneWay}"
+                                        StyleClass="box-value"
+                                        AutomationId="ItemValue" />
+                                </StackLayout>
+                            </yummy:PancakeView>
+                            <yummy:PancakeView StyleClass="round-card" IsVisible="{Binding Cipher.Identity.LicenseNumber, Converter={StaticResource stringHasValue}}">
+                                <StackLayout StyleClass="box-row"
+                                            AutomationId="ItemRow">
+                                    <Label
+                                        Text="{u:I18n LicenseNumber}"
+                                        StyleClass="box-label"
+                                        AutomationId="ItemName" />
+                                    <Label
+                                        Text="{Binding Cipher.Identity.LicenseNumber, Mode=OneWay}"
+                                        StyleClass="box-value"
+                                        AutomationId="ItemValue" />
+                                </StackLayout>
+                            </yummy:PancakeView>
+                            <yummy:PancakeView StyleClass="round-card" IsVisible="{Binding Cipher.Identity.Email, Converter={StaticResource stringHasValue}}">
+                                <StackLayout StyleClass="box-row"
+                                            AutomationId="ItemRow">
+                                    <Label
+                                        Text="{u:I18n Email}"
+                                        StyleClass="box-label"
+                                        AutomationId="ItemName" />
+                                    <Label
+                                        Text="{Binding Cipher.Identity.Email, Mode=OneWay}"
+                                        StyleClass="box-value"
+                                        AutomationId="ItemValue" />
+                                </StackLayout>
+                            </yummy:PancakeView>
+                            <yummy:PancakeView StyleClass="round-card" IsVisible="{Binding Cipher.Identity.Phone, Converter={StaticResource stringHasValue}}">
+                                <StackLayout StyleClass="box-row"
+                                            AutomationId="ItemRow" >
+                                    <Label
+                                        Text="{u:I18n Phone}"
+                                        StyleClass="box-label"
+                                        AutomationId="ItemName" />
+                                    <Label
+                                        Text="{Binding Cipher.Identity.Phone, Mode=OneWay}"
+                                        StyleClass="box-value"
+                                        AutomationId="ItemValue" />
+                                </StackLayout>
+                            </yummy:PancakeView>
+                            <yummy:PancakeView StyleClass="round-card" IsVisible="{Binding ShowIdentityAddress}">
+                                <StackLayout StyleClass="box-row"
+                                            AutomationId="ItemRow">
+                                    <Label
+                                        Text="{u:I18n Address}"
+                                        StyleClass="box-label"
+                                        AutomationId="ItemName" />
+                                    <Label
+                                        Text="{Binding Cipher.Identity.Address1, Mode=OneWay}"
+                                        IsVisible="{Binding Cipher.Identity.Address1, Converter={StaticResource stringHasValue}}"
+                                        StyleClass="box-value"
+                                        AutomationId="IdentityAddressOneLabel" />
+                                    <Label
+                                        Text="{Binding Cipher.Identity.Address2, Mode=OneWay}"
+                                        IsVisible="{Binding Cipher.Identity.Address2, Converter={StaticResource stringHasValue}}"
+                                        StyleClass="box-value"
+                                        AutomationId="IdentityAddressTwoLabel" />
+                                    <Label
+                                        Text="{Binding Cipher.Identity.Address3, Mode=OneWay}"
+                                        IsVisible="{Binding Cipher.Identity.Address3, Converter={StaticResource stringHasValue}}"
+                                        StyleClass="box-value"
+                                        AutomationId="IdentityAddressThreeLabel" />
+                                    <Label
+                                        Text="{Binding Cipher.Identity.FullAddressPart2, Mode=OneWay}"
+                                        IsVisible="{Binding Cipher.Identity.FullAddressPart2, Converter={StaticResource stringHasValue}}"
+                                        StyleClass="box-value"
+                                        AutomationId="IdentityFullAddressPartTwoLabel" />
+                                    <Label
+                                        Text="{Binding Cipher.Identity.Country, Mode=OneWay}"
+                                        IsVisible="{Binding Cipher.Identity.Country, Converter={StaticResource stringHasValue}}"
+                                        StyleClass="box-value"
+                                        AutomationId="IdentityCountryLabel" />
+                                </StackLayout>
+                            </yummy:PancakeView>
                         </StackLayout>
                         <StackLayout
                             IsVisible="{Binding IsFido2Key}"
@@ -646,80 +629,84 @@
                         <controls:RepeaterView ItemsSource="{Binding Cipher.Login.Uris}" AutomationId="CipherUriContainer">
                             <controls:RepeaterView.ItemTemplate>
                                 <DataTemplate x:DataType="views:LoginUriView">
-                                    <StackLayout Spacing="0" Padding="0">
-                                        <Grid StyleClass="box-row" AutomationId="UriRow">
-                                            <Grid.RowDefinitions>
-                                                <RowDefinition Height="Auto" />
-                                                <RowDefinition Height="*" />
-                                            </Grid.RowDefinitions>
-                                            <Grid.ColumnDefinitions>
-                                                <ColumnDefinition Width="*" />
-                                                <ColumnDefinition Width="Auto" />
-                                                <ColumnDefinition Width="Auto" />
-                                            </Grid.ColumnDefinitions>
-                                            <Label
-                                                Text="{u:I18n URI}"
-                                                StyleClass="box-label"
-                                                Grid.Row="0"
-                                                Grid.Column="0"
-                                                IsVisible="{Binding IsWebsite, Mode=OneWay, Converter={StaticResource inverseBool}}" />
-                                            <Label
-                                                Text="{u:I18n Website}"
-                                                StyleClass="box-label"
-                                                Grid.Row="0"
-                                                Grid.Column="0"
-                                                IsVisible="{Binding IsWebsite, Mode=OneWay}" />
-                                            <Label
-                                                Text="{Binding HostOrUri, Mode=OneWay}"
-                                                StyleClass="box-value"
-                                                Grid.Row="1"
-                                                Grid.Column="0"
-                                                AutomationId="UriValue" />
-                                            <controls:IconButton
-                                                StyleClass="box-row-button, box-row-button-platform"
-                                                Text="{Binding Source={x:Static core:BitwardenIcons.ShareSquare}}"
-                                                Command="{Binding BindingContext.LaunchUriCommand, Source={x:Reference _page}}"
-                                                CommandParameter="{Binding .}"
-                                                Grid.Row="0"
-                                                Grid.Column="1"
-                                                Grid.RowSpan="2"
-                                                IsVisible="{Binding CanLaunch, Mode=OneWay}"
-                                                AutomationProperties.IsInAccessibleTree="True"
-                                                AutomationProperties.Name="{u:I18n Launch}"
-                                                AutomationId="LaunchUriButton" />
-                                            <controls:IconButton
-                                                StyleClass="box-row-button, box-row-button-platform"
-                                                Text="{Binding Source={x:Static core:BitwardenIcons.Clone}}"
-                                                Command="{Binding BindingContext.CopyUriCommand, Source={x:Reference _page}}"
-                                                CommandParameter="{Binding .}"
-                                                Grid.Row="0"
-                                                Grid.Column="2"
-                                                Grid.RowSpan="2"
-                                                AutomationProperties.IsInAccessibleTree="True"
-                                                AutomationProperties.Name="{u:I18n Copy}"
-                                                AutomationId="CopyUriButton" />
-                                        </Grid>
-                                        <BoxView StyleClass="box-row-separator" />
-                                    </StackLayout>
+                                    <yummy:PancakeView StyleClass="round-card">
+                                        <StackLayout Spacing="0" Padding="0">
+                                            <Grid StyleClass="box-row" AutomationId="UriRow">
+                                                <Grid.RowDefinitions>
+                                                    <RowDefinition Height="Auto" />
+                                                    <RowDefinition Height="*" />
+                                                </Grid.RowDefinitions>
+                                                <Grid.ColumnDefinitions>
+                                                    <ColumnDefinition Width="*" />
+                                                    <ColumnDefinition Width="Auto" />
+                                                    <ColumnDefinition Width="Auto" />
+                                                </Grid.ColumnDefinitions>
+                                                <Label
+                                                    Text="{u:I18n URI}"
+                                                    StyleClass="box-label"
+                                                    Grid.Row="0"
+                                                    Grid.Column="0"
+                                                    IsVisible="{Binding IsWebsite, Mode=OneWay, Converter={StaticResource inverseBool}}" />
+                                                <Label
+                                                    Text="{u:I18n Website}"
+                                                    StyleClass="box-label"
+                                                    Grid.Row="0"
+                                                    Grid.Column="0"
+                                                    IsVisible="{Binding IsWebsite, Mode=OneWay}" />
+                                                <Label
+                                                    Text="{Binding HostOrUri, Mode=OneWay}"
+                                                    StyleClass="box-value"
+                                                    Grid.Row="1"
+                                                    Grid.Column="0"
+                                                    AutomationId="UriValue" />
+                                                <controls:IconButton
+                                                    StyleClass="box-row-button, box-row-button-platform"
+                                                    Text="{Binding Source={x:Static core:BitwardenIcons.ShareSquare}}"
+                                                    Command="{Binding BindingContext.LaunchUriCommand, Source={x:Reference _page}}"
+                                                    CommandParameter="{Binding .}"
+                                                    Grid.Row="0"
+                                                    Grid.Column="1"
+                                                    Grid.RowSpan="2"
+                                                    IsVisible="{Binding CanLaunch, Mode=OneWay}"
+                                                    AutomationProperties.IsInAccessibleTree="True"
+                                                    AutomationProperties.Name="{u:I18n Launch}"
+                                                    AutomationId="LaunchUriButton" />
+                                                <controls:IconButton
+                                                    StyleClass="box-row-button, box-row-button-platform"
+                                                    Text="{Binding Source={x:Static core:BitwardenIcons.Clone}}"
+                                                    Command="{Binding BindingContext.CopyUriCommand, Source={x:Reference _page}}"
+                                                    CommandParameter="{Binding .}"
+                                                    Grid.Row="0"
+                                                    Grid.Column="2"
+                                                    Grid.RowSpan="2"
+                                                    AutomationProperties.IsInAccessibleTree="True"
+                                                    AutomationProperties.Name="{u:I18n Copy}"
+                                                    AutomationId="CopyUriButton" />
+                                            </Grid>
+                                        </StackLayout>
+                                    </yummy:PancakeView>
                                 </DataTemplate>
                             </controls:RepeaterView.ItemTemplate>
                         </controls:RepeaterView>
                     </StackLayout>
                     <StackLayout StyleClass="box"
                                  IsVisible="{Binding Cipher.Notes, Converter={StaticResource stringHasValue}}">
-                        <StackLayout StyleClass="box-row-header">
-                            <Label Text="{u:I18n Notes, Header=True}"
-                                   StyleClass="box-header, box-header-platform" />
+                            <StackLayout StyleClass="box-row-header">
+                                <Label Text="{u:I18n Notes, Header=True}"
+                                    StyleClass="box-header, box-header-platform" />
+                            </StackLayout>
+                        <yummy:PancakeView StyleClass="round-card">
+                            <StackLayout StyleClass="box-row" AutomationId="NotesRow">
+                                <controls:SelectableLabel
+                                    Text="{Binding Cipher.Notes, Mode=OneWay}"
+                                    StyleClass="box-value"
+                                    AutomationId="CipherNotesLabel" />
+                            </StackLayout>
+                        </yummy:PancakeView>
                         </StackLayout>
-                        <StackLayout StyleClass="box-row" AutomationId="NotesRow">
-                            <controls:SelectableLabel
-                                Text="{Binding Cipher.Notes, Mode=OneWay}"
-                                StyleClass="box-value"
-                                AutomationId="CipherNotesLabel" />
-                        </StackLayout>
-                        <BoxView StyleClass="box-row-separator" />
-                    </StackLayout>
-                    <StackLayout StyleClass="box" IsVisible="{Binding Cipher.HasFields}" AutomationId="CustomFieldsContainer">
+                        <StackLayout StyleClass="box" 
+                                IsVisible="{Binding Cipher.HasFields}"
+                                AutomationId="CustomFieldsContainer">
                         <StackLayout StyleClass="box-row-header">
                             <Label Text="{u:I18n CustomFields, Header=True}"
                                    StyleClass="box-header, box-header-platform" />
@@ -737,32 +724,34 @@
                         <controls:RepeaterView ItemsSource="{Binding Cipher.Attachments}" AutomationId="CipherAttachmentsContainer">
                             <controls:RepeaterView.ItemTemplate>
                                 <DataTemplate x:DataType="views:AttachmentView">
-                                    <StackLayout Spacing="0" Padding="0">
-                                        <StackLayout Orientation="Horizontal" StyleClass="box-row" Spacing="10" AutomationId="CipherAttachment">
-                                            <Label
-                                                Text="{Binding FileName, Mode=OneWay}"
-                                                StyleClass="box-value"
-                                                VerticalTextAlignment="Center"
-                                                HorizontalOptions="StartAndExpand"
-                                                AutomationId="CipherAttachmentFileNameLabel" />
-                                            <Label
-                                                Text="{Binding SizeName, Mode=OneWay}"
-                                                StyleClass="box-sub-label"
-                                                HorizontalTextAlignment="End"
-                                                VerticalTextAlignment="Center"
-                                                AutomationId="CipherAttachmentFileSizeLabel" />
-                                            <controls:IconButton
-                                                StyleClass="box-row-button, box-row-button-platform"
-                                                Text="{Binding Source={x:Static core:BitwardenIcons.Download}}"
-                                                Command="{Binding BindingContext.DownloadAttachmentCommand, Source={x:Reference _page}}"
-                                                CommandParameter="{Binding .}"
-                                                VerticalOptions="Center"
-                                                AutomationProperties.IsInAccessibleTree="True"
-                                                AutomationProperties.Name="{u:I18n Download}"
-                                                AutomationId="CipherAttachmentDownloadButton" />
+                                    <yummy:PancakeView StyleClass="round-card">
+                                        <StackLayout Spacing="0" Padding="0">
+                                            <StackLayout Orientation="Horizontal" StyleClass="box-row" Spacing="10" AutomationId="CipherAttachment">
+                                                <Label
+                                                    Text="{Binding FileName, Mode=OneWay}"
+                                                    StyleClass="box-value"
+                                                    VerticalTextAlignment="Center"
+                                                    HorizontalOptions="StartAndExpand"
+                                                    AutomationId="CipherAttachmentFileNameLabel" />
+                                                <Label
+                                                    Text="{Binding SizeName, Mode=OneWay}"
+                                                    StyleClass="box-sub-label"
+                                                    HorizontalTextAlignment="End"
+                                                    VerticalTextAlignment="Center"
+                                                    AutomationId="CipherAttachmentFileSizeLabel" />
+                                                <controls:IconButton
+                                                    StyleClass="box-row-button, box-row-button-platform"
+                                                    Text="{Binding Source={x:Static core:BitwardenIcons.Download}}"
+                                                    Command="{Binding BindingContext.DownloadAttachmentCommand, Source={x:Reference _page}}"
+                                                    CommandParameter="{Binding .}"
+                                                    VerticalOptions="Center"
+                                                    AutomationProperties.IsInAccessibleTree="True"
+                                                    AutomationProperties.Name="{u:I18n Download}"
+                                                    AutomationId="CipherAttachmentDownloadButton" />
+                                            </StackLayout>
+                                            <BoxView StyleClass="box-row-separator" />
                                         </StackLayout>
-                                        <BoxView StyleClass="box-row-separator" />
-                                    </StackLayout>
+                                    </yummy:PancakeView>
                                 </DataTemplate>
                             </controls:RepeaterView.ItemTemplate>
                         </controls:RepeaterView>

--- a/src/App/Pages/Vault/CipherSelectionPage.xaml
+++ b/src/App/Pages/Vault/CipherSelectionPage.xaml
@@ -7,6 +7,7 @@
              xmlns:u="clr-namespace:Bit.App.Utilities"
              xmlns:controls="clr-namespace:Bit.App.Controls"
              xmlns:effects="clr-namespace:Bit.App.Effects;assembly=BitwardenApp"
+             xmlns:yummy="clr-namespace:Xamarin.Forms.PancakeView;assembly=Xamarin.Forms.PancakeView"
              x:DataType="pages:CipherSelectionPageViewModel"
              Title="{Binding PageTitle}"
              x:Name="_page">
@@ -47,10 +48,12 @@
 
             <DataTemplate x:Key="cipherTemplate"
                           x:DataType="pages:GroupingsPageListItem">
-                <controls:CipherViewCell
-                    Cipher="{Binding Cipher}"
-                    ButtonCommand="{Binding BindingContext.CipherOptionsCommand, Source={x:Reference _page}}"
-                    WebsiteIconsEnabled="{Binding BindingContext.WebsiteIconsEnabled, Source={x:Reference _page}}" />
+                <yummy:PancakeView StyleClass="round-card">
+                    <controls:CipherViewCell
+                        Cipher="{Binding Cipher}"
+                        ButtonCommand="{Binding BindingContext.CipherOptionsCommand, Source={x:Reference _page}}"
+                        WebsiteIconsEnabled="{Binding BindingContext.WebsiteIconsEnabled, Source={x:Reference _page}}" />
+                </yummy:PancakeView>
             </DataTemplate>
             
             <DataTemplate

--- a/src/App/Pages/Vault/GroupingsPage/GroupingsPage.xaml
+++ b/src/App/Pages/Vault/GroupingsPage/GroupingsPage.xaml
@@ -8,6 +8,7 @@
     xmlns:controls="clr-namespace:Bit.App.Controls"
     xmlns:xct="http://xamarin.com/schemas/2020/toolkit"
     xmlns:core="clr-namespace:Bit.Core;assembly=BitwardenCore"
+    xmlns:yummy="clr-namespace:Xamarin.Forms.PancakeView;assembly=Xamarin.Forms.PancakeView"
     x:DataType="pages:GroupingsPageViewModel"
     Title="{Binding PageTitle}"
     x:Name="_page">
@@ -57,38 +58,45 @@
 
             <DataTemplate x:Key="authenticatorTemplate"
                           x:DataType="pages:GroupingsPageTOTPListItem">
-                <controls:AuthenticatorViewCell 
-                    Cipher="{Binding Cipher}"
-                    WebsiteIconsEnabled="{Binding BindingContext.WebsiteIconsEnabled, Source={x:Reference _page}}"
-                    TotpSec="{Binding TotpSec}" />
+                <yummy:PancakeView StyleClass="round-card">
+                    <controls:AuthenticatorViewCell 
+                        Cipher="{Binding Cipher}"
+                        WebsiteIconsEnabled="{Binding BindingContext.WebsiteIconsEnabled, Source={x:Reference _page}}"
+                        TotpSec="{Binding TotpSec}" />
+                </yummy:PancakeView>
             </DataTemplate>
 
             <DataTemplate x:Key="groupTemplate"
                           x:DataType="pages:GroupingsPageListItem">
-                <controls:ExtendedStackLayout Orientation="Horizontal" 
-                                                StyleClass="list-row, list-row-platform"
-                                                AutomationId="{Binding AutomationId}">
-                    <controls:IconLabel Text="{Binding Icon, Mode=OneWay}"
-                                        HorizontalOptions="Start"
-                                        VerticalOptions="Center"
-                                        StyleClass="list-icon, list-icon-platform"
-                                        ShouldUpdateFontSizeDynamicallyForAccesibility="True">
-                        <controls:IconLabel.Effects>
-                            <effects:FixedSizeEffect />
-                        </controls:IconLabel.Effects>
-                    </controls:IconLabel>
-                    <Label Text="{Binding Name, Mode=OneWay}"
-                            LineBreakMode="TailTruncation"
-                            HorizontalOptions="FillAndExpand"
-                            VerticalOptions="CenterAndExpand"
-                            StyleClass="list-title"
-                            AutomationId="ItemNameLabel" />
-                    <Label Text="{Binding ItemCount, Mode=OneWay}"
-                            HorizontalOptions="End"
-                            VerticalOptions="CenterAndExpand"
-                            HorizontalTextAlignment="End"
-                            StyleClass="list-sub"
-                            AutomationId="ItemCountLabel" />
+                <controls:ExtendedStackLayout Orientation="Horizontal"
+                                        Padding="10,0,10,0"
+                                        StyleClass="list-row, list-row-platform">
+                    <yummy:PancakeView StyleClass="round-card" HorizontalOptions="FillAndExpand" VerticalOptions="FillAndExpand" Padding="15">
+                        <controls:ExtendedStackLayout Orientation="Horizontal" 
+                                                        AutomationId="{Binding AutomationId}">
+                            <controls:IconLabel Text="{Binding Icon, Mode=OneWay}"
+                                                HorizontalOptions="Start"
+                                                VerticalOptions="Center"
+                                                StyleClass="list-icon, list-icon-platform"
+                                                ShouldUpdateFontSizeDynamicallyForAccesibility="True">
+                                <controls:IconLabel.Effects>
+                                    <effects:FixedSizeEffect />
+                                </controls:IconLabel.Effects>
+                            </controls:IconLabel>
+                            <Label Text="{Binding Name, Mode=OneWay}"
+                                    LineBreakMode="TailTruncation"
+                                    HorizontalOptions="FillAndExpand"
+                                    VerticalOptions="CenterAndExpand"
+                                    StyleClass="list-title"
+                                    AutomationId="ItemNameLabel" />
+                            <Label Text="{Binding ItemCount, Mode=OneWay}"
+                                    HorizontalOptions="End"
+                                    VerticalOptions="CenterAndExpand"
+                                    HorizontalTextAlignment="End"
+                                    StyleClass="list-sub"
+                                    AutomationId="ItemCountLabel" />
+                        </controls:ExtendedStackLayout>
+                    </yummy:PancakeView>
                 </controls:ExtendedStackLayout>
             </DataTemplate>
 
@@ -96,13 +104,11 @@
                 x:Key="headerTemplate"
                 x:DataType="pages:GroupingsPageHeaderListItem">
                 <StackLayout
-                    Spacing="0"
-                    Padding="0"
+                    Spacing="10"
+                    Padding="10"
                     VerticalOptions="FillAndExpand"
                     StyleClass="list-row-header-container, list-row-header-container-platform"
                     AutomationId="{Binding AutomationId}">
-                    <BoxView
-                        StyleClass="list-section-separator-top, list-section-separator-top-platform" />
                     <StackLayout StyleClass="list-row-header, list-row-header-platform">
                         <Label
                             Text="{Binding Title}"
@@ -112,7 +118,6 @@
                             StyleClass="list-header-sub"
                             AutomationId="SectionItemCount" />
                     </StackLayout>
-                    <BoxView StyleClass="list-section-separator-bottom, list-section-separator-bottom-platform" />
                 </StackLayout>
 	        </DataTemplate>
 

--- a/src/App/Pages/Vault/GroupingsPage/GroupingsPage.xaml
+++ b/src/App/Pages/Vault/GroupingsPage/GroupingsPage.xaml
@@ -58,12 +58,10 @@
 
             <DataTemplate x:Key="authenticatorTemplate"
                           x:DataType="pages:GroupingsPageTOTPListItem">
-                <yummy:PancakeView StyleClass="round-card">
-                    <controls:AuthenticatorViewCell 
-                        Cipher="{Binding Cipher}"
-                        WebsiteIconsEnabled="{Binding BindingContext.WebsiteIconsEnabled, Source={x:Reference _page}}"
-                        TotpSec="{Binding TotpSec}" />
-                </yummy:PancakeView>
+                <controls:AuthenticatorViewCell 
+                    Cipher="{Binding Cipher}"
+                    WebsiteIconsEnabled="{Binding BindingContext.WebsiteIconsEnabled, Source={x:Reference _page}}"
+                    TotpSec="{Binding TotpSec}" />
             </DataTemplate>
 
             <DataTemplate x:Key="groupTemplate"
@@ -71,8 +69,8 @@
                 <controls:ExtendedStackLayout Orientation="Horizontal"
                                         Padding="10,0,10,0"
                                         StyleClass="list-row, list-row-platform">
-                    <yummy:PancakeView StyleClass="round-card" HorizontalOptions="FillAndExpand" VerticalOptions="FillAndExpand" Padding="15">
-                        <controls:ExtendedStackLayout Orientation="Horizontal" 
+                    <yummy:PancakeView StyleClass="round-card" HorizontalOptions="FillAndExpand" VerticalOptions="FillAndExpand" Padding="15" Margin="0,2.5,0,2.5">
+                        <StackLayout Orientation="Horizontal" 
                                                         AutomationId="{Binding AutomationId}">
                             <controls:IconLabel Text="{Binding Icon, Mode=OneWay}"
                                                 HorizontalOptions="Start"
@@ -95,7 +93,7 @@
                                     HorizontalTextAlignment="End"
                                     StyleClass="list-sub"
                                     AutomationId="ItemCountLabel" />
-                        </controls:ExtendedStackLayout>
+                        </StackLayout>
                     </yummy:PancakeView>
                 </controls:ExtendedStackLayout>
             </DataTemplate>
@@ -105,7 +103,7 @@
                 x:DataType="pages:GroupingsPageHeaderListItem">
                 <StackLayout
                     Spacing="10"
-                    Padding="10"
+                    Padding="10, 10, 0, 0"
                     VerticalOptions="FillAndExpand"
                     StyleClass="list-row-header-container, list-row-header-container-platform"
                     AutomationId="{Binding AutomationId}">
@@ -132,7 +130,7 @@
                     IsVisible="{Binding ShowVaultFilter}"
                     Orientation="Horizontal"
                     HorizontalOptions="FillAndExpand"
-                    Margin="0,5,0,0">
+                    Margin="0,2.5,0,2.5">
                     <Label
                         Text="{Binding VaultFilterDescription}"
                         LineBreakMode="TailTruncation"

--- a/src/App/Styles/Base.xaml
+++ b/src/App/Styles/Base.xaml
@@ -2,6 +2,7 @@
 <ResourceDictionary xmlns="http://xamarin.com/schemas/2014/forms"
                     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
                     xmlns:controls="clr-namespace:Bit.App.Controls;assembly=BitwardenApp"
+                    xmlns:yummy="clr-namespace:Xamarin.Forms.PancakeView;assembly=Xamarin.Forms.PancakeView"
                     x:Class="Bit.App.Styles.Base">
 
     <!-- General -->
@@ -588,5 +589,16 @@
                 Value="{DynamicResource PrimaryColor}" />
         <Setter Property="StrongColor"
                 Value="{DynamicResource SuccessColor}" />
+    </Style>
+
+    <Style TargetType="yummy:PancakeView" Class="round-card">
+        <Setter Property="CornerRadius"
+                Value="10" />
+        <Setter Property="Padding"
+                Value="10,0,10,0" />
+        <Setter Property="Margin"
+                Value="0,5,0,5" />
+        <Setter Property="BackgroundColor"
+                Value="{DynamicResource CardBackgroundColor}" />
     </Style>
 </ResourceDictionary>

--- a/src/App/Styles/Base.xaml
+++ b/src/App/Styles/Base.xaml
@@ -597,7 +597,7 @@
         <Setter Property="Padding"
                 Value="10,0,10,0" />
         <Setter Property="Margin"
-                Value="0,5,0,5" />
+                Value="0,2.5,0,2.5" />
         <Setter Property="BackgroundColor"
                 Value="{DynamicResource CardBackgroundColor}" />
     </Style>

--- a/src/App/Styles/Black.xaml
+++ b/src/App/Styles/Black.xaml
@@ -73,4 +73,5 @@
     <Color x:Key="HyperlinkColor">#52bdfb</Color>
     <Color x:Key="FingerprintPhrase">#F08DC7</Color>
     <Color x:Key="ScanningToggleModeTextColor">#80BDFF</Color>
+    <Color x:Key="CardBackgroundColor">#212121</Color>
 </ResourceDictionary>

--- a/src/App/Styles/Dark.xaml
+++ b/src/App/Styles/Dark.xaml
@@ -73,4 +73,5 @@
     <Color x:Key="HyperlinkColor">#52bdfb</Color>
     <Color x:Key="FingerprintPhrase">#F08DC7</Color>
     <Color x:Key="ScanningToggleModeTextColor">#80BDFF</Color>
+    <Color x:Key="CardBackgroundColor">#505050</Color>
 </ResourceDictionary>

--- a/src/App/Styles/Light.xaml
+++ b/src/App/Styles/Light.xaml
@@ -15,7 +15,7 @@
     <Color x:Key="InputPlaceholderColor">#d0d0d0</Color>
     <Color x:Key="DangerPressedColor">#9a0007</Color>
 
-    <Color x:Key="BackgroundColor">#ffffff</Color>
+    <Color x:Key="BackgroundColor">#f0f0f0</Color>
     <Color x:Key="SplashBackgroundColor">#ffffff</Color>
     <Color x:Key="BorderColor">#dddddd</Color>
     <Color x:Key="DisabledIconColor">#c7c7cd</Color>
@@ -73,4 +73,5 @@
     <Color x:Key="HyperlinkColor">#175DDC</Color>
     <Color x:Key="FingerprintPhrase">#C01176</Color>
     <Color x:Key="ScanningToggleModeTextColor">#80BDFF</Color>
+    <Color x:Key="CardBackgroundColor">#ffffff</Color>
 </ResourceDictionary>

--- a/src/App/Styles/Nord.xaml
+++ b/src/App/Styles/Nord.xaml
@@ -73,4 +73,5 @@
     <Color x:Key="HyperlinkColor">#81a1c1</Color>
     <Color x:Key="FingerprintPhrase">#F08DC7</Color>
     <Color x:Key="ScanningToggleModeTextColor">#80BDFF</Color>
+    <Color x:Key="CardBackgroundColor">#434c5e</Color>
 </ResourceDictionary>

--- a/src/App/Styles/SolarizedDark.xaml
+++ b/src/App/Styles/SolarizedDark.xaml
@@ -73,4 +73,5 @@
     <Color x:Key="HyperlinkColor">#859900</Color>
     <Color x:Key="FingerprintPhrase">#F08DC7</Color>
     <Color x:Key="ScanningToggleModeTextColor">#80BDFF</Color>
+    <Color x:Key="CardBackgroundColor">#073642</Color>
 </ResourceDictionary>


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
This PR updates the mobile UI to look more modern. It aims to look similar to the current desktop/web-extension interface.

## Code changes
- App.csproj: Add Xamarin.Forms.PancakeView for rounded rectangles
- */Styles/*.xaml: Add color for the cards, and add styles for the cards
- Rest: Wrap relevant items in PancakeViews, remove box-row-separators

## Screenshots
Before:
![image](https://github.com/bitwarden/mobile/assets/11866552/16195078-be81-4b94-8994-06c39b0ad345)


After:
![Screenshot from 2023-08-28 22-05-00](https://github.com/bitwarden/mobile/assets/11866552/c3c96bc4-cd45-46e9-8b41-149ba3f4b175)
![Screenshot from 2023-08-28 22-05-08](https://github.com/bitwarden/mobile/assets/11866552/376e3e14-66d1-47fd-b249-459ddce0c346)
![Screenshot from 2023-08-28 22-05-26](https://github.com/bitwarden/mobile/assets/11866552/6941f238-b323-4d1c-8657-1802c15a3a08)
[Screencast from 2023-08-28 22-10-16.webm](https://github.com/bitwarden/mobile/assets/11866552/897a7c7e-37fd-4473-8133-a980ffb4f4e1)



## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
