### PR TITLE
[PM-3699] fix: Add bitwarden.eu to HTTPS only resources

### DIFF
--- a/src/Android/Resources/xml/network_security_config.xml
+++ b/src/Android/Resources/xml/network_security_config.xml
@@ -9,6 +9,7 @@
   </base-config>
   <domain-config cleartextTrafficPermitted="false">
     <domain includeSubdomains="true">bitwarden.com</domain>
+    <domain includeSubdomains="true">bitwarden.eu</domain>
     <trust-anchors>
       <!-- Only trust pre-installed CAs for Bitwarden.com and all subdomains -->
       <certificates src="system" />


### PR DESCRIPTION
## Bug fix

## Objective
Make sure that if a user accesses https://bitwarden.eu, it's done though a HTTPS connection. 
