### PR TITLE
[PM-3803] Adding AutomationIDs for Set/Update password pages

### DIFF
--- a/src/App/Pages/Accounts/SetPasswordPage.xaml
+++ b/src/App/Pages/Accounts/SetPasswordPage.xaml
@@ -51,7 +51,8 @@
                         <Label
                             Text="{u:I18n ResetPasswordAutoEnrollInviteWarning}"
                             StyleClass="text-muted, text-sm, text-bold"
-                            HorizontalTextAlignment="Start" />
+                            HorizontalTextAlignment="Start"
+                            AutomationId="ResetPasswordAutoEnrollInviteWarningLabel" />
                     </Frame>
                 </Grid>
                 <Grid IsVisible="{Binding IsPolicyInEffect}"
@@ -73,7 +74,8 @@
                         <Label
                             Text="{Binding PolicySummary}"
                             StyleClass="text-muted, text-sm, text-bold"
-                            HorizontalTextAlignment="Start" />
+                            HorizontalTextAlignment="Start"
+                            AutomationId="PolicyInEffectLabel" />
                     </Frame>
                 </Grid>
                 <Grid StyleClass="box-row">
@@ -98,7 +100,8 @@
                         IsTextPredictionEnabled="False"
                         IsPassword="{Binding ShowPassword, Converter={StaticResource inverseBool}}"
                         Grid.Row="1"
-                        Grid.Column="0" />
+                        Grid.Column="0"
+                        AutomationId="MasterPasswordField" />
                     <controls:IconButton
                         StyleClass="box-row-button, box-row-button-platform"
                         Text="{Binding ShowPasswordIcon}"
@@ -108,7 +111,8 @@
                         Grid.RowSpan="2"
                         AutomationProperties.IsInAccessibleTree="True"
                         AutomationProperties.Name="{u:I18n ToggleVisibility}"
-                        AutomationProperties.HelpText="{Binding PasswordVisibilityAccessibilityText}" />
+                        AutomationProperties.HelpText="{Binding PasswordVisibilityAccessibilityText}"
+                        AutomationId="ToggleMasterPasswordVisibilityButton" />
                 </Grid>
                 <Label
                     Text="{u:I18n MasterPasswordDescription}"
@@ -137,7 +141,8 @@
                         IsTextPredictionEnabled="False"
                         IsPassword="{Binding ShowPassword, Converter={StaticResource inverseBool}}"
                         Grid.Row="1"
-                        Grid.Column="0" />
+                        Grid.Column="0"
+                        AutomationId="RetypePasswordField" />
                     <controls:IconButton
                         StyleClass="box-row-button, box-row-button-platform"
                         Text="{Binding ShowPasswordIcon}"
@@ -147,7 +152,8 @@
                         Grid.RowSpan="2"
                         AutomationProperties.IsInAccessibleTree="True"
                         AutomationProperties.Name="{u:I18n ToggleVisibility}"
-                        AutomationProperties.HelpText="{Binding PasswordVisibilityAccessibilityText}" />
+                        AutomationProperties.HelpText="{Binding PasswordVisibilityAccessibilityText}"
+                        AutomationId="ToggleRetypePasswordVisibilityButton" />
                 </Grid>
                 <StackLayout StyleClass="box-row">
                     <Label
@@ -158,7 +164,8 @@
                         Text="{Binding Hint}"
                         StyleClass="box-value"
                         ReturnType="Go"
-                        ReturnCommand="{Binding SubmitCommand}" />
+                        ReturnCommand="{Binding SubmitCommand}"
+                        AutomationId="MasterPasswordHintLabel" />
                 </StackLayout>
                 <Label
                     Text="{u:I18n MasterPasswordHintDescription}"

--- a/src/App/Pages/Accounts/UpdateTempPasswordPage.xaml
+++ b/src/App/Pages/Accounts/UpdateTempPasswordPage.xaml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8" ?>
+﻿<?xml version="1.0" encoding="utf-8" ?>
 <pages:BaseContentPage 
     xmlns="http://xamarin.com/schemas/2014/forms"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
@@ -48,7 +48,8 @@
                         <Label
                             Text="{Binding UpdateMasterPasswordWarningText }"
                             StyleClass="text-muted, text-sm, text-bold"
-                            HorizontalTextAlignment="Center" />
+                            HorizontalTextAlignment="Center"
+                            AutomationId="UpdatePasswordWarningLabel" />
                     </Frame>
                 </Grid>
                 <Grid IsVisible="{Binding IsPolicyInEffect}"
@@ -71,7 +72,8 @@
                         <Label
                             Text="{Binding PolicySummary}"
                             StyleClass="text-muted, text-sm, text-bold"
-                            HorizontalTextAlignment="Start" />
+                            HorizontalTextAlignment="Start"
+                            AutomationId="PolicySummaryLabel" />
                     </Frame>
                 </Grid>
                 <Grid StyleClass="box-row" IsVisible="{Binding RequireCurrentPassword }">
@@ -96,7 +98,8 @@
                         IsTextPredictionEnabled="False"
                         IsPassword="{Binding ShowPassword, Converter={StaticResource inverseBool}}"
                         Grid.Row="1"
-                        Grid.Column="0" />
+                        Grid.Column="0"
+                        AutomationId="MasterPasswordField" />
                     <controls:IconButton
                         StyleClass="box-row-button, box-row-button-platform"
                         Text="{Binding ShowPasswordIcon}"
@@ -106,7 +109,8 @@
                         Grid.RowSpan="2"
                         AutomationProperties.IsInAccessibleTree="True"
                         AutomationProperties.Name="{u:I18n ToggleVisibility}"
-                        AutomationProperties.HelpText="{Binding PasswordVisibilityAccessibilityText}" />
+                        AutomationProperties.HelpText="{Binding PasswordVisibilityAccessibilityText}"
+                        AutomationId="ToggleMasterPasswordVisibilityButton" />
                 </Grid>
                 <Grid StyleClass="box-row">
                     <Grid.RowDefinitions>
@@ -130,7 +134,8 @@
                         IsTextPredictionEnabled="False"
                         IsPassword="{Binding ShowPassword, Converter={StaticResource inverseBool}}"
                         Grid.Row="1"
-                        Grid.Column="0" />
+                        Grid.Column="0"
+                        AutomationId="NewPasswordField" />
                     <controls:IconButton
                         StyleClass="box-row-button, box-row-button-platform"
                         Text="{Binding ShowPasswordIcon}"
@@ -140,7 +145,8 @@
                         Grid.RowSpan="2"
                         AutomationProperties.IsInAccessibleTree="True"
                         AutomationProperties.Name="{u:I18n ToggleVisibility}"
-                        AutomationProperties.HelpText="{Binding PasswordVisibilityAccessibilityText}" />
+                        AutomationProperties.HelpText="{Binding PasswordVisibilityAccessibilityText}"
+                        AutomationId="NewPasswordVisibilityButton" />
                 </Grid>
             </StackLayout>
             <StackLayout StyleClass="box">
@@ -166,7 +172,8 @@
                         IsTextPredictionEnabled="False"
                         IsPassword="{Binding ShowPassword, Converter={StaticResource inverseBool}}"
                         Grid.Row="1"
-                        Grid.Column="0" />
+                        Grid.Column="0"
+                        AutomationId="RetypePasswordField" />
                     <controls:IconButton
                         StyleClass="box-row-button, box-row-button-platform"
                         Text="{Binding ShowPasswordIcon}"
@@ -176,7 +183,8 @@
                         Grid.RowSpan="2"
                         AutomationProperties.IsInAccessibleTree="True"
                         AutomationProperties.Name="{u:I18n ToggleVisibility}"
-                        AutomationProperties.HelpText="{Binding PasswordVisibilityAccessibilityText}" />
+                        AutomationProperties.HelpText="{Binding PasswordVisibilityAccessibilityText}"
+                        AutomationId="ToggleRetypePasswordVisibilityButton" />
                 </Grid>
                 <StackLayout StyleClass="box-row">
                     <Label
@@ -187,7 +195,8 @@
                         Text="{Binding Hint}"
                         StyleClass="box-value"
                         ReturnType="Go"
-                        ReturnCommand="{Binding SubmitCommand}" />
+                        ReturnCommand="{Binding SubmitCommand}"
+                        AutomationId="MasterPasswordHintLabel" />
                 </StackLayout>
                 <Label
                     Text="{u:I18n MasterPasswordHintDescription}"


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc.)
- [ ] Build/deploy pipeline (DevOps)
- [X] Other

## Objective
Adding more AutomationIDs to continue improving our mobile automation test suite

## Code changes
Some missing AutomationIDs were added to Set/UpdatePassword XAML files

* **SetPasswordPage.xaml:** Adding missing IDs for entry fields
* **UpdateTempPasswordPage.xaml:** Adding missing IDs for entry fields



## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
