### PR TITLE
[PM-3839] Fix crash logs and screen capture switches state on appear

### DIFF
--- a/src/App/Pages/Settings/AboutSettingsPage.xaml.cs
+++ b/src/App/Pages/Settings/AboutSettingsPage.xaml.cs
@@ -1,12 +1,37 @@
-﻿namespace Bit.App.Pages
+﻿using System;
+using Bit.App.Resources;
+using Bit.Core.Abstractions;
+using Bit.Core.Services;
+using Bit.Core.Utilities;
+
+namespace Bit.App.Pages
 {
     public partial class AboutSettingsPage : BaseContentPage
     {
+        private readonly AboutSettingsPageViewModel _vm;
+
         public AboutSettingsPage()
         {
             InitializeComponent();
-            var vm = BindingContext as AboutSettingsPageViewModel;
-            vm.Page = this;
+            _vm = BindingContext as AboutSettingsPageViewModel;
+            _vm.Page = this;
+        }
+
+        protected async override void OnAppearing()
+        {
+            base.OnAppearing();
+
+            try
+            {
+                await _vm.InitAsync();
+            }
+            catch (Exception ex)
+            {
+                LoggerHelper.LogEvenIfCantBeResolved(ex);
+                ServiceContainer.Resolve<IPlatformUtilsService>().ShowToast(null, null, AppResources.AnErrorHasOccurred);
+
+                Navigation.PopAsync().FireAndForget();
+            }
         }
     }
 }

--- a/src/App/Pages/Settings/AboutSettingsPageViewModel.cs
+++ b/src/App/Pages/Settings/AboutSettingsPageViewModel.cs
@@ -6,6 +6,7 @@ using Bit.App.Resources;
 using Bit.Core;
 using Bit.Core.Abstractions;
 using Bit.Core.Utilities;
+using Xamarin.CommunityToolkit.ObjectModel;
 using Xamarin.Essentials;
 
 namespace Bit.App.Pages
@@ -16,6 +17,7 @@ namespace Bit.App.Pages
         private readonly IDeviceActionService _deviceActionService;
         private readonly ILogger _logger;
 
+        private bool _inited;
         private bool _shouldSubmitCrashLogs;
 
         public AboutSettingsPageViewModel()
@@ -55,7 +57,7 @@ namespace Bit.App.Pages
             set
             {
                 SetProperty(ref _shouldSubmitCrashLogs, value);
-                ToggleSubmitCrashLogsCommand.Execute(null);
+                ((ICommand)ToggleSubmitCrashLogsCommand).Execute(null);
             }
         }
 
@@ -72,13 +74,26 @@ namespace Bit.App.Pages
             }
         }
 
-        public ICommand ToggleSubmitCrashLogsCommand { get; }
+        public AsyncCommand ToggleSubmitCrashLogsCommand { get; }
         public ICommand GoToHelpCenterCommand { get; }
         public ICommand ContactBitwardenSupportCommand { get; }
         public ICommand GoToWebVaultCommand { get; }
         public ICommand GoToLearnAboutOrgsCommand { get; }
         public ICommand RateTheAppCommand { get; }
         public ICommand CopyAppInfoCommand { get; }
+
+        public async Task InitAsync()
+        {
+            _shouldSubmitCrashLogs = await _logger.IsEnabled();
+
+            _inited = true;
+
+            MainThread.BeginInvokeOnMainThread(() =>
+            {
+                TriggerPropertyChanged(nameof(ShouldSubmitCrashLogs));
+                ToggleSubmitCrashLogsCommand.RaiseCanExecuteChanged();
+            });
+        }
 
         private async Task ToggleSubmitCrashLogsAsync()
         {

--- a/src/App/Pages/Settings/OtherSettingsPageViewModel.cs
+++ b/src/App/Pages/Settings/OtherSettingsPageViewModel.cs
@@ -113,12 +113,14 @@ namespace Bit.App.Pages
 
             await InitClearClipboardAsync();
 
+            _isScreenCaptureAllowed = await _stateService.GetScreenCaptureAllowedAsync();
             _shouldConnectToWatch = await _stateService.GetShouldConnectToWatchAsync();
 
             _inited = true;
 
             MainThread.BeginInvokeOnMainThread(() =>
             {
+                TriggerPropertyChanged(nameof(IsScreenCaptureAllowed));
                 TriggerPropertyChanged(nameof(ShouldConnectToWatch));
                 SyncCommand.RaiseCanExecuteChanged();
                 ClearClipboardPickerViewModel.SelectOptionCommand.RaiseCanExecuteChanged();


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Fix settings submit crash logs and screen capture switches state when page appears


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **AboutSettingsPage/ViewModel:** Init should submit crash logs on page appear
* **OtherSettingsPageViewModel:** Init is screen capture allowed on page appear


## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
