### PR TITLE
[PM-3522] Approve Login Request setting is not remembered if user logs out of mobile

### DIFF
--- a/src/Core/Services/StateService.cs
+++ b/src/Core/Services/StateService.cs
@@ -1538,7 +1538,6 @@ namespace Bit.Core.Services
                 SetEncryptedPasswordGenerationHistoryAsync(null, userId),
                 SetEncryptedSendsAsync(null, userId),
                 SetSettingsAsync(null, userId),
-                SetApprovePasswordlessLoginsAsync(null, userId),
                 SetEncKeyEncryptedAsync(null, userId),
                 SetKeyEncryptedAsync(null, userId),
                 SetPinProtectedAsync(null, userId));


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
`Approve Login Request` setting value is reset when the user logs out. 
Value should be kept saved. 


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->
Remove line that was clearing the `Approve Login Request` setting.

## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
