### PR TITLE
[PM-3086] Account switcher endpoint use domain string for Bitwarden p…

### DIFF
--- a/src/App/Controls/AccountViewCell/AccountViewCellViewModel.cs
+++ b/src/App/Controls/AccountViewCell/AccountViewCellViewModel.cs
@@ -36,7 +36,7 @@ namespace Bit.App.Controls
 
         public bool ShowHostname
         {
-            get => !string.IsNullOrWhiteSpace(AccountView.Hostname) && AccountView.Hostname != "vault.bitwarden.com";
+            get => !string.IsNullOrWhiteSpace(AccountView.Hostname);
         }
 
         public bool IsActive

--- a/src/Core/Models/View/AccountView.cs
+++ b/src/Core/Models/View/AccountView.cs
@@ -1,4 +1,5 @@
 ﻿using Bit.Core.Enums;
+using Bit.Core.Models.Data;
 using Bit.Core.Models.Domain;
 using Bit.Core.Utilities;
 
@@ -21,14 +22,21 @@ namespace Bit.Core.Models.View
             Email = a.Profile?.Email;
             Name = a.Profile?.Name;
             AvatarColor = a.Profile?.AvatarColor;
-            if (!string.IsNullOrWhiteSpace(a.Settings?.EnvironmentUrls?.WebVault))
+            Hostname = ParseEndpoint(a.Settings?.EnvironmentUrls);
+        }
+
+        private string ParseEndpoint(EnvironmentUrlData urls)
+        {
+            var url = urls?.WebVault ?? urls?.Base;
+            if (!string.IsNullOrWhiteSpace(url))
             {
-                Hostname = CoreHelpers.GetHostname(a.Settings?.EnvironmentUrls?.WebVault);
+                if (url.Contains("bitwarden.com") || url.Contains("bitwarden.eu"))
+                {
+                    return CoreHelpers.GetDomain(url);
+                }
+                return CoreHelpers.GetHostname(url);
             }
-            else if (!string.IsNullOrWhiteSpace(a.Settings?.EnvironmentUrls?.Base))
-            {
-                Hostname = CoreHelpers.GetHostname(a.Settings?.EnvironmentUrls?.Base);
-            }
+            return string.Empty;
         }
 
         public bool IsAccount { get; set; }


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Account switcher endpoint, use domain string for Bitwarden production environments and host for selfhosted.

## Screenshots
<!--Required for any UI changes. Delete if not applicable-->
<img width="441" alt="image" src="https://github.com/bitwarden/mobile/assets/4648522/e085ab9b-6b7b-4898-be28-eb8a204c5bca">

## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
