### PR TITLE
[PM-3737] Remove client version suffix sent to server

### DIFF
--- a/src/Core/Services/ApiService.cs
+++ b/src/Core/Services/ApiService.cs
@@ -42,7 +42,7 @@ namespace Bit.Core.Services
             var device = (int)_platformUtilsService.GetDevice();
             _httpClient.DefaultRequestHeaders.Add("Device-Type", device.ToString());
             _httpClient.DefaultRequestHeaders.Add("Bitwarden-Client-Name", _platformUtilsService.GetClientType().GetString());
-            _httpClient.DefaultRequestHeaders.Add("Bitwarden-Client-Version", _platformUtilsService.GetApplicationVersion());
+            _httpClient.DefaultRequestHeaders.Add("Bitwarden-Client-Version", VersionHelpers.RemoveSuffix(_platformUtilsService.GetApplicationVersion()));
             if (!string.IsNullOrWhiteSpace(customUserAgent))
             {
                 _httpClient.DefaultRequestHeaders.UserAgent.ParseAdd(customUserAgent);

--- a/src/Core/Utilities/VersionHelpers.cs
+++ b/src/Core/Utilities/VersionHelpers.cs
@@ -4,7 +4,7 @@ namespace Bit.Core.Utilities
 {
     public static class VersionHelpers
     {
-        private const char HOTFIX_SEPARATOR = '-';
+        private const char SUFFIX_SEPARATOR = '-';
 
         /// <summary>
         /// Compares two server versions and gets whether the <paramref name="targetVersion"/>
@@ -18,17 +18,17 @@ namespace Bit.Core.Utilities
         /// </returns>
         public static bool IsServerVersionGreaterThanOrEqualTo(string targetVersion, string compareToVersion)
         {
-            return GetServerVersionWithoutHotfix(targetVersion).CompareTo(GetServerVersionWithoutHotfix(compareToVersion)) >= 0;
+            return new Version(RemoveSuffix(targetVersion)).CompareTo(new Version(RemoveSuffix(compareToVersion))) >= 0;
         }
 
-        public static Version GetServerVersionWithoutHotfix(string version)
+        public static string RemoveSuffix(string version)
         {
             if (string.IsNullOrWhiteSpace(version))
             {
                 throw new ArgumentNullException(nameof(version));
             }
 
-            return new Version(version.Split(HOTFIX_SEPARATOR)[0]);
+            return version.Split(SUFFIX_SEPARATOR)[0];
         }
     }
 }


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Remove the suffix on the client version when sending it to the server on the `ApiService`.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **ApiService:** Remove suffix on client version default HttpClient header.
* **VersionHelpers:** Added helper to remove and return the string version without the suffix.

## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
