### PR TITLE
[PM-4046] Adding AutomationIDs for ExportVault page

### DIFF
--- a/src/App/Pages/Settings/ExportVaultPage.xaml
+++ b/src/App/Pages/Settings/ExportVaultPage.xaml
@@ -38,7 +38,8 @@
                 <Label
                     Text="{u:I18n DisablePersonalVaultExportPolicyInEffect}"
                     StyleClass="text-muted, text-sm, text-bold"
-                    HorizontalTextAlignment="Center" />
+                    HorizontalTextAlignment="Center"
+                    AutomationId="DisablePrivateVaultPolicyLabel" />
             </Frame>
             <Grid
                 RowSpacing="10"
@@ -55,7 +56,8 @@
                         SelectedIndex="{Binding FileFormatSelectedIndex}"
                         SelectedIndexChanged="FileFormat_Changed"
                         StyleClass="box-value"
-                        IsEnabled="{Binding DisablePrivateVaultPolicyEnabled, Converter={StaticResource inverseBool}}" />
+                        IsEnabled="{Binding DisablePrivateVaultPolicyEnabled, Converter={StaticResource inverseBool}}"
+                        AutomationId="FileFormatPicker" />
                 </StackLayout>
                 <StackLayout
                     StyleClass="box-row"
@@ -72,7 +74,8 @@
                         HorizontalOptions="Fill"
                         VerticalOptions="End"
                         IsEnabled="{Binding DisablePrivateVaultPolicyEnabled, Converter={StaticResource inverseBool}}"
-                        Margin="0,0,0,10"/>
+                        Margin="0,0,0,10"
+                        AutomationId="SendTOTPCodeButton" />
                 </StackLayout>
                 <Grid
                     StyleClass="box-row"
@@ -96,7 +99,8 @@
                         Grid.Row="1"
                         Grid.Column="0"
                         ReturnType="Go"
-                        ReturnCommand="{Binding ExportVaultCommand}" />
+                        ReturnCommand="{Binding ExportVaultCommand}"
+                        AutomationId="MasterPasswordEntry" />
                     <controls:IconButton
                         StyleClass="box-row-button, box-row-button-platform"
                         Text="{Binding ShowPasswordIcon}"
@@ -106,7 +110,8 @@
                         AutomationProperties.IsInAccessibleTree="True"
                         AutomationProperties.Name="{u:I18n ToggleVisibility}"
                         AutomationProperties.HelpText="{Binding PasswordVisibilityAccessibilityText}"
-                        IsVisible="{Binding UseOTPVerification, Converter={StaticResource inverseBool}}"/>
+                        IsVisible="{Binding UseOTPVerification, Converter={StaticResource inverseBool}}"
+                        AutomationId="TogglePasswordVisibilityButton" />
                     <Label
                         Text="{u:I18n ConfirmYourIdentity}"
                         StyleClass="box-footer-label"
@@ -128,7 +133,8 @@
                     Clicked="ExportVault_Clicked"
                     HorizontalOptions="Fill"
                     VerticalOptions="End"
-                    IsEnabled="{Binding DisablePrivateVaultPolicyEnabled, Converter={StaticResource inverseBool}}"/>
+                    IsEnabled="{Binding DisablePrivateVaultPolicyEnabled, Converter={StaticResource inverseBool}}"
+                    AutomationId="ExportVaultButton" />
             </StackLayout>
         </StackLayout>
     </ScrollView>


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [X] Other

## Objective
Adding more AutomationIDs to continue improving our mobile automation test suite


## Code changes

Some missing AutomationIDs were added to the ExportVault XAML file
* **ExportVaultPage.xaml:** Adding missing AutomationIDs


## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
