### PR TITLE
[PM-4081] Fix crash on export page

### DIFF
--- a/src/App/Services/MobilePasswordRepromptService.cs
+++ b/src/App/Services/MobilePasswordRepromptService.cs
@@ -51,13 +51,7 @@ namespace Bit.App.Services
             {
                 await AppHelpers.ResetInvalidUnlockAttemptsAsync();
 
-                var userKey = await _cryptoService.DecryptUserKeyWithMasterKeyAsync(masterKey);
-                await _cryptoService.SetMasterKeyAsync(masterKey);
-                var hasKey = await _cryptoService.HasUserKeyAsync();
-                if (!hasKey)
-                {
-                    await _cryptoService.SetUserKeyAsync(userKey);
-                }
+                await _cryptoService.UpdateMasterKeyAndUserKeyAsync(masterKey);
             }
 
             return passwordValid;

--- a/src/Core/Abstractions/ICryptoService.cs
+++ b/src/Core/Abstractions/ICryptoService.cs
@@ -62,5 +62,6 @@ namespace Bit.Core.Abstractions
         Task<EncByteArray> EncryptToBytesAsync(byte[] plainValue, SymmetricCryptoKey key = null);
         Task<UserKey> DecryptAndMigrateOldPinKeyAsync(bool masterPasswordOnRestart, string pin, string email, KdfConfig kdfConfig, EncString oldPinKey);
         Task<MasterKey> GetOrDeriveMasterKeyAsync(string password, string userId = null);
+        Task UpdateMasterKeyAndUserKeyAsync(MasterKey masterKey);
     }
 }

--- a/src/Core/Services/CryptoService.cs
+++ b/src/Core/Services/CryptoService.cs
@@ -719,6 +719,17 @@ namespace Bit.Core.Services
                 await _stateService.GetActiveUserCustomDataAsync(a => new KdfConfig(a?.Profile)));
         }
 
+        public async Task UpdateMasterKeyAndUserKeyAsync(MasterKey masterKey)
+        {
+            var userKey = await DecryptUserKeyWithMasterKeyAsync(masterKey);
+            await SetMasterKeyAsync(masterKey);
+            var hasKey = await HasUserKeyAsync();
+            if (!hasKey)
+            {
+                await SetUserKeyAsync(userKey);
+            }
+        }
+
         // --HELPER METHODS--
 
         private async Task StoreAdditionalKeysAsync(UserKey userKey, string userId = null)

--- a/src/Core/Services/UserVerificationService.cs
+++ b/src/Core/Services/UserVerificationService.cs
@@ -48,12 +48,14 @@ namespace Bit.Core.Services
             }
             else
             {
-                var passwordValid = await _cryptoService.CompareAndUpdateKeyHashAsync(secret, null);
+                var masterKey = await _cryptoService.GetOrDeriveMasterKeyAsync(secret);
+                var passwordValid = await _cryptoService.CompareAndUpdateKeyHashAsync(secret, masterKey);
                 if (!passwordValid)
                 {
                     await InvalidSecretErrorAsync(verificationType);
                     return false;
                 }
+                await _cryptoService.UpdateMasterKeyAndUserKeyAsync(masterKey);
             }
 
             return true;


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
Application is crashing to users that have biometrics active, updated to the most recent version without and try to export. 
This is caused by a missing `MasterKey`, this fix creates the missing `MasterKey` if necessary at export.


## Code changes

* **UserVerificationService.cs:** Calling method `GetOrDeriveMasterKeyAsync` to ensure that the `MasterKey` if doesn't exist is created. In case of success, use the same logic from `MasterPasswordRepromptService` to update the `MasterKey` and the `UserKey`
* **CryptoService.cs:** Created a method that updates the `MasterKey` and the `UserKey` based on the code from `MasterPasswordRepromptService` so that it can be reused by `UserVerificationService`
* **MasterPasswordRepromptService:** Replacing the code by the new created method from `CryptoService`

## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
