### PR TITLE
[PM-4207] Fix for the typo in Core.Test.csproj

### DIFF
--- a/test/Core.Test/Core.Test.csproj
+++ b/test/Core.Test/Core.Test.csproj
@@ -20,7 +20,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Core\Core.csproj" />
-    <ProjectReference Include="..\common\Common.csproj" />
+    <ProjectReference Include="..\Common\Common.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
Fixes issue #2809 
In Core.Test.csproj under test/Core.Test/
`..\common\Common.csproj` should have uppercase C instead of c since directory name is Common

## Code changes
Fixed the typo

* **Core.Test.csproj:** `..\common\Common.csproj` changed to `..\Common\Common.csproj`