### PR TITLE
[PM-868] Re-open app to item could crash the app

### DIFF
--- a/src/App/Pages/Vault/GroupingsPage/GroupingsPage.xaml.cs
+++ b/src/App/Pages/Vault/GroupingsPage/GroupingsPage.xaml.cs
@@ -130,24 +130,27 @@ namespace Bit.App.Pages
 
             await LoadOnAppearedAsync(_mainLayout, false, async () =>
             {
-                if (!_syncService.SyncInProgress || (await _cipherService.GetAllAsync()).Any())
+                if (_previousPage == null)
                 {
-                    try
+                    if (!_syncService.SyncInProgress || (await _cipherService.GetAllAsync()).Any())
                     {
-                        await _vm.LoadAsync();
+                        try
+                        {
+                            await _vm.LoadAsync();
+                        }
+                        catch (Exception e) when (e.Message.Contains("No key."))
+                        {
+                            await Task.Delay(1000);
+                            await _vm.LoadAsync();
+                        }
                     }
-                    catch (Exception e) when (e.Message.Contains("No key."))
+                    else
                     {
-                        await Task.Delay(1000);
-                        await _vm.LoadAsync();
-                    }
-                }
-                else
-                {
-                    await Task.Delay(5000);
-                    if (!_vm.Loaded)
-                    {
-                        await _vm.LoadAsync();
+                        await Task.Delay(5000);
+                        if (!_vm.Loaded)
+                        {
+                            await _vm.LoadAsync();
+                        }
                     }
                 }
                 await ShowPreviousPageAsync();

--- a/src/iOS.Core/Renderers/CollectionView/ExtendedGroupableItemsViewController.cs
+++ b/src/iOS.Core/Renderers/CollectionView/ExtendedGroupableItemsViewController.cs
@@ -38,7 +38,6 @@ namespace Bit.iOS.Core.Renderers.CollectionView
                     // Do nothing in here, this is temporary to get more info about the crash, if the logger fails, we want to get the info
                     // by crashing with the original exception and not the logger one
                 }
-                throw colEx;
             }
         }
     }

--- a/src/iOS.Core/Renderers/CollectionView/ExtendedGroupableItemsViewController.cs
+++ b/src/iOS.Core/Renderers/CollectionView/ExtendedGroupableItemsViewController.cs
@@ -38,6 +38,11 @@ namespace Bit.iOS.Core.Renderers.CollectionView
                     // Do nothing in here, this is temporary to get more info about the crash, if the logger fails, we want to get the info
                     // by crashing with the original exception and not the logger one
                 }
+                if (ex is IndexOutOfRangeException)
+                {
+                    return;
+                }
+                throw colEx;
             }
         }
     }


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Try fix the most reoccurring crash. If the app goes to background and there was an item open, when it comes to the foreground and tries to load the item again it could crash.
https://github.com/bitwarden/mobile/issues/2794
https://github.com/bitwarden/mobile/issues/2478

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->
Check for previous opened item before trying to load the vault list.

## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
