### PR TITLE
[PM-4250] Add support for the Cromite Android browser

### DIFF
--- a/src/Android/Accessibility/AccessibilityHelpers.cs
+++ b/src/Android/Accessibility/AccessibilityHelpers.cs
@@ -107,6 +107,7 @@ namespace Bit.Droid.Accessibility
             new Browser("org.bromite.chromium", "url_bar"),
             new Browser("org.chromium.chrome", "url_bar"),
             new Browser("org.codeaurora.swe.browser", "url_bar"),
+            new Browser("org.cromite.cromite", "url_bar"),
             new Browser("org.gnu.icecat", "url_bar_title,mozac_browser_toolbar_url_view"), // 2nd = Anticipation
             new Browser("org.mozilla.fenix", "mozac_browser_toolbar_url_view"),
             new Browser("org.mozilla.fenix.nightly", "mozac_browser_toolbar_url_view"), // [DEPRECATED ENTRY]

--- a/src/Android/Autofill/AutofillHelpers.cs
+++ b/src/Android/Autofill/AutofillHelpers.cs
@@ -128,6 +128,7 @@ namespace Bit.Droid.Autofill
             "org.bromite.chromium",
             "org.chromium.chrome",
             "org.codeaurora.swe.browser",
+            "org.cromite.cromite",
             "org.gnu.icecat",
             "org.mozilla.fenix",
             "org.mozilla.fenix.nightly",

--- a/src/Android/Resources/xml/autofillservice.xml
+++ b/src/Android/Resources/xml/autofillservice.xml
@@ -237,6 +237,9 @@
     android:name="org.codeaurora.swe.browser"
     android:maxLongVersionCode="10000000000"/>
   <compatibility-package
+    android:name="org.cromite.cromite"
+    android:maxLongVersionCode="10000000000"/>
+  <compatibility-package
     android:name="org.gnu.icecat"
     android:maxLongVersionCode="10000000000"/>
   <compatibility-package


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [ ] New feature development
- [x] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

This PR is meant to add complete autofill support for the [Cromite](https://github.com/uazo/cromite) Android browser.

Cromite is a fork of the popular Bromite privacy browser, which Bitwarden already supports. Unfortunately, Bromite has been abandoned for 10+ months at this point, with its last [update](https://github.com/bromite/bromite/releases/tag/108.0.5359.156) to Chrome 108 happening near the end of 2022. Cromite is maintained by a former Bromite contributor, and has proven reliable at keeping up with Chromium's frequent version updates since then, making it a natural choice for those looking for a safe-to-use Bromite alternative.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **`src/Android/Accessibility/AccessibilityHelpers.cs`:** Added a new `Browser` object to the `SupportedBrowsers` dictionary to add support for Cromite.
* **`src/Android/Autofill/AutofillHelpers.cs`:** Added a new item to the `CompatBrowsers` hashset to add support for Cromite.
* **`src/Android/Resources/xml/autofillservice.xml`:** Added a new `compatibility-package` object to add support for Cromite.
