### PR TITLE
[PM-4314] Removed move passkey to organization duplicate check

### DIFF
--- a/src/App/Pages/Vault/SharePageViewModel.cs
+++ b/src/App/Pages/Vault/SharePageViewModel.cs
@@ -113,14 +113,8 @@ namespace Bit.App.Pages
             try
             {
                 await _deviceActionService.ShowLoadingAsync(AppResources.Saving);
-                var error = await _cipherService.ShareWithServerAsync(cipherView, OrganizationId, checkedCollectionIds);
+                await _cipherService.ShareWithServerAsync(cipherView, OrganizationId, checkedCollectionIds);
                 await _deviceActionService.HideLoadingAsync();
-
-                if (error == ICipherService.ShareWithServerError.DuplicatedPasskeyInOrg)
-                {
-                    _platformUtilsService.ShowToast(null, null, AppResources.ThisItemCannotBeSharedWithTheOrganizationBecauseThereIsOneAlreadyWithTheSamePasskey);
-                    return false;
-                }
 
                 var movedItemToOrgText = string.Format(AppResources.MovedItemToOrg, cipherView.Name,
                    (await _organizationService.GetAsync(OrganizationId)).Name);

--- a/src/App/Resources/AppResources.Designer.cs
+++ b/src/App/Resources/AppResources.Designer.cs
@@ -6660,16 +6660,6 @@ namespace Bit.App.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to This item cannot be shared with the organization because there is one already with the same passkey..
-        /// </summary>
-        public static string ThisItemCannotBeSharedWithTheOrganizationBecauseThereIsOneAlreadyWithTheSamePasskey {
-            get {
-                return ResourceManager.GetString("ThisItemCannotBeSharedWithTheOrganizationBecauseThereIsOneAlreadyWithTheSamePassk" +
-                        "ey", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to This request is no longer valid.
         /// </summary>
         public static string ThisRequestIsNoLongerValid {

--- a/src/App/Resources/AppResources.resx
+++ b/src/App/Resources/AppResources.resx
@@ -2691,9 +2691,6 @@ Do you want to switch to this account?</value>
   <data name="VaultTimeoutActionChangedToLogOut" xml:space="preserve">
     <value>Vault timeout action changed to log out</value>
   </data>
-  <data name="ThisItemCannotBeSharedWithTheOrganizationBecauseThereIsOneAlreadyWithTheSamePasskey" xml:space="preserve">
-    <value>This item cannot be shared with the organization because there is one already with the same passkey.</value>
-  </data>
   <data name="BlockAutoFill" xml:space="preserve">
     <value>Block auto-fill</value>
   </data>

--- a/src/Core/Abstractions/ICipherService.cs
+++ b/src/Core/Abstractions/ICipherService.cs
@@ -10,12 +10,6 @@ namespace Bit.Core.Abstractions
 {
     public interface ICipherService
     {
-        public enum ShareWithServerError
-        {
-            None,
-            DuplicatedPasskeyInOrg
-        }
-
         Task ClearAsync(string userId);
         Task ClearCacheAsync();
         Task DeleteAsync(List<string> ids);
@@ -36,7 +30,7 @@ namespace Bit.Core.Abstractions
         Task<Cipher> SaveAttachmentRawWithServerAsync(Cipher cipher, CipherView cipherView, string filename, byte[] data);
         Task SaveCollectionsWithServerAsync(Cipher cipher);
         Task SaveWithServerAsync(Cipher cipher);
-        Task<ShareWithServerError> ShareWithServerAsync(CipherView cipher, string organizationId, HashSet<string> collectionIds);
+        Task ShareWithServerAsync(CipherView cipher, string organizationId, HashSet<string> collectionIds);
         Task UpdateLastUsedDateAsync(string id);
         Task UpsertAsync(CipherData cipher);
         Task UpsertAsync(List<CipherData> cipher);

--- a/src/Core/Services/CipherService.cs
+++ b/src/Core/Services/CipherService.cs
@@ -564,13 +564,8 @@ namespace Bit.Core.Services
             await UpsertAsync(data);
         }
 
-        public async Task<ICipherService.ShareWithServerError> ShareWithServerAsync(CipherView cipher, string organizationId, HashSet<string> collectionIds)
+        public async Task ShareWithServerAsync(CipherView cipher, string organizationId, HashSet<string> collectionIds)
         {
-            if (!await ValidateCanBeSharedWithOrgAsync(cipher, organizationId))
-            {
-                return ICipherService.ShareWithServerError.DuplicatedPasskeyInOrg;
-            }
-
             var attachmentTasks = new List<Task>();
             if (cipher.Attachments != null)
             {
@@ -591,21 +586,6 @@ namespace Bit.Core.Services
             var userId = await _stateService.GetActiveUserIdAsync();
             var data = new CipherData(response, userId, collectionIds);
             await UpsertAsync(data);
-
-            return ICipherService.ShareWithServerError.None;
-        }
-
-        private async Task<bool> ValidateCanBeSharedWithOrgAsync(CipherView cipher, string organizationId)
-        {
-            if (!cipher.HasFido2Credential)
-            {
-                return true;
-            }
-
-            var decCiphers = await GetAllDecryptedAsync();
-            return !decCiphers
-                .Where(c => c.OrganizationId == organizationId)
-                .Any(c => !cipher.Login.MainFido2Credential.IsUniqueAgainst(c.Login?.MainFido2Credential));
         }
 
         public async Task<Cipher> SaveAttachmentRawWithServerAsync(Cipher cipher, CipherView cipherView, string filename, byte[] data)


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Removed duplicate check when moving a passkey to an organization.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* Removed logic that was checking passkey duplication when moving a personal vault passkey to an organization.

## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
