### PR TITLE
[PM-4404] Add CreationDate to Fido2Credential objects

### DIFF
--- a/src/App/Pages/Vault/CipherAddEditPage.xaml
+++ b/src/App/Pages/Vault/CipherAddEditPage.xaml
@@ -12,6 +12,7 @@
     xmlns:dts="clr-namespace:Bit.App.Lists.DataTemplateSelectors"
     xmlns:il="clr-namespace:Bit.App.Lists.ItemLayouts.CustomFields"
     xmlns:core="clr-namespace:Bit.Core;assembly=BitwardenCore"
+    xmlns:appResources="clr-namespace:Bit.App.Resources"
     x:DataType="pages:CipherAddEditPageViewModel"
     x:Name="_page"
     Title="{Binding PageTitle}">
@@ -28,6 +29,8 @@
             <u:InverseBoolConverter x:Key="inverseBool" />
             <u:StringHasValueConverter x:Key="stringHasValue" />
             <u:IsNotNullConverter x:Key="notNull" />
+            <u:DateTimeConverter x:Key="dateTime" Format="{x:Static appResources:AppResources.CreatedXY}" />
+
             <ToolbarItem Text="{u:I18n Cancel}" Clicked="Close_Clicked" Order="Primary" Priority="-1"
                          x:Key="closeItem" x:Name="_closeItem" />
             <ToolbarItem Text="{u:I18n Collections}"
@@ -229,7 +232,7 @@
                         Margin="0,10,0,0"
                         IsVisible="{Binding ShowPasskeyInfo}"/>
                     <Entry
-                        Text="{Binding CreationDate}"
+                        Text="{Binding Cipher.Login.MainFido2Credential.CreationDate, Mode=OneWay, Converter={StaticResource dateTime}, FallbackValue=''}"
                         IsEnabled="False"
                         StyleClass="box-value,text-muted" 
                         IsVisible="{Binding ShowPasskeyInfo}" />

--- a/src/App/Pages/Vault/CipherDetailsPage.xaml
+++ b/src/App/Pages/Vault/CipherDetailsPage.xaml
@@ -11,6 +11,7 @@
     xmlns:dts="clr-namespace:Bit.App.Lists.DataTemplateSelectors"
     xmlns:il="clr-namespace:Bit.App.Lists.ItemLayouts.CustomFields"
     xmlns:core="clr-namespace:Bit.Core;assembly=BitwardenCore"
+    xmlns:appResources="clr-namespace:Bit.App.Resources"
     x:DataType="pages:CipherDetailsPageViewModel"
     x:Name="_page"
     Title="{Binding PageTitle}">
@@ -23,6 +24,7 @@
             <u:InverseBoolConverter x:Key="inverseBool" />
             <u:StringHasValueConverter x:Key="stringHasValue" />
             <u:IsNotNullConverter x:Key="notNull" />
+            <u:DateTimeConverter x:Key="dateTime" Format="{x:Static appResources:AppResources.CreatedXY}" />
             <ToolbarItem Text="{u:I18n Collections}"
                          x:Key="collectionsItem"
                          x:Name="_collectionsItem"
@@ -201,10 +203,10 @@
                                 Margin="0,10,0,0"
                                 IsVisible="{Binding Cipher.Login.MainFido2Credential, Converter={StaticResource notNull}}"/>
                             <Entry
-                                Text="{Binding CreationDate}"
+                                Text="{Binding Cipher.Login.MainFido2Credential.CreationDate, Mode=OneWay, Converter={StaticResource dateTime}, FallbackValue=''}"
                                 IsEnabled="False"
                                 StyleClass="box-value,text-muted"
-                                IsVisible="{Binding Cipher.Login.MainFido2Credential, Converter={StaticResource notNull}}" />
+                                IsVisible="{Binding Cipher.Login.MainFido2Credential, Converter={StaticResource notNull}, FallbackValue=False}" />
                             <Grid StyleClass="box-row"
                                   IsVisible="{Binding ShowTotp}"
                                   AutomationId="ItemRow">

--- a/src/App/Utilities/DateTimeConverter.cs
+++ b/src/App/Utilities/DateTimeConverter.cs
@@ -7,6 +7,8 @@ namespace Bit.App.Utilities
 {
     public class DateTimeConverter : IValueConverter
     {
+        public string Format { get; set; } = "{0} {1}";
+
         private readonly ILocalizeService _localizeService;
 
         public DateTimeConverter()
@@ -26,7 +28,7 @@ namespace Bit.App.Utilities
                 return string.Empty;
             }
             var d = ((DateTime)value).ToLocalTime();
-            return string.Format("{0} {1}",
+            return string.Format(Format,
                 _localizeService.GetLocaleShortDate(d),
                 _localizeService.GetLocaleShortTime(d));
         }

--- a/src/Core/Models/Api/Fido2CredentialApi.cs
+++ b/src/Core/Models/Api/Fido2CredentialApi.cs
@@ -1,4 +1,5 @@
-﻿using Bit.Core.Models.Domain;
+﻿using System;
+using Bit.Core.Models.Domain;
 
 namespace Bit.Core.Models.Api
 {
@@ -21,6 +22,7 @@ namespace Bit.Core.Models.Api
             UserHandle = fido2Key.UserHandle?.EncryptedString;
             UserName = fido2Key.UserName?.EncryptedString;
             Counter = fido2Key.Counter?.EncryptedString;
+            CreationDate = fido2Key.CreationDate;
         }
 
         public string CredentialId { get; set; }
@@ -34,5 +36,6 @@ namespace Bit.Core.Models.Api
         public string UserHandle { get; set; }
         public string UserName { get; set; }
         public string Counter { get; set; }
+        public DateTime CreationDate { get; set; }
     }
 }

--- a/src/Core/Models/Data/Fido2CredentialData.cs
+++ b/src/Core/Models/Data/Fido2CredentialData.cs
@@ -1,4 +1,5 @@
-﻿using Bit.Core.Models.Api;
+﻿using System;
+using Bit.Core.Models.Api;
 
 namespace Bit.Core.Models.Data
 {
@@ -19,6 +20,7 @@ namespace Bit.Core.Models.Data
             UserHandle = apiData.UserHandle;
             UserName = apiData.UserName;
             Counter = apiData.Counter;
+            CreationDate = apiData.CreationDate;
         }
 
         public string CredentialId { get; set; }
@@ -32,5 +34,6 @@ namespace Bit.Core.Models.Data
         public string UserHandle { get; set; }
         public string UserName { get; set; }
         public string Counter { get; set; }
+        public DateTime CreationDate { get; set; }
     }
 }

--- a/src/Core/Models/Domain/Fido2Credential.cs
+++ b/src/Core/Models/Domain/Fido2Credential.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Bit.Core.Models.Data;
 using Bit.Core.Models.View;
@@ -7,7 +9,7 @@ namespace Bit.Core.Models.Domain
 {
     public class Fido2Credential : Domain
     {
-        public static HashSet<string> EncryptableProperties => new HashSet<string>
+        public static HashSet<string> EncryptablePropertiesToMap => new HashSet<string>
         {
             nameof(CredentialId),
             nameof(Discoverable),
@@ -22,11 +24,18 @@ namespace Bit.Core.Models.Domain
             nameof(Counter)
         };
 
+        public static HashSet<string> NonEncryptablePropertiesToMap => new HashSet<string>
+        {
+            nameof(CreationDate)
+        };
+
+        public static HashSet<string> AllPropertiesToMap => new HashSet<string>(EncryptablePropertiesToMap.Concat(NonEncryptablePropertiesToMap));
+
         public Fido2Credential() { }
 
         public Fido2Credential(Fido2CredentialData data, bool alreadyEncrypted = false)
         {
-            BuildDomainModel(this, data, EncryptableProperties, alreadyEncrypted);
+            BuildDomainModel(this, data, AllPropertiesToMap, alreadyEncrypted, NonEncryptablePropertiesToMap);
         }
 
         public EncString CredentialId { get; set; }
@@ -40,16 +49,17 @@ namespace Bit.Core.Models.Domain
         public EncString UserHandle { get; set; }
         public EncString UserName { get; set; }
         public EncString Counter { get; set; }
+        public DateTime CreationDate { get; set; }
 
         public async Task<Fido2CredentialView> DecryptAsync(string orgId, SymmetricCryptoKey key = null)
         {
-            return await DecryptObjAsync(new Fido2CredentialView(), this, EncryptableProperties, orgId, key);
+            return await DecryptObjAsync(new Fido2CredentialView(this), this, EncryptablePropertiesToMap, orgId, key);
         }
 
         public Fido2CredentialData ToFido2CredentialData()
         {
             var data = new Fido2CredentialData();
-            BuildDataModel(this, data, EncryptableProperties);
+            BuildDataModel(this, data, AllPropertiesToMap, NonEncryptablePropertiesToMap);
             return data;
         }
     }

--- a/src/Core/Models/View/Fido2CredentialView.cs
+++ b/src/Core/Models/View/Fido2CredentialView.cs
@@ -1,10 +1,21 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using Bit.Core.Enums;
+using Bit.Core.Models.Domain;
 
 namespace Bit.Core.Models.View
 {
     public class Fido2CredentialView : ItemView, ILaunchableView
     {
+        public Fido2CredentialView()
+        {
+        }
+
+        public Fido2CredentialView(Fido2Credential fido2Credential)
+        {
+            CreationDate = fido2Credential.CreationDate;
+        }
+
         public string CredentialId { get; set; }
         public string Discoverable { get; set; }
         public string KeyType { get; set; } = Constants.DefaultFido2CredentialType;
@@ -16,6 +27,7 @@ namespace Bit.Core.Models.View
         public string UserHandle { get; set; }
         public string UserName { get; set; }
         public string Counter { get; set; }
+        public DateTime CreationDate { get; set; }
 
         public override string SubTitle => UserName;
         public override List<KeyValuePair<string, LinkedIdType>> LinkedFieldOptions => new List<KeyValuePair<string, LinkedIdType>>();

--- a/src/Core/Services/CipherService.cs
+++ b/src/Core/Services/CipherService.cs
@@ -1161,8 +1161,11 @@ namespace Bit.Core.Services
                         cipher.Login.Fido2Credentials = new List<Fido2Credential>();
                         foreach (var fido2Credential in model.Login.Fido2Credentials)
                         {
-                            var fido2CredentialDomain = new Fido2Credential();
-                            await EncryptObjPropertyAsync(fido2Credential, fido2CredentialDomain, Fido2Credential.EncryptableProperties, key);
+                            var fido2CredentialDomain = new Fido2Credential
+                            {
+                                CreationDate = fido2Credential.CreationDate
+                            };
+                            await EncryptObjPropertyAsync(fido2Credential, fido2CredentialDomain, Fido2Credential.EncryptablePropertiesToMap, key);
                             cipher.Login.Fido2Credentials.Add(fido2CredentialDomain);
                         }
                     }


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Add `CreationDate` to `Fido2Credential` objects and update the UI accordingly also fixing an issue where the date time was not being presented in local time.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **Fido2Credential...:** Added `CreationDate` and updated mappings.
* **...Page.xaml:** Updated bindings to the new creation date and use `DateTimeConverter` with the specific format to avoid creating a new property on the VMs.
* **DateTimeConverter:** Added `Format` property with a default value so we can customize it in specific occasions like this one.


## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
