### PR TITLE
[PM-891] Biometrics enabled ignores vault timeout set to Never

### DIFF
--- a/src/Core/Services/VaultTimeoutService.cs
+++ b/src/Core/Services/VaultTimeoutService.cs
@@ -63,13 +63,6 @@ namespace Bit.Core.Services
         /// </param>
         public async Task<bool> IsLockedAsync(string userId = null)
         {
-            // If biometrics are used, we can use the flag to determine locked state
-            var biometricSet = await IsBiometricLockSetAsync(userId);
-            if (biometricSet && await _stateService.GetBiometricLockedAsync(userId))
-            {
-                return true;
-            }
-
             if (!await _cryptoService.HasUserKeyAsync(userId))
             {
                 try


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Fix bug where if Unlock with Biometrics is Enabled, the app would still lock the vault even if the Vault Timeout is set to Never.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->
Remove old check for biometric state on vault timeout `IsLocked`


## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
