### PR TITLE
Trim TOTP key

### DIFF
--- a/src/Core/Services/TotpService.cs
+++ b/src/Core/Services/TotpService.cs
@@ -24,6 +24,9 @@ namespace Bit.Core.Services
             {
                 return null;
             }
+            
+            key = key.Trim();
+
             var period = Constants.TotpDefaultTimer;
             var alg = CryptoHashAlgorithm.Sha1;
             var digits = 6;


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
This PR resolves #2122.
When cloning a working entry that has a valid OTP and editing the cloned entry by putting a space at the beginning of otpauth:// a wrong OTP is generated.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **TotpService.cs:** The expected behaviour would be to still have a valid otp and therefore the whitespaces are trimmed.
Thanks to @FlorianLang06


## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
