### PR TITLE
[PM-4800] Send item domain name to fastmail

### DIFF
--- a/src/Core/Models/Domain/UsernameGenerationOptions.cs
+++ b/src/Core/Models/Domain/UsernameGenerationOptions.cs
@@ -46,8 +46,9 @@ namespace Bit.Core.Models.Domain
                 case ForwardedEmailServiceType.DuckDuckGo:
                     return new ForwarderOptions { ApiKey = DuckDuckGoApiKey };
                 case ForwardedEmailServiceType.Fastmail:
-                    return new FastmailForwarderOptions 
-                    {   ApiKey = FastMailApiKey,
+                    return new FastmailForwarderOptions
+                    {
+                        ApiKey = FastMailApiKey,
                         Website = EmailWebsite
                     };
                 case ForwardedEmailServiceType.FirefoxRelay:

--- a/src/Core/Models/Domain/UsernameGenerationOptions.cs
+++ b/src/Core/Models/Domain/UsernameGenerationOptions.cs
@@ -46,7 +46,10 @@ namespace Bit.Core.Models.Domain
                 case ForwardedEmailServiceType.DuckDuckGo:
                     return new ForwarderOptions { ApiKey = DuckDuckGoApiKey };
                 case ForwardedEmailServiceType.Fastmail:
-                    return new ForwarderOptions { ApiKey = FastMailApiKey };
+                    return new FastmailForwarderOptions 
+                    {   ApiKey = FastMailApiKey,
+                        Website = EmailWebsite
+                    };
                 case ForwardedEmailServiceType.FirefoxRelay:
                     return new ForwarderOptions { ApiKey = FirefoxRelayApiAccessToken };
                 case ForwardedEmailServiceType.SimpleLogin:

--- a/src/Core/Services/EmailForwarders/FastmailForwarder.cs
+++ b/src/Core/Services/EmailForwarders/FastmailForwarder.cs
@@ -61,7 +61,7 @@ namespace Bit.Core.Services.EmailForwarders
                                         ["description"] = "",
                                         ["url"] = "",
                                         ["emailPrefix"] = "",
-                                        ["forDomain"] = ( null == options.Website ? "" : options.Website )
+                                        ["forDomain"] = options.Website ?? ""
                                     }
                                 }
                             },

--- a/src/Core/Services/EmailForwarders/FastmailForwarder.cs
+++ b/src/Core/Services/EmailForwarders/FastmailForwarder.cs
@@ -9,16 +9,21 @@ using Newtonsoft.Json.Linq;
 
 namespace Bit.Core.Services.EmailForwarders
 {
-    public class FastmailForwarder : BaseForwarder<ForwarderOptions>
+    public class FastmailForwarderOptions : ForwarderOptions
+    {
+        public string Website { get; set; }
+    }
+
+    public class FastmailForwarder : BaseForwarder<FastmailForwarderOptions>
     {
         protected override string RequestUri => "https://api.fastmail.com/jmap/api/";
 
-        protected override void ConfigureHeaders(HttpRequestHeaders headers, ForwarderOptions options)
+        protected override void ConfigureHeaders(HttpRequestHeaders headers, FastmailForwarderOptions options)
         {
             headers.Add("Authorization", $"Bearer {options.ApiKey}");
         }
 
-        protected override async Task<HttpContent> GetContentAsync(IApiService apiService, ForwarderOptions options)
+        protected override async Task<HttpContent> GetContentAsync(IApiService apiService, FastmailForwarderOptions options)
         {
             string accountId = null;
             try
@@ -55,7 +60,8 @@ namespace Bit.Core.Services.EmailForwarders
                                         ["state"] = "enabled",
                                         ["description"] = "",
                                         ["url"] = "",
-                                        ["emailPrefix"] = ""
+                                        ["emailPrefix"] = "",
+                                        ["forDomain"] = ( null == options.Website ? "" : options.Website )
                                     }
                                 }
                             },

--- a/src/Core/Services/UsernameGenerationService.cs
+++ b/src/Core/Services/UsernameGenerationService.cs
@@ -150,8 +150,9 @@ namespace Bit.Core.Services
 
             if (options.ServiceType == ForwardedEmailServiceType.Fastmail)
             {
+                var fastmailEmailOptions = (FastmailForwarderOptions)options.GetForwarderOptions();
                 return await new FastmailForwarder()
-                                    .GenerateAsync(_apiService, (FastmailForwarderOptions)options.GetForwarderOptions());
+                                    .GenerateAsync(_apiService, fastmailEmailOptions);
             }
 
             BaseForwarder<ForwarderOptions> simpleForwarder = null;

--- a/src/Core/Services/UsernameGenerationService.cs
+++ b/src/Core/Services/UsernameGenerationService.cs
@@ -148,6 +148,12 @@ namespace Bit.Core.Services
                                     .GenerateAsync(_apiService, forwardedEmailOptions);
             }
 
+            if (options.ServiceType == ForwardedEmailServiceType.Fastmail)
+            {
+                return await new FastmailForwarder()
+                                    .GenerateAsync(_apiService, (FastmailForwarderOptions)options.GetForwarderOptions());
+            }
+
             BaseForwarder<ForwarderOptions> simpleForwarder = null;
 
             switch (options.ServiceType)
@@ -160,9 +166,6 @@ namespace Bit.Core.Services
                     break;
                 case ForwardedEmailServiceType.DuckDuckGo:
                     simpleForwarder = new DuckDuckGoForwarder();
-                    break;
-                case ForwardedEmailServiceType.Fastmail:
-                    simpleForwarder = new FastmailForwarder();
                     break;
                 default:
                     _logger.Value.Error($"Error UsernameGenerationService: ForwardedEmailServiceType {options.ServiceType} not implemented.");


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
Added a metadata field (forDomain:) to the Fastmail Forwarder API request that's set to the domain name of the item being added to the vault, or to "" if the username generator is being used in standalone mode. This allows the user's Fastmail account to display the domain name for the username that was generated.



## Code changes
- **src/Core/Models/Domain/UsernameGenerationOptions.cs:** `GetForwarderOptions()` will now return a `FastmailForwarderOptions` object with the new `Website` member set to the `EmailWebsite` of `UsernameGenerationOptions` for the fastmail case
- **src/Core/Services/EmailForwarders/FastmailForwarder.cs:** Added the `FastmailForwarderOptions` class that extends `ForwarderOptions` and updated declarations accordingly. Added the `forDomain:` field to the API request
- **src/Core/Services/UsernameGenerationService.cs:** Removed the fastmail case from the switch, and turned it into an if that casts the `ForwarderOptions` to `FastmailForwarderOptions`, mirroring handling of AnonAddy

## Screenshots
A Masked Email entry in Fastmail before the changes for the domain google.com:
image
![281215619-7a499a65-ab41-4294-a934-eaffb3a7bdbd](https://github.com/bitwarden/mobile/assets/16997120/d0a65800-6814-4ef9-a850-87f8af08575b)

A Masked Email entry in Fastmail after the changes for the domain google.com:
image
![281215539-e908bd01-faed-43dc-828a-46f19a6bedae](https://github.com/bitwarden/mobile/assets/16997120/6c271410-e97b-4550-b674-20e434821b54)

## Testing
Tested in the Android emulator and on Android hardware

## Dotnet Format Changes
None found
