### PR TITLE
[PM-4914] Sentry MAUI for crash reporting

### DIFF
--- a/src/App/App.csproj
+++ b/src/App/App.csproj
@@ -33,6 +33,24 @@
 		<!--<ForceSimulatorX64ArchitectureInIDE>true</ForceSimulatorX64ArchitectureInIDE>-->
 	</PropertyGroup>
 
+  <!-- Sentry -->
+
+<!--
+  For testing also uploading Debug builds but in general just Release is fine:
+  <PropertyGroup Condition="'$(Configuration)' == 'Release'">
+  -->
+  <PropertyGroup>
+    <!-- TODO Change. Can be set via env var or via command line to msbuild -->
+    <SentryOrg>bruno-garcia</SentryOrg>
+    <SentryProject>playground</SentryProject>
+    <!-- Missing property: Set SENTRY_AUTH_TOKEN env var at build time to upload symbols/sources -->
+
+    <!-- To get line number for release builds for C#, Java/Kotlin and Native (C/C++/Objective-C/Swift) stack traces. -->
+    <SentryUploadSymbols>true</SentryUploadSymbols>
+    <!-- Embeds all sources into the PDBs to get source context in Sentry -->
+    <EmbedAllSources>true</EmbedAllSources>
+  </PropertyGroup>
+
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net8.0-android|AnyCPU'">
     <AndroidEnableMultiDex>True</AndroidEnableMultiDex>
     <UseInterpreter>False</UseInterpreter>
@@ -99,6 +117,7 @@
 		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.1" />
 		<PackageReference Include="PCLCrypto" Version="2.1.40-alpha" />
 		<PackageReference Include="Portable.BouncyCastle" Version="1.9.0" />
+		<PackageReference Include="Sentry.Maui" Version="4.0.0-beta.1" />
 	</ItemGroup>
 
 	<!--<ItemGroup>

--- a/src/Core/Core.csproj
+++ b/src/Core/Core.csproj
@@ -68,6 +68,7 @@
 		<PackageReference Include="AsyncAwaitBestPractices.MVVM" Version="6.0.6" />
 		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.1" />
 		<PackageReference Include="Portable.BouncyCastle" Version="1.9.0" />
+		<PackageReference Include="Sentry.Maui" Version="4.0.0-beta.1" />
 	</ItemGroup>
 	<ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">
 	  <PackageReference Include="Xamarin.GooglePlayServices.SafetyNet" Version="118.0.1.5" />

--- a/src/Core/MauiProgram.cs
+++ b/src/Core/MauiProgram.cs
@@ -18,6 +18,9 @@ public static class MauiProgram
             builder.UseMauiApp<Bit.App.App>();
         }
         builder
+            .UseSentry(o => {
+                o.Dsn = "https://e247e6e48f8f482499052a65adaa9f6b@o117736.ingest.sentry.io/4504930623356928";
+            })
             .UseMauiCommunityToolkit()
             .UseMauiCompatibility()
             .UseMauiCameraView()

--- a/src/Core/Pages/Settings/AboutSettingsPage.xaml
+++ b/src/Core/Pages/Settings/AboutSettingsPage.xaml
@@ -58,6 +58,41 @@
             HorizontalOptions="FillAndExpand" />
         <BoxView StyleClass="box-row-separator" />
 
+        <controls:ExternalLinkItemView
+            Title="{u:I18n ThrowAndCapture}"
+            GoToLinkCommand="{Binding ThrowAndCaptureCommand}"
+            StyleClass="settings-external-link-item"
+            HorizontalOptions="FillAndExpand" />
+        <BoxView StyleClass="box-row-separator" />
+
+        <controls:ExternalLinkItemView
+            Title="{u:I18n ThrowUnhandled}"
+            GoToLinkCommand="{Binding ThrowUnhandledCommand}"
+            StyleClass="settings-external-link-item"
+            HorizontalOptions="FillAndExpand" />
+        <BoxView StyleClass="box-row-separator" />
+
+        <controls:ExternalLinkItemView
+            Title="{u:I18n ThrowBackgroundUnhandled}"
+            GoToLinkCommand="{Binding ThrowBackgroundUnhandledCommand}"
+            StyleClass="settings-external-link-item"
+            HorizontalOptions="FillAndExpand" />
+        <BoxView StyleClass="box-row-separator" />
+
+        <controls:ExternalLinkItemView
+            Title="{u:I18n JavaCrash}"
+            GoToLinkCommand="{Binding JavaCrashCommand}"
+            StyleClass="settings-external-link-item"
+            HorizontalOptions="FillAndExpand" />
+        <BoxView StyleClass="box-row-separator" />
+
+        <controls:ExternalLinkItemView
+            Title="{u:I18n NativeCrash}"
+            GoToLinkCommand="{Binding NativeCrashCommand}"
+            StyleClass="settings-external-link-item"
+            HorizontalOptions="FillAndExpand" />
+        <BoxView StyleClass="box-row-separator" />
+
         <StackLayout
             Padding="16,12"
             Orientation="Horizontal">
@@ -80,5 +115,30 @@
             </controls:IconLabel>
 
         </StackLayout>
+        <VerticalStackLayout
+            Spacing="25"
+            Padding="30,0"
+            VerticalOptions="Center">
+
+            <Image
+                Source="dotnet_bot.png"
+                SemanticProperties.Description="Cute dot net bot waving hi to you!"
+                HeightRequest="200"
+                HorizontalOptions="Center" />
+
+            <Label
+                Text="Hello, World!"
+                SemanticProperties.HeadingLevel="Level1"
+                FontSize="32"
+                HorizontalOptions="Center" />
+
+            <Label
+                Text="Welcome to .NET Multi-platform App UI"
+                SemanticProperties.HeadingLevel="Level2"
+                SemanticProperties.Description="Welcome to dot net Multi platform App U I"
+                FontSize="18"
+                HorizontalOptions="Center" />
+
+        </VerticalStackLayout>
     </StackLayout>
 </pages:BaseContentPage>


### PR DESCRIPTION
Adds `Sentry.Maui`, initializes with the app. And configures msbuild to upload symbols automatically.

Before merging we'd need to change csproj props to take a different Sentry account (not my test one).

Added some sample buttons to make different crashes. We can remove them before merging. Or hide them somehow to be able to test things out easily.

Version is a beta right now, but the team is working on a final release soon (weeks away).

## Android

A managed C# exception, with source context:

![image](https://github.com/bitwarden/mobile/assets/1633368/f2d2239e-0d42-4718-b19e-9547d507d15d)

Note that Sentry **does** give you line numbers for Android crashes in Release builds published on the stores.

This is a crash done from `C` (P/Invoked):

![image](https://github.com/bitwarden/mobile/assets/1633368/f543c6b9-848c-40ea-9ba9-bae0f36252bc)

Notice there's actually no line number. That's because the native library that crashed didn't get uploaded, this was fixed today and will be out on the next release of the SDK: 
* https://github.com/getsentry/sentry-dotnet/pull/2876

Some of the Android context: 
![image](https://github.com/bitwarden/mobile/assets/1633368/1f72b2bf-c037-4f1c-a847-a7f1c5a382d0)

## iOS

Example iOS Simulator managed crash:

![image](https://github.com/bitwarden/mobile/assets/1633368/25fddbe9-24ec-4e8d-8cfe-c44716cd9c19)
![image](https://github.com/bitwarden/mobile/assets/1633368/ecca569e-6425-4bad-8cc9-6a317b78e559)
![image](https://github.com/bitwarden/mobile/assets/1633368/5dcd8302-496c-4302-837d-f370c38718d7)
![image](https://github.com/bitwarden/mobile/assets/1633368/a949b6c1-f140-4e48-92b3-1dd238ed4942)

I'm getting an issue with the simulator though we need to look at.

## Debug files

Sentry supports Portable PDB (.NET) but also DWARF, ELF, ProGuard, etc. It gets uploaded with the MSBuild. You'll see it in the logs.

```
 Preparing upload to Sentry for project 'App' (Debug/net8.0-ios): collecting debug symbols from bin/Debug/net8.0-ios/iossimulator-arm64/
  > Found 98 debug information files (30 with embedded sources)
  > Prepared debug information files for upload
  > Nothing to upload, all files are on the server
```

This log was on a second build without code changes but shows on the terminal during `dotnet build`
And you can see it in Sentry too:

![image](https://github.com/bitwarden/mobile/assets/1633368/c726b1f6-4d5e-4b88-9b53-5b31baef15fb)

## Other features

We can get performance monitoring going but there's that creates transactions automatically yet so would need a bit of code. It's in the plan though. 

It does pass a `trace-id` to the backend so you can link errors that happen on your app with anything on the backend. Super useful for debugging stuff.

## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
