### PR TITLE
PM-4920: Add Username to Fido2Credential

### DIFF
--- a/src/Core/Models/Api/Fido2CredentialApi.cs
+++ b/src/Core/Models/Api/Fido2CredentialApi.cs
@@ -21,6 +21,7 @@ namespace Bit.Core.Models.Api
             RpName = fido2Key.RpName?.EncryptedString;
             UserHandle = fido2Key.UserHandle?.EncryptedString;
             UserName = fido2Key.UserName?.EncryptedString;
+            // Username is already implemented? But userDisplayName is missing?
             Counter = fido2Key.Counter?.EncryptedString;
             CreationDate = fido2Key.CreationDate;
         }


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

We added a userName to the Fido2Credential models.  This needs to be propagated to the mobile client so that editing a cipher with a passkey does not wipe out the value by passing NULL to the server.

There are no UI changes in this PR.

## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
