### PR TITLE
Fix Build workflow - Install OpenJDK 11

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -529,7 +529,6 @@ jobs:
             ./.github/secrets/dist_watch_app_extension.mobileprovision.gpg
           gpg --quiet --batch --yes --decrypt --passphrase="$DECRYPT_FILE_PASSWORD" \
             --output ./src/watchOS/bitwarden/GoogleService-Info.plist ./.github/secrets/GoogleService-Info.plist.gpg
-        shell: bash
 
       - name: Increment version
         run: |
@@ -545,8 +544,6 @@ jobs:
           perl -0777 -pi.bak -e 's/<key>CFBundleVersion<\/key>\s*<string>1<\/string>/<key>CFBundleVersion<\/key>\n\t<string>'"$BUILD_NUMBER"'<\/string>/' ./src/iOS.ShareExtension/Info.plist
           cd src/watchOS/bitwarden
           agvtool new-version -all  $BUILD_NUMBER
-          cd ../../..
-        shell: bash
 
       - name: Update Entitlements
         run: |
@@ -555,7 +552,6 @@ jobs:
           echo "########################################"
 
           perl -0777 -pi.bak -e 's/<key>aps-environment<\/key>\s*<string>development<\/string>/<key>aps-environment<\/key>\n\t<string>production<\/string>/' ./src/iOS/Entitlements.plist
-        shell: bash
 
       - name: Set up Keychain
         env:
@@ -572,7 +568,6 @@ jobs:
           security import ~/secrets/iphone-distribution-cert.p12 -k build.keychain -P $DIST_CERT_PASSWORD \
             -T /usr/bin/codesign -T /usr/bin/security
           security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k $KEYCHAIN_PASSWORD build.keychain
-        shell: bash
 
       - name: Set up provisioning profiles
         run: |
@@ -603,7 +598,6 @@ jobs:
 
           WATCH_APP_EXTENSION_UUID=$(grep UUID -A1 -a $WATCH_APP_EXTENSION_PROFILE_PATH | grep -io "[-A-F0-9]\{36\}")
           cp $WATCH_APP_EXTENSION_PROFILE_PATH "$PROFILES_DIR_PATH/$WATCH_APP_EXTENSION_UUID.mobileprovision"
-        shell: bash
 
       - name: Bulid WatchApp
         run: |
@@ -616,7 +610,6 @@ jobs:
           echo "########################################"
           echo "##### Done"
           echo "########################################"
-        shell: bash
 
       - name: Restore packages
         run: nuget restore
@@ -662,7 +655,6 @@ jobs:
 
           xcodebuild -exportArchive -archivePath $ARCHIVE_PATH -exportPath $EXPORT_PATH \
             -exportOptionsPlist $EXPORT_OPTIONS_PATH
-        shell: bash
 
       - name: Export .app for Automation CI
         run: |
@@ -671,7 +663,6 @@ jobs:
 
           zip -r -q BitwardeniOS.app.zip $ARCHIVE_PATH
           mv BitwardeniOS.app.zip $EXPORT_PATH
-        shell: bash
 
       - name: Copy all dSYMs files to upload
         run: |
@@ -684,7 +675,6 @@ jobs:
           cp -r -v $ARCHIVE_DSYMS_PATH $EXPORT_PATH
           mkdir $WATCH_DSYMS_EXPORT_PATH
           cp -r -v $WATCH_ARCHIVE_DSYMS_PATH $WATCH_DSYMS_EXPORT_PATH
-        shell: bash
 
       - name: Upload App Store .ipa & dSYMs artifacts
         uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
@@ -721,7 +711,6 @@ jobs:
         env:
           APPCENTER_IOS_TOKEN: ${{ steps.retrieve-secrets.outputs.appcenter-ios-token }}
         run: appcenter crashes upload-symbols -a bitwarden/bitwarden -s "./bitwarden-export/dSYMs" --token $APPCENTER_IOS_TOKEN
-        shell: bash
 
       - name: Upload Watch dSYMs to Firebase Crashlytics
         if: |
@@ -731,13 +720,11 @@ jobs:
           || (github.ref == 'refs/heads/rc' && needs.setup.outputs.hotfix_branch_exists == 0)
           || github.ref == 'refs/heads/hotfix-rc'
         run: |
-
           echo "########################################"
           echo "##### Uploading Watch dSYMs to Firebase"
           echo "########################################"
 
           find "$HOME/Library/Developer/XCode/DerivedData" -name "upload-symbols" -exec chmod +x {} \; -exec {} -gsp "./src/watchOS/bitwarden/GoogleService-Info.plist" -p ios "./bitwarden-export/Watch_dSYMs" \;
-        shell: bash
 
       - name: Deploy to App Store
         if: |
@@ -752,7 +739,6 @@ jobs:
         run: |
           xcrun altool --upload-app --type ios --file "./bitwarden-export/Bitwarden.ipa" \
               --username "$APPLE_ID_USERNAME" --password "$APPLE_ID_PASSWORD"
-        shell: bash
 
 
   crowdin-push:


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [X] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
This PR fixes the `build` workflow by installing Microsoft OpenJDK 11.  Other various improvements have also been applied.

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **.github/workflows/build.yml:** Update actions. Update runner versions. Add step for installing Microsoft OpenJDK 11. Remove unnecessary shell keys. Remove old retrieve-secrets step and use our action. 

## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
