### PR TITLE
[PM-5064] Fix lock interaction between biometrics and vault timeout never

### DIFF
--- a/src/Core/Services/VaultTimeoutService.cs
+++ b/src/Core/Services/VaultTimeoutService.cs
@@ -63,12 +63,20 @@ namespace Bit.Core.Services
         /// </param>
         public async Task<bool> IsLockedAsync(string userId = null)
         {
+            // If biometrics are used, we can use the flag to determine locked state taking into account the auto unlock key for vault timeout never.
+            var biometricSet = await IsBiometricLockSetAsync(userId);
+            var hasAutoUnlockKey = await _cryptoService.HasAutoUnlockKeyAsync(userId);
+            if (biometricSet && await _stateService.GetBiometricLockedAsync(userId) && !hasAutoUnlockKey)
+            {
+                return true;
+            }
+
             if (!await _cryptoService.HasUserKeyAsync(userId))
             {
                 try
                 {
                     // Filter out accounts without auto key
-                    if (!await _cryptoService.HasAutoUnlockKeyAsync(userId))
+                    if (!hasAutoUnlockKey)
                     {
                         return true;
                     }
@@ -84,7 +92,6 @@ namespace Bit.Core.Services
                     // Legacy users must migrate on web vault before login
                     await LogOutAsync(false, userId);
                 }
-
             }
 
             // Check again to verify auto key was set


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Fix lock interaction between biometrics and vault timeout never


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **VaultTimeoutService:** Reintroduced the code deleted by #2853 and added the appropriate check for vault timeout never so the Auto Unlock key is also checked on the biometrics verification for `IsLocked(...)` method.


## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
