### PR TITLE
add Waterfox Android support from FD399097

### DIFF
--- a/src/Android/Accessibility/AccessibilityHelpers.cs
+++ b/src/Android/Accessibility/AccessibilityHelpers.cs
@@ -125,6 +125,7 @@ namespace Bit.Droid.Accessibility
             new Browser("org.ungoogled.chromium.extensions.stable", "url_bar"),
             new Browser("org.ungoogled.chromium.stable", "url_bar"),
             new Browser("us.spotco.fennec_dos", "mozac_browser_toolbar_url_view,url_bar_title"), // 2nd = Legacy
+            new Browser("net.waterfox.android.release", "mozac_browser_toolbar_url_view"),
 
             // [Section B] Entries only present here
             //

--- a/src/Android/Autofill/AutofillHelpers.cs
+++ b/src/Android/Autofill/AutofillHelpers.cs
@@ -142,6 +142,7 @@ namespace Bit.Droid.Autofill
             "org.ungoogled.chromium.extensions.stable",
             "org.ungoogled.chromium.stable",
             "us.spotco.fennec_dos",
+            "net.waterfox.android.release",
         };
 
         // The URLs are blacklisted from autofilling

--- a/src/Android/Resources/xml/autofillservice.xml
+++ b/src/Android/Resources/xml/autofillservice.xml
@@ -278,4 +278,7 @@
   <compatibility-package
     android:name="us.spotco.fennec_dos"
     android:maxLongVersionCode="10000000000"/>
+  <compatibility-package
+    android:name="net.waterfox.android.release"
+    android:maxLongVersionCode="10000000000"/>
 </autofill-service>


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [ ] New feature development
- [x] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

This PR is meant to add complete autofill support for the [Waterfox](https://www.waterfox.net/) Android browser.

Waterfox is getting ready for GR on Android (https://www.waterfox.net/docs/releases/G6.0b5/ )

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- src/Android/Accessibility/AccessibilityHelpers.cs: Added a new Browser object to the SupportedBrowsers dictionary to add support for Waterfox.
- src/Android/Autofill/AutofillHelpers.cs: Added a new item to the CompatBrowsers hashset to add support for Waterfox.
- src/Android/Resources/xml/autofillservice.xml: Added a new compatibility-package object to add support for Waterfox.
