### PR TITLE
Remove tools ownership for store/google/Publisher

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -32,3 +32,4 @@ src/App/Resources/AppResources.resx
 src/watchOS/bitwarden/bitwarden\ WatchKit\ Extension/Localization/en.lproj
 store/apple/en
 store/google/en
+store/google/Publisher


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [X] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
The @bitwarden/team-tools-dev is getting asked for a review of https://github.com/bitwarden/mobile/pull/2545. This adds an exception to the ownership of `store/google/Publisher`

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **.github/CODEOWNERS:** Add `store/google/Publisher` to the existing Locales exception.


## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
