### PR TITLE
[PM-5072] Update minimum version for cipher key encryption in preparation for release

### DIFF
--- a/src/Core/Constants.cs
+++ b/src/Core/Constants.cs
@@ -70,7 +70,7 @@ namespace Bit.Core
         public const int Argon2Parallelism = 4;
         public const int MasterPasswordMinimumChars = 12;
         public const int CipherKeyRandomBytesLength = 64;
-        public const string CipherKeyEncryptionMinServerVersion = "2023.9.1";
+        public const string CipherKeyEncryptionMinServerVersion = "2024.1.0";
         public const string DefaultFido2CredentialType = "public-key";
         public const string DefaultFido2CredentialAlgorithm = "ECDSA";
         public const string DefaultFido2CredentialCurve = "P-256";


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
Updated minimum server version that will support cipher key encryption to `2024.1.0`.  See https://github.com/bitwarden/clients/pull/7351 for other clients.

## Code changes
* **Constants.cs:** Updated the minimum supported server version to `2024.1.0`.

## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
