### PR TITLE
[PM-5715] Route to import page when clicking on import items button

### DIFF
--- a/src/App/Pages/Settings/VaultSettingsPageViewModel.cs
+++ b/src/App/Pages/Settings/VaultSettingsPageViewModel.cs
@@ -40,7 +40,7 @@ namespace Bit.App.Pages
 
         private async Task GoToImportItemsAsync()
         {
-            var webVaultUrl = _environmentService.GetWebVaultUrl();
+            var webVaultUrl = _environmentService.GetWebVaultUrl() + "/#/tools/import";
             var body = string.Format(AppResources.YouCanImportDataToYourVaultOnX, webVaultUrl);
             if (await _platformUtilsService.ShowDialogAsync(body, AppResources.ContinueToWebApp, AppResources.Continue, AppResources.Cancel))
             {


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
When tapping on the Import items button, the user gets asked if they want to get redirected to the web vault to import the items.

Clicking yes, opens the web-vault in the browser, but after logging in, they are on the vault page instead of the tools/import page.

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **src/App/Pages/Settings/VaultSettingsPageViewModel.cs:** Extend the existing url with "/#/tools/import" to route to the import page

## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
