### PR TITLE
[PM-5760] Add autofill support for Spin Browser

### DIFF
--- a/src/Android/Accessibility/AccessibilityHelpers.cs
+++ b/src/Android/Accessibility/AccessibilityHelpers.cs
@@ -66,6 +66,7 @@ namespace Bit.Droid.Accessibility
             new Browser("com.mmbox.browser", "search_box"),
             new Browser("com.mmbox.xbrowser", "search_box"),
             new Browser("com.mycompany.app.soulbrowser", "edit_text"),
+            new Browser("com.nationaledtech.spinbrowser", "mozac_browser_toolbar_url_view"),
             new Browser("com.naver.whale", "url_bar"),
             new Browser("com.neeva.app", "full_url_text_view"),
             new Browser("com.opera.browser", "url_field"),
@@ -528,7 +529,7 @@ namespace Bit.Droid.Accessibility
             return nodes;
         }
 
-        public static AccessibilityNodeInfo GetUsernameEditText(string uriString, 
+        public static AccessibilityNodeInfo GetUsernameEditText(string uriString,
             IEnumerable<AccessibilityNodeInfo> allEditTexts)
         {
             string uriAuthority = null;
@@ -621,7 +622,7 @@ namespace Bit.Droid.Accessibility
             // no match found, attempt to establish username field based on password field
             return GetUsernameEditTextIfPasswordExists(allEditTexts);
         }
-        
+
         private static AccessibilityNodeInfo GetUsernameEditTextIfPasswordExists(
             IEnumerable<AccessibilityNodeInfo> allEditTexts)
         {
@@ -670,7 +671,7 @@ namespace Bit.Droid.Accessibility
                 {
                     return true;
                 }
-                
+
                 var appOpsMgr = (AppOpsManager)Application.Context.GetSystemService(Context.AppOpsService);
                 var mode = appOpsMgr.CheckOpNoThrow("android:system_alert_window", Process.MyUid(),
                     Application.Context.PackageName);
@@ -678,7 +679,7 @@ namespace Bit.Droid.Accessibility
                 {
                     return true;
                 }
-                
+
                 try
                 {
                     var wm = Application.Context.GetSystemService(Context.WindowService)
@@ -694,10 +695,10 @@ namespace Bit.Droid.Accessibility
                     return true;
                 }
                 catch { }
-                
+
                 return false;
             }
-            
+
             // older android versions are always true
             return true;
         }
@@ -738,7 +739,7 @@ namespace Bit.Droid.Accessibility
             return layoutParams;
         }
 
-        public static Point GetOverlayAnchorPosition(AccessibilityService service, AccessibilityNodeInfo anchorView, 
+        public static Point GetOverlayAnchorPosition(AccessibilityService service, AccessibilityNodeInfo anchorView,
             int overlayViewHeight, bool isOverlayAboveAnchor)
         {
             var anchorViewRect = new Rect();
@@ -746,7 +747,7 @@ namespace Bit.Droid.Accessibility
             var anchorViewX = anchorViewRect.Left;
             var anchorViewY = isOverlayAboveAnchor ? anchorViewRect.Top : anchorViewRect.Bottom;
             anchorViewRect.Dispose();
-            
+
             if (isOverlayAboveAnchor)
             {
                 anchorViewY -= overlayViewHeight;
@@ -756,8 +757,8 @@ namespace Bit.Droid.Accessibility
             return new Point(anchorViewX, anchorViewY);
         }
 
-        public static Point GetOverlayAnchorPosition(AccessibilityService service, AccessibilityNodeInfo anchorNode, 
-            AccessibilityNodeInfo root, IEnumerable<AccessibilityWindowInfo> windows, int overlayViewHeight, 
+        public static Point GetOverlayAnchorPosition(AccessibilityService service, AccessibilityNodeInfo anchorNode,
+            AccessibilityNodeInfo root, IEnumerable<AccessibilityWindowInfo> windows, int overlayViewHeight,
             bool isOverlayAboveAnchor)
         {
             Point point = null;
@@ -809,7 +810,7 @@ namespace Bit.Droid.Accessibility
                         point.X = -1;
                         point.Y = -1;
                     }
-                } 
+                }
                 else if (point.Y > (maxY - overlayViewHeight))
                 {
                     if (isOverlayAboveAnchor)
@@ -824,7 +825,7 @@ namespace Bit.Droid.Accessibility
                         point.X = 0;
                         point.Y = -1;
                     }
-                } 
+                }
                 else if (isOverlayAboveAnchor && point.Y < (maxY - (overlayViewHeight * 2) - GetNodeHeight(anchorNode)))
                 {
                     // This else block forces the overlay to return to bottom alignment as soon as space is available
@@ -873,11 +874,11 @@ namespace Bit.Droid.Accessibility
             }
             return inputMethodWindowHeight;
         }
-        
+
         public static bool IsAutofillServicePromptVisible(IEnumerable<AccessibilityWindowInfo> windows)
         {
             // Autofill framework not available until API 26
-            if (Build.VERSION.SdkInt >= BuildVersionCodes.O) 
+            if (Build.VERSION.SdkInt >= BuildVersionCodes.O)
             {
                 return windows?.Any(w => w.Title?.ToLower().Contains("autofill") ?? false) ?? false;
             }

--- a/src/Android/Autofill/AutofillHelpers.cs
+++ b/src/Android/Autofill/AutofillHelpers.cs
@@ -88,6 +88,7 @@ namespace Bit.Droid.Autofill
             "com.mmbox.browser",
             "com.mmbox.xbrowser",
             "com.mycompany.app.soulbrowser",
+            "com.nationaledtech.spinbrowser",
             "com.naver.whale",
             "com.neeva.app",
             "com.opera.browser",
@@ -119,7 +120,7 @@ namespace Bit.Droid.Autofill
             "mark.via.gp",
             "net.dezor.browser",
             "net.slions.fulguris.full.download",
-            "net.slions.fulguris.full.download.debug",            
+            "net.slions.fulguris.full.download.debug",
             "net.slions.fulguris.full.playstore",
             "net.slions.fulguris.full.playstore.debug",
             "org.adblockplus.browser",
@@ -190,7 +191,7 @@ namespace Bit.Droid.Autofill
                 inlinePresentationSpecs = inlineSuggestionsRequest?.InlinePresentationSpecs;
                 inlinePresentationSpecsCount = inlinePresentationSpecs?.Count ?? 0;
             }
-            
+
             // Build response
             var responseBuilder = new FillResponse.Builder();
             if (items != null && items.Count > 0)
@@ -217,7 +218,7 @@ namespace Bit.Droid.Autofill
                             inlinePresentationSpec = inlinePresentationSpecs[inlinePresentationSpecsCount - 1];
                         }
                     }
-                    var dataset = BuildDataset(parser.ApplicationContext, parser.FieldCollection, items[i], 
+                    var dataset = BuildDataset(parser.ApplicationContext, parser.FieldCollection, items[i],
                         true, inlinePresentationSpec);
                     if (dataset != null)
                     {
@@ -239,13 +240,13 @@ namespace Bit.Droid.Autofill
                 filledItem.Subtitle,
                 filledItem.Icon,
                 context);
-            
+
             var inlinePresentation = BuildInlinePresentation(
-                inlinePresentationSpec, 
-                filledItem.Name, 
-                filledItem.Subtitle, 
-                filledItem.Icon, 
-                null, 
+                inlinePresentationSpec,
+                filledItem.Name,
+                filledItem.Subtitle,
+                filledItem.Icon,
+                null,
                 context);
 
             var datasetBuilder = new Dataset.Builder(overlayPresentation);
@@ -301,11 +302,11 @@ namespace Bit.Droid.Autofill
                 context);
 
             var inlinePresentation = BuildInlinePresentation(
-                inlinePresentationSpecs?.Last(), 
-                AppResources.Bitwarden, 
-                locked ? AppResources.VaultIsLocked : AppResources.MyVault, 
-                Resource.Drawable.icon, 
-                pendingIntent, 
+                inlinePresentationSpecs?.Last(),
+                AppResources.Bitwarden,
+                locked ? AppResources.VaultIsLocked : AppResources.MyVault,
+                Resource.Drawable.icon,
+                pendingIntent,
                 context);
 
             var datasetBuilder = new Dataset.Builder(overlayPresentation);
@@ -402,7 +403,7 @@ namespace Bit.Droid.Autofill
             return contentBuilder.Build().JavaCast<InlineSuggestionUi.Content>()?.Slice;
         }
 
-        public static void AddSaveInfo(Parser parser, FillRequest fillRequest, FillResponse.Builder responseBuilder, 
+        public static void AddSaveInfo(Parser parser, FillRequest fillRequest, FillResponse.Builder responseBuilder,
             FieldCollection fields)
         {
             // Docs state that password fields cannot be reliably saved in Compat mode since they will show as

--- a/src/Android/Resources/xml/autofillservice.xml
+++ b/src/Android/Resources/xml/autofillservice.xml
@@ -117,6 +117,9 @@
     android:name="com.mycompany.app.soulbrowser"
     android:maxLongVersionCode="10000000000"/>
   <compatibility-package
+    android:name="com.nationaledtech.spinbrowser"
+    android:maxLongVersionCode="10000000000"/>
+  <compatibility-package
     android:name="com.naver.whale"
     android:maxLongVersionCode="10000000000"/>
   <compatibility-package


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [x] Other

## Objective
Bitwarden autofill doesn't work in Spin Browser. More details in this issue: https://github.com/bitwarden/mobile/issues/2848. 
Spin Browser is a browser based on Firefox for mobile that adds built-in internet filtering functionality. 
Website: https://spinsafebrowser.com
Google Play: https://play.google.com/store/apps/details?id=com.nationaledtech.spinbrowser

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->
* **AutofillHelpers.cs**: Added `"com.nationaledtech.spinbrowser",`
* **AccessibilityHelpers.cs:** Added `new Browser("com.nationaledtech.spinbrowser", "mozac_browser_toolbar_url_view"),`
* **autofillservice.xml** Added `<compatibility-package android:name="com.nationaledtech.spinbrowser" android:maxLongVersionCode="10000000000"/>`
* Some trailing whitespace was also auto-removed from `AutofillHelpers.cs` and `AccessibilityHelpers.cs`

## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
