### PR TITLE
[PM-5461] Fix item saving with blank URI

### DIFF
--- a/src/Core/Services/CipherService.cs
+++ b/src/Core/Services/CipherService.cs
@@ -1146,6 +1146,7 @@ namespace Bit.Core.Services
                     if (model.Login.Uris != null)
                     {
                         cipher.Login.Uris = new List<LoginUri>();
+                        model.Login.Uris.RemoveAll(u => u.Uri == null);
                         foreach (var uri in model.Login.Uris)
                         {
                             var loginUri = new LoginUri


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Fix defect [PM-5461](https://bitwarden.atlassian.net/browse/PM-5461) where saving items with blank URI field would cause the mobile app to crash while creating the uri checksum value.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **CipherService.cs:** Remove from the model the URI views without URI.


## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
