### PR TITLE
[PM-5832] Use package name for autofill when website is not set

### DIFF
--- a/src/Android/Autofill/Parser.cs
+++ b/src/Android/Autofill/Parser.cs
@@ -107,16 +107,16 @@ namespace Bit.Droid.Autofill
                 }
                 ParseNode(node.RootViewNode);
             }
-            if (string.IsNullOrWhiteSpace(PackageName) && string.IsNullOrWhiteSpace(Website))
-            {
-                PackageName = titlePackageId;
-            }
             if (!AutofillHelpers.TrustedBrowsers.Contains(PackageName) &&
                 !AutofillHelpers.CompatBrowsers.Contains(PackageName))
             {
                 Website = null;
             }
-        }
+            if (string.IsNullOrWhiteSpace(PackageName) && string.IsNullOrWhiteSpace(Website))
+            {
+                PackageName = titlePackageId;
+            }
+       }
 
         private void ParseNode(ViewNode node)
         {


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
When an app presents a webview, Bitwarden will populate `Website` with the webview's url. Because `Website` is not null, `PackageName` will not be assigned. If the app is not on Bitwarden's built-in browsers list, `Website` will be unassigned after that, effectively rendering autofill unusable.

This PR swaps the two blocks so that package name will be assigned and autofill will be offered. 
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->



## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **file.ext:** Description of what was changed and why

## Screenshots
<!--Required for any UI changes. Delete if not applicable-->



## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
