### PR TITLE
[PM-5638] Update minimum version for vault item encryption to 2024.2.0

### DIFF
--- a/src/Core/Constants.cs
+++ b/src/Core/Constants.cs
@@ -70,7 +70,7 @@ namespace Bit.Core
         public const int Argon2Parallelism = 4;
         public const int MasterPasswordMinimumChars = 12;
         public const int CipherKeyRandomBytesLength = 64;
-        public const string CipherKeyEncryptionMinServerVersion = "2024.1.3";
+        public const string CipherKeyEncryptionMinServerVersion = "2024.2.0";
         public const string DefaultFido2CredentialType = "public-key";
         public const string DefaultFido2CredentialAlgorithm = "ECDSA";
         public const string DefaultFido2CredentialCurve = "P-256";


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Set the minimum server version that will support vault item encryption to `2024.2.0`, as the final pieces of this will be released with the release on 2/6, which will be server `2023.2.0`.

(Note that https://github.com/bitwarden/mobile/pull/2959 incremented to `2024.1.3`, but the upcoming release version will be `2024.2.0`.)

Server PR: https://github.com/bitwarden/server/pull/3718
Clients PR: https://github.com/bitwarden/clients/pull/7705

## Code changes
- **Constants.cs:** Updated minimum server version.


## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
