### PR TITLE
[PM-5910] Workaround for for sliding elements in Duo 2FA flow

### DIFF
--- a/src/Core/Pages/Accounts/TwoFactorPage.xaml
+++ b/src/Core/Pages/Accounts/TwoFactorPage.xaml
@@ -138,8 +138,7 @@
                     x:Name="_duoWebView"
                     HorizontalOptions="FillAndExpand"
                     VerticalOptions="FillAndExpand"
-                    MinimumHeightRequest="{OnPlatform iOS=400}"
-                    HeightRequest="{OnPlatform Android={Binding DuoWebViewHeight, Mode=OneWay}}" />
+                    HeightRequest="{Binding DuoWebViewHeight, Mode=OneWay}" />
                 <StackLayout StyleClass="box" VerticalOptions="End">
                     <StackLayout StyleClass="box-row, box-row-switch">
                         <Label

--- a/src/Core/Pages/Accounts/TwoFactorPage.xaml
+++ b/src/Core/Pages/Accounts/TwoFactorPage.xaml
@@ -138,7 +138,8 @@
                     x:Name="_duoWebView"
                     HorizontalOptions="FillAndExpand"
                     VerticalOptions="FillAndExpand"
-                    HeightRequest="{Binding DuoWebViewHeight, Mode=OneWay}" />
+                    MinimumHeightRequest="{OnPlatform iOS=400}"
+                    HeightRequest="{OnPlatform Android={Binding DuoWebViewHeight, Mode=OneWay}}" />
                 <StackLayout StyleClass="box" VerticalOptions="End">
                     <StackLayout StyleClass="box-row, box-row-switch">
                         <Label

--- a/src/Core/Pages/Accounts/TwoFactorPage.xaml
+++ b/src/Core/Pages/Accounts/TwoFactorPage.xaml
@@ -133,12 +133,12 @@
                 </StackLayout>
             </StackLayout>
             <StackLayout Spacing="0" Padding="0" IsVisible="{Binding DuoMethod, Mode=OneWay}"
-                         VerticalOptions="FillAndExpand">
+                         VerticalOptions="StartAndExpand">
                 <controls:HybridWebView
                     x:Name="_duoWebView"
                     HorizontalOptions="FillAndExpand"
                     VerticalOptions="FillAndExpand"
-                    MinimumHeightRequest="400" />
+                    HeightRequest="{Binding DuoWebViewHeight, Mode=OneWay}" />
                 <StackLayout StyleClass="box" VerticalOptions="End">
                     <StackLayout StyleClass="box-row, box-row-switch">
                         <Label

--- a/src/Core/Pages/Accounts/TwoFactorPageViewModel.cs
+++ b/src/Core/Pages/Accounts/TwoFactorPageViewModel.cs
@@ -34,6 +34,7 @@ namespace Bit.App.Pages
         private string _webVaultUrl = "https://vault.bitwarden.com";
         private bool _enableContinue = false;
         private bool _showContinue = true;
+        private double _duoWebViewHeight;
 
         public TwoFactorPageViewModel()
         {
@@ -63,6 +64,12 @@ namespace Bit.App.Pages
             set => SetProperty(ref _totpInstruction, value);
         }
 
+        public double DuoWebViewHeight
+        {
+            get => _duoWebViewHeight;
+            set => SetProperty(ref _duoWebViewHeight, value);
+        }
+        
         public bool Remember { get; set; }
 
         public bool AuthingWithSso { get; set; }
@@ -172,6 +179,7 @@ namespace Bit.App.Pages
                     break;
                 case TwoFactorProviderType.Duo:
                 case TwoFactorProviderType.OrganizationDuo:
+                    SetDuoWebViewHeight();
                     var host = WebUtility.UrlEncode(providerData["Host"] as string);
                     var req = WebUtility.UrlEncode(providerData["Signature"] as string);
                     page.DuoWebView.Uri = $"{_webVaultUrl}/duo-connector.html?host={host}&request={req}";
@@ -201,6 +209,12 @@ namespace Bit.App.Pages
                 _messagingService.Send("listenYubiKeyOTP", false);
             }
             ShowContinue = !(SelectedProviderType == null || DuoMethod || Fido2Method);
+        }
+
+        public void SetDuoWebViewHeight()
+        {
+            var screenHeight = DeviceDisplay.MainDisplayInfo.Height / DeviceDisplay.MainDisplayInfo.Density;
+            DuoWebViewHeight = screenHeight > 0 ? (screenHeight / 8) * 6 : 400;
         }
 
         public async Task Fido2AuthenticateAsync(Dictionary<string, object> providerData = null)

--- a/src/Core/Pages/Accounts/TwoFactorPageViewModel.cs
+++ b/src/Core/Pages/Accounts/TwoFactorPageViewModel.cs
@@ -179,7 +179,9 @@ namespace Bit.App.Pages
                     break;
                 case TwoFactorProviderType.Duo:
                 case TwoFactorProviderType.OrganizationDuo:
+#if ANDROID
                     SetDuoWebViewHeight();
+#endif
                     var host = WebUtility.UrlEncode(providerData["Host"] as string);
                     var req = WebUtility.UrlEncode(providerData["Signature"] as string);
                     page.DuoWebView.Uri = $"{_webVaultUrl}/duo-connector.html?host={host}&request={req}";

--- a/src/Core/Pages/Accounts/TwoFactorPageViewModel.cs
+++ b/src/Core/Pages/Accounts/TwoFactorPageViewModel.cs
@@ -179,9 +179,7 @@ namespace Bit.App.Pages
                     break;
                 case TwoFactorProviderType.Duo:
                 case TwoFactorProviderType.OrganizationDuo:
-#if ANDROID
                     SetDuoWebViewHeight();
-#endif
                     var host = WebUtility.UrlEncode(providerData["Host"] as string);
                     var req = WebUtility.UrlEncode(providerData["Signature"] as string);
                     page.DuoWebView.Uri = $"{_webVaultUrl}/duo-connector.html?host={host}&request={req}";


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
To stop the sliding bottom layout on the Duo 2FA page we're now setting a fixed height for the webview based on a simple measurement.  The gap at the bottom can vary depending on the device height (screenshots below), but thankfully Duo's new [frameless implementation](https://github.com/bitwarden/mobile/pull/2956) will demote this flow to an edge case.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **TwoFactorPage/Viewmodel:** Added height property and calculation using `DeviceDisplay.MainDisplayInfo` height & density

## Screenshots
<!--Required for any UI changes. Delete if not applicable-->

![Screenshot 2024-01-29 at 12 38 59 PM](https://github.com/bitwarden/mobile/assets/59324545/cd34ecf8-e40e-44c8-8f89-30722b63fcb2)
![Screenshot 2024-01-29 at 12 39 11 PM](https://github.com/bitwarden/mobile/assets/59324545/6bc67a5a-2148-4c46-a8c2-172f79e2b96a)

In the rare case we aren't able to obtain the available height for measuring, we default to 400dp as a safe minimum as seen here:

![Screenshot 2024-01-29 at 12 57 25 PM](https://github.com/bitwarden/mobile/assets/59324545/8d72305f-5b4e-42a0-9334-4c6604ce4f7b)
![Screenshot 2024-01-29 at 12 58 11 PM](https://github.com/bitwarden/mobile/assets/59324545/edd12b0c-62e7-4d6c-ad82-7499f32f872a)


## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
