### PR TITLE
[PM-5896] Fix MAUI iOS Background crash due to lock files on suspension

### DIFF
--- a/src/App/Platforms/iOS/AppDelegate.cs
+++ b/src/App/Platforms/iOS/AppDelegate.cs
@@ -462,21 +462,20 @@ namespace Bit.iOS
             _eventTimer?.Invalidate();
             _eventTimer?.Dispose();
             _eventTimer = null;
-            // TODO: Uncomment, this is just a test to see if this is causing the background crash on release when sending the app to background
-            //MainThread.BeginInvokeOnMainThread(() =>
-            //{
-            //    try
-            //    {
-            //        _eventTimer = NSTimer.CreateScheduledTimer(60, true, timer =>
-            //        {
-            //            _eventService?.UploadEventsAsync().FireAndForget();
-            //        });
-            //    }
-            //    catch (Exception ex)
-            //    {
-            //        LoggerHelper.LogEvenIfCantBeResolved(ex);
-            //    }
-            //});
+            MainThread.BeginInvokeOnMainThread(() =>
+            {
+                try
+                {
+                    _eventTimer = NSTimer.CreateScheduledTimer(60, true, timer =>
+                    {
+                        _eventService?.UploadEventsAsync().FireAndForget();
+                    });
+                }
+                catch (Exception ex)
+                {
+                    LoggerHelper.LogEvenIfCantBeResolved(ex);
+                }
+            });
         }
 
         private async Task StopEventTimerAsync()
@@ -486,20 +485,19 @@ namespace Bit.iOS
                 _eventTimer?.Invalidate();
                 _eventTimer?.Dispose();
                 _eventTimer = null;
-                // TODO: Uncomment, this is just a test to see if this is causing the background crash on release when sending the app to background
-                //if (_eventBackgroundTaskId > 0)
-                //{
-                //    UIApplication.SharedApplication.EndBackgroundTask(_eventBackgroundTaskId);
-                //    _eventBackgroundTaskId = 0;
-                //}
-                //_eventBackgroundTaskId = UIApplication.SharedApplication.BeginBackgroundTask(() =>
-                //{
-                //    UIApplication.SharedApplication.EndBackgroundTask(_eventBackgroundTaskId);
-                //    _eventBackgroundTaskId = 0;
-                //});
-                //await _eventService.UploadEventsAsync();
-                //UIApplication.SharedApplication.EndBackgroundTask(_eventBackgroundTaskId);
-                //_eventBackgroundTaskId = 0;
+                if (_eventBackgroundTaskId > 0)
+                {
+                    UIApplication.SharedApplication.EndBackgroundTask(_eventBackgroundTaskId);
+                    _eventBackgroundTaskId = 0;
+                }
+                _eventBackgroundTaskId = UIApplication.SharedApplication.BeginBackgroundTask(() =>
+                {
+                    UIApplication.SharedApplication.EndBackgroundTask(_eventBackgroundTaskId);
+                    _eventBackgroundTaskId = 0;
+                });
+                await _eventService.UploadEventsAsync();
+                UIApplication.SharedApplication.EndBackgroundTask(_eventBackgroundTaskId);
+                _eventBackgroundTaskId = 0;
             }
             catch (Exception ex)
             {

--- a/src/Core/Controls/AuthenticatorViewCell/AuthenticatorViewCell.xaml
+++ b/src/Core/Controls/AuthenticatorViewCell/AuthenticatorViewCell.xaml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
-<controls:ExtendedGrid xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+<controls:BaseCipherViewCell xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
                        xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
                        x:Class="Bit.App.Controls.AuthenticatorViewCell"
                        xmlns:controls="clr-namespace:Bit.App.Controls"
@@ -13,34 +13,33 @@
                        RowSpacing="0"
                        Padding="0,10,0,0"
                        RowDefinitions="*,*">
-    <Grid.Resources>
+    <controls:BaseCipherViewCell.Resources>
         <u:IconGlyphConverter x:Key="iconGlyphConverter" />
         <u:InverseBoolConverter x:Key="inverseBool" />
-    </Grid.Resources>
-
-    <controls:IconLabel
-        Grid.Column="0"
-        HorizontalOptions="Center"
-        VerticalOptions="Center"
-        StyleClass="list-icon, list-icon-platform"
-        Grid.RowSpan="2"
-        IsVisible="{Binding ShowIconImage, Converter={StaticResource inverseBool}}"
-        Text="{Binding Cipher, Converter={StaticResource iconGlyphConverter}}"
-        AutomationProperties.IsInAccessibleTree="False" />
+    </controls:BaseCipherViewCell.Resources>
 
     <controls:CachedImage
+        x:Name="_iconImage"
         Grid.Column="0"
+        Grid.RowSpan="2"
         BitmapOptimizations="True"
         HorizontalOptions="Center"
         VerticalOptions="Center"
         WidthRequest="22"
         HeightRequest="22"
-        Grid.RowSpan="2"
-        IsVisible="{Binding ShowIconImage}"
-        Source="{Binding IconImageSource, Mode=OneTime}"
+        Success="Icon_Success"
+        Error="Icon_Error"
         AutomationProperties.IsInAccessibleTree="False" />
-        <!-- ErrorPlaceholder="login.png"
-        LoadingPlaceholder="login.png" -->
+
+    <controls:IconLabel
+        x:Name="_iconPlaceholderImage"
+        Grid.Column="0"
+        Grid.RowSpan="2"
+        HorizontalOptions="Center"
+        VerticalOptions="Center"
+        StyleClass="list-icon, list-icon-platform"
+        Text="{Binding Cipher, Converter={StaticResource iconGlyphConverter}}"
+        AutomationProperties.IsInAccessibleTree="False" />
 
     <Label
         LineBreakMode="TailTruncation"
@@ -124,4 +123,4 @@
         HorizontalOptions="Center"
         VerticalOptions="Center"
         SemanticProperties.Description="{u:I18n CopyTotp}" />
-</controls:ExtendedGrid>
+</controls:BaseCipherViewCell>

--- a/src/Core/Controls/AuthenticatorViewCell/AuthenticatorViewCell.xaml.cs
+++ b/src/Core/Controls/AuthenticatorViewCell/AuthenticatorViewCell.xaml.cs
@@ -1,10 +1,14 @@
 ﻿namespace Bit.App.Controls
 {
-    public partial class AuthenticatorViewCell : ExtendedGrid
+    public partial class AuthenticatorViewCell : BaseCipherViewCell
     {
         public AuthenticatorViewCell()
         {
             InitializeComponent();
         }
+
+        protected override CachedImage Icon => _iconImage;
+
+        protected override IconLabel IconPlaceholder => _iconPlaceholderImage;
     }
 }

--- a/src/Core/Controls/CipherViewCell/BaseCipherViewCell.cs
+++ b/src/Core/Controls/CipherViewCell/BaseCipherViewCell.cs
@@ -1,5 +1,4 @@
-﻿using System.Diagnostics.CodeAnalysis;
-using Bit.App.Pages;
+﻿using Bit.App.Pages;
 
 namespace Bit.App.Controls
 {
@@ -48,7 +47,7 @@ namespace Bit.App.Controls
             });
         }
 
-        protected void Icon_Success(object sender, FFImageLoading.Maui.CachedImageEvents.SuccessEventArgs e)
+        public void Icon_Success(object sender, FFImageLoading.Maui.CachedImageEvents.SuccessEventArgs e)
         {
             if (BindingContext is CipherItemViewModel cipherItemVM)
             {
@@ -61,7 +60,7 @@ namespace Bit.App.Controls
             });
         }
 
-        protected void Icon_Error(object sender, FFImageLoading.Maui.CachedImageEvents.ErrorEventArgs e)
+        public void Icon_Error(object sender, FFImageLoading.Maui.CachedImageEvents.ErrorEventArgs e)
         {
             if (BindingContext is CipherItemViewModel cipherItemVM)
             {
@@ -72,6 +71,33 @@ namespace Bit.App.Controls
                 Icon.IsVisible = false;
                 IconPlaceholder.IsVisible = true;
             });
+        }
+    }
+
+    public class StubBaseCipherViewCellSoLinkerDoesntRemoveMethods : BaseCipherViewCell
+    {
+        protected override CachedImage Icon => new CachedImage();
+        protected override IconLabel IconPlaceholder => new IconLabel();
+
+        public static void CallThisSoLinkerDoesntRemoveMethods()
+        {
+            var stub = new StubBaseCipherViewCellSoLinkerDoesntRemoveMethods();
+
+            try
+            {
+                stub.Icon_Success(stub, new FFImageLoading.Maui.CachedImageEvents.SuccessEventArgs(new FFImageLoading.Work.ImageInformation(), FFImageLoading.Work.LoadingResult.Disk));
+            }
+            catch (Exception)
+            {
+            }
+
+            try
+            {
+                stub.Icon_Error(stub, new FFImageLoading.Maui.CachedImageEvents.ErrorEventArgs(new InvalidOperationException("stub")));
+            }
+            catch (Exception)
+            {
+            }
         }
     }
 }

--- a/src/Core/Controls/CipherViewCell/BaseCipherViewCell.cs
+++ b/src/Core/Controls/CipherViewCell/BaseCipherViewCell.cs
@@ -1,4 +1,5 @@
-﻿using Bit.App.Pages;
+﻿using System.Diagnostics.CodeAnalysis;
+using Bit.App.Pages;
 
 namespace Bit.App.Controls
 {
@@ -47,7 +48,7 @@ namespace Bit.App.Controls
             });
         }
 
-        void Icon_Success(object sender, FFImageLoading.Maui.CachedImageEvents.SuccessEventArgs e)
+        protected void Icon_Success(object sender, FFImageLoading.Maui.CachedImageEvents.SuccessEventArgs e)
         {
             if (BindingContext is CipherItemViewModel cipherItemVM)
             {
@@ -60,7 +61,7 @@ namespace Bit.App.Controls
             });
         }
 
-        void Icon_Error(object sender, FFImageLoading.Maui.CachedImageEvents.ErrorEventArgs e)
+        protected void Icon_Error(object sender, FFImageLoading.Maui.CachedImageEvents.ErrorEventArgs e)
         {
             if (BindingContext is CipherItemViewModel cipherItemVM)
             {

--- a/src/Core/Controls/CipherViewCell/BaseCipherViewCell.cs
+++ b/src/Core/Controls/CipherViewCell/BaseCipherViewCell.cs
@@ -1,0 +1,76 @@
+﻿using Bit.App.Pages;
+
+namespace Bit.App.Controls
+{
+    public abstract class BaseCipherViewCell : ExtendedGrid
+    {
+        protected virtual CachedImage Icon { get; }
+
+        protected virtual IconLabel IconPlaceholder { get; }
+
+        // HACK: PM-5896 Fix for Background Crash on iOS
+        // While loading the cipher icon and the user sent the app to background
+        // the app was crashing sometimes when the "LoadingPlaceholder" or "ErrorPlaceholder"
+        // were being accessed, thus locked, and as soon the app got suspended by the OS
+        // the app would crash because there can't be any lock files by the app when it gets suspended.
+        // So, the approach has changed to reuse the IconLabel default icon to use it for these placeholders
+        // as well. In order to do that both icon controls change their visibility dynamically here reacting to 
+        // CachedImage events and binding context changes.
+
+        protected override void OnBindingContextChanged()
+        {
+            Icon.Source = null;
+            if (BindingContext is CipherItemViewModel cipherItemVM)
+            {
+                Icon.Source = cipherItemVM.IconImageSource;
+                if (!cipherItemVM.IconImageSuccesfullyLoaded)
+                {
+                    UpdateIconImages(cipherItemVM.ShowIconImage);
+                }
+            }
+
+            base.OnBindingContextChanged();
+        }
+
+        private void UpdateIconImages(bool showIcon)
+        {
+            MainThread.BeginInvokeOnMainThread(() =>
+            {
+                if (!showIcon)
+                {
+                    Icon.IsVisible = false;
+                    IconPlaceholder.IsVisible = true;
+                    return;
+                }
+
+                IconPlaceholder.IsVisible = Icon.IsLoading;
+            });
+        }
+
+        void Icon_Success(object sender, FFImageLoading.Maui.CachedImageEvents.SuccessEventArgs e)
+        {
+            if (BindingContext is CipherItemViewModel cipherItemVM)
+            {
+                cipherItemVM.IconImageSuccesfullyLoaded = true;
+            }
+            MainThread.BeginInvokeOnMainThread(() =>
+            {
+                Icon.IsVisible = true;
+                IconPlaceholder.IsVisible = false;
+            });
+        }
+
+        void Icon_Error(object sender, FFImageLoading.Maui.CachedImageEvents.ErrorEventArgs e)
+        {
+            if (BindingContext is CipherItemViewModel cipherItemVM)
+            {
+                cipherItemVM.IconImageSuccesfullyLoaded = false;
+            }
+            MainThread.BeginInvokeOnMainThread(() =>
+            {
+                Icon.IsVisible = false;
+                IconPlaceholder.IsVisible = true;
+            });
+        }
+    }
+}

--- a/src/Core/Controls/CipherViewCell/CipherViewCell.xaml
+++ b/src/Core/Controls/CipherViewCell/CipherViewCell.xaml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
-<controls:ExtendedGrid xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+<controls:BaseCipherViewCell xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     x:Class="Bit.App.Controls.CipherViewCell"
     xmlns:controls="clr-namespace:Bit.App.Controls"
@@ -29,17 +29,6 @@
         <ColumnDefinition Width="60" />
     </Grid.ColumnDefinitions>
 
-    <controls:IconLabel
-        Grid.Column="0"
-        HorizontalOptions="Center"
-        VerticalOptions="Center"
-        StyleClass="list-icon, list-icon-platform"
-        IsVisible="{Binding ShowIconImage, Converter={StaticResource inverseBool}}"
-        Text="{Binding Cipher, Converter={StaticResource iconGlyphConverter}}"
-        ShouldUpdateFontSizeDynamicallyForAccesibility="True"
-        AutomationProperties.IsInAccessibleTree="False"
-        AutomationId="CipherTypeIcon" />
-
     <controls:CachedImage
         x:Name="_iconImage"
         Grid.Column="0"
@@ -50,12 +39,21 @@
         WidthRequest="22"
         HeightRequest="22"
         Aspect="AspectFit"
-        IsVisible="{Binding ShowIconImage}"
-        Source="{Binding IconImageSource, Mode=OneTime}"
+        Success="Icon_Success"
+        Error="Icon_Error"
         AutomationProperties.IsInAccessibleTree="False"
         AutomationId="CipherWebsiteIcon" />
-        <!-- ErrorPlaceholder="login.png"
-        LoadingPlaceholder="login.png" -->
+
+    <controls:IconLabel
+        x:Name="_iconPlaceholderImage"
+        Grid.Column="0"
+        HorizontalOptions="Center"
+        VerticalOptions="Center"
+        StyleClass="list-icon, list-icon-platform"
+        Text="{Binding Cipher, Converter={StaticResource iconGlyphConverter}}"
+        ShouldUpdateFontSizeDynamicallyForAccesibility="True"
+        AutomationProperties.IsInAccessibleTree="False"
+        AutomationId="CipherTypeIcon" />
 
     <Grid RowSpacing="0" ColumnSpacing="0" Grid.Row="0" Grid.Column="1" VerticalOptions="Center" Padding="0, 7">
         <Grid.RowDefinitions>
@@ -121,4 +119,4 @@
         SemanticProperties.Description="{u:I18n Options}"
         AutomationId="CipherOptionsButton" />
 
-</controls:ExtendedGrid>
+</controls:BaseCipherViewCell>

--- a/src/Core/Controls/CipherViewCell/CipherViewCell.xaml.cs
+++ b/src/Core/Controls/CipherViewCell/CipherViewCell.xaml.cs
@@ -5,7 +5,7 @@ using Bit.Core.Utilities;
 
 namespace Bit.App.Controls
 {
-    public partial class CipherViewCell : ExtendedGrid
+    public partial class CipherViewCell : BaseCipherViewCell
     {
         private const int ICON_COLUMN_DEFAULT_WIDTH = 40;
         private const int ICON_IMAGE_DEFAULT_WIDTH = 22;
@@ -22,6 +22,10 @@ namespace Bit.App.Controls
             _iconImage.WidthRequest = ICON_IMAGE_DEFAULT_WIDTH * fontScale;
             _iconImage.HeightRequest = ICON_IMAGE_DEFAULT_WIDTH * fontScale;
         }
+
+        protected override CachedImage Icon => _iconImage;
+
+        protected override IconLabel IconPlaceholder => _iconPlaceholderImage;
 
         public ICommand ButtonCommand
         {

--- a/src/Core/MauiProgram.cs
+++ b/src/Core/MauiProgram.cs
@@ -1,4 +1,5 @@
-﻿using Camera.MAUI;
+﻿using Bit.App.Controls;
+using Camera.MAUI;
 using CommunityToolkit.Maui;
 #if !UT
 using FFImageLoading.Maui;
@@ -62,6 +63,13 @@ public static class MauiProgram
         builder.Logging.AddDebug();
 #endif
 
+        ExplicitlyPreventThingsGetRemovedBecauseOfLinker();
+
         return builder;
+    }
+
+    private static void ExplicitlyPreventThingsGetRemovedBecauseOfLinker()
+    {
+        StubBaseCipherViewCellSoLinkerDoesntRemoveMethods.CallThisSoLinkerDoesntRemoveMethods();
     }
 }

--- a/src/Core/Pages/Vault/CipherItemViewModel.cs
+++ b/src/Core/Pages/Vault/CipherItemViewModel.cs
@@ -38,5 +38,11 @@ namespace Bit.App.Pages
                 return _iconImageSource;
             }
         }
+
+        /// <summary>
+        /// Flag that indicates if FFImageLoading has successfully finished loading  the image.
+        /// This is useful to check when the cell is being reused.
+        /// </summary>
+        public bool IconImageSuccesfullyLoaded { get; set; }
     }
 }


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Fix background crash happening on iOS due to having a lock file (login.png) when the app got to suspended state.
This is due to the `CachedImage` loading and error placeholders which try to load the _login.png_ file and at the same time the user sends the app to background, and when it reaches the suspended state, sometimes the file is still locked which causes the app to crash afterwards with this reason on the crashlog `RUNNINGBOARD 0xdead10cc` and this message can be seen on the Console output `suspended with locked system files` referencing afterwards the _login.png_ file.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **BaseCipherViewCell.cs:** Added this class to hold the new logic for the cached image source and visibility changes between the cached image and the placeholder icon. This is shared between `CipherViewCell` and `AuthenticatorViewCell`, the two cells that had the issue.
* **CipherViewCell/AuthenticatorViewCell:** Implemented the base class and changed the layout a bit so that the placeholder icon (the glyph of this icon is the same as the image `login.png`) is on top of the cached image to be seen correctly by the user at the proper time. Also added the cached image events so that we can toggle the visibility of the icons accordingly.
* **AppDelegate:** Uncommented events upload code given that it didn't have to do with the crash.
* **CipherItemViewModel:** Added a new flag `IconImageSuccesfullyLoaded` which is `true` when the cached image loads successfully and is checked on binding context changes to prevent odd behaviors on cell reuse.

## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
