### PR TITLE
[PM-5903] Fix Account Switcher visible on Android when no Accounts are logged in

### DIFF
--- a/src/App/Platforms/Android/MainActivity.cs
+++ b/src/App/Platforms/Android/MainActivity.cs
@@ -76,7 +76,8 @@ namespace Bit.Droid
 
             //We need to get and set the Options before calling OnCreate as that will "trigger" CreateWindow on App.xaml.cs
             _appOptions = GetOptions();
-            ((Bit.App.App)Microsoft.Maui.Controls.Application.Current).SetOptions(_appOptions);
+            //This does not replace existing Options in App.xaml.cs if it exists already. It only updates properties in Options related with Autofill/CreateSend/etc..
+            ((Bit.App.App)Microsoft.Maui.Controls.Application.Current).SetAndroidOptions(_appOptions);
 
             base.OnCreate(savedInstanceState);
 

--- a/src/Core/App.xaml.cs
+++ b/src/Core/App.xaml.cs
@@ -85,10 +85,27 @@ namespace Bit.App
             }
         }
 
-        //Allows setting Options from MainActivity before base.OnCreate
-        public void SetOptions(AppOptions appOptions)
+        /// <summary>
+        /// Allows setting Options from MainActivity before base.OnCreate
+        /// Note 1: This is only be used by Android due to way it's Lifecycle works
+        /// Note 2: This method does not replace existing Options in App.xaml.cs if it exists already.
+        ///         It only updates properties in Options related with Autofill/CreateSend/etc..
+        /// </summary>
+        /// <param name="appOptions">Options created in Android MainActivity.cs</param>
+        public void SetAndroidOptions(AppOptions appOptions)
         {
-            Options = appOptions ?? new AppOptions();
+            if (Options == null)
+            {
+                Options = appOptions ?? new AppOptions();
+            }
+            else if(appOptions != null)
+            { 
+                Options.Uri = appOptions.Uri;
+                Options.MyVaultTile = appOptions.MyVaultTile;
+                Options.GeneratorTile = appOptions.GeneratorTile;
+                Options.FromAutofillFramework = appOptions.FromAutofillFramework;
+                Options.CreateSend = appOptions.CreateSend;
+            }
         }
 
         protected override Window CreateWindow(IActivationState activationState)


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
Fix Account Switcher visible on Android when no Accounts are logged in.
This is happening because on Android `App.xaml.cs.SetOptions()` can get called after `App.xaml.cs` already has Options set. In this scenario it would get replaced and specifically the property `HideAccountSwitcher` will have an incorrect value of `false`.

## Code changes
* **App.xaml.cs:** Update the `SetOptions()` method to only update the properties that we need from Android instead of replacing the entire object. Also added some comments and changed the method name to `SetAndroidOptions()` to make it more clear.

## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
