### PR TITLE
[PM-5902] Fix Account Switcher can't be dismissed when tapping outside of it

### DIFF
--- a/src/Core/Controls/AccountSwitchingOverlay/AccountSwitchingOverlayView.xaml
+++ b/src/Core/Controls/AccountSwitchingOverlay/AccountSwitchingOverlayView.xaml
@@ -12,12 +12,14 @@
     BackgroundColor="#22000000"
     Padding="0"
     IsVisible="False">
-    <VerticalStackLayout
+    <Grid
         x:Name="_accountListContainer"
         VerticalOptions="Fill"
-        HorizontalOptions="FillAndExpand"
-        BackgroundColor="Transparent">
+        HorizontalOptions="Fill"
+        BackgroundColor="Transparent"
+        RowDefinitions="Auto, *">
         <Frame
+            Grid.Row="0"
             Padding="0"
             HorizontalOptions="Fill"
             VerticalOptions="Start">
@@ -49,12 +51,13 @@
             </ListView>
         </Frame>
         <BoxView
+            Grid.Row="1"
             BackgroundColor="Transparent"
             HorizontalOptions="Fill"
-            VerticalOptions="FillAndExpand">
+            VerticalOptions="Fill">
             <BoxView.GestureRecognizers>
                 <TapGestureRecognizer Tapped="FreeSpaceOverlay_Tapped" />
             </BoxView.GestureRecognizers>
         </BoxView>
-    </VerticalStackLayout>
+    </Grid>
 </ContentView>


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
Account Switcher can't be dismissed by tapping in the empty space below it like we could with the Xamarin Forms app.
This is caused because `FillAndExpand` works differently in MAUI and will not "expand to fill" the entire screen space with the BoxView that we had before for detecting and dismissing the Account Switcher.


## Code changes
* **AccountSwitchingOverlayView.xaml:** Replace `StackLayout` with a Grid and set `RowDefinitions`. Setting "*" for the `BoxView `will ensure it "fills" the entire screen and therefore will detect the tap event that triggers the dismiss of the Account Switcher.

## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
