### PR TITLE
[PM-5906] Fix for incorrect Send MaxAccess white text color on label when using light theme on iOS

### DIFF
--- a/src/Core/Pages/Send/SendAddEditPage.xaml.cs
+++ b/src/Core/Pages/Send/SendAddEditPage.xaml.cs
@@ -184,12 +184,11 @@ namespace Bit.App.Pages
             var maxAccessEntry = (Microsoft.Maui.Controls.Entry)sender;
 
 #if IOS
-            //Workaround: To avoid a bug that incorrectly sets the TextColor when changing text
+            // HACK: To avoid a bug that incorrectly sets the TextColor when changing text
             // programatically we need to set it to null and back to the correct color
             // MAUI issue https://github.com/dotnet/maui/pull/20100
             maxAccessEntry.TextColor = null;
-            var color = ThemeManager.GetResourceColor("TextColor");
-            maxAccessEntry.TextColor = color;
+            maxAccessEntry.TextColor = ThemeManager.GetResourceColor("TextColor");
 #endif
 
             if (string.IsNullOrWhiteSpace(e.NewTextValue))


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
Fix for incorrect Send MaxAccess white text color on label when using light theme on iOS.
This fix is a workaround for the MAUI Issue https://github.com/dotnet/maui/pull/20100

## Code changes
* **SendAddEditPage.xaml.cs:** Set the TextColor to null and back to the correct color whenever we try to programatically change the entry text. Doing this avoids the bug.


## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
