### PR TITLE
[PM-5907] Fix for incorrect TOTP white text color on label when using light theme on iOS

### DIFF
--- a/src/Core/Pages/Vault/CipherAddEditPage.xaml.cs
+++ b/src/Core/Pages/Vault/CipherAddEditPage.xaml.cs
@@ -268,6 +268,15 @@ namespace Bit.App.Pages
                         {
                             await Navigation.PopModalAsync();
                             await _vm.UpdateTotpKeyAsync(key);
+
+#if IOS
+                            //Workaround: To avoid a bug that incorrectly sets the TextColor when changing text
+                            // programatically we need to set it to null and back to the correct color
+                            // MAUI issue https://github.com/dotnet/maui/pull/20100
+                            _loginTotpEntry.TextColor = null;
+                            var color = ThemeManager.GetResourceColor("TextColor");
+                            _loginTotpEntry.TextColor = color;
+#endif
                         }
                         catch (Exception ex)
                         {

--- a/src/Core/Pages/Vault/CipherAddEditPage.xaml.cs
+++ b/src/Core/Pages/Vault/CipherAddEditPage.xaml.cs
@@ -270,12 +270,11 @@ namespace Bit.App.Pages
                             await _vm.UpdateTotpKeyAsync(key);
 
 #if IOS
-                            //Workaround: To avoid a bug that incorrectly sets the TextColor when changing text
+                            // HACK: To avoid a bug that incorrectly sets the TextColor when changing text
                             // programatically we need to set it to null and back to the correct color
                             // MAUI issue https://github.com/dotnet/maui/pull/20100
                             _loginTotpEntry.TextColor = null;
-                            var color = ThemeManager.GetResourceColor("TextColor");
-                            _loginTotpEntry.TextColor = color;
+                            _loginTotpEntry.TextColor = ThemeManager.GetResourceColor("TextColor");
 #endif
                         }
                         catch (Exception ex)


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
Fix for incorrect TOTP white text color on label when using light theme on iOS.
This fix is a workaround for the MAUI Issue https://github.com/dotnet/maui/pull/20100

## Code changes
* **CipherAddEditPage.xaml.cs:** Set the TextColor to null and back to the correct color whenever we try to programatically change the entry text. Doing this avoids the bug.


## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
