### PR TITLE
[PM-5913] Fix for MAUI not reporting the correct Theme when resuming an iOS App

### DIFF
--- a/src/Core/Utilities/ThemeManager.cs
+++ b/src/Core/Utilities/ThemeManager.cs
@@ -158,9 +158,9 @@ namespace Bit.App.Utilities
         {
 #if ANDROID
             return Application.Current.RequestedTheme == AppTheme.Dark;
-#elif IOS
+#else
             var requestedTheme = AppTheme.Unspecified;
-            if ((OperatingSystem.IsIOS() && !OperatingSystem.IsIOSVersionAtLeast(13, 0)))
+            if (!OperatingSystem.IsIOSVersionAtLeast(13, 0))
                 return false;
 
             var traits = InvokeOnMainThread(() => WindowStateManager.Default.GetCurrentUIViewController()?.TraitCollection) ?? UITraitCollection.CurrentTraitCollection;


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
We want to implement a fix/workaround for MAUI not reporting the correct Theme when resuming an iOS App.

## Code changes

* **ThemeManager.cs:** Added iOS/Android specific implementations for OsDarkModeEnabled() so that we can directly fetch the Theme on the iOS API for the iOS implementation.

## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
