### PR TITLE
[PM-5900] Fix for Device Login push notifications cause the app to show HomePage

### DIFF
--- a/src/App/Platforms/Android/Services/AndroidPushNotificationService.cs
+++ b/src/App/Platforms/Android/Services/AndroidPushNotificationService.cs
@@ -79,7 +79,7 @@ namespace Bit.Droid.Services
             }
             
             var context = Android.App.Application.Context;
-            var intent = new Intent(context, typeof(MainActivity));
+            var intent = context.PackageManager?.GetLaunchIntentForPackage(context.PackageName ?? string.Empty);
             intent.PutExtra(Bit.Core.Constants.NotificationData, JsonConvert.SerializeObject(data));
             var pendingIntentFlags = AndroidHelpers.AddPendingIntentMutabilityFlag(PendingIntentFlags.UpdateCurrent, true);
             var pendingIntent = PendingIntent.GetActivity(context, 20220801, intent, pendingIntentFlags);


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
 Fix for Device Login push notifications causing the app to show HomePage.
 MAUI is treating the Intent on the push notification as a triggering the creation of a new Activity and we just want to open the existing one.

## Code changes
* **AndroidPushNotificationService.cs:** Changed the Intent when tapping the push notification to launch the existing activity instead of creating a new one.

## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
