### PR TITLE
Version Bump workflow - Fix location of AndroidManifest.xml file

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -196,18 +196,16 @@ jobs:
         env:
           NEW_VERSION: ${{ inputs.version_number }}
         run: |
-          CURRENT_VERSION=$(xmllint --xpath '
+          # Wait for version to change.
+          do
+            echo "Waiting for version to be updated..."
+            git pull --force
+            CURRENT_VERSION=$(xmllint --xpath '
             string(/manifest/@*[local-name()="versionName" 
               and namespace-uri()="http://schemas.android.com/apk/res/android"])
             ' src/App/Platforms/Android/AndroidManifest.xml)
-
-          # Wait for version to change.
-          while [[ "$NEW_VERSION" != "$CURRENT_VERSION" ]]
-          do
-            echo "Waiting for version to be updated..."
             sleep 10
-            git pull --force
-          done
+          done while [[ "$NEW_VERSION" != "$CURRENT_VERSION" ]]
 
       - name: Cut RC branch
         run: |

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -199,7 +199,7 @@ jobs:
           CURRENT_VERSION=$(xmllint --xpath '
             string(/manifest/@*[local-name()="versionName" 
               and namespace-uri()="http://schemas.android.com/apk/res/android"])
-            ' src/Android/Properties/AndroidManifest.xml)
+            ' src/App/Platforms/Android/AndroidManifest.xml)
 
           # Wait for version to change.
           while [[ "$NEW_VERSION" != "$CURRENT_VERSION" ]]


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [X] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
This PR fixes the version check step by using the proper location of `AndroidManifest.xml`.

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **.github/workflows/version-bump.yml:** Update path to `AndroidManifest.xml`. Fix `while` loop logic.

## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
