### PR TITLE
[PM-6291] Fix Device Login Pending Requests screen not displaying anything

### DIFF
--- a/src/Core/Pages/Settings/LoginPasswordlessRequestsListPage.xaml
+++ b/src/Core/Pages/Settings/LoginPasswordlessRequestsListPage.xaml
@@ -76,12 +76,10 @@
         RowDefinitions="*, Auto"
         Padding="0, 10">
         <RefreshView
-            x:Name="_refreshView"
-            IsVisible="False"
             Grid.Row="0"
             IsRefreshing="{Binding IsRefreshing}"
             Command="{Binding RefreshCommand}"
-            VerticalOptions="FillAndExpand"
+            VerticalOptions="Fill"
             BackgroundColor="{DynamicResource BackgroundColor}">
             <Grid RowDefinitions="Auto, *">
                 <VerticalStackLayout Grid.Row="0" 
@@ -129,10 +127,11 @@
             IsVisible="{Binding HasLoginRequests}"
             AutomationId="DeleteAllRequestsButton" />
 
-        <ActivityIndicator x:Name="_activityIndicator" Grid.Row="0" Grid.RowSpan="2" 
-                           VerticalOptions="Center" 
-                           HorizontalOptions="Center" />
-
+        <Grid x:Name="_activityIndicatorGrid" Grid.Row="0" Grid.RowSpan="2" BackgroundColor="{DynamicResource BackgroundColor}">
+            <ActivityIndicator IsRunning="True"
+                               VerticalOptions="Center" 
+                               HorizontalOptions="Center" />
+        </Grid>
     </Grid>
 
 </pages:BaseContentPage>

--- a/src/Core/Pages/Settings/LoginPasswordlessRequestsListPage.xaml
+++ b/src/Core/Pages/Settings/LoginPasswordlessRequestsListPage.xaml
@@ -37,7 +37,6 @@
                         <Label
                             Text="{u:I18n FingerprintPhrase}"
                             FontSize="Small"
-                            Padding="0, 10, 0 ,0"
                             FontAttributes="Bold"/>
                         <controls:MonoLabel
                             FormattedText="{Binding FingerprintPhrase}"
@@ -70,64 +69,71 @@
                             Grid.ColumnSpan="2"/>
                     </Grid>
 	        </DataTemplate>
-
-            <StackLayout
-                x:Key="mainLayout"
-                x:Name="_mainLayout"
-                Padding="0, 10">
-                <RefreshView
-                    IsRefreshing="{Binding IsRefreshing}"
-                    Command="{Binding RefreshCommand}"
-                    VerticalOptions="FillAndExpand"
-                    BackgroundColor="{DynamicResource BackgroundColor}">
-                    <StackLayout>
-                        <Image
-                            x:Name="_emptyPlaceholder"
-                            Source="empty_login_requests"
-                            HorizontalOptions="Center"
-                            WidthRequest="160"
-                            HeightRequest="160"
-                            Margin="0,70,0,0"
-                            IsVisible="{Binding HasLoginRequests, Converter={StaticResource inverseBool}}"
-                            SemanticProperties.Description="{u:I18n NoPendingRequests}" />
-                        <controls:CustomLabel
-                            StyleClass="box-label-regular"
-                            Text="{u:I18n NoPendingRequests}"
-                            IsVisible="{Binding HasLoginRequests, Converter={StaticResource inverseBool}}"
-                            FontAttributes="{OnPlatform iOS=Bold}"
-                            FontWeight="500"
-                            HorizontalTextAlignment="Center"
-                            Margin="14,10,14,0"/>
-                        <controls:ExtendedCollectionView
-                            ItemsSource="{Binding LoginRequests}"
-                            ItemTemplate="{StaticResource loginRequestTemplate}"
-                            SelectionMode="Single"
-                            IsVisible="{Binding HasLoginRequests}"
-                            ExtraDataForLogging="Login requests page" >
-                            <controls:ExtendedCollectionView.Behaviors>
-                                <xct:EventToCommandBehavior
-                                    EventName="SelectionChanged"
-                                    Command="{Binding AnswerRequestCommand}"
-                                    EventArgsConverter="{StaticResource SelectionChangedEventArgsConverter}" />
-                            </controls:ExtendedCollectionView.Behaviors>
-                        </controls:ExtendedCollectionView>
-                    </StackLayout>
-                </RefreshView>
-                <controls:IconLabelButton
-                        VerticalOptions="End"
-                        Margin="10,0"
-                        Icon="{Binding Source={x:Static core:BitwardenIcons.Trash}}"
-                        Label="{u:I18n DeclineAllRequests}"
-                        ButtonCommand="{Binding DeclineAllRequestsCommand}"
-                        IsVisible="{Binding HasLoginRequests}"
-                        AutomationId="DeleteAllRequestsButton" />
-            </StackLayout>
         </ResourceDictionary>
     </ContentPage.Resources>
 
-    <ContentView 
-        x:Name="_mainContent">
-    </ContentView>
+    <Grid
+        RowDefinitions="*, Auto"
+        Padding="0, 10">
+        <RefreshView
+            x:Name="_refreshView"
+            IsVisible="False"
+            Grid.Row="0"
+            IsRefreshing="{Binding IsRefreshing}"
+            Command="{Binding RefreshCommand}"
+            VerticalOptions="FillAndExpand"
+            BackgroundColor="{DynamicResource BackgroundColor}">
+            <Grid RowDefinitions="Auto, *">
+                <VerticalStackLayout Grid.Row="0" 
+                                     HorizontalOptions="Center">
+                    <Image
+                        x:Name="_emptyPlaceholder"
+                        Source="empty_login_requests"
+                        WidthRequest="160"
+                        HeightRequest="160"
+                        Margin="0,70,0,0"
+                        IsVisible="{Binding HasLoginRequests, Converter={StaticResource inverseBool}}"
+                        SemanticProperties.Description="{u:I18n NoPendingRequests}" />
+                    <controls:CustomLabel
+                        StyleClass="box-label-regular"
+                        Text="{u:I18n NoPendingRequests}"
+                        IsVisible="{Binding HasLoginRequests, Converter={StaticResource inverseBool}}"
+                        FontAttributes="{OnPlatform iOS=Bold}"
+                        FontWeight="500"
+                        Margin="14,10,14,0"/>
+                </VerticalStackLayout>
+                <controls:ExtendedCollectionView
+                    Grid.Row="1"
+                    ItemsSource="{Binding LoginRequests}"
+                    ItemTemplate="{StaticResource loginRequestTemplate}"
+                    SelectionMode="Single"
+                    IsVisible="{Binding HasLoginRequests}"
+                    ExtraDataForLogging="Login requests page" >
+                    <controls:ExtendedCollectionView.Behaviors>
+                        <xct:EventToCommandBehavior
+                            EventName="SelectionChanged"
+                            Command="{Binding AnswerRequestCommand}"
+                            EventArgsConverter="{StaticResource SelectionChangedEventArgsConverter}" />
+                    </controls:ExtendedCollectionView.Behaviors>
+                </controls:ExtendedCollectionView>
+            </Grid>
+        </RefreshView>
+        
+        <controls:IconLabelButton
+            Grid.Row="1"
+            VerticalOptions="End"
+            Margin="10,0"
+            Icon="{Binding Source={x:Static core:BitwardenIcons.Trash}}"
+            Label="{u:I18n DeclineAllRequests}"
+            ButtonCommand="{Binding DeclineAllRequestsCommand}"
+            IsVisible="{Binding HasLoginRequests}"
+            AutomationId="DeleteAllRequestsButton" />
+
+        <ActivityIndicator x:Name="_activityIndicator" Grid.Row="0" Grid.RowSpan="2" 
+                           VerticalOptions="Center" 
+                           HorizontalOptions="Center" />
+
+    </Grid>
 
 </pages:BaseContentPage>
 

--- a/src/Core/Pages/Settings/LoginPasswordlessRequestsListPage.xaml.cs
+++ b/src/Core/Pages/Settings/LoginPasswordlessRequestsListPage.xaml.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using Bit.App.Utilities;
 using Bit.Core.Abstractions;
 using Bit.Core.Models.Response;
+using Bit.Core.Services;
 using Bit.Core.Utilities;
 using Microsoft.Maui.ApplicationModel;
 using Microsoft.Maui.Controls;
@@ -19,7 +20,7 @@ namespace Bit.App.Pages
         public LoginPasswordlessRequestsListPage()
         {
             InitializeComponent();
-            SetActivityIndicator(_mainContent);
+            _activityIndicator.IsRunning = true;
             _vm = BindingContext as LoginPasswordlessRequestsListViewModel;
             _vm.Page = this;
         }
@@ -27,9 +28,22 @@ namespace Bit.App.Pages
         protected override async void OnAppearing()
         {
             base.OnAppearing();
-            await LoadOnAppearedAsync(_mainLayout, false, _vm.RefreshAsync, _mainContent);
 
-            UpdatePlaceholder();
+            try
+            {
+                await _vm.RefreshAsync();
+                UpdatePlaceholder();
+            }
+            catch (Exception ex)
+            {
+                LoggerHelper.LogEvenIfCantBeResolved(ex);
+            }
+            finally
+            {
+                _activityIndicator.IsRunning = false;
+                _activityIndicator.IsVisible = false;
+                _refreshView.IsVisible = true;
+            }
         }
 
         private async void Close_Clicked(object sender, System.EventArgs e)

--- a/src/Core/Pages/Settings/LoginPasswordlessRequestsListPage.xaml.cs
+++ b/src/Core/Pages/Settings/LoginPasswordlessRequestsListPage.xaml.cs
@@ -20,7 +20,6 @@ namespace Bit.App.Pages
         public LoginPasswordlessRequestsListPage()
         {
             InitializeComponent();
-            _activityIndicator.IsRunning = true;
             _vm = BindingContext as LoginPasswordlessRequestsListViewModel;
             _vm.Page = this;
         }
@@ -28,9 +27,10 @@ namespace Bit.App.Pages
         protected override async void OnAppearing()
         {
             base.OnAppearing();
-
             try
             {
+                _activityIndicatorGrid.IsVisible = true;
+
                 await _vm.RefreshAsync();
                 UpdatePlaceholder();
             }
@@ -40,9 +40,7 @@ namespace Bit.App.Pages
             }
             finally
             {
-                _activityIndicator.IsRunning = false;
-                _activityIndicator.IsVisible = false;
-                _refreshView.IsVisible = true;
+                _activityIndicatorGrid.IsVisible = false;
             }
         }
 

--- a/src/Core/Pages/Settings/LoginPasswordlessRequestsListViewModel.cs
+++ b/src/Core/Pages/Settings/LoginPasswordlessRequestsListViewModel.cs
@@ -108,7 +108,7 @@ namespace Bit.App.Pages
                 Origin = loginRequestData.Origin
             });
 
-            await Device.InvokeOnMainThreadAsync(() => Application.Current.MainPage.Navigation.PushModalAsync(new NavigationPage(page)));
+            await MainThread.InvokeOnMainThreadAsync(() => Application.Current.MainPage.Navigation.PushModalAsync(new NavigationPage(page)));
         }
 
         private async Task DeclineAllRequestsAsync()


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
The Device Login Pending Requests screen is not displaying anything.
If there are no items to show sometimes rotating the device would make the "No pending requests" message and image to appear which hints at a layout/arrange issue. When there are items to show the page never seems to load anything. 

## Code changes
Notes:
* As I started fixing issues with this screen I noticed there are multiple ones and they all seem to be related with the `RefreshView` not "layouting" itself properly when the `CollectionView` items change. I tried using `InvalidateArrange()` on several elements of the layout tree but it doesn't seem to help either.
* The changes that I found avoided this issue were having the layout directly on the Page at compile time instead of adding it to the `ContentView` in runtime and also switching the StackLayout's to Grids and that seems to "force" the `RefreshView` to take full width/height and allow the inner `CollectionView` to be able to update itself (at least on Android)
* For iOS I also had to use a background color on a full screen grid that has the activity indicator and hides the refreshview below because using `IsVisible` on the `RefreshView` "layout tree" causes issues with the layout in iOS. (in practice when making the refreshview visible the size doesn't seem to be calculating properly on iOS and having it there "behind" the activity indicator grid avoids this issue.

* **LoginPasswordlessRequestsListPage.xaml:** Moved the page xaml from the `Resources` to the Content of the page directly. Changed StackLayout's to Grids and added a new Grid for showing the `ActivityIndicator`
* **LoginPasswordlessRequestsListPage.xaml.cs:** Changes to no longer use the `BaseContentPage` `SetActivityIndicator()` and `LoadOnAppearedAsync()`
* **LoginPasswordlessRequestsListViewModel.cs:** Minor change to use `MainThread` instead of the old `Device`


## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
