### PR TITLE
[PM-5909] Fix Font MAUI Sizes

### DIFF
--- a/src/Core/Pages/Send/SendGroupingsPage/SendGroupingsPage.xaml
+++ b/src/Core/Pages/Send/SendGroupingsPage/SendGroupingsPage.xaml
@@ -50,6 +50,7 @@
                           x:DataType="pages:SendGroupingsPageListItem">
                 <controls:ExtendedStackLayout Orientation="Horizontal" 
                                               StyleClass="list-row, list-row-platform"
+                                              Spacing="6"
                                               AutomationId="{Binding AutomationId}">
                     <controls:IconLabel Text="{Binding Icon, Mode=OneWay}"
                                       HorizontalOptions="Start"

--- a/src/Core/Resources/Styles/Android.xaml
+++ b/src/Core/Resources/Styles/Android.xaml
@@ -11,11 +11,15 @@
                 Value="{DynamicResource TextColor}" />
         <Setter Property="Margin"
                 Value="-4, 0, -4, -4" />
+        <Setter Property="FontSize"
+                Value="18" />
     </Style>
     <Style TargetType="Picker"
            ApplyToDerivedTypes="True">
         <Setter Property="TextColor"
                 Value="{DynamicResource TextColor}" />
+        <Setter Property="FontSize"
+                Value="18" />
         <Setter Property="Margin"
                 Value="-4, 0, -4, -4" />
     </Style>
@@ -39,6 +43,8 @@
                 Value="{DynamicResource TextColor}" />
         <Setter Property="PlaceholderColor"
                 Value="{DynamicResource InputPlaceholderColor}" />
+        <Setter Property="FontSize"
+                Value="18" />
         <Setter Property="Margin"
                 Value="-4, 0, -4, -4" />
     </Style>
@@ -46,6 +52,8 @@
            ApplyToDerivedTypes="True">
         <Setter Property="BackgroundColor"
                 Value="Transparent" />
+        <Setter Property="FontSize"
+                Value="18" />
         <Setter Property="TextColor"
                 Value="{DynamicResource TitleEntryTextColor}" />
         <Setter Property="CancelButtonColor"

--- a/src/Core/Resources/Styles/iOS.xaml
+++ b/src/Core/Resources/Styles/iOS.xaml
@@ -9,6 +9,8 @@
                 Value="{DynamicResource InputPlaceholderColor}" />
         <Setter Property="TextColor"
                 Value="{DynamicResource TextColor}" />
+        <Setter Property="FontSize"
+                Value="18" />
         <Setter Property="Margin"
                 Value="0, 5, 0, 12" />
     </Style>
@@ -16,6 +18,8 @@
            ApplyToDerivedTypes="True">
         <Setter Property="TextColor"
                 Value="{DynamicResource TextColor}" />
+        <Setter Property="FontSize"
+                Value="18" />
         <Setter Property="Margin"
                 Value="0, 5, 0, 12" />
     </Style>
@@ -37,6 +41,8 @@
            ApplyToDerivedTypes="True">
         <Setter Property="TextColor"
                 Value="{DynamicResource TextColor}" />
+        <Setter Property="FontSize"
+                Value="18" />
         <Setter Property="BackgroundColor"
                 Value="{DynamicResource BackgroundColor}" />
         <Setter Property="PlaceholderColor"
@@ -51,6 +57,8 @@
     </Style>
     <Style TargetType="SearchBar"
            ApplyToDerivedTypes="True">
+        <Setter Property="FontSize"
+                Value="18" />
         <Setter Property="BackgroundColor"
                 Value="{DynamicResource ListHeaderBackgroundColor}" />
         <Setter Property="TextColor"


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
Font Size on some controls in the MAUI app is different from Xamarin Forms. Ideally it should be the same.

## Code changes
As far as I could tell MAUI no longer uses the same Font Size default that we had in Xamarin Forms.
The most obvious issues seemed to be on `Entry`, `Editor`, `Picker` and `SearchBar`.
In code I set these base controls to always have a default of `FontSize="18"` which seems to be the same as the Xamarin Forms app.

Also added a spacing on `SendGroupingsPage.xaml` between icon and text. (this wasn't an issue in Xamarin Forms because XF has a default Spacing of 6)

* **Android.xaml:** Set the default FontSize to 18 on `Entry`, `Editor`, `Picker` and `SearchBar`. (for Android)
* **iOS.xaml:** Set the default FontSize to 18 on `Entry`, `Editor`, `Picker` and `SearchBar`. (for iOS)
* **SendGroupingsPage.xaml:** Added a spacing on `SendGroupingsPage.xaml` between icon and text.

## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
