### PR TITLE
[PM-5154] Implement iOS Passkey -> Add login item

### DIFF
--- a/src/iOS.Autofill/Fido2MakeCredentialUserInterface.cs
+++ b/src/iOS.Autofill/Fido2MakeCredentialUserInterface.cs
@@ -22,6 +22,7 @@ namespace Bit.iOS.Autofill
         {
             _context.ConfirmNewCredentialTcs?.SetCanceled();
             _context.ConfirmNewCredentialTcs = new TaskCompletionSource<(string CipherId, bool UserVerified)>();
+            _context.PasskeyCreationParams = confirmNewCredentialParams;
 
             _onConfirmingNewCredential();
 

--- a/src/iOS.Autofill/LoginAddViewController.cs
+++ b/src/iOS.Autofill/LoginAddViewController.cs
@@ -1,4 +1,12 @@
 using System;
+using System.Threading.Tasks;
+using Bit.Core.Abstractions;
+using Bit.Core.Models.View;
+using Bit.Core.Resources.Localization;
+using Bit.Core.Services;
+using Bit.Core.Utilities;
+using Bit.iOS.Autofill.Models;
+using Bit.iOS.Core.Utilities;
 using Bit.iOS.Core.Views;
 using Foundation;
 using UIKit;
@@ -7,6 +15,8 @@ namespace Bit.iOS.Autofill
 {
     public partial class LoginAddViewController : Core.Controllers.LoginAddViewController
     {
+        LazyResolve<ICipherService> _cipherService = new LazyResolve<ICipherService>();
+
         public LoginAddViewController(IntPtr handle)
             : base(handle)
         {
@@ -20,11 +30,31 @@ namespace Bit.iOS.Autofill
         public override UIBarButtonItem BaseCancelButton => CancelBarButton;
         public override UIBarButtonItem BaseSaveButton => SaveBarButton;
 
-        public override Action<string> Success => id =>
+        private new Context Context => (Context)base.Context;
+
+        public override Action<string> Success => cipherId =>
         {
+            if (IsCreatingPasskey)
+            {
+                Context.ConfirmNewCredentialTcs.TrySetResult((cipherId, true));
+                return;
+            }
+
             LoginListController?.DismissModal();
             LoginSearchController?.DismissModal();
         };
+
+        public override void ViewDidLoad()
+        {
+            IsCreatingPasskey = Context.IsCreatingPasskey;
+            if (IsCreatingPasskey)
+            {
+                NameCell.TextField.Text = Context.PasskeyCreationParams?.CredentialName;
+                UsernameCell.TextField.Text = Context.PasskeyCreationParams?.UserName;
+            }
+
+            base.ViewDidLoad();
+        }
 
         partial void CancelBarButton_Activated(UIBarButtonItem sender)
         {
@@ -34,6 +64,39 @@ namespace Bit.iOS.Autofill
         private void Cancel()
         {
             DismissViewController(true, null);
+        }
+
+        protected override async Task EncryptAndSaveAsync(CipherView cipher)
+        {
+            if (!IsCreatingPasskey)
+            {
+                await base.EncryptAndSaveAsync(cipher);
+                return;
+            }
+
+            if (!UIDevice.CurrentDevice.CheckSystemVersion(17, 0))
+            {
+                Context?.ConfirmNewCredentialTcs?.TrySetException(new InvalidOperationException("Trying to save passkey as new login on iOS less than 17."));
+                return;
+            }
+
+            var loadingAlert = Dialogs.CreateLoadingAlert(AppResources.Saving);
+            try
+            {
+                PresentViewController(loadingAlert, true, null);
+
+                var encryptedCipher = await _cipherService.Value.EncryptAsync(cipher);
+                await _cipherService.Value.SaveWithServerAsync(encryptedCipher);
+
+                await loadingAlert.DismissViewControllerAsync(true);
+
+                Success(encryptedCipher.Id);
+            }
+            catch
+            {
+                await loadingAlert.DismissViewControllerAsync(false);
+                throw;
+            }
         }
 
         async partial void SaveBarButton_Activated(UIBarButtonItem sender)

--- a/src/iOS.Autofill/LoginListViewController.cs
+++ b/src/iOS.Autofill/LoginListViewController.cs
@@ -290,7 +290,7 @@ namespace Bit.iOS.Autofill
                         return headerItemView;
                     }
 
-                    return new UIView(CGRect.Empty);// base.GetViewForHeader(tableView, section);
+                    return new UIView(CGRect.Empty);
                 }
                 catch (Exception ex)
                 {

--- a/src/iOS.Autofill/Models/Context.cs
+++ b/src/iOS.Autofill/Models/Context.cs
@@ -15,7 +15,9 @@ namespace Bit.iOS.Autofill.Models
         public ASPasswordCredentialIdentity PasswordCredentialIdentity { get; set; }
         public ASPasskeyCredentialRequest PasskeyCredentialRequest { get; set; }
         public bool Configuring { get; set; }
+
         public bool IsCreatingPasskey { get; set; }
+        public Fido2ConfirmNewCredentialParams? PasskeyCreationParams { get; set; }
         public TaskCompletionSource<bool> UnlockVaultTcs { get; set; }
         public TaskCompletionSource<(string CipherId, bool UserVerified)> ConfirmNewCredentialTcs { get; set; }
 


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Add Passkey creation logic to "Add login item" flow on iOS Autofill.
This includes autofilling fields on "Add login item" view and saving the new Passkey login item appropriately.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **Fido2MakeCredentailUserInterface:** Added params to the context so we can autofill the values on the "Add login item" view.
* **LoginAddViewController:** Added logic to autofill values with the ones in the context params and also to encrypt and save the new passkey login item.
* **LoginAddViewController (base):** Added new logic for when a passkey is being created and refactor a bit the methods so they can be overridden with passkey specific logic on the iOS Autofill add view controller.

## Screenshots
<!--Required for any UI changes. Delete if not applicable-->

### Add login Passkey creation flow.
<img width="314" alt="Add login Passkey creation flow" src="https://github.com/bitwarden/mobile/assets/15682323/28dfb635-467b-4734-aac3-c603c053bf6c">


## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
