### PR TITLE
WIP implementation for the app unlock flow when called from Passkey

### DIFF
--- a/src/App/Platforms/Android/Autofill/CredentialProviderConstants.cs
+++ b/src/App/Platforms/Android/Autofill/CredentialProviderConstants.cs
@@ -2,6 +2,7 @@
 {
     public class CredentialProviderConstants
     {
+        public const string PasskeyFramework = "passkeyFramework";
         public const string CredentialProviderCipherId = "credentialProviderCipherId";
         public const string CredentialDataIntentExtra = "CREDENTIAL_DATA";
         public const string CredentialIdIntentExtra = "credId";

--- a/src/App/Platforms/Android/MainActivity.cs
+++ b/src/App/Platforms/Android/MainActivity.cs
@@ -331,6 +331,7 @@ namespace Bit.Droid
                 MyVaultTile = Intent.GetBooleanExtra("myVaultTile", false),
                 GeneratorTile = Intent.GetBooleanExtra("generatorTile", false),
                 FromAutofillFramework = Intent.GetBooleanExtra(AutofillConstants.AutofillFramework, false),
+                FromPasskeyFramework = Intent.GetBooleanExtra(CredentialProviderConstants.PasskeyFramework, false),
                 CreateSend = GetCreateSendRequest(Intent)
             };
             var fillType = Intent.GetIntExtra(AutofillConstants.AutofillFrameworkFillType, 0);

--- a/src/Core/Abstractions/IDeviceActionService.cs
+++ b/src/Core/Abstractions/IDeviceActionService.cs
@@ -40,6 +40,7 @@ namespace Bit.App.Abstractions
         void OpenCredentialProviderSettings();
         void OpenAutofillSettings();
         long GetActiveTime();
+        Task ReturnToPasskeyAfterUnlock();
         void CloseMainApp();
         float GetSystemFontSizeScale();
         Task OnAccountSwitchCompleteAsync();

--- a/src/Core/App.xaml.cs
+++ b/src/Core/App.xaml.cs
@@ -104,6 +104,7 @@ namespace Bit.App
                 Options.MyVaultTile = appOptions.MyVaultTile;
                 Options.GeneratorTile = appOptions.GeneratorTile;
                 Options.FromAutofillFramework = appOptions.FromAutofillFramework;
+                Options.FromPasskeyFramework = appOptions.FromPasskeyFramework;
                 Options.CreateSend = appOptions.CreateSend;
             }
         }
@@ -120,8 +121,17 @@ namespace Bit.App
                 return new Window(new NavigationPage()); //No actual page needed. Only used for auto-filling the fields directly (externally)
             }
 
+            //When executing from CredentialProviderSelectionActivity we don't have "Options" so we need to filter "manually"
+            //In the CredentialProviderSelectionActivity we don't need to show any Page, so we just create a "dummy" Window with a NavigationPage to avoid crashing.
+            if (activationState != null 
+                && activationState.State.ContainsKey("CREDENTIAL_DATA")
+                && activationState.State.ContainsKey("credentialProviderCipherId"))
+            {
+                return new Window(new NavigationPage()); //No actual page needed. Only used for auto-filling the fields directly (externally)
+            }
+
             //"Internal" Autofill and Uri/Otp/CreateSend. This is where we create the autofill specific Window
-            if (Options != null && (Options.FromAutofillFramework || Options.Uri != null || Options.OtpData != null || Options.CreateSend != null))
+            if (Options != null && (Options.FromAutofillFramework || Options.Uri != null || Options.OtpData != null || Options.CreateSend != null || Options.FromPasskeyFramework))
             {
                 _isResumed = true; //Specifically for the Autofill scenario we need to manually set the _isResumed here
                 _hasNavigatedToAutofillWindow = true;

--- a/src/Core/Models/AppOptions.cs
+++ b/src/Core/Models/AppOptions.cs
@@ -9,6 +9,7 @@ namespace Bit.App.Models
         public bool MyVaultTile { get; set; }
         public bool GeneratorTile { get; set; }
         public bool FromAutofillFramework { get; set; }
+        public bool FromPasskeyFramework { get; set; }
         public CipherType? FillType { get; set; }
         public string Uri { get; set; }
         public CipherType? SaveType { get; set; }

--- a/src/Core/Utilities/AppHelpers.cs
+++ b/src/Core/Utilities/AppHelpers.cs
@@ -434,6 +434,13 @@ namespace Bit.App.Utilities
                     App.MainPage = new NavigationPage(new CipherAddEditPage(appOptions: appOptions));
                     return true;
                 }
+                if (appOptions.FromPasskeyFramework)
+                {
+                    appOptions.FromPasskeyFramework = false;
+                    var deviceActionService = Bit.Core.Utilities.ServiceContainer.Resolve<IDeviceActionService>();
+                    deviceActionService.ReturnToPasskeyAfterUnlock().FireAndForget();
+                    return true;
+                }
                 if (appOptions.Uri != null
                     ||
                     appOptions.OtpData != null)


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
- Implement Unlock flow when launched from Passkey
- Make sure Window workarounds on Android work

## Code changes
- WIP implementation for the app unlock flow when called from Passkey.
- Also added a new Window workaround in App.xaml.cs to allow CredentialProviderSelectionActivity to launch separately.

## TODO
- Organize code in DeviceActionService.cs into some place where it can be shared with CredentialProviderService

## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
