### PR TITLE
[PM-6301] Fix for pending login view breaks after closing one request

### DIFF
--- a/src/Core/Pages/Settings/LoginPasswordlessRequestsListViewModel.cs
+++ b/src/Core/Pages/Settings/LoginPasswordlessRequestsListViewModel.cs
@@ -66,7 +66,6 @@ namespace Bit.App.Pages
         {
             try
             {
-                IsRefreshing = true;
                 LoginRequests.ReplaceRange(await _authService.GetActivePasswordlessLoginRequestsAsync());
             }
             catch (Exception ex)


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
Currently on iOS there are still Layout issues related with the RefreshView.
These seem to be caused by the IsRefreshing being set to true on RefreshAsync which the RefreshView seems to use to trigger the RefreshCommand again. This duplicate execution causes layout issues on iOS.

## Code changes
Removing `IsRefreshing=true` fixes the issue. The only worry is that the busy indicator would not appear, but this doesn't seem to be a problem because when doing PullToRefresh the RefreshView changes IsRefreshing and shows the indicator.
For the other situations where we execute RefreshAsync the `LoginPasswordlessRequestsListPage.xaml.cs` takes care of the busy indicator.

* **LoginPasswordlessRequestsListViewModel.cs:** Removed `IsRefreshing=true`

## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
