### PR TITLE
[PM-5912] Fix for some iOS buttons not having the correct height and corner radius

### DIFF
--- a/src/Core/Pages/Accounts/LoginPasswordlessPage.xaml
+++ b/src/Core/Pages/Accounts/LoginPasswordlessPage.xaml
@@ -85,7 +85,6 @@
         <Button
                 Text="{u:I18n DenyLogIn}"
                 Command="{Binding RejectRequestCommand}"
-                StyleClass="btn-secundary"
                 AutomationId="DenyLoginButton" />
 
     </StackLayout>

--- a/src/Core/Resources/Styles/iOS.xaml
+++ b/src/Core/Resources/Styles/iOS.xaml
@@ -143,6 +143,10 @@
                 Value="Medium" />
         <Setter Property="Margin"
                 Value="0, 5, 0, 0" />
+        <Setter Property="CornerRadius"
+                Value="5" />
+        <Setter Property="MinimumHeightRequest"
+                Value="45" />
         <Setter Property="VisualStateManager.VisualStateGroups">
             <VisualStateGroupList>
                 <VisualStateGroup x:Name="CommonStates">
@@ -183,10 +187,6 @@
                 Value="Bold" />
         <Setter Property="Margin"
                 Value="0, 5, 0, 0" />
-        <Setter Property="CornerRadius"
-                Value="5" />
-        <Setter Property="MinimumHeightRequest"
-                Value="45" />
         <Setter Property="VisualStateManager.VisualStateGroups">
             <VisualStateGroupList>
                 <VisualStateGroup x:Name="CommonStates">
@@ -223,8 +223,6 @@
                 Value="{DynamicResource ButtonTextColorOpacity}" />
         <Setter Property="FontSize"
                 Value="Medium" />
-        <Setter Property="CornerRadius"
-                Value="5" />
         <Setter Property="VisualStateManager.VisualStateGroups">
             <VisualStateGroupList>
                 <VisualStateGroup x:Name="CommonStates">


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
Some buttons on iOS don't have the correct Height and Corner Radius

## Code changes
Xamarin Forms doesn't seem to have the same defaults for Buttons than MAUI on iOS.
To fix these issues I added default min height and corner radius for iOS buttons.
Also removed incorrect style class from one button.

* **iOS.xaml:** Added default CornerRadius and MinHeightRequest for iOS Buttons and removed redundant properties from other Button styles that are based from default one.
* **LoginPasswordlessPage.xaml:** Removed incorrect class

## Screenshots
Before             |  After
:-------------------------:|:-------------------------:
<img width="768" alt="Device_Aprove_Before" src="https://github.com/bitwarden/mobile/assets/2824952/c3264a18-f980-4414-b3af-0f8b93879b24">  |  <img width="768" alt="Device_Aprove_After" src="https://github.com/bitwarden/mobile/assets/2824952/dc23ea5a-4ac5-488e-97f8-41f89de91d4c">
<img width="768" alt="Cipher_Add_Edit_Before" src="https://github.com/bitwarden/mobile/assets/2824952/505a07fe-262a-4ab0-abcf-d8068cfdc1e7">  |  <img width="768" alt="Cipher_Add_Edit_After" src="https://github.com/bitwarden/mobile/assets/2824952/b328fc5f-2c30-493c-8116-f63e7289b2b7">


## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
