### PR TITLE
Added ConditionedAwaiter to avoid race condition issue where HomePage navigation would run after the main navigation

### DIFF
--- a/src/Core/Abstractions/IConditionedAwaiterManager.cs
+++ b/src/Core/Abstractions/IConditionedAwaiterManager.cs
@@ -5,7 +5,8 @@ namespace Bit.Core.Abstractions
 {
     public enum AwaiterPrecondition
     {
-        EnvironmentUrlsInited
+        EnvironmentUrlsInited,
+        AndroidWindowCreated
     }
 
     public interface IConditionedAwaiterManager

--- a/src/Core/Pages/Accounts/HomePage.xaml.cs
+++ b/src/Core/Pages/Accounts/HomePage.xaml.cs
@@ -12,12 +12,14 @@ namespace Bit.App.Pages
         private readonly HomeViewModel _vm;
         private readonly AppOptions _appOptions;
         private IBroadcasterService _broadcasterService;
+        private IConditionedAwaiterManager _conditionedAwaiterManager;
 
         readonly LazyResolve<ILogger> _logger = new LazyResolve<ILogger>();
 
         public HomePage(AppOptions appOptions = null)
         {
             _broadcasterService = ServiceContainer.Resolve<IBroadcasterService>();
+            _conditionedAwaiterManager = ServiceContainer.Resolve<IConditionedAwaiterManager>();
             _appOptions = appOptions;
             InitializeComponent();
             _vm = BindingContext as HomeViewModel;
@@ -56,6 +58,8 @@ namespace Bit.App.Pages
                 PerformNavigationOnAccountChangedOnLoad = false;
                 accountsManager.NavigateOnAccountChangeAsync().FireAndForget();
             }
+
+            _conditionedAwaiterManager.SetAsCompleted(AwaiterPrecondition.AndroidWindowCreated);
 #endif
         }
 

--- a/src/Core/Pages/AndroidNavigationRedirectPage.xaml.cs
+++ b/src/Core/Pages/AndroidNavigationRedirectPage.xaml.cs
@@ -1,4 +1,5 @@
 ﻿using Bit.App.Abstractions;
+using Bit.Core.Abstractions;
 using Bit.Core.Utilities;
 
 namespace Bit.Core.Pages;
@@ -6,15 +7,18 @@ namespace Bit.Core.Pages;
 public partial class AndroidNavigationRedirectPage : ContentPage
 {
     private readonly IAccountsManager _accountsManager;
+    private readonly IConditionedAwaiterManager _conditionedAwaiterManager;
 
 	public AndroidNavigationRedirectPage()
     {
         _accountsManager = ServiceContainer.Resolve<IAccountsManager>("accountsManager");
+        _conditionedAwaiterManager = ServiceContainer.Resolve<IConditionedAwaiterManager>();
 		InitializeComponent();
 	}
 
     private void AndroidNavigationRedirectPage_OnLoaded(object sender, EventArgs e)
     {
         _accountsManager.NavigateOnAccountChangeAsync().FireAndForget();
+        _conditionedAwaiterManager.SetAsCompleted(AwaiterPrecondition.AndroidWindowCreated);
     }
 }

--- a/src/Core/Services/ConditionedAwaiterManager.cs
+++ b/src/Core/Services/ConditionedAwaiterManager.cs
@@ -10,7 +10,8 @@ namespace Bit.Core.Services
     {
         private readonly ConcurrentDictionary<AwaiterPrecondition, TaskCompletionSource<bool>> _preconditionsTasks = new ConcurrentDictionary<AwaiterPrecondition, TaskCompletionSource<bool>>
         {
-            [AwaiterPrecondition.EnvironmentUrlsInited] = new TaskCompletionSource<bool>()
+            [AwaiterPrecondition.EnvironmentUrlsInited] = new TaskCompletionSource<bool>(),
+            [AwaiterPrecondition.AndroidWindowCreated] = new TaskCompletionSource<bool>()
         };
 
         public Task GetAwaiterForPrecondition(AwaiterPrecondition awaiterPrecondition)

--- a/src/Core/Utilities/AccountManagement/AccountsManager.cs
+++ b/src/Core/Utilities/AccountManagement/AccountsManager.cs
@@ -60,7 +60,9 @@ namespace Bit.App.Utilities.AccountManagement
         public async Task StartDefaultNavigationFlowAsync(Action<AppOptions> appOptionsAction)
         {
             await _conditionedAwaiterManager.GetAwaiterForPrecondition(AwaiterPrecondition.EnvironmentUrlsInited);
-
+#if ANDROID
+            await _conditionedAwaiterManager.GetAwaiterForPrecondition(AwaiterPrecondition.AndroidWindowCreated);
+#endif
             appOptionsAction(Options);
 
             await NavigateOnAccountChangeAsync();
@@ -69,6 +71,9 @@ namespace Bit.App.Utilities.AccountManagement
         public async Task NavigateOnAccountChangeAsync(bool? isAuthed = null)
         {
             await _conditionedAwaiterManager.GetAwaiterForPrecondition(AwaiterPrecondition.EnvironmentUrlsInited);
+#if ANDROID
+            await _conditionedAwaiterManager.GetAwaiterForPrecondition(AwaiterPrecondition.AndroidWindowCreated);
+#endif
 
             // TODO: this could be improved by doing chain of responsability pattern
             // but for now it may be an overkill, if logic gets more complex consider refactoring it


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
Try to ensure the main navigation always runs after the homepage navigation.

## Code changes
Using the ConditionedAwaiterManager I initially tried using SetCompleted in the Window ctor but that was apparently to early still.
Moved it to HomePage after it "fires" it's own Navigation and that does seem to work.

## Screenshots
<!--Required for any UI changes. Delete if not applicable-->



## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
