### PR TITLE
[PM-6309] Fix for 'Show website icons' option not being respected

### DIFF
--- a/src/Core/Controls/CipherViewCell/BaseCipherViewCell.cs
+++ b/src/Core/Controls/CipherViewCell/BaseCipherViewCell.cs
@@ -53,12 +53,13 @@ namespace Bit.App.Controls
             if (BindingContext is CipherItemViewModel cipherItemVM)
             {
                 cipherItemVM.IconImageSuccesfullyLoaded = true;
+
+                MainThread.BeginInvokeOnMainThread(() =>
+                {
+                    Icon.IsVisible = cipherItemVM.ShowIconImage;
+                    IconPlaceholder.IsVisible = !cipherItemVM.ShowIconImage;
+                });
             }
-            MainThread.BeginInvokeOnMainThread(() =>
-            {
-                Icon.IsVisible = true;
-                IconPlaceholder.IsVisible = false;
-            });
         }
 
         public void Icon_Error(object sender, FFImageLoading.Maui.CachedImageEvents.ErrorEventArgs e)


### PR DESCRIPTION
… 

## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
'Show website icons' option is not being respected.

## Code changes
The issue seems to be caused by the `Icon_Success` setting Icon to visible after loading it without taking into account the current WebsiteIcons setting.

* **BaseCipherViewCell.cs:** Updated `Icon_Success` method to take into account the current WebsiteIcons setting.

## Screenshots
<!--Required for any UI changes. Delete if not applicable-->



## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
