### PR TITLE
[PM-5917] Fix for send arrow now being touch sensitive to expand collapse

### DIFF
--- a/src/Core/Pages/Send/SendAddEditPage.xaml
+++ b/src/Core/Pages/Send/SendAddEditPage.xaml
@@ -267,7 +267,7 @@
                             <controls:IconButton
                                 x:Name="_btnOptionsUp"
                                 InputTransparent="True"
-                                MinimumWidthRequest="20"
+                                MinimumWidthRequest="25"
                                 Text="{Binding Source={x:Static core:BitwardenIcons.ChevronUp}}"
                                 StyleClass="box-row-button"
                                 TextColor="{DynamicResource PrimaryColor}"
@@ -277,7 +277,7 @@
                             <controls:IconButton
                                 x:Name="_btnOptionsDown"
                                 InputTransparent="True"
-                                MinimumWidthRequest="20"
+                                MinimumWidthRequest="25"
                                 Text="{Binding Source={x:Static core:BitwardenIcons.AngleDown}}"
                                 StyleClass="box-row-button"
                                 TextColor="{DynamicResource PrimaryColor}"


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
Touching the arrow icon itself doesn't trigger the expand/collapse command likely because the icon button is handling/ignoring the even and it doesn't propagate to the TapGestureRecognizer.

## Code changes
Set the icon buttons to be InputTransparent.
Also took the chance to add the Min Width to ensure the arrow isn't right next to the label on iOS. (so it's looking like the Xamarin Forms app)

* **SendAddEditPage.xaml:** Added `InputTransparent="True"` and `MinimumWidthRequest="25"`
## Screenshots
Before             |  After
:-------------------------:|:-------------------------:
<img width="1024" alt="iOS Before" src="https://github.com/bitwarden/mobile/assets/2824952/d9197eaf-2f61-439c-ab9c-5f2efe155a8b"> | <img width="1024" alt="iOS After" src="https://github.com/bitwarden/mobile/assets/2824952/cacb3bb3-5b72-4858-b487-06922d28520b">

## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
