### PR TITLE
[PM-6513] Omit creating CredentialIdentity if it throws an exception

### DIFF
--- a/src/iOS.Core/Utilities/ASHelpers.cs
+++ b/src/iOS.Core/Utilities/ASHelpers.cs
@@ -2,6 +2,7 @@
 using Bit.Core.Abstractions;
 using Bit.Core.Enums;
 using Bit.Core.Models.View;
+using Bit.Core.Services;
 using Bit.Core.Utilities;
 using Foundation;
 using UIKit;
@@ -135,21 +136,29 @@ namespace Bit.iOS.Core.Utilities
 
         public static IASCredentialIdentity? ToCredentialIdentity(CipherView cipher)
         {
-            if (!cipher.HasFido2Credential)
+            try
             {
-                return ToPasswordCredentialIdentity(cipher);
-            }
+                if (!cipher.HasFido2Credential)
+                {
+                    return ToPasswordCredentialIdentity(cipher);
+                }
 
-            if (!cipher.Login.MainFido2Credential.DiscoverableValue)
+                if (!cipher.Login.MainFido2Credential.DiscoverableValue)
+                {
+                    return null;
+                }
+
+                return new ASPasskeyCredentialIdentity(cipher.Login.MainFido2Credential.RpId,
+                    cipher.Login.MainFido2Credential.UserName,
+                    NSData.FromArray(cipher.Login.MainFido2Credential.CredentialId.GuidToRawFormat()),
+                    cipher.Login.MainFido2Credential.UserHandle,
+                    cipher.Id);
+            }
+            catch (Exception ex)
             {
+                LoggerHelper.LogEvenIfCantBeResolved(ex);
                 return null;
             }
-
-            return new ASPasskeyCredentialIdentity(cipher.Login.MainFido2Credential.RpId,
-                cipher.Login.MainFido2Credential.UserName,
-                NSData.FromArray(cipher.Login.MainFido2Credential.CredentialId.GuidToRawFormat()),
-                cipher.Login.MainFido2Credential.UserHandle,
-                cipher.Id);
         }
     }
 }

--- a/src/iOS.Core/Utilities/ASHelpers.cs
+++ b/src/iOS.Core/Utilities/ASHelpers.cs
@@ -148,8 +148,19 @@ namespace Bit.iOS.Core.Utilities
                     return null;
                 }
 
+                var userName = cipher.Login.MainFido2Credential.UserName;
+                if (string.IsNullOrWhiteSpace(userName))
+                {
+                    userName = cipher.Login.MainFido2Credential.UserDisplayName;
+
+                    if (string.IsNullOrWhiteSpace(userName))
+                    {
+                        userName = cipher.Login.Username;
+                    }
+                }
+
                 return new ASPasskeyCredentialIdentity(cipher.Login.MainFido2Credential.RpId,
-                    cipher.Login.MainFido2Credential.UserName,
+                    userName,
                     NSData.FromArray(cipher.Login.MainFido2Credential.CredentialId.GuidToRawFormat()),
                     cipher.Login.MainFido2Credential.UserHandle,
                     cipher.Id);


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Omit creating CredentialIdentity if it throws an exception. E.g. if a Passkey doesn't have a UserName it will throw and it shouldn't break replacing all the other identities.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **ASHelpers:** Added a try...catch when creating the `CredentialIdentity` which returns `null` if an exception happens so it's ignored when registering all identities and it doesn't break it.


## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
