### PR TITLE
[PM-5916] Fix for incorrect fonts in fingerprint phrases

### DIFF
--- a/src/Core/Pages/Accounts/LoginPasswordlessPage.xaml
+++ b/src/Core/Pages/Accounts/LoginPasswordlessPage.xaml
@@ -39,7 +39,7 @@
                     FontSize="Small"
                     FontAttributes="Bold"/>
                 <controls:MonoLabel
-                    FormattedText="{Binding LoginRequest.FingerprintPhrase}"
+                    Text="{Binding LoginRequest.FingerprintPhrase}"
                     FontSize="Medium"
                     TextColor="{DynamicResource FingerprintPhrase}"
                     Margin="0,0,0,27"

--- a/src/Core/Pages/Accounts/LoginPasswordlessRequestPage.xaml
+++ b/src/Core/Pages/Accounts/LoginPasswordlessRequestPage.xaml
@@ -41,7 +41,7 @@
                 FontSize="Small"
                 FontAttributes="Bold" />
             <controls:MonoLabel
-                FormattedText="{Binding FingerprintPhrase}"
+                Text="{Binding FingerprintPhrase}"
                 FontSize="Small"
                 TextColor="{DynamicResource FingerprintPhrase}"
                 AutomationId="FingerprintPhraseValue" />

--- a/src/Core/Pages/Settings/LoginPasswordlessRequestsListPage.xaml
+++ b/src/Core/Pages/Settings/LoginPasswordlessRequestsListPage.xaml
@@ -39,7 +39,7 @@
                             FontSize="Small"
                             FontAttributes="Bold"/>
                         <controls:MonoLabel
-                            FormattedText="{Binding FingerprintPhrase}"
+                            Text="{Binding FingerprintPhrase}"
                             Grid.Row="1"
                             Grid.ColumnSpan="2"
                             FontSize="Small"


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
Fingerprint phrases are being shown with the incorrect font

## Code changes
The correct font is set for MonoLabel but apparently they are not set when using FormattedText.
Changing to Text instead fixes the issue. (FormattedText doesn't really seem to be needed in this scenario)
I applied this to other MonoLabel in the app that had the same issue.

* **LoginPasswordlessPage.xaml:** Changed `FormattedText` to `Text`
* **LoginPasswordlessRequestPage.xaml:** Changed `FormattedText` to `Text`
* **LoginPasswordlessRequestsListPage.xaml:** Changed `FormattedText` to `Text`

## Screenshots
Before             |  After
:-------------------------:|:-------------------------:
 ![Before](https://github.com/bitwarden/mobile/assets/2824952/f4530f16-cf8a-4bf2-807b-04a63290f035) | ![After](https://github.com/bitwarden/mobile/assets/2824952/8a1ca494-99e0-4b7f-b980-eb48acd76ec9)

## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
