### PR TITLE
[PM-6552] Fix for App only showing Home (Login) Page after closed after opening Accessibility Settings

### DIFF
--- a/src/Core/App.xaml.cs
+++ b/src/Core/App.xaml.cs
@@ -108,6 +108,8 @@ namespace Bit.App
             }
         }
 
+        public bool HasNavigatedToAccessibilitySettings { get; set; }
+
         protected override Window CreateWindow(IActivationState activationState)
         {
             //When executing from AutofillExternalActivity we don't have "Options" so we need to filter "manually"
@@ -144,6 +146,18 @@ namespace Bit.App
                 // and it performs it directly.
                 _isResumed = true; 
                 _hasNavigatedToAutofillWindow = false;
+            }
+
+            // WORKAROUND: This workaround is similar to the one above (_hasNavigatedToAutofillWindow) related with Accessibility Services but this one specifically
+            // is due to trying to open the Accessibility Settings Page for enabled/disabling
+            if(HasNavigatedToAccessibilitySettings)
+            {
+                homePage.PerformNavigationOnAccountChangedOnLoad = true;
+                // this is needed because when coming back from AutofillWindow OnResume won't be called and we need this flag
+                // so that void Navigate(NavigationTarget navTarget, INavigationParams navParams) doesn't enqueue the navigation
+                // and it performs it directly.
+                _isResumed = true; 
+                HasNavigatedToAccessibilitySettings = false;
             }
 
             //If we have an existing MainAppWindow we can use that one

--- a/src/Core/Pages/Settings/AutofillSettingsPageViewModel.android.cs
+++ b/src/Core/Pages/Settings/AutofillSettingsPageViewModel.android.cs
@@ -158,6 +158,11 @@ namespace Bit.App.Pages
                 await MainThread.InvokeOnMainThreadAsync(() => TriggerPropertyChanged(nameof(UseAccessibility)));
                 return;
             }
+
+#if ANDROID
+            // WORKAROUND: Set workaround property to avoid an issue when launching the app after being in Accessibility Settings. More Info on App.xaml.cs
+            ((App)Application.Current).HasNavigatedToAccessibilitySettings = true;
+#endif
             _deviceActionService.OpenAccessibilitySettings();
         }
 


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
The app is showing the Home Login page when we open the Accessibility Settings on Android from the App and then close the bitwarden app.
This is due to the Accessibility Service being kept alive (and therefore `App.xaml.cs`). When we open the app again it doesn't try to Navigate to the proper page because of that.
We need to have the app navigate normally even in these scenarios.

## Code changes
A workaround similar to the existing one for Autofill can be implemented. It's done separately with a different variable so that the app can handle edge cases where both are needed simultaneously. 

* **App.xaml.cs:** Added a workaround block similar to the existing one for Autofill. This will basically allow executing Navigations if `HasNavigatedToAccessibilitySettings` is set to true.
* **AutofillSettingsPageViewModel.android.cs:** This is where we set the `HasNavigatedToAccessibilitySettings` to true so that the next time CreateWindow executes it can set the app to also execute Navigation afterward. Also added `#if ANDROID` to avoid compile time error.

## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
