### PR TITLE
[PM-6726] Fix for Android 14 devices crashing when using the Tiles

### DIFF
--- a/src/App/Platforms/Android/Autofill/AutofillHelpers.cs
+++ b/src/App/Platforms/Android/Autofill/AutofillHelpers.cs
@@ -347,7 +347,7 @@ namespace Bit.Droid.Autofill
                 // InlinePresentation requires nonNull pending intent (even though we only utilize one for the
                 // "my vault" presentation) so we're including an empty one here
                 pendingIntent = PendingIntent.GetService(context, 0, new Intent(),
-                    AndroidHelpers.AddPendingIntentMutabilityFlag(PendingIntentFlags.OneShot | PendingIntentFlags.UpdateCurrent, true));
+                    AndroidHelpers.AddPendingIntentMutabilityFlag(PendingIntentFlags.OneShot | PendingIntentFlags.UpdateCurrent, false));
             }
             var slice = CreateInlinePresentationSlice(
                 inlinePresentationSpec,

--- a/src/App/Platforms/Android/Tiles/AutofillTileService.cs
+++ b/src/App/Platforms/Android/Tiles/AutofillTileService.cs
@@ -77,7 +77,7 @@ namespace Bit.Droid.Tile
             var intent = new Intent(this, typeof(AccessibilityActivity));
             intent.SetFlags(ActivityFlags.NewTask | ActivityFlags.SingleTop | ActivityFlags.ClearTop);
             intent.PutExtra("autofillTileClicked", true);
-            intent.StartActivityAndCollapseFromTileService(this, isMutable: true);
+            this.StartActivityAndCollapseWithIntent(intent, isMutable: true);
         }
 
         private void ShowConfigErrorDialog()

--- a/src/App/Platforms/Android/Tiles/AutofillTileService.cs
+++ b/src/App/Platforms/Android/Tiles/AutofillTileService.cs
@@ -1,6 +1,7 @@
 ﻿using Android;
 using Android.App;
 using Android.Content;
+using Android.OS;
 using Android.Runtime;
 using Android.Service.QuickSettings;
 using Bit.Core.Resources.Localization;
@@ -76,7 +77,24 @@ namespace Bit.Droid.Tile
             var intent = new Intent(this, typeof(AccessibilityActivity));
             intent.SetFlags(ActivityFlags.NewTask | ActivityFlags.SingleTop | ActivityFlags.ClearTop);
             intent.PutExtra("autofillTileClicked", true);
-            StartActivityAndCollapse(intent);
+
+            //For Android 14+ We need to use PendingIntent instead of Intent directly. Older versions still need to use Intent.
+            if (Build.VERSION.SdkInt >= BuildVersionCodes.UpsideDownCake)
+            {
+                var pendingIntent = PendingIntent.GetActivity(
+                    ApplicationContext,
+                    0,
+                    intent,
+                    PendingIntentFlags.Mutable | PendingIntentFlags.UpdateCurrent
+                );
+                if (pendingIntent == null) { return; }
+
+                StartActivityAndCollapse(pendingIntent);
+            }
+            else
+            {
+                StartActivityAndCollapse(intent);
+            }
         }
 
         private void ShowConfigErrorDialog()

--- a/src/App/Platforms/Android/Tiles/AutofillTileService.cs
+++ b/src/App/Platforms/Android/Tiles/AutofillTileService.cs
@@ -1,7 +1,6 @@
 ﻿using Android;
 using Android.App;
 using Android.Content;
-using Android.OS;
 using Android.Runtime;
 using Android.Service.QuickSettings;
 using Bit.Core.Resources.Localization;
@@ -9,6 +8,7 @@ using Bit.Core.Abstractions;
 using Bit.Core.Utilities;
 using Bit.Droid.Accessibility;
 using Java.Lang;
+using Bit.App.Droid.Utilities;
 
 namespace Bit.Droid.Tile
 {
@@ -77,24 +77,7 @@ namespace Bit.Droid.Tile
             var intent = new Intent(this, typeof(AccessibilityActivity));
             intent.SetFlags(ActivityFlags.NewTask | ActivityFlags.SingleTop | ActivityFlags.ClearTop);
             intent.PutExtra("autofillTileClicked", true);
-
-            //For Android 14+ We need to use PendingIntent instead of Intent directly. Older versions still need to use Intent.
-            if (Build.VERSION.SdkInt >= BuildVersionCodes.UpsideDownCake)
-            {
-                var pendingIntent = PendingIntent.GetActivity(
-                    ApplicationContext,
-                    0,
-                    intent,
-                    PendingIntentFlags.Mutable | PendingIntentFlags.UpdateCurrent
-                );
-                if (pendingIntent == null) { return; }
-
-                StartActivityAndCollapse(pendingIntent);
-            }
-            else
-            {
-                StartActivityAndCollapse(intent);
-            }
+            intent.StartActivityAndCollapseFromTileService(this, isMutable: true);
         }
 
         private void ShowConfigErrorDialog()

--- a/src/App/Platforms/Android/Tiles/GeneratorTileService.cs
+++ b/src/App/Platforms/Android/Tiles/GeneratorTileService.cs
@@ -1,15 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
-using Android.App;
+﻿using Android.App;
 using Android.Content;
 using Android.OS;
 using Android.Runtime;
 using Android.Service.QuickSettings;
-using Android.Views;
-using Android.Widget;
 using Java.Lang;
 
 namespace Bit.Droid.Tile
@@ -62,7 +55,24 @@ namespace Bit.Droid.Tile
             var intent = new Intent(this, typeof(MainActivity));
             intent.SetFlags(ActivityFlags.NewTask | ActivityFlags.SingleTop | ActivityFlags.ClearTop);
             intent.PutExtra("generatorTile", true);
-            StartActivityAndCollapse(intent);
+
+            //For Android 14+ We need to use PendingIntent instead of Intent directly. Older versions still need to use Intent.
+            if (Build.VERSION.SdkInt >= BuildVersionCodes.UpsideDownCake)
+            {
+                var pendingIntent = PendingIntent.GetActivity(
+                    ApplicationContext,
+                    0,
+                    intent,
+                    PendingIntentFlags.Immutable | PendingIntentFlags.UpdateCurrent
+                );
+                if (pendingIntent == null) { return; }
+
+                StartActivityAndCollapse(pendingIntent);
+            }
+            else
+            {
+                StartActivityAndCollapse(intent);
+            }
         }
     }
 }

--- a/src/App/Platforms/Android/Tiles/GeneratorTileService.cs
+++ b/src/App/Platforms/Android/Tiles/GeneratorTileService.cs
@@ -55,7 +55,7 @@ namespace Bit.Droid.Tile
             var intent = new Intent(this, typeof(MainActivity));
             intent.SetFlags(ActivityFlags.NewTask | ActivityFlags.SingleTop | ActivityFlags.ClearTop);
             intent.PutExtra("generatorTile", true);
-            intent.StartActivityAndCollapseFromTileService(this, isMutable: false);
+            this.StartActivityAndCollapseWithIntent(intent, isMutable: false);
         }
     }
 }

--- a/src/App/Platforms/Android/Tiles/GeneratorTileService.cs
+++ b/src/App/Platforms/Android/Tiles/GeneratorTileService.cs
@@ -1,8 +1,8 @@
 ﻿using Android.App;
 using Android.Content;
-using Android.OS;
 using Android.Runtime;
 using Android.Service.QuickSettings;
+using Bit.App.Droid.Utilities;
 using Java.Lang;
 
 namespace Bit.Droid.Tile
@@ -55,24 +55,7 @@ namespace Bit.Droid.Tile
             var intent = new Intent(this, typeof(MainActivity));
             intent.SetFlags(ActivityFlags.NewTask | ActivityFlags.SingleTop | ActivityFlags.ClearTop);
             intent.PutExtra("generatorTile", true);
-
-            //For Android 14+ We need to use PendingIntent instead of Intent directly. Older versions still need to use Intent.
-            if (Build.VERSION.SdkInt >= BuildVersionCodes.UpsideDownCake)
-            {
-                var pendingIntent = PendingIntent.GetActivity(
-                    ApplicationContext,
-                    0,
-                    intent,
-                    PendingIntentFlags.Immutable | PendingIntentFlags.UpdateCurrent
-                );
-                if (pendingIntent == null) { return; }
-
-                StartActivityAndCollapse(pendingIntent);
-            }
-            else
-            {
-                StartActivityAndCollapse(intent);
-            }
+            intent.StartActivityAndCollapseFromTileService(this, isMutable: false);
         }
     }
 }

--- a/src/App/Platforms/Android/Tiles/MyVaultTileService.cs
+++ b/src/App/Platforms/Android/Tiles/MyVaultTileService.cs
@@ -56,7 +56,7 @@ namespace Bit.Droid.Tile
             var intent = new Intent(this, typeof(MainActivity));
             intent.SetFlags(ActivityFlags.NewTask | ActivityFlags.SingleTop | ActivityFlags.ClearTop);
             intent.PutExtra("myVaultTile", true);
-            intent.StartActivityAndCollapseFromTileService(this, isMutable: false);
+            this.StartActivityAndCollapseWithIntent(intent, isMutable: false);
         }
     }
 }

--- a/src/App/Platforms/Android/Tiles/MyVaultTileService.cs
+++ b/src/App/Platforms/Android/Tiles/MyVaultTileService.cs
@@ -1,15 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
-using Android.App;
+﻿using Android.App;
 using Android.Content;
 using Android.OS;
 using Android.Runtime;
 using Android.Service.QuickSettings;
-using Android.Views;
-using Android.Widget;
 using Java.Lang;
 
 namespace Bit.Droid.Tile
@@ -63,7 +56,24 @@ namespace Bit.Droid.Tile
             var intent = new Intent(this, typeof(MainActivity));
             intent.SetFlags(ActivityFlags.NewTask | ActivityFlags.SingleTop | ActivityFlags.ClearTop);
             intent.PutExtra("myVaultTile", true);
-            StartActivityAndCollapse(intent);
+
+            //For Android 14+ We need to use PendingIntent instead of Intent directly. Older versions still need to use Intent.
+            if (Build.VERSION.SdkInt >= BuildVersionCodes.UpsideDownCake)
+            {
+                var pendingIntent = PendingIntent.GetActivity(
+                    ApplicationContext,
+                    0,
+                    intent,
+                    PendingIntentFlags.Immutable | PendingIntentFlags.UpdateCurrent
+                );
+                if (pendingIntent == null) { return; }
+
+                StartActivityAndCollapse(pendingIntent);
+            }
+            else
+            {
+                StartActivityAndCollapse(intent);
+            }
         }
     }
 }

--- a/src/App/Platforms/Android/Tiles/MyVaultTileService.cs
+++ b/src/App/Platforms/Android/Tiles/MyVaultTileService.cs
@@ -1,8 +1,8 @@
 ﻿using Android.App;
 using Android.Content;
-using Android.OS;
 using Android.Runtime;
 using Android.Service.QuickSettings;
+using Bit.App.Droid.Utilities;
 using Java.Lang;
 
 namespace Bit.Droid.Tile
@@ -56,24 +56,7 @@ namespace Bit.Droid.Tile
             var intent = new Intent(this, typeof(MainActivity));
             intent.SetFlags(ActivityFlags.NewTask | ActivityFlags.SingleTop | ActivityFlags.ClearTop);
             intent.PutExtra("myVaultTile", true);
-
-            //For Android 14+ We need to use PendingIntent instead of Intent directly. Older versions still need to use Intent.
-            if (Build.VERSION.SdkInt >= BuildVersionCodes.UpsideDownCake)
-            {
-                var pendingIntent = PendingIntent.GetActivity(
-                    ApplicationContext,
-                    0,
-                    intent,
-                    PendingIntentFlags.Immutable | PendingIntentFlags.UpdateCurrent
-                );
-                if (pendingIntent == null) { return; }
-
-                StartActivityAndCollapse(pendingIntent);
-            }
-            else
-            {
-                StartActivityAndCollapse(intent);
-            }
+            intent.StartActivityAndCollapseFromTileService(this, isMutable: false);
         }
     }
 }

--- a/src/App/Platforms/Android/Utilities/AndroidHelpers.cs
+++ b/src/App/Platforms/Android/Utilities/AndroidHelpers.cs
@@ -2,6 +2,7 @@
 using Android.Content;
 using Android.OS;
 using Android.Provider;
+using Android.Service.QuickSettings;
 using Bit.App.Utilities;
 
 namespace Bit.App.Droid.Utilities
@@ -63,6 +64,27 @@ namespace Bit.App.Droid.Utilities
             }
 
             return pendingIntentFlags;
+        }
+
+        public static void StartActivityAndCollapseFromTileService(this Intent intent, TileService service, bool isMutable = false)
+        {
+            //For Android 14+ We need to use PendingIntent instead of Intent directly. Older versions still need to use Intent.
+            if (Build.VERSION.SdkInt >= BuildVersionCodes.UpsideDownCake)
+            {
+                var pendingIntent = PendingIntent.GetActivity(
+                    service.ApplicationContext,
+                    0,
+                    intent,
+                    AddPendingIntentMutabilityFlag(PendingIntentFlags.UpdateCurrent, isMutable)
+                );
+                if (pendingIntent == null) { return; }
+
+                service.StartActivityAndCollapse(pendingIntent);
+            }
+            else
+            {
+                service.StartActivityAndCollapse(intent);
+            }
         }
     }
 }

--- a/src/App/Platforms/Android/Utilities/AndroidHelpers.cs
+++ b/src/App/Platforms/Android/Utilities/AndroidHelpers.cs
@@ -66,25 +66,25 @@ namespace Bit.App.Droid.Utilities
             return pendingIntentFlags;
         }
 
-        public static void StartActivityAndCollapseFromTileService(this Intent intent, TileService service, bool isMutable = false)
+        public static void StartActivityAndCollapseFromTileService(this TileService service, Intent intent, bool isMutable)
         {
             //For Android 14+ We need to use PendingIntent instead of Intent directly. Older versions still need to use Intent.
-            if (Build.VERSION.SdkInt >= BuildVersionCodes.UpsideDownCake)
-            {
-                var pendingIntent = PendingIntent.GetActivity(
-                    service.ApplicationContext,
-                    0,
-                    intent,
-                    AddPendingIntentMutabilityFlag(PendingIntentFlags.UpdateCurrent, isMutable)
-                );
-                if (pendingIntent == null) { return; }
-
-                service.StartActivityAndCollapse(pendingIntent);
-            }
-            else
+            if (Build.VERSION.SdkInt < BuildVersionCodes.UpsideDownCake)
             {
                 service.StartActivityAndCollapse(intent);
+                return;
             }
+            var pendingIntent = PendingIntent.GetActivity(
+                service.ApplicationContext,
+                0,
+                intent,
+                AddPendingIntentMutabilityFlag(PendingIntentFlags.UpdateCurrent, isMutable)
+            );
+            if (pendingIntent == null) 
+            { 
+                return; 
+            }
+            service.StartActivityAndCollapse(pendingIntent);
         }
     }
 }

--- a/src/App/Platforms/Android/Utilities/AndroidHelpers.cs
+++ b/src/App/Platforms/Android/Utilities/AndroidHelpers.cs
@@ -66,7 +66,7 @@ namespace Bit.App.Droid.Utilities
             return pendingIntentFlags;
         }
 
-        public static void StartActivityAndCollapseFromTileService(this TileService service, Intent intent, bool isMutable)
+        public static void StartActivityAndCollapseWithIntent(this TileService service, Intent intent, bool isMutable)
         {
             //For Android 14+ We need to use PendingIntent instead of Intent directly. Older versions still need to use Intent.
             if (Build.VERSION.SdkInt < BuildVersionCodes.UpsideDownCake)


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
When using Android Tiles on Android 14+ the TileService crashes.

## Code changes
Android now requires that TileServices using `PendingIntent` instead of Intent for `StartActivityAndCollapse()`
Doing this change avoids the crash. We still keep the "old" Intent code for older versions of Android.

There was also a background crash on AccessibilityService due to a PendingIntent being mutable which also seems to no longer being allowed in Android14 for that specific scenario.

* **AutofillTileService.cs:** Added if scenario for Android 14 to use `PendingIntent` instead of `Intent`.
* **MyVaultTileService.cs:** Added if scenario for Android 14 to use `PendingIntent` instead of `Intent`
* **GeneratorTileService.cs:** Added if scenario for Android 14 to use `PendingIntent` instead of `Intent`
* **AutofillHelpers.cs:** Changed InlinePresentationBuilder PendingItent to be Immutable to avoid crash in Android 14

## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
