### PR TITLE
[PM-6751]Added missing query intent for CustomTabs that might be responsible for the Exception in WebAuthenticator

### DIFF
--- a/src/App/Platforms/Android/AndroidManifest.xml
+++ b/src/App/Platforms/Android/AndroidManifest.xml
@@ -43,6 +43,9 @@
 	<!-- Support for Xamarin.Essentials.Browser.OpenAsync  (for Android > 11) -->
 	<!-- Related docs: https://learn.microsoft.com/en-us/xamarin/essentials/open-browser?tabs=android -->
 	<queries>
+        <intent>
+            <action android:name="android.support.customtabs.action.CustomTabsService" />
+        </intent>
 		<intent>
 			<action android:name="android.intent.action.VIEW" />
 			<data android:scheme="http" />

--- a/src/App/Platforms/Android/AndroidManifest.xml
+++ b/src/App/Platforms/Android/AndroidManifest.xml
@@ -43,8 +43,8 @@
 	<!-- Support for Xamarin.Essentials.Browser.OpenAsync  (for Android > 11) -->
 	<!-- Related docs: https://learn.microsoft.com/en-us/xamarin/essentials/open-browser?tabs=android -->
 	<queries>
-        <intent>
-            <action android:name="android.support.customtabs.action.CustomTabsService" />
+		<intent>
+			<action android:name="android.support.customtabs.action.CustomTabsService" />
 		</intent>
 		<intent>
 			<action android:name="android.intent.action.VIEW" />

--- a/src/App/Platforms/Android/AndroidManifest.xml
+++ b/src/App/Platforms/Android/AndroidManifest.xml
@@ -45,7 +45,7 @@
 	<queries>
         <intent>
             <action android:name="android.support.customtabs.action.CustomTabsService" />
-        </intent>
+		</intent>
 		<intent>
 			<action android:name="android.intent.action.VIEW" />
 			<data android:scheme="http" />


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
There's a `NullPointerException` ocurring in `WebAuthenticatorIntermediateActivity`.
This is likely related with `WebAuthenticatorCallbackActivity` in Android.
As explained in the [Microsoft Docs](https://learn.microsoft.com/en-us/dotnet/maui/platform-integration/communication/authentication?view=net-maui-8.0&tabs=android) when   using this WebAuthenticator on Android we need to add the appropriate query.
This might be the cause of the bug.

```
<queries>
    <intent>
        <action android:name="android.support.customtabs.action.CustomTabsService" />
    </intent>
</queries>
```

## Code changes
Added the query intent for CustomTabs as it might fix the exception that is occurring in Android WebAuthenticator.

* **AndroidManifest.xml:** Added the query

## Screenshots
<!--Required for any UI changes. Delete if not applicable-->



## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
