### PR TITLE
[PM-6685] Fix fingerprint verification on unlocked accounts because of race condition

### DIFF
--- a/src/Core/Abstractions/IConditionedAwaiterManager.cs
+++ b/src/Core/Abstractions/IConditionedAwaiterManager.cs
@@ -1,12 +1,10 @@
-﻿using System;
-using System.Threading.Tasks;
-
-namespace Bit.Core.Abstractions
+﻿namespace Bit.Core.Abstractions
 {
     public enum AwaiterPrecondition
     {
         EnvironmentUrlsInited,
-        AndroidWindowCreated
+        AndroidWindowCreated,
+        AutofillIOSExtensionViewDidAppear
     }
 
     public interface IConditionedAwaiterManager
@@ -14,5 +12,6 @@ namespace Bit.Core.Abstractions
         Task GetAwaiterForPrecondition(AwaiterPrecondition awaiterPrecondition);
         void SetAsCompleted(AwaiterPrecondition awaiterPrecondition);
         void SetException(AwaiterPrecondition awaiterPrecondition, Exception ex);
+        void Recreate(AwaiterPrecondition awaiterPrecondition);
     }
 }

--- a/src/Core/Resources/Localization/AppResources.Designer.cs
+++ b/src/Core/Resources/Localization/AppResources.Designer.cs
@@ -7677,6 +7677,15 @@ namespace Bit.Core.Resources.Localization {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Verifying identity....
+        /// </summary>
+        public static string VerifyingIdentityEllipsis {
+            get {
+                return ResourceManager.GetString("VerifyingIdentityEllipsis", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Verify master password.
         /// </summary>
         public static string VerifyMasterPassword {

--- a/src/Core/Resources/Localization/AppResources.resx
+++ b/src/Core/Resources/Localization/AppResources.resx
@@ -2936,4 +2936,7 @@ Do you want to switch to this account?</value>
     <value>There was a problem reading your passkey for {0}. Try again later.</value>
     <comment>The parameter is the RpId</comment>
   </data>
+  <data name="VerifyingIdentityEllipsis" xml:space="preserve">
+    <value>Verifying identity...</value>
+  </data>
 </root>

--- a/src/Core/Services/ConditionedAwaiterManager.cs
+++ b/src/Core/Services/ConditionedAwaiterManager.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Concurrent;
-using System.Collections.Generic;
-using System.Threading.Tasks;
+﻿using System.Collections.Concurrent;
 using Bit.Core.Abstractions;
 
 namespace Bit.Core.Services
@@ -11,7 +8,8 @@ namespace Bit.Core.Services
         private readonly ConcurrentDictionary<AwaiterPrecondition, TaskCompletionSource<bool>> _preconditionsTasks = new ConcurrentDictionary<AwaiterPrecondition, TaskCompletionSource<bool>>
         {
             [AwaiterPrecondition.EnvironmentUrlsInited] = new TaskCompletionSource<bool>(),
-            [AwaiterPrecondition.AndroidWindowCreated] = new TaskCompletionSource<bool>()
+            [AwaiterPrecondition.AndroidWindowCreated] = new TaskCompletionSource<bool>(),
+            [AwaiterPrecondition.AutofillIOSExtensionViewDidAppear] = new TaskCompletionSource<bool>()
         };
 
         public Task GetAwaiterForPrecondition(AwaiterPrecondition awaiterPrecondition)
@@ -37,6 +35,16 @@ namespace Bit.Core.Services
             if (_preconditionsTasks.TryGetValue(awaiterPrecondition, out var tcs))
             {
                 tcs.TrySetException(ex);
+            }
+        }
+
+        public void Recreate(AwaiterPrecondition awaiterPrecondition)
+        {
+            if (_preconditionsTasks.TryRemove(awaiterPrecondition, out var oldTcs))
+            {
+                oldTcs.TrySetCanceled();
+
+                _preconditionsTasks.TryAdd(awaiterPrecondition, new TaskCompletionSource<bool>());
             }
         }
     }

--- a/src/Core/Services/UserVerification/Fido2UserVerificationPreferredServiceStrategy.cs
+++ b/src/Core/Services/UserVerification/Fido2UserVerificationPreferredServiceStrategy.cs
@@ -19,7 +19,10 @@ namespace Bit.Core.Services.UserVerification
                 return true;
             }
 
-            options.OnNeedUI?.Invoke();
+            if (options.OnNeedUITask != null)
+            {
+                await options.OnNeedUITask();
+            }
 
             var (canPerformOSUnlock, isOSUnlocked) = await _userVerificationMediatorService.PerformOSUnlockAsync();
             if (canPerformOSUnlock)

--- a/src/Core/Services/UserVerification/Fido2UserVerificationRequiredServiceStrategy.cs
+++ b/src/Core/Services/UserVerification/Fido2UserVerificationRequiredServiceStrategy.cs
@@ -23,7 +23,10 @@ namespace Bit.Core.Services.UserVerification
                 return true;
             }
 
-            options.OnNeedUI?.Invoke();
+            if (options.OnNeedUITask != null)
+            {
+                await options.OnNeedUITask();
+            }
 
             var (canPerformOSUnlock, isOSUnlocked) = await _userVerificationMediatorService.PerformOSUnlockAsync();
             if (canPerformOSUnlock)

--- a/src/Core/Services/UserVerification/UserVerificationMediatorService.cs
+++ b/src/Core/Services/UserVerification/UserVerificationMediatorService.cs
@@ -39,7 +39,11 @@ namespace Bit.Core.Services.UserVerification
         {
             if (await ShouldPerformMasterPasswordRepromptAsync(options))
             {
-                options.OnNeedUI?.Invoke();
+                if (options.OnNeedUITask != null)
+                {
+                    await options.OnNeedUITask();
+                }
+
                 return await _passwordRepromptService.PromptAndCheckPasswordIfNeededAsync(Enums.CipherRepromptType.Password);
             }
 

--- a/src/Core/Utilities/Fido2/Fido2UserVerificationOptions.cs
+++ b/src/Core/Utilities/Fido2/Fido2UserVerificationOptions.cs
@@ -6,19 +6,19 @@
             Fido2UserVerificationPreference userVerificationPreference,
             bool hasVaultBeenUnlockedInTransaction,
             string rpId = null,
-            Action onNeedUI = null)
+            Func<Task> onNeedUITask = null)
         {
             ShouldCheckMasterPasswordReprompt = shouldCheckMasterPasswordReprompt;
             UserVerificationPreference = userVerificationPreference;
             HasVaultBeenUnlockedInTransaction = hasVaultBeenUnlockedInTransaction;
             RpId = rpId;
-            OnNeedUI = onNeedUI;
+            OnNeedUITask = onNeedUITask;
         }
 
         public bool ShouldCheckMasterPasswordReprompt { get; }
         public Fido2UserVerificationPreference UserVerificationPreference { get; }
         public bool HasVaultBeenUnlockedInTransaction { get; }
         public string RpId { get; }
-        public Action OnNeedUI { get; }
+        public Func<Task> OnNeedUITask { get; }
     }
 }

--- a/src/iOS.Autofill/CredentialProviderViewController.Passkeys.cs
+++ b/src/iOS.Autofill/CredentialProviderViewController.Passkeys.cs
@@ -252,13 +252,21 @@ namespace Bit.iOS.Autofill
                         userVerificationPreference,
                         _context.VaultUnlockedDuringThisSession,
                         _context.PasskeyCredentialIdentity?.RelyingPartyIdentifier,
-                        () =>
+                        async () =>
                         {
                             if (_context.IsExecutingWithoutUserInteraction)
                             {
                                 CancelRequest(ASExtensionErrorCode.UserInteractionRequired);
                                 throw new InvalidOperationNeedsUIException();
                             }
+
+                            // HACK: [PM-6685] There are some devices that end up with a race condition when doing biometrics authentication
+                            // that the check is trying to be done before the iOS extension UI is shown, which cause the bio check to fail.
+                            // So a workaround is to show a toast which force the iOS extension UI to be shown and then awaiting for the
+                            // precondition that the view did appear before continuing with the verification.
+                            _platformUtilsService.Value.ShowToast(null, null, AppResources.VerifyingIdentityEllipsis);
+
+                            await _conditionedAwaiterManager.Value.GetAwaiterForPrecondition(AwaiterPrecondition.AutofillIOSExtensionViewDidAppear);
                         })
                     );
             }

--- a/src/iOS.Autofill/CredentialProviderViewController.cs
+++ b/src/iOS.Autofill/CredentialProviderViewController.cs
@@ -32,6 +32,7 @@ namespace Bit.iOS.Autofill
         private IAccountsManager _accountsManager;
 
         private readonly LazyResolve<IStateService> _stateService = new LazyResolve<IStateService>();
+        private readonly LazyResolve<IConditionedAwaiterManager> _conditionedAwaiterManager = new LazyResolve<IConditionedAwaiterManager>();
 
         public CredentialProviderViewController(IntPtr handle)
             : base(handle)
@@ -56,11 +57,20 @@ namespace Bit.iOS.Autofill
                 {
                     ExtContext = ExtensionContext
                 };
+
+                _conditionedAwaiterManager.Value.Recreate(AwaiterPrecondition.AutofillIOSExtensionViewDidAppear);
             }
             catch (Exception ex)
             {
                 OnProvidingCredentialException(ex);
             }
+        }
+
+        public override void ViewDidAppear(bool animated)
+        {
+            base.ViewDidAppear(animated);
+
+            _conditionedAwaiterManager.Value.SetAsCompleted(AwaiterPrecondition.AutofillIOSExtensionViewDidAppear);
         }
 
         public override async void PrepareCredentialList(ASCredentialServiceIdentifier[] serviceIdentifiers)


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Fix fingerprint verification on unlocked accounts because of race condition

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **CredentialProviderViewController.Passkeys:** Added a hack here to wait until `ViewDidAppear` happens using the `ConditionedAwaiterManager` for `OnNeedUITask` callback of user verification in order to have the UI displayed before trying to perform the biometrics check. In order for this to happen I've added a toast to be shown which forces the UI to be presented, was the easiest way I could come up to actually show the UI and trigger `ViewDidAppear`.
* **Fido2UserVerificationOptions:** Changed `OnNeedUITask` to be async.

## Screenshots
<!--Required for any UI changes. Delete if not applicable-->

https://github.com/bitwarden/mobile/assets/15682323/7df9dd22-98d0-4c90-833b-7c9ec11e497d



## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
