### PR TITLE
Added spaced card nubmer to the card view

### DIFF
--- a/src/Core/Models/View/CardView.cs
+++ b/src/Core/Models/View/CardView.cs
@@ -21,6 +21,19 @@ namespace Bit.Core.Models.View
         public string Code { get; set; }
         public string MaskedCode => Code != null ? new string('•', Code.Length) : null;
         public string MaskedNumber => Number != null ? new string('•', Number.Length) : null;
+        public string SpacedNumber {
+            get {
+                if (Number == null) return null;
+                var sb = new StringBuilder();
+                for (int i = 0; i < Number.Length; i++) {
+                    sb.Append(Number[i]);
+                    if ((i + 1) % 4 == 0 && i + 1 < Number.Length) {
+                        sb.Append(" ");
+                    }
+                }
+                return sb.ToString();
+            }
+        }
 
         public string Brand
         {

--- a/src/Core/Pages/Vault/CipherDetailsPage.xaml
+++ b/src/Core/Pages/Vault/CipherDetailsPage.xaml
@@ -313,7 +313,7 @@
                                     IsVisible="{Binding ShowCardNumber, Converter={StaticResource inverseBool}}"
                                     AutomationId="ItemValue" />
                                 <controls:MonoLabel
-                                    Text="{Binding Cipher.Card.Number, Mode=OneWay}"
+                                    Text="{Binding Cipher.Card.SpacedNumber, Mode=OneWay}"
                                     StyleClass="box-value"
                                     Grid.Row="1"
                                     Grid.Column="0"


### PR DESCRIPTION
## Type of change
- [✅] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
The card number in bitwarden mobile is not spaced in the mobile view. This pull request fixes the view such that the number is spaced in splits of 4.



## Code changes
A new property in the CardView named SpacedNumber was added that adds a space in every 4 digits from the "CardView.Number"

