### PR TITLE
[PM-6852 ] Fix F-Droid build constant

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -363,15 +363,14 @@ jobs:
 
       - name: Clean for F-Droid
         run: |
-          $appPath = $($env:GITHUB_WORKSPACE + "/${{ env.main_app_project_path }}");
-          $corePath = $($env:GITHUB_WORKSPACE + "/src/Core/Core.csproj");
+          $directoryBuildProps = $($env:GITHUB_WORKSPACE + "/Directory.Build.props");
 
           $androidManifest = $($env:GITHUB_WORKSPACE + "/${{ env.android_manifest_path }}");
 
           Write-Output "##### Back up project files"
 
           Copy-Item $androidManifest $($androidManifest + ".original");
-          Copy-Item $appPath $($appPath + ".original");
+          Copy-Item $directoryBuildProps $($directoryBuildProps + ".original");
 
           Write-Output "##### Cleanup Android Manifest"
 
@@ -382,6 +381,10 @@ jobs:
           $nsAndroid.AddNamespace("android", "http://schemas.android.com/apk/res/android");
 
           $xml.Save($androidManifest);
+
+          Write-Output "##### Enabling FDROID constant"
+
+          (Get-Content $directoryBuildProps).Replace('<!-- <CustomConstants>FDROID</CustomConstants> -->', '<CustomConstants>FDROID</CustomConstants>') | Set-Content $directoryBuildProps
 
       - name: Restore packages
         run: dotnet restore
@@ -401,8 +404,7 @@ jobs:
             /p:AndroidSigningKeyStore=$signingFdroidKeyStore `
             /p:AndroidSigningKeyAlias=bitwarden `
             /p:AndroidSigningKeyPass="$($env:FDROID_KEYSTORE_PASSWORD)" `
-            /p:AndroidSigningStorePass="$($env:FDROID_KEYSTORE_PASSWORD)" `
-            /p:CustomConstants="FDROID" --no-restore
+            /p:AndroidSigningStorePass="$($env:FDROID_KEYSTORE_PASSWORD)" ` --no-restore
 
           Write-Output "##### Copy FDroid apk to project root"
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -396,12 +396,12 @@ jobs:
           Write-Output "##### Sign FDroid"
 
           $signingFdroidKeyStore = "$($env:GITHUB_WORKSPACE)\${{ env.android_folder_path }}\app_fdroid-keystore.jks"
-          dotnet build $projToBuild -c Release -f ${{ env.target-net-version }}-android `
-            /p:AndroidKeyStore=true `
-            /p:AndroidSigningKeyStore=$signingFdroidKeyStore `
-            /p:AndroidSigningKeyAlias=bitwarden `
-            /p:AndroidSigningKeyPass="$($env:FDROID_KEYSTORE_PASSWORD)" `
-            /p:AndroidSigningStorePass="$($env:FDROID_KEYSTORE_PASSWORD)" `
+          dotnet build $projToBuild -c Release -f ${{ env.target-net-version }}-android \
+            /p:AndroidKeyStore=true \
+            /p:AndroidSigningKeyStore=$signingFdroidKeyStore \
+            /p:AndroidSigningKeyAlias=bitwarden \
+            /p:AndroidSigningKeyPass="$($env:FDROID_KEYSTORE_PASSWORD)" \
+            /p:AndroidSigningStorePass="$($env:FDROID_KEYSTORE_PASSWORD)" \
             /p:CustomConstants="FDROID" --no-restore
 
           Write-Output "##### Copy FDroid apk to project root"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -396,7 +396,7 @@ jobs:
           Write-Output "##### Sign FDroid"
 
           $signingFdroidKeyStore = "$($env:GITHUB_WORKSPACE)\${{ env.android_folder_path }}\app_fdroid-keystore.jks"
-          dotnet publish $projToBuild -c Release -f ${{ env.target-net-version }}-android `
+          dotnet build $projToBuild -c Release -f ${{ env.target-net-version }}-android `
             /p:AndroidKeyStore=true `
             /p:AndroidSigningKeyStore=$signingFdroidKeyStore `
             /p:AndroidSigningKeyAlias=bitwarden `
@@ -406,7 +406,7 @@ jobs:
 
           Write-Output "##### Copy FDroid apk to project root"
 
-          $signedApkPath = "$($env:GITHUB_WORKSPACE)\${{ env.main_app_folder_path }}\bin\Release\${{ env.target-net-version }}-android\publish\$($packageName)-Signed.apk";
+          $signedApkPath = "$($env:GITHUB_WORKSPACE)\${{ env.main_app_folder_path }}\bin\Release\${{ env.target-net-version }}-android\$($packageName)-Signed.apk";
           $signedApkDestPath = "$($env:GITHUB_WORKSPACE)\com.x8bit.bitwarden-fdroid.apk";
 
           Copy-Item $signedApkPath $signedApkDestPath

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -396,12 +396,12 @@ jobs:
           Write-Output "##### Sign FDroid"
 
           $signingFdroidKeyStore = "$($env:GITHUB_WORKSPACE)\${{ env.android_folder_path }}\app_fdroid-keystore.jks"
-          dotnet build $projToBuild -c Release -f ${{ env.target-net-version }}-android \
-            /p:AndroidKeyStore=true \
-            /p:AndroidSigningKeyStore=$signingFdroidKeyStore \
-            /p:AndroidSigningKeyAlias=bitwarden \
-            /p:AndroidSigningKeyPass="$($env:FDROID_KEYSTORE_PASSWORD)" \
-            /p:AndroidSigningStorePass="$($env:FDROID_KEYSTORE_PASSWORD)" \
+          dotnet build $projToBuild -c Release -f ${{ env.target-net-version }}-android `
+            /p:AndroidKeyStore=true `
+            /p:AndroidSigningKeyStore=$signingFdroidKeyStore `
+            /p:AndroidSigningKeyAlias=bitwarden `
+            /p:AndroidSigningKeyPass="$($env:FDROID_KEYSTORE_PASSWORD)" `
+            /p:AndroidSigningStorePass="$($env:FDROID_KEYSTORE_PASSWORD)" `
             /p:CustomConstants="FDROID" --no-restore
 
           Write-Output "##### Copy FDroid apk to project root"

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,5 +9,8 @@
    
    <!-- Uncomment this when Unit Testing-->
    <!-- <CustomConstants>UT</CustomConstants> -->
+
+   <!-- Uncomment this when building FDROID-->
+   <!-- <CustomConstants>FDROID</CustomConstants> -->
  </PropertyGroup>
 </Project>


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Fix CI/CD to for F-Droid build to pass the constant as it's supposed to so AppCenter and Firebase are removed from the final apk.

There seems to be an issue when building for `Release` configuration where the `:/p CustomConstants=FDROID` is not added to the `DefineConstants` or replaced at some point, causing the corresponding packages not to be removed from the build. So the approach was changed by not passing the parameter in the command and enabling the constant in the `Directory.Build.props`

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **Directory.Build.props:** Added a comment for the FDROID custom constant.
* **build.yml:** Enabled FDROID custom constant on the `Directory.Build.props` by replacing the commented line with the uncommented version of it.


## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
