### PR TITLE
[PM-7009] Improved exception messages for the Broadcast Service message callback function

### DIFF
--- a/src/Core/App.xaml.cs
+++ b/src/Core/App.xaml.cs
@@ -284,6 +284,7 @@ namespace Bit.App
                 }
                 else if (message.Command == Constants.ForceSetPassword)
                 {
+                    ArgumentNullException.ThrowIfNull(MainPage);
                     await MainThread.InvokeOnMainThreadAsync(NavigateToSetPasswordPageAction);
                     void NavigateToSetPasswordPageAction()
                     {

--- a/src/Core/App.xaml.cs
+++ b/src/Core/App.xaml.cs
@@ -275,6 +275,7 @@ namespace Bit.App
                 }
                 else if (message.Command == Constants.ForceUpdatePassword)
                 {
+                    ArgumentNullException.ThrowIfNull(MainPage);
                     await MainThread.InvokeOnMainThreadAsync(NavigateToUpdateTempPasswordPageAction);
                     async Task NavigateToUpdateTempPasswordPageAction()
                     {

--- a/src/Core/App.xaml.cs
+++ b/src/Core/App.xaml.cs
@@ -233,6 +233,8 @@ namespace Bit.App
                     {
                         if (MainPage is TabsPage tabsPage)
                         {
+                            ArgumentNullException.ThrowIfNull(tabsPage.Navigation);
+                            ArgumentNullException.ThrowIfNull(tabsPage.Navigation.ModalStack);
                             while (tabsPage.Navigation.ModalStack.Count > 0)
                             {
                                 await tabsPage.Navigation.PopModalAsync(false);

--- a/src/Core/App.xaml.cs
+++ b/src/Core/App.xaml.cs
@@ -258,6 +258,7 @@ namespace Bit.App
                             else if (message.Command == DeepLinkContext.NEW_OTP_MESSAGE)
                             {
                                 tabsPage.ResetToVaultPage();
+                                ArgumentNullException.ThrowIfNull(tabsPage.Navigation);
                                 await tabsPage.Navigation.PushModalAsync(new NavigationPage(new CipherSelectionPage(Options)));
                             }
                         }

--- a/src/Core/App.xaml.cs
+++ b/src/Core/App.xaml.cs
@@ -266,6 +266,7 @@ namespace Bit.App
                 }
                 else if (message.Command == "convertAccountToKeyConnector")
                 {
+                    ArgumentNullException.ThrowIfNull(MainPage);
                     await MainThread.InvokeOnMainThreadAsync(NavigateToRemoveMasterPasswordPageAction);
                     async Task NavigateToRemoveMasterPasswordPageAction()
                     {

--- a/src/Core/App.xaml.cs
+++ b/src/Core/App.xaml.cs
@@ -181,6 +181,9 @@ namespace Bit.App
                 if (message.Command == "showDialog")
                 {
                     var details = message.Data as DialogDetails;
+                    ArgumentNullException.ThrowIfNull(details);
+                    ArgumentNullException.ThrowIfNull(MainPage);
+                    
                     var confirmed = true;
                     var confirmText = string.IsNullOrWhiteSpace(details.ConfirmText) ?
                         AppResources.Ok : details.ConfirmText;

--- a/src/Core/App.xaml.cs
+++ b/src/Core/App.xaml.cs
@@ -177,6 +177,7 @@ namespace Bit.App
         {
            try
            {
+                ArgumentNullException.ThrowIfNull(message);
                 if (message.Command == "showDialog")
                 {
                     var details = message.Data as DialogDetails;


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [ ] New feature development
- [x] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
When exceptions occur inside the lambda for the BroadcastService Callback in `App.xaml.cs` they can be difficult to read or incomplete.
The idea is to try to make them a bit more clear when looking at AppCenter diagnostics.

## Code changes
One potential way to improve them was to change the callback to be a named method instead off a lambda.
Also all the `MainThread` Invoke inside this callback were changed to have local functions instead of lambdas.

As an example a stacktrace that looked like this:
`at Bit.App.App.<>c__DisplayClass28_0.<<-ctor>b__2>d.MoveNext(`
Now looks like this:
`at Bit.App.App.<>c__DisplayClass29_0.<<BroadcastServiceMessageCallbackAsync>g__ExecuteNavigationAction|0>d.MoveNext(`

* **App.xaml.cs:** 

## Screenshots
<!--Required for any UI changes. Delete if not applicable-->



## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
