### PR TITLE
[PM-7010] Fix for Android App crashing when launching app with invalid package name

### DIFF
--- a/src/App/Platforms/Android/Services/DeviceActionService.cs
+++ b/src/App/Platforms/Android/Services/DeviceActionService.cs
@@ -72,17 +72,28 @@ namespace Bit.Droid.Services
 
         public bool LaunchApp(string appName)
         {
-            if ((int)Build.VERSION.SdkInt < 33)
+            try
             {
-                // API 33 required to avoid using wildcard app visibility or dangerous permissions
-                // https://developer.android.com/reference/android/content/pm/PackageManager#getLaunchIntentSenderForPackage(java.lang.String)
+                if ((int)Build.VERSION.SdkInt < 33)
+                {
+                    // API 33 required to avoid using wildcard app visibility or dangerous permissions
+                    // https://developer.android.com/reference/android/content/pm/PackageManager#getLaunchIntentSenderForPackage(java.lang.String)
+                    return false;
+                }
+                var activity = Microsoft.Maui.ApplicationModel.Platform.CurrentActivity;
+                appName = appName.Replace("androidapp://", string.Empty);
+                var launchIntentSender = activity?.PackageManager?.GetLaunchIntentSenderForPackage(appName);
+                launchIntentSender?.SendIntent(activity, Result.Ok, null, null, null);
+                return launchIntentSender != null;
+            }
+            catch (IntentSender.SendIntentException)
+            {
                 return false;
             }
-            var activity = Microsoft.Maui.ApplicationModel.Platform.CurrentActivity;
-            appName = appName.Replace("androidapp://", string.Empty);
-            var launchIntentSender = activity?.PackageManager?.GetLaunchIntentSenderForPackage(appName);
-            launchIntentSender?.SendIntent(activity, Result.Ok, null, null, null);
-            return launchIntentSender != null;
+            catch (Android.Util.AndroidException)
+            {
+                return false;
+            }
         }
 
         public async Task ShowLoadingAsync(string text)


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
Android App is currently crashing when launching a package name that is not found on the device.

## Code changes
Added specific Exception Try Catch to avoid crashing when the package name is not found.
`IntentSender.SendIntentException` is the Exception we get in Debug when trying to launch an invalid package name.
`Android.Util.AndroidException` is an Exception that seems to be reported on AppCenter for the same issue.

* **DeviceActionService:** Added the specific TryCatch

## Screenshots
<!--Required for any UI changes. Delete if not applicable-->



## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
