### PR TITLE
[PM-6848] Improved User verification on passkeys creation

### DIFF
--- a/src/Core/Abstractions/IPlatformUtilsService.cs
+++ b/src/Core/Abstractions/IPlatformUtilsService.cs
@@ -26,7 +26,7 @@ namespace Bit.Core.Abstractions
         bool SupportsDuo();
         Task<bool> SupportsBiometricAsync();
         Task<bool> IsBiometricIntegrityValidAsync(string bioIntegritySrcKey = null);
-        Task<bool> AuthenticateBiometricAsync(string text = null, string fallbackText = null, Action fallback = null, bool logOutOnTooManyAttempts = false, bool allowAlternativeAuthentication = false);
+        Task<bool?> AuthenticateBiometricAsync(string text = null, string fallbackText = null, Action fallback = null, bool logOutOnTooManyAttempts = false, bool allowAlternativeAuthentication = false);
         long GetActiveTime();
     }
 }

--- a/src/Core/Abstractions/IUserVerificationMediatorService.cs
+++ b/src/Core/Abstractions/IUserVerificationMediatorService.cs
@@ -1,14 +1,28 @@
-﻿using Bit.Core.Utilities.Fido2;
+﻿using Bit.Core.Utilities;
+using Bit.Core.Utilities.Fido2;
 
 namespace Bit.Core.Abstractions
 {
     public interface IUserVerificationMediatorService
     {
-        Task<bool> VerifyUserForFido2Async(Fido2UserVerificationOptions options);
+        Task<CancellableResult<bool>> VerifyUserForFido2Async(Fido2UserVerificationOptions options);
         Task<bool> CanPerformUserVerificationPreferredAsync(Fido2UserVerificationOptions options);
         Task<bool> ShouldPerformMasterPasswordRepromptAsync(Fido2UserVerificationOptions options);
-        Task<(bool CanPerfom, bool IsUnlocked)> PerformOSUnlockAsync();
-        Task<(bool canPerformUnlockWithPin, bool pinVerified)> VerifyPinCodeAsync();
-        Task<(bool canPerformUnlockWithMasterPassword, bool mpVerified)> VerifyMasterPasswordAsync(bool isMasterPasswordReprompt);
+        Task<bool> ShouldEnforceFido2RequiredUserVerificationAsync(Fido2UserVerificationOptions options);
+        Task<CancellableResult<UVResult>> PerformOSUnlockAsync();
+        Task<CancellableResult<UVResult>> VerifyPinCodeAsync();
+        Task<CancellableResult<UVResult>> VerifyMasterPasswordAsync(bool isMasterPasswordReprompt);
+
+        public struct UVResult
+        {
+            public UVResult(bool canPerform, bool isVerified)
+            {
+                CanPerform = canPerform;
+                IsVerified = isVerified;
+            }
+
+            public bool CanPerform { get; set; }
+            public bool IsVerified { get; set; }
+        }
     }
 }

--- a/src/Core/Pages/Accounts/LockPageViewModel.cs
+++ b/src/Core/Pages/Accounts/LockPageViewModel.cs
@@ -515,7 +515,7 @@ namespace Bit.App.Pages
                 var success = await _platformUtilsService.AuthenticateBiometricAsync(null,
                     PinEnabled ? AppResources.PIN : AppResources.MasterPassword,
                     () => _secretEntryFocusWeakEventManager.RaiseEvent((int?)null, nameof(FocusSecretEntry)),
-                    !PinEnabled && !HasMasterPassword);
+                    !PinEnabled && !HasMasterPassword) ?? false;
 
                 await _stateService.SetBiometricLockedAsync(!success);
                 if (success)

--- a/src/Core/Pages/Settings/SecuritySettingsPageViewModel.cs
+++ b/src/Core/Pages/Settings/SecuritySettingsPageViewModel.cs
@@ -370,7 +370,7 @@ namespace Bit.App.Pages
 
             if (!_supportsBiometric
                 ||
-                !await _platformUtilsService.AuthenticateBiometricAsync(null, DeviceInfo.Platform == DevicePlatform.Android ? "." : null))
+                await _platformUtilsService.AuthenticateBiometricAsync(null, DeviceInfo.Platform == DevicePlatform.Android ? "." : null) != true)
             {
                 _canUnlockWithBiometrics = false;
                 MainThread.BeginInvokeOnMainThread(() => TriggerPropertyChanged(nameof(CanUnlockWithBiometrics)));

--- a/src/Core/Services/Fido2AuthenticatorService.cs
+++ b/src/Core/Services/Fido2AuthenticatorService.cs
@@ -74,7 +74,7 @@ namespace Bit.Core.Services
 
                 if (!userVerified
                 &&
-                await ShouldEnforceRequiredUserVerificationAsync(new Fido2UserVerificationOptions(
+                await _userVerificationMediatorService.ShouldEnforceFido2RequiredUserVerificationAsync(new Fido2UserVerificationOptions(
                     cipher.Reprompt != CipherRepromptType.None,
                     makeCredentialParams.UserVerificationPreference,
                     userInterface.HasVaultBeenUnlockedInThisTransaction)))
@@ -158,7 +158,7 @@ namespace Bit.Core.Services
 
             if (!userVerified
                 &&
-                await ShouldEnforceRequiredUserVerificationAsync(new Fido2UserVerificationOptions(
+                await _userVerificationMediatorService.ShouldEnforceFido2RequiredUserVerificationAsync(new Fido2UserVerificationOptions(
                     selectedCipher.Reprompt != CipherRepromptType.None,
                     assertionParams.UserVerificationPreference,
                     userInterface.HasVaultBeenUnlockedInThisTransaction)))
@@ -456,19 +456,6 @@ namespace Bit.Core.Services
             }
 
             return dsa.SignData(sigBase, HashAlgorithmName.SHA256, DSASignatureFormat.Rfc3279DerSequence);
-        }
-
-        private async Task<bool> ShouldEnforceRequiredUserVerificationAsync(Fido2UserVerificationOptions options)
-        {
-            switch (options.UserVerificationPreference)
-            {
-                case Fido2UserVerificationPreference.Required:
-                    return true;
-                case Fido2UserVerificationPreference.Discouraged:
-                    return await _userVerificationMediatorService.ShouldPerformMasterPasswordRepromptAsync(options);
-                default:
-                    return await _userVerificationMediatorService.CanPerformUserVerificationPreferredAsync(options);
-            }
         }
 
         private class PublicKey

--- a/src/Core/Services/MobilePlatformUtilsService.cs
+++ b/src/Core/Services/MobilePlatformUtilsService.cs
@@ -238,7 +238,7 @@ namespace Bit.App.Services
             return await stateService.IsAccountBiometricIntegrityValidAsync(bioIntegritySrcKey);
         }
 
-        public async Task<bool> AuthenticateBiometricAsync(string text = null, string fallbackText = null,
+        public async Task<bool?> AuthenticateBiometricAsync(string text = null, string fallbackText = null,
             Action fallback = null, bool logOutOnTooManyAttempts = false, bool allowAlternativeAuthentication = false)
         {
             try
@@ -261,6 +261,10 @@ namespace Bit.App.Services
                 if (result.Authenticated)
                 {
                     return true;
+                }
+                if (result.Status == FingerprintAuthenticationResultStatus.Canceled)
+                {
+                    return null;
                 }
                 if (result.Status == FingerprintAuthenticationResultStatus.FallbackRequested)
                 {

--- a/src/Core/Services/UserVerification/IUserVerificationServiceStrategy.cs
+++ b/src/Core/Services/UserVerification/IUserVerificationServiceStrategy.cs
@@ -1,9 +1,10 @@
-﻿using Bit.Core.Utilities.Fido2;
+﻿using Bit.Core.Utilities;
+using Bit.Core.Utilities.Fido2;
 
 namespace Bit.Core.Services.UserVerification
 {
     public interface IUserVerificationServiceStrategy
     {
-        Task<bool> VerifyUserForFido2Async(Fido2UserVerificationOptions options);
+        Task<CancellableResult<bool>> VerifyUserForFido2Async(Fido2UserVerificationOptions options);
     }
 }

--- a/src/Core/Utilities/CancellableResult.cs
+++ b/src/Core/Utilities/CancellableResult.cs
@@ -1,0 +1,15 @@
+﻿namespace Bit.Core.Utilities
+{
+    public readonly struct CancellableResult<T>
+    {
+        public CancellableResult(T result, bool isCancelled = false)
+        {
+            Result = result;
+            IsCancelled = isCancelled;
+        }
+
+        public T Result { get; }
+
+        public bool IsCancelled { get; }
+    }
+}

--- a/src/iOS.Autofill/CredentialProviderViewController.Passkeys.cs
+++ b/src/iOS.Autofill/CredentialProviderViewController.Passkeys.cs
@@ -264,7 +264,7 @@ namespace Bit.iOS.Autofill
                 var encrypted = await _cipherService.Value.GetAsync(selectedCipherId);
                 var cipher = await encrypted.DecryptAsync();
 
-                return await _userVerificationMediatorService.Value.VerifyUserForFido2Async(
+                var cResult = await _userVerificationMediatorService.Value.VerifyUserForFido2Async(
                     new Fido2UserVerificationOptions(
                         cipher?.Reprompt == Bit.Core.Enums.CipherRepromptType.Password,
                         userVerificationPreference,
@@ -285,8 +285,10 @@ namespace Bit.iOS.Autofill
                             _platformUtilsService.Value.ShowToast(null, null, AppResources.VerifyingIdentityEllipsis);
 
                             await _conditionedAwaiterManager.Value.GetAwaiterForPrecondition(AwaiterPrecondition.AutofillIOSExtensionViewDidAppear);
-                        })
-                    );
+                        }
+                    )
+                );
+                return !cResult.IsCancelled && cResult.Result;
             }
             catch (InvalidOperationNeedsUIException)
             {

--- a/src/iOS.Autofill/LoginListViewController.cs
+++ b/src/iOS.Autofill/LoginListViewController.cs
@@ -379,12 +379,22 @@ namespace Bit.iOS.Autofill
             }
         }
 
-        private Fido2UserVerificationOptions Fido2UserVerificationOptions => new Fido2UserVerificationOptions(
-            false,
-            Context.PasskeyCreationParams.Value.UserVerificationPreference,
-            Context.VaultUnlockedDuringThisSession,
-            Context.PasskeyCredentialIdentity?.RelyingPartyIdentifier
-        );
+        private Fido2UserVerificationOptions Fido2UserVerificationOptions
+        {
+            get
+            {
+                ArgumentNullException.ThrowIfNull(Context);
+                ArgumentNullException.ThrowIfNull(Context.PasskeyCreationParams);
+
+                return new Fido2UserVerificationOptions
+                (
+                    false,
+                    Context.PasskeyCreationParams.Value.UserVerificationPreference,
+                    Context.VaultUnlockedDuringThisSession,
+                    Context.PasskeyCredentialIdentity?.RelyingPartyIdentifier
+                );
+            }
+        }
 
         public override void PrepareForSegue(UIStoryboardSegue segue, NSObject sender)
         {

--- a/src/iOS.Core/Controllers/BaseLockPasswordViewController.cs
+++ b/src/iOS.Core/Controllers/BaseLockPasswordViewController.cs
@@ -424,7 +424,7 @@ namespace Bit.iOS.Core.Controllers
                 var success = await _platformUtilsService.AuthenticateBiometricAsync(null,
                     _pinEnabled ? AppResources.PIN : AppResources.MasterPassword,
                     () => MasterPasswordCell.TextField.BecomeFirstResponder(),
-                    !_pinEnabled && !_hasMasterPassword);
+                    !_pinEnabled && !_hasMasterPassword) ?? false;
 
                 await _stateService.SetBiometricLockedAsync(!success);
                 if (success)


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Improved user verification on passkeys creation to better take into account User verification cancellation and also enforcement at the moment of creation.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **MobilePlatformUtilsService:** Now `AuthenticateBiometricAsync` returns `null` when cancelled by the user.
* **UserVerificationMediatorService:** Changed to use `CancellableResult<T>` to tackle cancellation flows.
  * Same applies to its strategies
* **LoginListViewController/LoginAddViewController:** Added cancellation flow so the user can try again and also implemented user verification enforcement at this stage as well to prevent the cipher to be created if the verification fails and is required.


## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
