### PR TITLE
[PM-6844] Fix passkey cipher list empty view label small device

### DIFF
--- a/src/iOS.Autofill/MainInterface.storyboard
+++ b/src/iOS.Autofill/MainInterface.storyboard
@@ -145,7 +145,7 @@
                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="empty_items_state" translatesAutoresizingMaskIntoConstraints="NO" id="FDN-Dp-jl3">
                                         <rect key="frame" x="128.5" y="0.0" width="157" height="110.5"/>
                                     </imageView>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="ThereAreNoItemsInYourVaultForX" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tEp-qe-xvE">
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="749" text="ThereAreNoItemsInYourVaultForX" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tEp-qe-xvE">
                                         <rect key="frame" x="19" y="125.5" width="376" height="20.5"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <color key="textColor" name="LightTextMuted"/>
@@ -224,7 +224,7 @@
                         <viewLayoutGuide key="safeArea" id="BQW-dG-XMM"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
-                            <constraint firstItem="BQW-dG-XMM" firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="wNm-Sy-bJv" secondAttribute="bottom" constant="200" id="42A-4V-UIl"/>
+                            <constraint firstItem="BQW-dG-XMM" firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="wNm-Sy-bJv" secondAttribute="bottom" constant="10" id="42A-4V-UIl"/>
                             <constraint firstItem="Tq0-Ep-tHr" firstAttribute="leading" secondItem="BQW-dG-XMM" secondAttribute="leading" id="4wL-FF-CVk"/>
                             <constraint firstItem="BQW-dG-XMM" firstAttribute="trailing" secondItem="Tq0-Ep-tHr" secondAttribute="trailing" id="5BV-0y-vU1"/>
                             <constraint firstItem="BQW-dG-XMM" firstAttribute="bottom" secondItem="2305" secondAttribute="bottom" id="6EB-rh-lLS"/>


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Fix passkey cipher list empty view label on small devices

## Screenshots
<!--Required for any UI changes. Delete if not applicable-->

### iPhone SE - Passkey cipher list empty view
<img width="314" alt="iPhone SE - Passkey cipher list empty view" src="https://github.com/bitwarden/mobile/assets/15682323/a709409a-6d03-49e5-b1e4-9b9e65c02a9f">


## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
