### PR TITLE
[PM-6798] Fix account switch on autofill

### DIFF
--- a/src/Core/Abstractions/IStateService.cs
+++ b/src/Core/Abstractions/IStateService.cs
@@ -186,6 +186,7 @@ namespace Bit.Core.Abstractions
         Task<BwRegion?> GetActiveUserRegionAsync();
         Task<BwRegion?> GetPreAuthRegionAsync();
         Task SetPreAuthRegionAsync(BwRegion value);
+        Task ReloadStateAsync();
         [Obsolete("Use GetPinKeyEncryptedUserKeyAsync instead, left for migration purposes")]
         Task<string> GetPinProtectedAsync(string userId = null);
         [Obsolete("Use SetPinKeyEncryptedUserKeyAsync instead, left for migration purposes")]

--- a/src/Core/Services/StateService.cs
+++ b/src/Core/Services/StateService.cs
@@ -1688,6 +1688,11 @@ namespace Bit.Core.Services
             await _storageService.SaveAsync(Constants.iOSExtensionActiveUserIdKey, userId);
         }
 
+        public async Task ReloadStateAsync()
+        {
+            _state = await GetStateFromStorageAsync() ?? new State();
+        }
+
         private async Task CheckStateAsync()
         {
             if (!_migrationChecked)
@@ -1699,7 +1704,7 @@ namespace Bit.Core.Services
 
             if (_state == null)
             {
-                _state = await GetStateFromStorageAsync() ?? new State();
+                await ReloadStateAsync();
             }
         }
 

--- a/src/iOS.Autofill/CredentialProviderViewController.Passkeys.cs
+++ b/src/iOS.Autofill/CredentialProviderViewController.Passkeys.cs
@@ -66,6 +66,10 @@ namespace Bit.iOS.Autofill
                 }
 
             }
+            catch (Fido2AuthenticatorException)
+            {
+                CancelRequest(ASExtensionErrorCode.Failed);
+            }
             catch (Exception ex)
             {
                 OnProvidingCredentialException(ex);
@@ -79,7 +83,7 @@ namespace Bit.iOS.Autofill
                 return;
             }
 
-            InitAppIfNeededAsync();
+            await InitAppIfNeededAsync();
 
             if (!await IsAuthed())
             {
@@ -174,7 +178,7 @@ namespace Bit.iOS.Autofill
 
         private async Task ProvideCredentialWithoutUserInteractionAsync(ASPasskeyCredentialRequest passkeyCredentialRequest)
         {
-            InitAppIfNeededAsync();
+            await InitAppIfNeededAsync();
             await _stateService.Value.SetPasswordRepromptAutofillAsync(false);
             await _stateService.Value.SetPasswordVerifiedAutofillAsync(false);
             if (!await IsAuthed() || await IsLocked())

--- a/src/iOS.Autofill/CredentialProviderViewController.Passkeys.cs
+++ b/src/iOS.Autofill/CredentialProviderViewController.Passkeys.cs
@@ -79,7 +79,7 @@ namespace Bit.iOS.Autofill
                 return;
             }
 
-            InitAppIfNeeded();
+            InitAppIfNeededAsync();
 
             if (!await IsAuthed())
             {
@@ -174,7 +174,7 @@ namespace Bit.iOS.Autofill
 
         private async Task ProvideCredentialWithoutUserInteractionAsync(ASPasskeyCredentialRequest passkeyCredentialRequest)
         {
-            InitAppIfNeeded();
+            InitAppIfNeededAsync();
             await _stateService.Value.SetPasswordRepromptAutofillAsync(false);
             await _stateService.Value.SetPasswordVerifiedAutofillAsync(false);
             if (!await IsAuthed() || await IsLocked())

--- a/src/iOS.Autofill/CredentialProviderViewController.cs
+++ b/src/iOS.Autofill/CredentialProviderViewController.cs
@@ -46,7 +46,7 @@ namespace Bit.iOS.Autofill
         {
             try
             {
-                InitAppIfNeeded();
+                InitAppIfNeededAsync();
 
                 base.ViewDidLoad();
 
@@ -77,7 +77,7 @@ namespace Bit.iOS.Autofill
         {
             try
             {
-                InitAppIfNeeded();
+                InitAppIfNeededAsync();
                 _context.ServiceIdentifiers = serviceIdentifiers;
                 if (serviceIdentifiers.Length > 0)
                 {
@@ -209,7 +209,7 @@ namespace Bit.iOS.Autofill
         {
             try
             {
-                InitAppIfNeeded();
+                InitAppIfNeededAsync();
                 _context.Configuring = true;
                 _context.VaultUnlockedDuringThisSession = false;
 
@@ -228,7 +228,7 @@ namespace Bit.iOS.Autofill
         
         private async Task ProvideCredentialWithoutUserInteractionAsync(ASPasswordCredentialIdentity credentialIdentity)
         {
-            InitAppIfNeeded();
+            InitAppIfNeededAsync();
             await _stateService.Value.SetPasswordRepromptAutofillAsync(false);
             await _stateService.Value.SetPasswordVerifiedAutofillAsync(false);
             if (!await IsAuthed() || await IsLocked())
@@ -244,7 +244,7 @@ namespace Bit.iOS.Autofill
 
         private async Task PrepareInterfaceToProvideCredentialAsync(Action<Context> updateContext)
         {
-            InitAppIfNeeded();
+            InitAppIfNeededAsync();
             if (!await IsAuthed())
             {
                 await _accountsManager.NavigateOnAccountChangeAsync(false);
@@ -541,12 +541,14 @@ namespace Bit.iOS.Autofill
                 _nfcSession, out _nfcDelegate, out _accountsManager);
         }
 
-        private void InitAppIfNeeded()
+        private async Task InitAppIfNeededAsync()
         {
             if (ServiceContainer.RegisteredServices == null || ServiceContainer.RegisteredServices.Count == 0)
             {
-                InitApp();
+                await MainThread.InvokeOnMainThreadAsync(InitApp);
             }
+
+            await _stateService.Value.ReloadStateAsync();
         }
 
         private void LaunchHomePage()


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Fix account switching to work correctly on autofill, loading the latest state of the accounts.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **StateService:** Added way to force reloading the state
* **CredentialProviderViewController:** Made `InitAppIfNeededAsync` async to be able to force reloading the state when loading the extension and also on the several callbacks for actions on the extension.
* **Others:** Also, ignored `Fido2AuthenticatorException` from logging them into AppCenter given they don't add any valuable logging if an exception is raised, and if that happens we log the problem in a different part of the code.

## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
