### PR TITLE
[PM-6655] Add null fallback cipher name on passkeys

### DIFF
--- a/src/Core/Models/View/CipherView.cs
+++ b/src/Core/Models/View/CipherView.cs
@@ -1,5 +1,7 @@
 ﻿using Bit.Core.Enums;
 using Bit.Core.Models.Domain;
+using Bit.Core.Resources.Localization;
+using Bit.Core.Utilities;
 
 namespace Bit.Core.Models.View
 {
@@ -119,5 +121,14 @@ namespace Bit.Core.Models.View
         public bool IsClonable => OrganizationId is null;
 
         public bool HasFido2Credential => Type == CipherType.Login && Login?.HasFido2Credentials == true;
+
+        public string GetMainFido2CredentialUsername()
+        {
+            return Login?.MainFido2Credential?.UserName
+                    .FallbackOnNullOrWhiteSpace(Login?.MainFido2Credential?.UserDisplayName)
+                    .FallbackOnNullOrWhiteSpace(Login?.Username)
+                    .FallbackOnNullOrWhiteSpace(Name)
+                    .FallbackOnNullOrWhiteSpace(AppResources.UnknownAccount);
+        }
     }
 }

--- a/src/Core/Models/View/LoginView.cs
+++ b/src/Core/Models/View/LoginView.cs
@@ -1,7 +1,5 @@
 ﻿using Bit.Core.Enums;
 using Bit.Core.Models.Domain;
-using Bit.Core.Resources.Localization;
-using Bit.Core.Utilities;
 
 namespace Bit.Core.Models.View
 {
@@ -37,17 +35,6 @@ namespace Bit.Core.Models.View
                 new KeyValuePair<string, LinkedIdType>("Username", LinkedIdType.Login_Username),
                 new KeyValuePair<string, LinkedIdType>("Password", LinkedIdType.Login_Password),
             };
-        }
-    }
-
-    public static class LoginViewExtensions
-    {
-        public static string GetMainFido2CredentialUsername(this LoginView loginView)
-        {
-            return loginView.MainFido2Credential.UserName
-                    .FallbackOnNullOrWhiteSpace(loginView.MainFido2Credential.UserDisplayName)
-                    .FallbackOnNullOrWhiteSpace(loginView.Username)
-                    .FallbackOnNullOrWhiteSpace(AppResources.UnknownAccount);
         }
     }
 }

--- a/src/iOS.Autofill/Utilities/BaseLoginListTableSource.cs
+++ b/src/iOS.Autofill/Utilities/BaseLoginListTableSource.cs
@@ -111,6 +111,21 @@ namespace Bit.iOS.Autofill.Utilities
             return IsPasskeySection(indexPath.Section) || !item.ForceSectionIcon;
         }
 
+        protected override string GetCipherCellSubtitle(CipherViewModel item, NSIndexPath indexPath)
+        {
+            if (!item.HasFido2Credential)
+            {
+                return base.GetCipherCellSubtitle(item, indexPath);
+            }
+
+            if (Context.IsPreparingListForPasskey && !IsPasskeySection(indexPath.Section))
+            {
+                return item.Username;
+            }
+
+            return item.CipherView?.GetMainFido2CredentialUsername() ?? item.Username;
+        }
+
         public override UIView GetViewForHeader(UITableView tableView, nint section)
         {
             try

--- a/src/iOS.Core/Utilities/ASHelpers.cs
+++ b/src/iOS.Core/Utilities/ASHelpers.cs
@@ -144,13 +144,8 @@ namespace Bit.iOS.Core.Utilities
                     return ToPasswordCredentialIdentity(cipher);
                 }
 
-                if (!cipher.Login.MainFido2Credential.DiscoverableValue)
-                {
-                    return null;
-                }
-
                 return new ASPasskeyCredentialIdentity(cipher.Login.MainFido2Credential.RpId,
-                    cipher.Login.GetMainFido2CredentialUsername(),
+                    cipher.GetMainFido2CredentialUsername(),
                     NSData.FromArray(cipher.Login.MainFido2Credential.CredentialId.GuidToRawFormat()),
                     cipher.Login.MainFido2Credential.UserHandle,
                     cipher.Id);

--- a/src/iOS.Core/Utilities/ASHelpers.cs
+++ b/src/iOS.Core/Utilities/ASHelpers.cs
@@ -144,6 +144,11 @@ namespace Bit.iOS.Core.Utilities
                     return ToPasswordCredentialIdentity(cipher);
                 }
 
+                if (!cipher.Login.MainFido2Credential.DiscoverableValue)
+                {
+                    return null;
+                }
+
                 return new ASPasskeyCredentialIdentity(cipher.Login.MainFido2Credential.RpId,
                     cipher.GetMainFido2CredentialUsername(),
                     NSData.FromArray(cipher.Login.MainFido2Credential.CredentialId.GuidToRawFormat()),

--- a/src/iOS.Core/Views/ExtensionTableSource.cs
+++ b/src/iOS.Core/Views/ExtensionTableSource.cs
@@ -144,7 +144,7 @@ namespace Bit.iOS.Core.Views
                 }
 
                 cipherCell.SetTitle(item.Name);
-                cipherCell.SetSubtitle(item.Username);
+                cipherCell.SetSubtitle(GetCipherCellSubtitle(item, indexPath));
                 cipherCell.UpdateMainIcon(ShouldUseMainIconAsPasskey(item, indexPath));
                 if (item.IsShared)
                 {
@@ -160,6 +160,8 @@ namespace Bit.iOS.Core.Views
         protected virtual int GetIndexForItemAt(UITableView tableView, NSIndexPath indexPath) => indexPath.Row;
 
         protected virtual bool ShouldUseMainIconAsPasskey(CipherViewModel item, NSIndexPath indexPath) => item.HasFido2Credential;
+
+        protected virtual string GetCipherCellSubtitle(CipherViewModel item, NSIndexPath indexPath) => item.Username;
 
         public override nfloat GetHeightForRow(UITableView tableView, NSIndexPath indexPath)
         {


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
If all usernames are null on a cipher item that has passkeys, then `Cipher.Name` should be displayed for username.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **CipherView:** Moved method to get the Username and take into account `Cipher.Name` as a possible fallback.
* **BaseLoginListTableSource:** Take into account username fallbacks for passkey items.


## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
