### PR TITLE
[PM-6538][PM-7185] Remove Non-Discoverable filter for passkeys when setting the credentials on the ASStore

### DIFF
--- a/src/iOS.Core/Utilities/ASHelpers.cs
+++ b/src/iOS.Core/Utilities/ASHelpers.cs
@@ -144,11 +144,6 @@ namespace Bit.iOS.Core.Utilities
                     return ToPasswordCredentialIdentity(cipher);
                 }
 
-                if (!cipher.Login.MainFido2Credential.DiscoverableValue)
-                {
-                    return null;
-                }
-
                 return new ASPasskeyCredentialIdentity(cipher.Login.MainFido2Credential.RpId,
                     cipher.Login.GetMainFido2CredentialUsername(),
                     NSData.FromArray(cipher.Login.MainFido2Credential.CredentialId.GuidToRawFormat()),


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Remove Non-Discoverable filter for passkeys when setting the credentials on the ASStore to see if that fixes some sites not displaying the passkey for quick OS bottom sheet selection.


## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
