### PR TITLE
[PM-6850] Remove duplicate MP-reprompt on passkey selection

### DIFF
--- a/src/iOS.Autofill/Utilities/BaseLoginListTableSource.cs
+++ b/src/iOS.Autofill/Utilities/BaseLoginListTableSource.cs
@@ -302,11 +302,6 @@ namespace Bit.iOS.Autofill.Utilities
                 return;
             }
 
-            if (!await _passwordRepromptService.PromptAndCheckPasswordIfNeededAsync(item.Reprompt))
-            {
-                return;
-            }
-
             Context.PickCredentialForFido2CreationTcs.SetResult((item.Id, null));
         }
 


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Remove duplicate master password reprompt when selecting a cipher for Passkey creation.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **BaseLoginListTableSource:** Remove duplicate master password reprompt when selecting a cipher for Passkey creation.

## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
