### PR TITLE
[PM-6798] Fix account switch on iOS Autofill extension

### DIFF
--- a/src/Core/Services/Logging/ClipLogger.cs
+++ b/src/Core/Services/Logging/ClipLogger.cs
@@ -38,7 +38,7 @@
 //        {
 //            _currentBreadcrumbs.AppendLine($"{DateTime.Now.ToShortTimeString()}: {breadcrumb}");
 //#if IOS
-//            UIPasteboard.General.String = _currentBreadcrumbs.ToString();
+//            MainThread.BeginInvokeOnMainThread(() => UIPasteboard.General.String = _currentBreadcrumbs.ToString());
 //#endif
 //        }
 

--- a/src/Core/Utilities/Fido2/Fido2AuthenticatorException.cs
+++ b/src/Core/Utilities/Fido2/Fido2AuthenticatorException.cs
@@ -34,4 +34,11 @@ namespace Bit.Core.Utilities.Fido2
         {
         }
     }
+
+    public class AccountSwitchedException : Fido2AuthenticatorException
+    {
+        public AccountSwitchedException() : base(nameof(AccountSwitchedException))
+        {
+        }
+    }
 }

--- a/src/iOS.Autofill/Fido2MakeCredentialUserInterface.cs
+++ b/src/iOS.Autofill/Fido2MakeCredentialUserInterface.cs
@@ -31,7 +31,7 @@ namespace Bit.iOS.Autofill
 
         public async Task<(string CipherId, bool UserVerified)> ConfirmNewCredentialAsync(Fido2ConfirmNewCredentialParams confirmNewCredentialParams)
         {
-            _context.PickCredentialForFido2CreationTcs?.SetCanceled();
+            _context.PickCredentialForFido2CreationTcs?.TrySetCanceled();
             _context.PickCredentialForFido2CreationTcs = new TaskCompletionSource<(string, bool?)>();
             _context.PasskeyCreationParams = confirmNewCredentialParams;
 

--- a/src/iOS.Autofill/Utilities/BaseLoginListTableSource.cs
+++ b/src/iOS.Autofill/Utilities/BaseLoginListTableSource.cs
@@ -270,7 +270,7 @@ namespace Bit.iOS.Autofill.Utilities
 
                 if (Context.IsPreparingListForPasskey && item.IsFido2ListItem)
                 {
-                    Context.PickCredentialForFido2GetAssertionFromListTcs.SetResult(item.Id);
+                    Context.PickCredentialForFido2GetAssertionFromListTcs.TrySetResult(item.Id);
                     return;
                 }
 
@@ -307,7 +307,7 @@ namespace Bit.iOS.Autofill.Utilities
                 return;
             }
 
-            Context.PickCredentialForFido2CreationTcs.SetResult((item.Id, null));
+            Context.PickCredentialForFido2CreationTcs.TrySetResult((item.Id, null));
         }
 
         private async Task<CipherViewModel> DeselectRowAndGetItemAsync(UITableView tableView, NSIndexPath indexPath)

--- a/src/iOS.Autofill/Utilities/Fido2GetAssertionFromListUserInterface.cs
+++ b/src/iOS.Autofill/Utilities/Fido2GetAssertionFromListUserInterface.cs
@@ -51,7 +51,7 @@ namespace Bit.iOS.Autofill.Utilities
 
             _onAllowedFido2Credentials?.Invoke(credentials.Select(c => c.CipherId).ToList() ?? new List<string>());
 
-            _context.PickCredentialForFido2GetAssertionFromListTcs?.SetCanceled();
+            _context.PickCredentialForFido2GetAssertionFromListTcs?.TrySetCanceled();
             _context.PickCredentialForFido2GetAssertionFromListTcs = new TaskCompletionSource<string>();
 
             var cipherId = await _context.PickCredentialForFido2GetAssertionFromListTcs.Task;


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Fix account switch on iOS Autofill extension


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **Fido2AuthenticatorService:** Added a do...while for the first part of the flows so if the account is changed an exception is raised and the flow starts over. This was the fastest thing I could come up with to fix this situation.
* **CredentialProviderViewController:** Subscribed to account switched completed to reset and set the `AccountSwitchedException` on the TaskCompletionSources necessary for passkeys. Also improved the code and refactored a bit to be able to reuse some of it in another place.
* **CredentialProviderViewController.Passkeys:** Changed how we ensure vault is unlocked to consider more account states and reuse the navigation on the `CredentialProviderViewController`
* **Ohers:** Some fixes to use `Try...` way for setting state on `TaskCompletionSource`

## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
