### PR TITLE
[PM-7191] Add fallback to showing passwords when trying to request passkey for websites that only support password

### DIFF
--- a/src/iOS.Autofill/LoginListViewController.cs
+++ b/src/iOS.Autofill/LoginListViewController.cs
@@ -96,6 +96,17 @@ namespace Bit.iOS.Autofill
                 TableView.Source = tableSource;
                 tableSource.RegisterTableViewCells(TableView);
 
+                //In some scenarios iOS can send an RPId for which we have no passkeys. In that case we want to be able to fallback to Passwords
+                if (Context.IsPreparingListForPasskey && UIDevice.CurrentDevice.CheckSystemVersion(17, 0))
+                {
+                    var credentials = await _fido2MediatorService.Value.SilentCredentialDiscoveryAsync(Context.PasskeyCredentialRequestParameters.RelyingPartyIdentifier);
+                    if (credentials == null || credentials.Count() == 0)
+                    {
+                        Context.PasskeyCredentialRequestParameters = null;
+                        TableView.SectionHeaderHeight = 0;
+                    }
+                }
+
                 if (Context.IsCreatingOrPreparingListForPasskey)
                 {
                     TableView.SectionHeaderHeight = 55;


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
When the user tries to autofill a webpage and there’s a passkey related error, they’ll see our iOS extension open with an error message. After pressing ok, the activity indicator / loading spinner isn’t removed and search won’t work, preventing users from autofilling other credentials.
We should fallback to passwords in this scenario. This fallback is based on calling **SilentCredentialDiscoveryAsync()**

## Code changes
During initialization we could call SilentCredentialDiscoveryAsync() to check if any passkey exists for the given RPId, if not we configure the UI to show Passwords.

* **LoginListViewController.cs:** 

## Screenshots
<!--Required for any UI changes. Delete if not applicable-->



## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
