### PR TITLE
[PM-7186] Cancel the Extension when an exception occurs

### DIFF
--- a/src/iOS.Autofill/LoginListViewController.cs
+++ b/src/iOS.Autofill/LoginListViewController.cs
@@ -218,6 +218,8 @@ namespace Bit.iOS.Autofill
                         await _platformUtilsService.Value.ShowDialogAsync(
                             string.Format(AppResources.ThereWasAProblemReadingAPasskeyForXTryAgainLater, Context.PasskeyCredentialRequestParameters.RelyingPartyIdentifier),
                             AppResources.ErrorReadingPasskey);
+
+                        Cancel();
                     }
                 }
                 catch (Exception ex)


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
Currently the Autofill Extension can get stuck in a Loading if an exception occurss.
We also suspect there might be other errors causing our extension to get disabled by Apple and/or the ASStore to be deleted.
This is still under investigation.

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **LoginListViewController.cs:** Added Cancel after showing error to user. This way the Extension closes gracefully


## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
