### PR TITLE
[PM-7186] Fallback to password list on exception

### DIFF
--- a/src/iOS.Autofill/LoginListViewController.cs
+++ b/src/iOS.Autofill/LoginListViewController.cs
@@ -215,9 +215,10 @@ namespace Bit.iOS.Autofill
                 {
                     if (Context?.IsExecutingWithoutUserInteraction == false)
                     {
-                        await _platformUtilsService.Value.ShowDialogAsync(
-                            string.Format(AppResources.ThereWasAProblemReadingAPasskeyForXTryAgainLater, Context.PasskeyCredentialRequestParameters.RelyingPartyIdentifier),
-                            AppResources.ErrorReadingPasskey);
+                        TableView.SectionHeaderHeight = 0; 
+                        Context.IsPasswordFallback = true;
+                        await ReloadItemsAsync();
+                        _alreadyLoadItemsOnce = true;
                     }
                 }
                 catch (Exception ex)

--- a/src/iOS.Autofill/LoginListViewController.cs
+++ b/src/iOS.Autofill/LoginListViewController.cs
@@ -215,6 +215,10 @@ namespace Bit.iOS.Autofill
                 {
                     if (Context?.IsExecutingWithoutUserInteraction == false)
                     {
+                        _ = _platformUtilsService.Value.ShowDialogAsync(
+                            string.Format(AppResources.ThereWasAProblemReadingAPasskeyForXTryAgainLater, Context.PasskeyCredentialRequestParameters.RelyingPartyIdentifier),
+                            AppResources.ErrorReadingPasskey);
+
                         TableView.SectionHeaderHeight = 0; 
                         Context.IsPasswordFallback = true;
                         await ReloadItemsAsync();

--- a/src/iOS.Autofill/Models/Context.cs
+++ b/src/iOS.Autofill/Models/Context.cs
@@ -70,7 +70,9 @@ namespace Bit.iOS.Autofill.Models
 
         public bool IsPasskey => PasskeyCredentialRequest != null;
 
-        public bool IsPreparingListForPasskey => PasskeyCredentialRequestParameters != null;
+        public bool IsPasswordFallback { get; set; }
+
+        public bool IsPreparingListForPasskey => PasskeyCredentialRequestParameters != null && !IsPasswordFallback;
 
         public bool IsCreatingOrPreparingListForPasskey => IsCreatingPasskey || IsPreparingListForPasskey;
     }


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
When the user tries to autofill a webpage and there’s a passkey related error, they’ll see our iOS extension open with an error message. After pressing ok, the activity indicator / loading spinner isn’t removed and search won’t work, preventing users from autofilling other credentials.
We should fallback to passwords in this scenario.

## Code changes

* **LoginListViewController.cs:** Added fallback reload scenario
* **Context.cs:** Added new boolean Flag to distinguish the fallback scenario

## Screenshots
<!--Required for any UI changes. Delete if not applicable-->
Fallback Password List if exception occurs.

<img width="1024" alt="Fallback password list" src="https://github.com/bitwarden/mobile/assets/2824952/970e2b91-5260-478e-afd6-41a93c00aa08">

## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
