### PR TITLE
[PM-7186] Remove error message when showing password list as a fallback

### DIFF
--- a/src/iOS.Autofill/LoginListViewController.cs
+++ b/src/iOS.Autofill/LoginListViewController.cs
@@ -215,10 +215,12 @@ namespace Bit.iOS.Autofill
                 {
                     if (Context?.IsExecutingWithoutUserInteraction == false)
                     {
-                        _ = _platformUtilsService.Value.ShowDialogAsync(
-                            string.Format(AppResources.ThereWasAProblemReadingAPasskeyForXTryAgainLater, Context.PasskeyCredentialRequestParameters.RelyingPartyIdentifier),
-                            AppResources.ErrorReadingPasskey);
+                        // Ideally we should inform the user an error has occurred but for the specific scenario where we have user interaction and we can fallback to password list we'll try to do that.
+                        //_ = _platformUtilsService.Value.ShowDialogAsync(
+                        //    string.Format(AppResources.ThereWasAProblemReadingAPasskeyForXTryAgainLater, Context.PasskeyCredentialRequestParameters.RelyingPartyIdentifier),
+                        //    AppResources.ErrorReadingPasskey);
 
+                        //Reset TableView formatting to Password and reload passwords
                         TableView.SectionHeaderHeight = 0; 
                         Context.IsPasswordFallback = true;
                         await ReloadItemsAsync();


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
Remove error message when showing passwords as fallback

## Code changes
Message commented and added some comments to code also.

* **LoginListViewController.cs:**


## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
