### PR TITLE
[PM-7369] Show passkey icon on android when the item has a Fido2 credential

### DIFF
--- a/src/Core/Controls/CipherViewCell/CipherViewCell.xaml
+++ b/src/Core/Controls/CipherViewCell/CipherViewCell.xaml
@@ -50,7 +50,7 @@
         HorizontalOptions="Center"
         VerticalOptions="Center"
         StyleClass="list-icon, list-icon-platform"
-        Text="{Binding Cipher, Converter={StaticResource iconGlyphConverter}}"
+        Text="{Binding ., Converter={StaticResource iconGlyphConverter}}"
         ShouldUpdateFontSizeDynamicallyForAccesibility="True"
         AutomationProperties.IsInAccessibleTree="False"
         AutomationId="CipherTypeIcon" />

--- a/src/Core/Models/View/CipherView.cs
+++ b/src/Core/Models/View/CipherView.cs
@@ -51,7 +51,6 @@ namespace Bit.Core.Models.View
         public DateTime? DeletedDate { get; set; }
         public CipherRepromptType Reprompt { get; set; }
         public CipherKey Key { get; set; }
-        public bool CanShowPasskeyIcon { get; set; }
         
         public ItemView Item
         {

--- a/src/Core/Models/View/CipherView.cs
+++ b/src/Core/Models/View/CipherView.cs
@@ -51,7 +51,8 @@ namespace Bit.Core.Models.View
         public DateTime? DeletedDate { get; set; }
         public CipherRepromptType Reprompt { get; set; }
         public CipherKey Key { get; set; }
-
+        public bool CanShowPasskeyIcon { get; set; }
+        
         public ItemView Item
         {
             get

--- a/src/Core/Pages/Vault/AutofillCiphersPageViewModel.cs
+++ b/src/Core/Pages/Vault/AutofillCiphersPageViewModel.cs
@@ -52,19 +52,10 @@ namespace Bit.App.Pages
             var groupedItems = new List<GroupingsPageListGroup>();
             var ciphers = await _cipherService.GetAllDecryptedByUrlAsync(Uri, null);
 
-            var matching = ciphers.Item1?.Select(c => new CipherItemViewModel(c, WebsiteIconsEnabled)).ToList();
-
-            //Change CipherView to show Passkey icon only for scenarios of creating a new fido credential
-            if (_isAndroidFido2CredentialCreation && matching != null)
+            var matching = ciphers.Item1?.Select(c => new CipherItemViewModel(c, WebsiteIconsEnabled)
             {
-                foreach (var cipher in matching)
-                {
-                    if (cipher?.Cipher != null && cipher.Cipher.HasFido2Credential)
-                    {
-                        cipher.Cipher.CanShowPasskeyIcon = true;
-                    }
-                }
-            }
+                UsePasskeyIconAsPlaceholderFallback = _isAndroidFido2CredentialCreation
+            }).ToList();
 
             var hasMatching = matching?.Any() ?? false;
             if (matching?.Any() ?? false)

--- a/src/Core/Pages/Vault/AutofillCiphersPageViewModel.cs
+++ b/src/Core/Pages/Vault/AutofillCiphersPageViewModel.cs
@@ -53,6 +53,19 @@ namespace Bit.App.Pages
             var ciphers = await _cipherService.GetAllDecryptedByUrlAsync(Uri, null);
 
             var matching = ciphers.Item1?.Select(c => new CipherItemViewModel(c, WebsiteIconsEnabled)).ToList();
+
+            //Change CipherView to show Passkey icon only for scenarios of creating a new fido credential
+            if (_isAndroidFido2CredentialCreation && matching != null)
+            {
+                foreach (var cipher in matching)
+                {
+                    if (cipher?.Cipher != null && cipher.Cipher.HasFido2Credential)
+                    {
+                        cipher.Cipher.CanShowPasskeyIcon = true;
+                    }
+                }
+            }
+
             var hasMatching = matching?.Any() ?? false;
             if (matching?.Any() ?? false)
             {

--- a/src/Core/Pages/Vault/CipherItemViewModel.cs
+++ b/src/Core/Pages/Vault/CipherItemViewModel.cs
@@ -44,5 +44,7 @@ namespace Bit.App.Pages
         /// This is useful to check when the cell is being reused.
         /// </summary>
         public bool IconImageSuccesfullyLoaded { get; set; }
+
+        public bool UsePasskeyIconAsPlaceholderFallback { get; set; }
     }
 }

--- a/src/Core/Utilities/IconGlyphConverter.cs
+++ b/src/Core/Utilities/IconGlyphConverter.cs
@@ -13,7 +13,7 @@ namespace Bit.App.Utilities
         {
             if (value is CipherItemViewModel cipherItemViewModel)
             {
-                return cipherItemViewModel.Cipher.GetIcon(cipherItemViewModel.UsePasskeyIconAsPlaceholderFallback);
+                return cipherItemViewModel.Cipher?.GetIcon(cipherItemViewModel.UsePasskeyIconAsPlaceholderFallback);
             }
 
             if (value is CipherView cipher)

--- a/src/Core/Utilities/IconGlyphConverter.cs
+++ b/src/Core/Utilities/IconGlyphConverter.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Globalization;
+using Bit.App.Pages;
 using Bit.Core.Models.View;
 using Microsoft.Maui.Controls;
 using Microsoft.Maui;
@@ -10,6 +11,11 @@ namespace Bit.App.Utilities
     {
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
+            if (value is CipherItemViewModel cipherItemViewModel)
+            {
+                return cipherItemViewModel.Cipher.GetIcon(cipherItemViewModel.UsePasskeyIconAsPlaceholderFallback);
+            }
+
             if (value is CipherView cipher)
             {
                 return cipher.GetIcon();

--- a/src/Core/Utilities/IconGlyphExtensions.cs
+++ b/src/Core/Utilities/IconGlyphExtensions.cs
@@ -6,12 +6,12 @@ namespace Bit.App.Utilities
 {
     public static class IconGlyphExtensions
     {
-        public static string GetIcon(this CipherView cipher)
+        public static string GetIcon(this CipherView cipher, bool usePasskeyIconAsPlaceholderFallback = false)
         {
             switch (cipher.Type)
             {
                 case CipherType.Login:
-                    return GetLoginIconGlyph(cipher);
+                    return GetLoginIconGlyph(cipher, usePasskeyIconAsPlaceholderFallback);
                 case CipherType.SecureNote:
                     return BitwardenIcons.StickyNote;
                 case CipherType.Card:
@@ -22,9 +22,9 @@ namespace Bit.App.Utilities
             return null;
         }
 
-        static string GetLoginIconGlyph(CipherView cipher)
+        static string GetLoginIconGlyph(CipherView cipher, bool usePasskeyIconAsPlaceholderFallback = false)
         {
-            var icon = cipher.CanShowPasskeyIcon ? BitwardenIcons.Passkey : BitwardenIcons.Globe;
+            var icon = cipher.HasFido2Credential && usePasskeyIconAsPlaceholderFallback ? BitwardenIcons.Passkey : BitwardenIcons.Globe;
             if (cipher.Login.Uri != null)
             {
                 var hostnameUri = cipher.Login.Uri;

--- a/src/Core/Utilities/IconGlyphExtensions.cs
+++ b/src/Core/Utilities/IconGlyphExtensions.cs
@@ -24,7 +24,7 @@ namespace Bit.App.Utilities
 
         static string GetLoginIconGlyph(CipherView cipher)
         {
-            var icon = BitwardenIcons.Globe;
+            var icon = cipher.HasFido2Credential ? BitwardenIcons.Passkey : BitwardenIcons.Globe;
             if (cipher.Login.Uri != null)
             {
                 var hostnameUri = cipher.Login.Uri;

--- a/src/Core/Utilities/IconGlyphExtensions.cs
+++ b/src/Core/Utilities/IconGlyphExtensions.cs
@@ -24,7 +24,7 @@ namespace Bit.App.Utilities
 
         static string GetLoginIconGlyph(CipherView cipher)
         {
-            var icon = cipher.HasFido2Credential ? BitwardenIcons.Passkey : BitwardenIcons.Globe;
+            var icon = cipher.CanShowPasskeyIcon ? BitwardenIcons.Passkey : BitwardenIcons.Globe;
             if (cipher.Login.Uri != null)
             {
                 var hostnameUri = cipher.Login.Uri;


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
Android is not showing passkey icon when "show website icons" is disabled

## Code changes
Changed IconGlyphExtensions to take into account if the cipher has Fido2Credential and return passkey icon in that scenario.

* **IconGlyphExtensions.cs:** 

## Screenshots
Before             |  After
:-------------------------:|:-------------------------:
![Screenshot_1712768117](https://github.com/bitwarden/mobile/assets/2824952/0d83f975-62bd-4762-aa1c-99b330b20ee3) | ![Screenshot_1712767855](https://github.com/bitwarden/mobile/assets/2824952/ddab0c83-70d4-4644-9a79-18112ab2288b)

## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
