### PR TITLE
[PM-7407] Implemented check for organizations with unassigned items

### DIFF
--- a/src/Core/Abstractions/IApiService.cs
+++ b/src/Core/Abstractions/IApiService.cs
@@ -46,6 +46,7 @@ namespace Bit.Core.Abstractions
         Task<CipherResponse> PutShareCipherAsync(string id, CipherShareRequest request);
         Task PutDeleteCipherAsync(string id);
         Task<CipherResponse> PutRestoreCipherAsync(string id);
+        Task<bool> HasUnassignedCiphersAsync();
         Task RefreshIdentityTokenAsync();
         Task<SsoPrevalidateResponse> PreValidateSsoAsync(string identifier);
         Task<TResponse> SendAsync<TRequest, TResponse>(HttpMethod method, string path,

--- a/src/Core/Abstractions/ICipherService.cs
+++ b/src/Core/Abstractions/ICipherService.cs
@@ -37,5 +37,6 @@ namespace Bit.Core.Abstractions
         Task<byte[]> DownloadAndDecryptAttachmentAsync(string cipherId, AttachmentView attachment, string organizationId);
         Task SoftDeleteWithServerAsync(string id);
         Task RestoreWithServerAsync(string id);
+        Task<bool> VerifyOrganizationHasUnassignedItemsAsync();
     }
 }

--- a/src/Core/Abstractions/IStateService.cs
+++ b/src/Core/Abstractions/IStateService.cs
@@ -186,6 +186,8 @@ namespace Bit.Core.Abstractions
         Task<BwRegion?> GetActiveUserRegionAsync();
         Task<BwRegion?> GetPreAuthRegionAsync();
         Task SetPreAuthRegionAsync(BwRegion value);
+        Task<bool> GetShouldCheckOrganizationUnassignedItemsAsync(string userId = null);
+        Task SetShouldCheckOrganizationUnassignedItemsAsync(bool shouldCheck, string userId = null);
         [Obsolete("Use GetPinKeyEncryptedUserKeyAsync instead, left for migration purposes")]
         Task<string> GetPinProtectedAsync(string userId = null);
         [Obsolete("Use SetPinKeyEncryptedUserKeyAsync instead, left for migration purposes")]

--- a/src/Core/Constants.cs
+++ b/src/Core/Constants.cs
@@ -46,6 +46,7 @@ namespace Bit.Core
         public const string PreLoginEmailKey = "preLoginEmailKey";
         public const string ConfigsKey = "configsKey";
         public const string DisplayEuEnvironmentFlag = "display-eu-environment";
+        public const string UnassignedItemsBannerFlag = "unassigned-items-banner";
         public const string RegionEnvironment = "regionEnvironment";
         public const string DuoCallback = "bitwarden://duo-callback";
 
@@ -136,6 +137,7 @@ namespace Bit.Core
         public static string ShouldConnectToWatchKey(string userId) => $"shouldConnectToWatch_{userId}";
         public static string ScreenCaptureAllowedKey(string userId) => $"screenCaptureAllowed_{userId}";
         public static string PendingAdminAuthRequest(string userId) => $"pendingAdminAuthRequest_{userId}";
+        public static string ShouldCheckOrganizationUnassignedItemsKey(string userId) => $"shouldCheckOrganizationUnassignedItems_{userId}";
         [Obsolete]
         public static string KeyKey(string userId) => $"key_{userId}";
         [Obsolete]

--- a/src/Core/Models/AppOptions.cs
+++ b/src/Core/Models/AppOptions.cs
@@ -25,6 +25,7 @@ namespace Bit.App.Models
         public bool CopyInsteadOfShareAfterSaving { get; set; }
         public bool HideAccountSwitcher { get; set; }
         public OtpData? OtpData { get; set; }
+        public bool HasJustLoggedInOrUnlocked { get; set; }
 
         public void SetAllFrom(AppOptions o)
         {

--- a/src/Core/Pages/Accounts/LockPage.xaml.cs
+++ b/src/Core/Pages/Accounts/LockPage.xaml.cs
@@ -233,6 +233,7 @@ namespace Bit.App.Pages
             }
             var previousPage = await AppHelpers.ClearPreviousPage();
 
+            _appOptions.HasJustLoggedInOrUnlocked = true;
             App.MainPage = new TabsPage(_appOptions, previousPage);
         }
     }

--- a/src/Core/Pages/Accounts/LoginApproveDevicePage.xaml.cs
+++ b/src/Core/Pages/Accounts/LoginApproveDevicePage.xaml.cs
@@ -35,6 +35,8 @@ namespace Bit.App.Pages
             {
                 return;
             }
+            
+            _appOptions.HasJustLoggedInOrUnlocked = true;
             var previousPage = await AppHelpers.ClearPreviousPage();
             App.MainPage = new TabsPage(_appOptions, previousPage);
         }

--- a/src/Core/Pages/Accounts/LoginPage.xaml.cs
+++ b/src/Core/Pages/Accounts/LoginPage.xaml.cs
@@ -195,6 +195,8 @@ namespace Bit.App.Pages
                 {
                     return;
                 }
+                
+                _appOptions.HasJustLoggedInOrUnlocked = true;
                 var previousPage = await AppHelpers.ClearPreviousPage();
                 App.MainPage = new TabsPage(_appOptions, previousPage);
             }

--- a/src/Core/Pages/Accounts/LoginPasswordlessRequestPage.xaml.cs
+++ b/src/Core/Pages/Accounts/LoginPasswordlessRequestPage.xaml.cs
@@ -55,6 +55,8 @@ namespace Bit.App.Pages
                 {
                     return;
                 }
+                
+                _appOptions.HasJustLoggedInOrUnlocked = true;
                 var previousPage = await AppHelpers.ClearPreviousPage();
                 App.MainPage = new TabsPage(_appOptions, previousPage);
             }

--- a/src/Core/Pages/Accounts/SetPasswordPage.xaml.cs
+++ b/src/Core/Pages/Accounts/SetPasswordPage.xaml.cs
@@ -71,6 +71,8 @@ namespace Bit.App.Pages
                 {
                     return;
                 }
+                
+                _appOptions.HasJustLoggedInOrUnlocked = true;
                 var previousPage = await AppHelpers.ClearPreviousPage();
                 App.MainPage = new TabsPage(_appOptions, previousPage);
             }

--- a/src/Core/Pages/Accounts/TwoFactorPage.xaml.cs
+++ b/src/Core/Pages/Accounts/TwoFactorPage.xaml.cs
@@ -206,6 +206,8 @@ namespace Bit.App.Pages
             {
                 return;
             }
+
+            _appOptions.HasJustLoggedInOrUnlocked = true;
             var previousPage = await AppHelpers.ClearPreviousPage();
             App.MainPage = new TabsPage(_appOptions, previousPage);
         }

--- a/src/Core/Pages/TabsPage.cs
+++ b/src/Core/Pages/TabsPage.cs
@@ -33,7 +33,7 @@ namespace Bit.App.Pages
             _keyConnectorService = ServiceContainer.Resolve<IKeyConnectorService>("keyConnectorService");
             _stateService = ServiceContainer.Resolve<IStateService>();
 
-            _groupingsPage = new NavigationPage(new GroupingsPage(true, previousPage: previousPage))
+            _groupingsPage = new NavigationPage(new GroupingsPage(true, previousPage: previousPage, appOptions: appOptions))
             {
                 Title = AppResources.MyVault,
                 IconImageSource = "lock.png"

--- a/src/Core/Pages/Vault/GroupingsPage/GroupingsPage.xaml.cs
+++ b/src/Core/Pages/Vault/GroupingsPage/GroupingsPage.xaml.cs
@@ -1,5 +1,6 @@
 ﻿using Bit.App.Abstractions;
 using Bit.App.Controls;
+using Bit.App.Models;
 using Bit.Core.Abstractions;
 using Bit.Core.Enums;
 using Bit.Core.Models.Data;
@@ -27,7 +28,7 @@ namespace Bit.App.Pages
 
         public GroupingsPage(bool mainPage, CipherType? type = null, string folderId = null,
             string collectionId = null, string pageTitle = null, string vaultFilterSelection = null,
-            PreviousPageInfo previousPage = null, bool deleted = false, bool showTotp = false)
+            PreviousPageInfo previousPage = null, bool deleted = false, bool showTotp = false, AppOptions appOptions = null)
         {
             _pageName = string.Concat(nameof(GroupingsPage), "_", DateTime.UtcNow.Ticks);
             InitializeComponent();
@@ -50,6 +51,7 @@ namespace Bit.App.Pages
             _vm.CollectionId = collectionId;
             _vm.Deleted = deleted;
             _vm.ShowTotp = showTotp;
+            _vm.AppOptions = appOptions;
             _previousPage = previousPage;
             if (pageTitle != null)
             {
@@ -159,6 +161,8 @@ namespace Bit.App.Pages
                 {
                     return;
                 }
+
+                await _vm.CheckOrganizationUnassignedItemsAsync();
 
                 // Push registration
                 var lastPushRegistration = await _stateService.GetPushLastRegistrationDateAsync();

--- a/src/Core/Pages/Vault/GroupingsPage/GroupingsPageViewModel.cs
+++ b/src/Core/Pages/Vault/GroupingsPage/GroupingsPageViewModel.cs
@@ -1,6 +1,7 @@
 ﻿using System.Windows.Input;
 using Bit.App.Abstractions;
 using Bit.App.Controls;
+using Bit.App.Models;
 using Bit.App.Utilities;
 using Bit.Core.Abstractions;
 using Bit.Core.Enums;
@@ -45,6 +46,7 @@ namespace Bit.App.Pages
         private readonly IPasswordRepromptService _passwordRepromptService;
         private readonly IOrganizationService _organizationService;
         private readonly IPolicyService _policyService;
+        private readonly IConfigService _configService;
         private readonly ILogger _logger;
 
         public GroupingsPageViewModel()
@@ -61,6 +63,7 @@ namespace Bit.App.Pages
             _passwordRepromptService = ServiceContainer.Resolve<IPasswordRepromptService>("passwordRepromptService");
             _organizationService = ServiceContainer.Resolve<IOrganizationService>("organizationService");
             _policyService = ServiceContainer.Resolve<IPolicyService>("policyService");
+            _configService = ServiceContainer.Resolve<IConfigService>();
             _logger = ServiceContainer.Resolve<ILogger>("logger");
 
             Loading = true;
@@ -104,6 +107,7 @@ namespace Bit.App.Pages
         public List<Core.Models.View.CollectionView> Collections { get; set; }
         public List<TreeNode<Core.Models.View.CollectionView>> NestedCollections { get; set; }
 
+        public AppOptions AppOptions { get; internal set; }
         protected override ICipherService cipherService => _cipherService;
         protected override IPolicyService policyService => _policyService;
         protected override IOrganizationService organizationService => _organizationService;
@@ -698,6 +702,56 @@ namespace Bit.App.Pages
         {
             var folders = decFolders.Where(f => _allCiphers.Any(c => c.FolderId == f.Id)).ToList();
             return folders.Any() ? folders : null;
+        }
+
+        internal async Task CheckOrganizationUnassignedItemsAsync()
+        {
+            try
+            {
+                if (AppOptions?.HasJustLoggedInOrUnlocked != true)
+                {
+                    return;
+                }
+
+                AppOptions.HasJustLoggedInOrUnlocked = false;
+
+                if (!await _configService.GetFeatureFlagBoolAsync(Core.Constants.UnassignedItemsBannerFlag)
+                    ||
+                    !await _stateService.GetShouldCheckOrganizationUnassignedItemsAsync())
+                {
+                    return;
+                }
+
+                var waitSyncTask = Task.Run(async () =>
+                {
+                    while (_syncService.SyncInProgress)
+                    {
+                        await Task.Delay(100);
+                    }
+                });
+                await waitSyncTask.WaitAsync(TimeSpan.FromMinutes(5));
+
+                if (!await _cipherService.VerifyOrganizationHasUnassignedItemsAsync())
+                {
+                    return;
+                }
+
+                var response = await _deviceActionService.DisplayAlertAsync(AppResources.Notice,
+                    AppResources.OrganizationUnassignedItemsMessageDescriptionLong,
+                    null,
+                    AppResources.RemindMeLater,
+                    AppResources.Ok);
+
+                if (response == AppResources.Ok)
+                {
+                    await _stateService.SetShouldCheckOrganizationUnassignedItemsAsync(false);
+                }
+            }
+            catch (TimeoutException) { }
+            catch (Exception ex)
+            {
+                _logger.Exception(ex);
+            }
         }
     }
 }

--- a/src/Core/Resources/Localization/AppResources.Designer.cs
+++ b/src/Core/Resources/Localization/AppResources.Designer.cs
@@ -4867,6 +4867,15 @@ namespace Bit.Core.Resources.Localization {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Notice.
+        /// </summary>
+        public static string Notice {
+            get {
+                return ResourceManager.GetString("Notice", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to This account has two-step login set up, however, none of the configured two-step providers are supported on this device. Please use a supported device and/or add additional providers that are better supported across devices (such as an authenticator app)..
         /// </summary>
         public static string NoTwoStepAvailable {
@@ -5098,6 +5107,15 @@ namespace Bit.Core.Resources.Localization {
         public static string OrganizationSsoIdentifierRequired {
             get {
                 return ResourceManager.GetString("OrganizationSsoIdentifierRequired", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Unassigned organization items are no longer visible in the All Vaults view and only accessible via the Admin Console. Assign these items to a collection from the Admin Console to make them visible..
+        /// </summary>
+        public static string OrganizationUnassignedItemsMessageDescriptionLong {
+            get {
+                return ResourceManager.GetString("OrganizationUnassignedItemsMessageDescriptionLong", resourceCulture);
             }
         }
         
@@ -5675,6 +5693,15 @@ namespace Bit.Core.Resources.Localization {
         public static string RememberThisDevice {
             get {
                 return ResourceManager.GetString("RememberThisDevice", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Remind me later.
+        /// </summary>
+        public static string RemindMeLater {
+            get {
+                return ResourceManager.GetString("RemindMeLater", resourceCulture);
             }
         }
         

--- a/src/Core/Resources/Localization/AppResources.resx
+++ b/src/Core/Resources/Localization/AppResources.resx
@@ -2886,4 +2886,13 @@ Do you want to switch to this account?</value>
   <data name="LaunchDuo" xml:space="preserve">
     <value>Launch Duo</value>
   </data>
+  <data name="OrganizationUnassignedItemsMessageDescriptionLong" xml:space="preserve">
+    <value>Unassigned organization items are no longer visible in the All Vaults view and only accessible via the Admin Console. Assign these items to a collection from the Admin Console to make them visible.</value>
+  </data>
+  <data name="RemindMeLater" xml:space="preserve">
+    <value>Remind me later</value>
+  </data>
+  <data name="Notice" xml:space="preserve">
+    <value>Notice</value>
+  </data>
 </root>

--- a/src/Core/Services/ApiService.cs
+++ b/src/Core/Services/ApiService.cs
@@ -334,6 +334,11 @@ namespace Bit.Core.Services
             return SendAsync<object, CipherResponse>(HttpMethod.Put, string.Concat("/ciphers/", id, "/restore"), null, true, true);
         }
 
+        public Task<bool> HasUnassignedCiphersAsync()
+        {
+            return SendAsync<object, bool>(HttpMethod.Get, "/ciphers/has-unassigned-ciphers", null, true, true);
+        }
+
         #endregion
 
         #region Attachments APIs

--- a/src/Core/Services/CipherService.cs
+++ b/src/Core/Services/CipherService.cs
@@ -829,6 +829,24 @@ namespace Bit.Core.Services
             await ClearCacheAsync();
         }
 
+        public async Task<bool> VerifyOrganizationHasUnassignedItemsAsync()
+        {
+            var organizations = await _stateService.GetOrganizationsAsync();
+            if (organizations?.Any() != true)
+            {
+                return false;
+            }
+
+            try
+            {
+                return await _apiService.HasUnassignedCiphersAsync();
+            }
+            catch (ApiException ex) when (ex.Error?.StatusCode == System.Net.HttpStatusCode.BadRequest)
+            {
+                return false;
+            }
+        }
+
         // Helpers
 
         private async Task<Tuple<SymmetricCryptoKey, EncString, SymmetricCryptoKey>> MakeAttachmentKeyAsync(string organizationId, Cipher cipher = null, CipherView cipherView = null)

--- a/src/Core/Services/StateService.cs
+++ b/src/Core/Services/StateService.cs
@@ -1384,6 +1384,16 @@ namespace Bit.Core.Services
             await _storageMediatorService.SaveAsync(Constants.RegionEnvironment, value);
         }
 
+        public async Task<bool> GetShouldCheckOrganizationUnassignedItemsAsync(string userId = null)
+        {
+            return await _storageMediatorService.GetAsync<bool?>(await ComposeKeyAsync(Constants.ShouldCheckOrganizationUnassignedItemsKey, userId)) ?? true;
+        }
+
+        public async Task SetShouldCheckOrganizationUnassignedItemsAsync(bool shouldCheck, string userId = null)
+        {
+            await _storageMediatorService.SaveAsync<bool?>(await ComposeKeyAsync(Constants.ShouldCheckOrganizationUnassignedItemsKey, userId), shouldCheck);
+        }
+
         // Helpers
 
         [Obsolete("Use IStorageMediatorService instead")]

--- a/src/Core/Utilities/ServiceContainer.cs
+++ b/src/Core/Utilities/ServiceContainer.cs
@@ -46,6 +46,7 @@ namespace Bit.Core.Utilities
             var settingsService = new SettingsService(stateService);
             var fileUploadService = new FileUploadService(apiService);
             var configService = new ConfigService(apiService, stateService, logger);
+            var environmentService = new EnvironmentService(apiService, stateService, conditionedRunner);
             var cipherService = new CipherService(cryptoService, stateService, settingsService, apiService,
                 fileUploadService, storageService, i18nService, () => searchService, configService, clearCipherCacheKey,
                 allClearCipherCacheKeys);
@@ -87,7 +88,6 @@ namespace Bit.Core.Utilities
                 keyConnectorService, passwordGenerationService, policyService, deviceTrustCryptoService, passwordResetEnrollmentService);
             var exportService = new ExportService(folderService, cipherService, cryptoService);
             var auditService = new AuditService(cryptoFunctionService, apiService);
-            var environmentService = new EnvironmentService(apiService, stateService, conditionedRunner);
             var eventService = new EventService(apiService, stateService, organizationService, cipherService);
             var usernameGenerationService = new UsernameGenerationService(cryptoService, apiService, stateService);
 


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Add check for organization with unassigned items to display a message to the user if it's needed.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **Constants:** Added new feature flag for this check
* **ApiService:** Added new endpoint call to check whether the organization has any unassigned items
* **CipherService:** Added method to verify if an organization has any unassigned items
* **AppOptions:** Added flag to see if the user has just logged in / unlocked their vault when displaying the `GroupingsPage`
  * **Other files related with AppOptions**: Updated the new flag of `AppOptions` and passed along the options object to get to the `GroupingsPage`
* **StateService:** Added new Get/Set method for the flag of if one should or not perform this check
* **GroupingsPageViewModel:** Added logic to check the organization unassigned items based on the feature flag and the "should check" local flag (depending on what the user chose on an already shown dialog). Also, it waits if a sync is in progress to have the latest data locally as I'm checking whether the user has any organizations so not to call the endpoint on the cases where the user doesn't belong to an org.

## Screenshots
<!--Required for any UI changes. Delete if not applicable-->

### Unassigned items notice iOS
<img width="314" alt="Unassigned items notice iOS" src="https://github.com/bitwarden/mobile/assets/15682323/c77aa9ac-d1ae-457b-b961-29d1ff715adb">

### Unassigned items notice Android
<img width="314" alt="Unassigned items notice Android" src="https://github.com/bitwarden/mobile/assets/15682323/873f9df3-d15a-46dc-a525-b312ec30adfe">

## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
