### PR TITLE
[PM-7365] Fix User Verification to be done correctly on passkey creation on Never timeout vault

### DIFF
--- a/src/Core/Abstractions/IFido2MakeCredentialConfirmationUserInterface.cs
+++ b/src/Core/Abstractions/IFido2MakeCredentialConfirmationUserInterface.cs
@@ -28,5 +28,7 @@ namespace Bit.Core.Abstractions
         void OnConfirmationException(Exception ex);
 
         Fido2UserVerificationOptions? GetCurrentUserVerificationOptions();
+
+        void SetCheckHasVaultBeenUnlockedInThisTransaction(Func<bool> checkHasVaultBeenUnlockedInThisTransaction);
     }
 }

--- a/src/Core/Utilities/AccountManagement/AccountsManager.cs
+++ b/src/Core/Utilities/AccountManagement/AccountsManager.cs
@@ -254,6 +254,10 @@ namespace Bit.App.Utilities.AccountManagement
                 await _accountsManagerHost.UpdateThemeAsync();
                 _watchDeviceService.SyncDataToWatchAsync().FireAndForget();
                 _messagingService.Send(AccountsManagerMessageCommands.ACCOUNT_SWITCH_COMPLETED);
+                if (Options != null)
+                {
+                    Options.HasUnlockedInThisTransaction = false;
+                }
             });
         }
 

--- a/src/Core/Utilities/AppHelpers.cs
+++ b/src/Core/Utilities/AppHelpers.cs
@@ -432,6 +432,9 @@ namespace Bit.App.Utilities
                 // this is called after login in or unlocking so we can assume the vault has been unlocked in this transaction here.
                 appOptions.HasUnlockedInThisTransaction = true;
 
+                ServiceContainer.Resolve<IFido2MakeCredentialConfirmationUserInterface>()
+                    .SetCheckHasVaultBeenUnlockedInThisTransaction(() => appOptions?.HasUnlockedInThisTransaction == true);
+
                 if (appOptions.FromAutofillFramework && appOptions.SaveType.HasValue)
                 {
                     App.MainPage = new NavigationPage(new CipherAddEditPage(appOptions: appOptions));


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Fix updating flag of having unlocked in the current transaction on passkey creation in order for the User Verification to perform correctly on unlocked vaults.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **Fido2MakeCredentialUserInterface:** Added function setter that gets the current state of if the vault has been unlocked in the current transaction and used that inside the flow.
* **AppHelpers:** Set the aforementioned function with the `AppOptions` property.
* **AccountsManager:** Clear has been unlocked in the current transaction flag when switching accounts.


## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
