### PR TITLE
[PM-7366] Select cipher on search on Fido2 creation

### DIFF
--- a/src/App/Platforms/Android/MainApplication.cs
+++ b/src/App/Platforms/Android/MainApplication.cs
@@ -115,7 +115,8 @@ namespace Bit.Droid
                     ServiceContainer.Resolve<IVaultTimeoutService>(),
                     ServiceContainer.Resolve<ICipherService>(),
                     ServiceContainer.Resolve<IUserVerificationMediatorService>(),
-                    ServiceContainer.Resolve<IDeviceActionService>());
+                    ServiceContainer.Resolve<IDeviceActionService>(),
+                    ServiceContainer.Resolve<IPlatformUtilsService>());
                 ServiceContainer.Register<IFido2MakeCredentialConfirmationUserInterface>(fido2MakeCredentialUserInterface);
 
                 var fido2ClientService = new Fido2ClientService(

--- a/src/Core/Abstractions/IFido2MakeCredentialConfirmationUserInterface.cs
+++ b/src/Core/Abstractions/IFido2MakeCredentialConfirmationUserInterface.cs
@@ -5,7 +5,7 @@ namespace Bit.Core.Abstractions
     public interface IFido2MakeCredentialConfirmationUserInterface : IFido2MakeCredentialUserInterface
     {
         /// <summary>
-        /// Call this method after the use chose where to save the new Fido2 credential.
+        /// Call this method after the user chose where to save the new Fido2 credential.
         /// </summary>
         /// <param name="cipherId">
         /// Cipher ID where to save the new credential.
@@ -18,7 +18,7 @@ namespace Bit.Core.Abstractions
         void Confirm(string cipherId, bool? userVerified);
 
         /// <summary>
-        /// Call this method after the use chose where to save the new Fido2 credential.
+        /// Call this method after the user chose where to save the new Fido2 credential.
         /// </summary>
         /// <param name="cipherId">
         /// Cipher ID where to save the new credential.

--- a/src/Core/Abstractions/IFido2MakeCredentialConfirmationUserInterface.cs
+++ b/src/Core/Abstractions/IFido2MakeCredentialConfirmationUserInterface.cs
@@ -18,6 +18,22 @@ namespace Bit.Core.Abstractions
         void Confirm(string cipherId, bool? userVerified);
 
         /// <summary>
+        /// Call this method after the use chose where to save the new Fido2 credential.
+        /// </summary>
+        /// <param name="cipherId">
+        /// Cipher ID where to save the new credential.
+        /// If <c>null</c> a new default passkey cipher item will be created
+        /// </param>
+        /// <param name="alreadyHasFido2Credential">
+        /// If the cipher corresponding to the <paramref name="cipherId"/> already has a Fido2 credential.
+        /// </param>
+        /// <param name="userVerified">
+        /// Whether the user has been verified or not.
+        /// If <c>null</c> verification has not taken place yet.
+        /// </param>
+        Task ConfirmAsync(string cipherId, bool alreadyHasFido2Credential, bool? userVerified);
+
+        /// <summary>
         /// Cancels the current flow to make a credential
         /// </summary>
         void Cancel();

--- a/src/Core/Pages/Vault/AutofillCiphersPageViewModel.cs
+++ b/src/Core/Pages/Vault/AutofillCiphersPageViewModel.cs
@@ -95,7 +95,7 @@ namespace Bit.App.Pages
             {
                 if (_appOptions.Fido2CredentialAction == CredentialProviderConstants.Fido2CredentialCreate)
                 {
-                    await CreateFido2CredentialIntoAsync(cipher);
+                    await _fido2MakeCredentialConfirmationUserInterface.Value.ConfirmAsync(cipher.Id, cipher.Login.HasFido2Credentials, null);
                 }
                 return;
             }
@@ -150,22 +150,6 @@ namespace Bit.App.Pages
             {
                 _autofillHandler.Autofill(cipher);
             }
-        }
-
-        private async Task CreateFido2CredentialIntoAsync(CipherView cipher)
-        {
-            if (cipher.Login.HasFido2Credentials
-                &&
-                !await _platformUtilsService.ShowDialogAsync(
-                    AppResources.ThisItemAlreadyContainsAPasskeyAreYouSureYouWantToOverwriteTheCurrentPasskey,
-                    AppResources.OverwritePasskey,
-                    AppResources.Yes,
-                    AppResources.No))
-            {
-                return;
-            }
-
-            _fido2MakeCredentialConfirmationUserInterface.Value.Confirm(cipher.Id, null);
         }
 
         protected override async Task AddFabCipherAsync()

--- a/src/Core/Pages/Vault/CiphersPageViewModel.cs
+++ b/src/Core/Pages/Vault/CiphersPageViewModel.cs
@@ -7,6 +7,7 @@ using Bit.Core.Enums;
 using Bit.Core.Exceptions;
 using Bit.Core.Models.View;
 using Bit.Core.Utilities;
+using Bit.Core.Utilities.Fido2;
 
 namespace Bit.App.Pages
 {
@@ -21,6 +22,8 @@ namespace Bit.App.Pages
         private readonly IPasswordRepromptService _passwordRepromptService;
         private readonly IOrganizationService _organizationService;
         private readonly IPolicyService _policyService;
+        private readonly LazyResolve<IFido2MakeCredentialConfirmationUserInterface> _fido2MakeCredentialConfirmationUserInterface = new LazyResolve<IFido2MakeCredentialConfirmationUserInterface>();
+
         private CancellationTokenSource _searchCancellationTokenSource;
         private readonly ILogger _logger;
 
@@ -172,6 +175,15 @@ namespace Bit.App.Pages
 
         public async Task SelectCipherAsync(CipherView cipher)
         {
+            if (_appOptions.FromFido2Framework)
+            {
+                if (_appOptions.Fido2CredentialAction == CredentialProviderConstants.Fido2CredentialCreate)
+                {
+                    await _fido2MakeCredentialConfirmationUserInterface.Value.ConfirmAsync(cipher.Id, cipher.Login.HasFido2Credentials, null);
+                }
+                return;
+            }
+
             string selection = null;
 
             if (!string.IsNullOrWhiteSpace(AutofillUrl))


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Implemented cipher selection on search on Fido2 creation


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **Fido2MakeCredentialUserInterface:** Moved logic of cipher selection check to create a Fido2 credential here in order to be reused between cipher list and search.
* **CiphersPageViewModel:** Added call to the aforementioned UserInterface to select a cipher for Fido2 creation


## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
