### PR TITLE
[PM-7385] Fix IFido2MakeCredentialConfirmationUserInterface usages

### DIFF
--- a/src/Core/Pages/Vault/CipherAddEditPage.xaml.cs
+++ b/src/Core/Pages/Vault/CipherAddEditPage.xaml.cs
@@ -19,7 +19,9 @@ namespace Bit.App.Pages
         private readonly IAutofillHandler _autofillHandler;
         private readonly IVaultTimeoutService _vaultTimeoutService;
         private readonly IUserVerificationService _userVerificationService;
+#if ANDROID
         private readonly LazyResolve<IFido2MakeCredentialConfirmationUserInterface> _fido2MakeCredentialConfirmationUserInterface = new LazyResolve<IFido2MakeCredentialConfirmationUserInterface>();
+#endif
 
         private CipherAddEditPageViewModel _vm;
         private bool _fromAutofill;
@@ -46,7 +48,9 @@ namespace Bit.App.Pages
             _appOptions = appOptions;
             _fromAutofill = fromAutofill;
             FromAutofillFramework = _appOptions?.FromAutofillFramework ?? false;
+#if ANDROID
             FromAndroidFido2Framework = _fido2MakeCredentialConfirmationUserInterface.Value.IsConfirmingNewCredential;
+#endif
             InitializeComponent();
             _vm = BindingContext as CipherAddEditPageViewModel;
             _vm.Page = this;

--- a/src/Core/Pages/Vault/CipherAddEditPageViewModel.cs
+++ b/src/Core/Pages/Vault/CipherAddEditPageViewModel.cs
@@ -96,7 +96,10 @@ namespace Bit.App.Pages
             _autofillHandler = ServiceContainer.Resolve<IAutofillHandler>();
             _watchDeviceService = ServiceContainer.Resolve<IWatchDeviceService>();
             _accountsManager = ServiceContainer.Resolve<IAccountsManager>();
-            _fido2MakeCredentialConfirmationUserInterface = ServiceContainer.Resolve<IFido2MakeCredentialConfirmationUserInterface>();
+            if (ServiceContainer.TryResolve<IFido2MakeCredentialConfirmationUserInterface>(out var fido2MakeService))
+            {
+                _fido2MakeCredentialConfirmationUserInterface = fido2MakeService;
+            }
             _userVerificationMediatorService = ServiceContainer.Resolve<IUserVerificationMediatorService>(); 
 
             GeneratePasswordCommand = new Command(GeneratePassword);
@@ -332,7 +335,7 @@ namespace Bit.App.Pages
         public async Task<bool> LoadAsync(AppOptions appOptions = null)
         {
             _fromOtp = appOptions?.OtpData != null;
-            IsFromFido2Framework = _fido2MakeCredentialConfirmationUserInterface.IsConfirmingNewCredential;
+            IsFromFido2Framework = _fido2MakeCredentialConfirmationUserInterface?.IsConfirmingNewCredential == true;
 
             var myEmail = await _stateService.GetEmailAsync();
             OwnershipOptions.Add(new KeyValuePair<string, string>(myEmail, null));

--- a/src/Core/Pages/Vault/CiphersPageViewModel.cs
+++ b/src/Core/Pages/Vault/CiphersPageViewModel.cs
@@ -22,7 +22,9 @@ namespace Bit.App.Pages
         private readonly IPasswordRepromptService _passwordRepromptService;
         private readonly IOrganizationService _organizationService;
         private readonly IPolicyService _policyService;
+#if ANDROID
         private readonly LazyResolve<IFido2MakeCredentialConfirmationUserInterface> _fido2MakeCredentialConfirmationUserInterface = new LazyResolve<IFido2MakeCredentialConfirmationUserInterface>();
+#endif
 
         private CancellationTokenSource _searchCancellationTokenSource;
         private readonly ILogger _logger;
@@ -175,11 +177,13 @@ namespace Bit.App.Pages
 
         public async Task SelectCipherAsync(CipherView cipher)
         {
+#if ANDROID
             if (_fido2MakeCredentialConfirmationUserInterface.Value.IsConfirmingNewCredential)
             {
                 await _fido2MakeCredentialConfirmationUserInterface.Value.ConfirmAsync(cipher.Id, cipher.Login.HasFido2Credentials, null);
                 return;
             }
+#endif
 
             string selection = null;
 

--- a/src/Core/Utilities/AccountManagement/AccountsManager.cs
+++ b/src/Core/Utilities/AccountManagement/AccountsManager.cs
@@ -20,7 +20,9 @@ namespace Bit.App.Utilities.AccountManagement
         private readonly IMessagingService _messagingService;
         private readonly IWatchDeviceService _watchDeviceService;
         private readonly IConditionedAwaiterManager _conditionedAwaiterManager;
-        private LazyResolve<IFido2MakeCredentialConfirmationUserInterface> _userVerificationMediatorService = new LazyResolve<IFido2MakeCredentialConfirmationUserInterface>();
+#if ANDROID
+        private LazyResolve<IFido2MakeCredentialConfirmationUserInterface> _fido2MakeCredentialConfirmationUserInterface = new LazyResolve<IFido2MakeCredentialConfirmationUserInterface>();
+#endif
 
         Func<AppOptions> _getOptionsFunc;
         private IAccountsManagerHost _accountsManagerHost;
@@ -101,12 +103,14 @@ namespace Bit.App.Utilities.AccountManagement
                 {
                     _accountsManagerHost.Navigate(NavigationTarget.AddEditCipher);
                 }
-                else if (_userVerificationMediatorService.Value.IsConfirmingNewCredential)
+#if ANDROID
+                else if (_fido2MakeCredentialConfirmationUserInterface.Value.IsConfirmingNewCredential)
                 {
                     // If we are already confirming a credential we don't need to navigate again.
                     // This could happen when switching accounts for example.
                     return;
                 }
+#endif
                 else if (Options.FromFido2Framework)
                 {
                     var deviceActionService = Bit.Core.Utilities.ServiceContainer.Resolve<IDeviceActionService>();

--- a/src/Core/Utilities/AppHelpers.cs
+++ b/src/Core/Utilities/AppHelpers.cs
@@ -432,8 +432,10 @@ namespace Bit.App.Utilities
                 // this is called after login in or unlocking so we can assume the vault has been unlocked in this transaction here.
                 appOptions.HasUnlockedInThisTransaction = true;
                 
-                var userVerificationMediatorService = ServiceContainer.Resolve<IFido2MakeCredentialConfirmationUserInterface>();
-                userVerificationMediatorService.SetCheckHasVaultBeenUnlockedInThisTransaction(() => appOptions?.HasUnlockedInThisTransaction == true);
+#if ANDROID
+                var fido2MakeCredentialConfirmationUserInterface = ServiceContainer.Resolve<IFido2MakeCredentialConfirmationUserInterface>();
+                fido2MakeCredentialConfirmationUserInterface.SetCheckHasVaultBeenUnlockedInThisTransaction(() => appOptions?.HasUnlockedInThisTransaction == true);
+#endif
 
                 if (appOptions.FromAutofillFramework && appOptions.SaveType.HasValue)
                 {
@@ -441,13 +443,15 @@ namespace Bit.App.Utilities
                     return true;
                 }
 
+#if ANDROID
                 // If we are waiting for an unlock vault we don't want to trigger 'ExecuteFido2CredentialActionAsync' again,
                 // as it's already running. We just need to 'ConfirmUnlockVault' on the 'userVerificationMediatorService'.
-                if (userVerificationMediatorService.IsWaitingUnlockVault)
+                if (fido2MakeCredentialConfirmationUserInterface.IsWaitingUnlockVault)
                 {
-                    userVerificationMediatorService.ConfirmVaultUnlocked();
+                    fido2MakeCredentialConfirmationUserInterface.ConfirmVaultUnlocked();
                     return true;
                 }
+#endif
 
                 if (appOptions.FromFido2Framework && !string.IsNullOrWhiteSpace(appOptions.Fido2CredentialAction))
                 {


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Fix Android only interfaces to be constrained to Android on Fido2 flows.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **Everything:** Constrained to Android the resolve and usage of `IFido2MakeCredentialConfirmationUserInterface`


## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
