### PR TITLE
[PM-7518] Update favicons placeholder color autofill iOS

### DIFF
--- a/src/iOS.Core/Views/CipherLoginTableViewCell.cs
+++ b/src/iOS.Core/Views/CipherLoginTableViewCell.cs
@@ -48,7 +48,7 @@ namespace Bit.iOS.Core.Views
                 _mainIcon.Font = UIFont.FromName("bwi-font", 24);
                 _mainIcon.AdjustsFontSizeToFitWidth = true;
                 _mainIcon.Text = BitwardenIcons.Globe;
-                _mainIcon.TextColor = ThemeHelpers.PrimaryColor;
+                _mainIcon.TextColor = ThemeHelpers.MutedColor;
 
                 _orgIcon.Font = UIFont.FromName("bwi-font", 15);
                 _orgIcon.TextColor = ThemeHelpers.MutedColor;


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Update favicons placeholder color on autofill iOS to be alike main app


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **CipherLoginListTableViewCell:** Updated icon color

## Screenshots
<!--Required for any UI changes. Delete if not applicable-->

### Search list icon color update
<img width="314" alt="Search list icon color update" src="https://github.com/bitwarden/mobile/assets/15682323/88bb34b9-9ecc-4c7c-99a0-b0f1cb2cb690">

## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
