### PR TITLE
[PM-7365] Fix UserVerification on Fido2 credential creation on Android

### DIFF
--- a/src/App/Platforms/Android/MainActivity.cs
+++ b/src/App/Platforms/Android/MainActivity.cs
@@ -168,6 +168,13 @@ namespace Bit.Droid
             base.OnNewIntent(intent);
             try
             {
+                if (intent?.GetStringExtra(CredentialProviderConstants.Fido2CredentialAction) == CredentialProviderConstants.Fido2CredentialCreate
+                    &&
+                    _appOptions != null)
+                {
+                    _appOptions.HasUnlockedInThisTransaction = false;
+                }
+
                 if (intent?.GetStringExtra("uri") is string uri)
                 {
                     _messagingService.Send(App.App.POP_ALL_AND_GO_TO_AUTOFILL_CIPHERS_MESSAGE);


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Fix UserVerification on Fido2 credential creation on Android


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **MainActivity:** Reset `HasUnlockedInThisTransaction` when a new transaction starts on Fido2 credential creation on Android so User verification is done correctly


## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
