### PR TITLE
[PM-7257] android add support for web authn resident key credential property in our net mobile app 2

### DIFF
--- a/src/App/Platforms/Android/Autofill/CredentialProviderSelectionActivity.cs
+++ b/src/App/Platforms/Android/Autofill/CredentialProviderSelectionActivity.cs
@@ -76,17 +76,17 @@ namespace Bit.Droid.Autofill
                     hasVaultBeenUnlockedInThisTransaction: () => hasVaultBeenUnlockedInThisTransaction,
                     verifyUserCallback: (cipherId, uvPreference) => VerifyUserAsync(cipherId, uvPreference, RpId, hasVaultBeenUnlockedInThisTransaction));
 
-                var assertParams = new Fido2AuthenticatorGetAssertionParams
+                var clientAssertParams = new Fido2ClientAssertCredentialParams
                 {
                     Challenge = requestOptions.GetChallenge(),
                     RpId = RpId,
-                    UserVerificationPreference = Fido2UserVerificationPreferenceExtensions.ToFido2UserVerificationPreference(requestOptions.UserVerification),
-                    Hash = credentialPublic.GetClientDataHash(),
-                    AllowCredentialDescriptorList = new Core.Utilities.Fido2.PublicKeyCredentialDescriptor[] { new Core.Utilities.Fido2.PublicKeyCredentialDescriptor { Id = credentialId } },
-                    Extensions = new object()
+                    AllowCredentials = new Core.Utilities.Fido2.PublicKeyCredentialDescriptor[] { new Core.Utilities.Fido2.PublicKeyCredentialDescriptor { Id = credentialId } },
+                    Origin = androidOrigin,
+                    SameOriginWithAncestors = true,
+                    UserVerification = requestOptions.UserVerification
                 };
 
-                var assertResult = await _fido2MediatorService.Value.GetAssertionAsync(assertParams, userInterface);
+                var assertResult = await _fido2MediatorService.Value.AssertCredentialAsync(clientAssertParams, credentialPublic.GetClientDataHash());
 
                 var response = new AuthenticatorAssertionResponse(
                     requestOptions,
@@ -98,7 +98,7 @@ namespace Bit.Droid.Autofill
                     false,
                     assertResult.SelectedCredential.UserHandle,
                     packageName,
-                    credentialPublic.GetClientDataHash() //clientDataHash
+                    assertResult.ClientDataHash
                 );
                 response.SetAuthenticatorData(assertResult.AuthenticatorData);
                 response.SetSignature(assertResult.Signature);
@@ -117,7 +117,7 @@ namespace Bit.Droid.Autofill
             }
             catch (NotAllowedError)
             {
-                await MainThread.InvokeOnMainThreadAsync(async() =>
+                await MainThread.InvokeOnMainThreadAsync(async () =>
                 {
                     await _deviceActionService.Value.DisplayAlertAsync(AppResources.ErrorReadingPasskey, string.Format(AppResources.ThereWasAProblemReadingAPasskeyForXTryAgainLater, RpId), AppResources.Ok);
                     Finish();
@@ -126,7 +126,7 @@ namespace Bit.Droid.Autofill
             catch (Exception ex)
             {
                 LoggerHelper.LogEvenIfCantBeResolved(ex);
-                await MainThread.InvokeOnMainThreadAsync(async() =>
+                await MainThread.InvokeOnMainThreadAsync(async () =>
                 {
                     await _deviceActionService.Value.DisplayAlertAsync(AppResources.ErrorReadingPasskey, string.Format(AppResources.ThereWasAProblemReadingAPasskeyForXTryAgainLater, RpId), AppResources.Ok);
                     Finish();

--- a/src/App/Platforms/Android/Autofill/CredentialProviderSelectionActivity.cs
+++ b/src/App/Platforms/Android/Autofill/CredentialProviderSelectionActivity.cs
@@ -68,6 +68,7 @@ namespace Bit.Droid.Autofill
 
                 var androidOrigin = AppInfoToOrigin(getRequest?.CallingAppInfo);
                 var packageName = getRequest?.CallingAppInfo.PackageName;
+                var appInfoOrigin = getRequest?.CallingAppInfo.Origin;
 
                 var userInterface = new Fido2GetAssertionUserInterface(
                     cipherId: cipherId,
@@ -81,7 +82,7 @@ namespace Bit.Droid.Autofill
                     Challenge = requestOptions.GetChallenge(),
                     RpId = RpId,
                     AllowCredentials = new Core.Utilities.Fido2.PublicKeyCredentialDescriptor[] { new Core.Utilities.Fido2.PublicKeyCredentialDescriptor { Id = credentialId } },
-                    Origin = androidOrigin,
+                    Origin = appInfoOrigin,
                     SameOriginWithAncestors = true,
                     UserVerification = requestOptions.UserVerification
                 };

--- a/src/Core/Abstractions/IFido2ClientService.cs
+++ b/src/Core/Abstractions/IFido2ClientService.cs
@@ -21,7 +21,7 @@ namespace Bit.Core.Abstractions
         /// </summary>
         /// <param name="createCredentialParams">The parameters for the credential creation operation</param>
         /// <returns>The new credential</returns>
-        Task<Fido2ClientCreateCredentialResult> CreateCredentialAsync(Fido2ClientCreateCredentialParams createCredentialParams);
+        Task<Fido2ClientCreateCredentialResult> CreateCredentialAsync(Fido2ClientCreateCredentialParams createCredentialParams, byte[] clientDataHash);
 
         /// <summary>
         /// Allows WebAuthn Relying Party scripts to discover and use an existing public key credential, with the user’s consent.
@@ -30,6 +30,6 @@ namespace Bit.Core.Abstractions
         /// </summary>
         /// <param name="assertCredentialParams">The parameters for the credential assertion operation</param>
         /// <returns>The asserted credential</returns>
-        Task<Fido2ClientAssertCredentialResult> AssertCredentialAsync(Fido2ClientAssertCredentialParams assertCredentialParams);
+        Task<Fido2ClientAssertCredentialResult> AssertCredentialAsync(Fido2ClientAssertCredentialParams assertCredentialParams, byte[] clientDataHash);
     }
 }

--- a/src/Core/Abstractions/IFido2MediatorService.cs
+++ b/src/Core/Abstractions/IFido2MediatorService.cs
@@ -4,8 +4,8 @@ namespace Bit.Core.Abstractions
 {
     public interface IFido2MediatorService
     {
-        Task<Fido2ClientCreateCredentialResult> CreateCredentialAsync(Fido2ClientCreateCredentialParams createCredentialParams);
-        Task<Fido2ClientAssertCredentialResult> AssertCredentialAsync(Fido2ClientAssertCredentialParams assertCredentialParams);
+        Task<Fido2ClientCreateCredentialResult> CreateCredentialAsync(Fido2ClientCreateCredentialParams createCredentialParams, byte[] clientDataHash = null);
+        Task<Fido2ClientAssertCredentialResult> AssertCredentialAsync(Fido2ClientAssertCredentialParams assertCredentialParams, byte[] clientDataHash = null);
 
         Task<Fido2AuthenticatorMakeCredentialResult> MakeCredentialAsync(Fido2AuthenticatorMakeCredentialParams makeCredentialParams, IFido2MakeCredentialUserInterface userInterface);
         Task<Fido2AuthenticatorGetAssertionResult> GetAssertionAsync(Fido2AuthenticatorGetAssertionParams assertionParams, IFido2GetAssertionUserInterface userInterface);

--- a/src/Core/Services/Fido2AuthenticatorService.cs
+++ b/src/Core/Services/Fido2AuthenticatorService.cs
@@ -184,7 +184,7 @@ namespace Bit.Core.Services
             {
                 throw new NotAllowedError();
             }
-             
+
             if (!userVerified
                 &&
                 await _userVerificationMediatorService.ShouldEnforceFido2RequiredUserVerificationAsync(new Fido2UserVerificationOptions(
@@ -224,7 +224,7 @@ namespace Bit.Core.Services
 
                 return new Fido2AuthenticatorGetAssertionResult
                 {
-                    SelectedCredential = new Fido2AuthenticatorGetAssertionSelectedCredential
+                    SelectedCredential = new Fido2SelectedCredential
                     {
                         Id = selectedCredentialId.GuidToRawFormat(),
                         UserHandle = selectedFido2Credential.UserHandleValue,

--- a/src/Core/Services/Fido2ClientService.cs
+++ b/src/Core/Services/Fido2ClientService.cs
@@ -228,8 +228,8 @@ namespace Bit.Core.Services
                     Id = CoreHelpers.Base64UrlEncode(getAssertionResult.SelectedCredential.Id),
                     RawId = getAssertionResult.SelectedCredential.Id,
                     Signature = getAssertionResult.Signature,
-                    UserHandle = getAssertionResult.SelectedCredential.UserHandle,
-                    Cipher = getAssertionResult.SelectedCredential.Cipher
+                    SelectedCredential = getAssertionResult.SelectedCredential,
+                    ClientDataHash = clientDataHash
                 };
             }
             catch (InvalidStateError)

--- a/src/Core/Services/Fido2ClientService.cs
+++ b/src/Core/Services/Fido2ClientService.cs
@@ -33,7 +33,7 @@ namespace Bit.Core.Services
             _makeCredentialUserInterface = makeCredentialUserInterface;
         }
 
-        public async Task<Fido2ClientCreateCredentialResult> CreateCredentialAsync(Fido2ClientCreateCredentialParams createCredentialParams)
+        public async Task<Fido2ClientCreateCredentialResult> CreateCredentialAsync(Fido2ClientCreateCredentialParams createCredentialParams, byte[] clientDataHash = null)
         {
             var blockedUris = await _stateService.GetAutofillBlacklistedUrisAsync();
             var domain = CoreHelpers.GetHostname(createCredentialParams.Origin);
@@ -109,16 +109,20 @@ namespace Bit.Core.Services
                 throw new Fido2ClientException(Fido2ClientException.ErrorCode.NotSupportedError, "No supported algorithms found");
             }
 
-            var clientDataJSON = JsonSerializer.Serialize(new
+            byte[] clientDataJSONBytes = null;
+            if (clientDataHash == null)
             {
-                type = "webauthn.create",
-                challenge = CoreHelpers.Base64UrlEncode(createCredentialParams.Challenge),
-                origin = createCredentialParams.Origin,
-                crossOrigin = !createCredentialParams.SameOriginWithAncestors,
-                // tokenBinding: {} // Not supported
-            });
-            var clientDataJSONBytes = Encoding.UTF8.GetBytes(clientDataJSON);
-            var clientDataHash = await _cryptoFunctionService.HashAsync(clientDataJSONBytes, CryptoHashAlgorithm.Sha256);
+                var clientDataJSON = JsonSerializer.Serialize(new
+                {
+                    type = "webauthn.create",
+                    challenge = CoreHelpers.Base64UrlEncode(createCredentialParams.Challenge),
+                    origin = createCredentialParams.Origin,
+                    crossOrigin = !createCredentialParams.SameOriginWithAncestors,
+                    // tokenBinding: {} // Not supported
+                });
+                clientDataJSONBytes = Encoding.UTF8.GetBytes(clientDataJSON);
+                clientDataHash = await _cryptoFunctionService.HashAsync(clientDataJSONBytes, CryptoHashAlgorithm.Sha256);
+            }
             var makeCredentialParams = MapToMakeCredentialParams(createCredentialParams, credTypesAndPubKeyAlgs, clientDataHash);
 
             try
@@ -159,7 +163,7 @@ namespace Bit.Core.Services
             }
         }
 
-        public async Task<Fido2ClientAssertCredentialResult> AssertCredentialAsync(Fido2ClientAssertCredentialParams assertCredentialParams)
+        public async Task<Fido2ClientAssertCredentialResult> AssertCredentialAsync(Fido2ClientAssertCredentialParams assertCredentialParams, byte[] clientDataHash = null)
         {
             var blockedUris = await _stateService.GetAutofillBlacklistedUrisAsync();
             var domain = CoreHelpers.GetHostname(assertCredentialParams.Origin);
@@ -198,15 +202,19 @@ namespace Bit.Core.Services
                     "RP ID cannot be used with this origin");
             }
 
-            var clientDataJSON = JsonSerializer.Serialize(new
+            byte[] clientDataJSONBytes = null;
+            if (clientDataHash == null)
             {
-                type = "webauthn.get",
-                challenge = CoreHelpers.Base64UrlEncode(assertCredentialParams.Challenge),
-                origin = assertCredentialParams.Origin,
-                crossOrigin = !assertCredentialParams.SameOriginWithAncestors,
-            });
-            var clientDataJSONBytes = Encoding.UTF8.GetBytes(clientDataJSON);
-            var clientDataHash = await _cryptoFunctionService.HashAsync(clientDataJSONBytes, CryptoHashAlgorithm.Sha256);
+                var clientDataJSON = JsonSerializer.Serialize(new
+                {
+                    type = "webauthn.get",
+                    challenge = CoreHelpers.Base64UrlEncode(assertCredentialParams.Challenge),
+                    origin = assertCredentialParams.Origin,
+                    crossOrigin = !assertCredentialParams.SameOriginWithAncestors,
+                });
+                clientDataJSONBytes = Encoding.UTF8.GetBytes(clientDataJSON);
+                clientDataHash = await _cryptoFunctionService.HashAsync(clientDataJSONBytes, CryptoHashAlgorithm.Sha256);
+            }
             var getAssertionParams = MapToGetAssertionParams(assertCredentialParams, clientDataHash);
 
             try

--- a/src/Core/Services/Fido2MediatorService.cs
+++ b/src/Core/Services/Fido2MediatorService.cs
@@ -22,9 +22,9 @@ namespace Bit.Core.Services
         {
             var result = await _fido2ClientService.AssertCredentialAsync(assertCredentialParams, clientDataHash);
 
-            if (result?.Cipher != null)
+            if (result?.SelectedCredential?.Cipher != null)
             {
-                await _cipherService.CopyTotpCodeIfNeededAsync(result.Cipher);
+                await _cipherService.CopyTotpCodeIfNeededAsync(result.SelectedCredential.Cipher);
             }
 
             return result;

--- a/src/Core/Services/Fido2MediatorService.cs
+++ b/src/Core/Services/Fido2MediatorService.cs
@@ -18,9 +18,9 @@ namespace Bit.Core.Services
             _cipherService = cipherService;
         }
 
-        public async Task<Fido2ClientAssertCredentialResult> AssertCredentialAsync(Fido2ClientAssertCredentialParams assertCredentialParams)
+        public async Task<Fido2ClientAssertCredentialResult> AssertCredentialAsync(Fido2ClientAssertCredentialParams assertCredentialParams, byte[] clientDataHash = null)
         {
-            var result = await _fido2ClientService.AssertCredentialAsync(assertCredentialParams);
+            var result = await _fido2ClientService.AssertCredentialAsync(assertCredentialParams, clientDataHash);
 
             if (result?.Cipher != null)
             {
@@ -30,9 +30,9 @@ namespace Bit.Core.Services
             return result;
         }
 
-        public Task<Fido2ClientCreateCredentialResult> CreateCredentialAsync(Fido2ClientCreateCredentialParams createCredentialParams)
+        public Task<Fido2ClientCreateCredentialResult> CreateCredentialAsync(Fido2ClientCreateCredentialParams createCredentialParams, byte[] clientDataHash = null)
         {
-            return _fido2ClientService.CreateCredentialAsync(createCredentialParams);
+            return _fido2ClientService.CreateCredentialAsync(createCredentialParams, clientDataHash);
         }
 
         public async Task<Fido2AuthenticatorGetAssertionResult> GetAssertionAsync(Fido2AuthenticatorGetAssertionParams assertionParams, IFido2GetAssertionUserInterface userInterface)

--- a/src/Core/Utilities/Fido2/Fido2AuthenticatorGetAssertionResult.cs
+++ b/src/Core/Utilities/Fido2/Fido2AuthenticatorGetAssertionResult.cs
@@ -8,16 +8,7 @@ namespace Bit.Core.Utilities.Fido2
 
         public byte[] Signature { get; set; }
 
-        public Fido2AuthenticatorGetAssertionSelectedCredential SelectedCredential { get; set; }
-    }
-
-    public class Fido2AuthenticatorGetAssertionSelectedCredential {
-        public byte[] Id { get; set; }
-
-        #nullable enable
-        public byte[]? UserHandle { get; set; }
-
-        public CipherView? Cipher { get; set; }
+        public Fido2SelectedCredential SelectedCredential { get; set; }
     }
 }
 

--- a/src/Core/Utilities/Fido2/Fido2ClientAssertCredentialResult.cs
+++ b/src/Core/Utilities/Fido2/Fido2ClientAssertCredentialResult.cs
@@ -26,6 +26,11 @@ namespace Bit.Core.Utilities.Fido2
         public required byte[] ClientDataJSON { get; set; }
 
         /// <summary>
+        /// The hash of the serialized client data used to generate the assertion.
+        /// </summary>
+        public required byte[] ClientDataHash { get; set; }
+
+        /// <summary>
         /// The authenticator data returned by the authenticator.
         /// </summary>
         public required byte[] AuthenticatorData { get; set; }
@@ -36,14 +41,8 @@ namespace Bit.Core.Utilities.Fido2
         public required byte[] Signature { get; set; }
 
         /// <summary>
-        /// The user handle returned from the authenticator, or null if the authenticator did not
-        /// return a user handle.
+        /// The selected credential that was used to generate the assertion.
         /// </summary>
-        public byte[]? UserHandle { get; set; }
-
-        /// <summary>
-        /// The selected cipher login item that has the credential
-        /// </summary>
-        public CipherView? Cipher { get; set; }
+        public Fido2SelectedCredential SelectedCredential { get; set; }
     }
 }

--- a/src/Core/Utilities/Fido2/Fido2SelectedCredential.cs
+++ b/src/Core/Utilities/Fido2/Fido2SelectedCredential.cs
@@ -1,0 +1,10 @@
+using Bit.Core.Models.View;
+
+public class Fido2SelectedCredential
+{
+    public byte[] Id { get; set; }
+
+    public byte[] UserHandle { get; set; }
+
+    public CipherView Cipher { get; set; }
+}


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
This redirects all android fido2 calls to the `Fido2Client`, and correctly maps to/from extension objects

## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
