### PR TITLE
[PM-7623] Fix proper implementation of IFido2GetAssertionUserInterface Android

### DIFF
--- a/src/App/Platforms/Android/Autofill/Fido2GetAssertionUserInterface.cs
+++ b/src/App/Platforms/Android/Autofill/Fido2GetAssertionUserInterface.cs
@@ -1,21 +1,77 @@
 ﻿using Bit.Core.Abstractions;
+using Bit.Core.Services;
+using Bit.Core.Utilities.Fido2;
 
 namespace Bit.App.Platforms.Android.Autofill
 {
-    //TODO: WIP: Temporary Dummy implementation
-    public class Fido2GetAssertionUserInterface : IFido2GetAssertionUserInterface
+    public interface IFido2AndroidGetAssertionUserInterface : IFido2GetAssertionUserInterface
     {
-        public bool HasVaultBeenUnlockedInThisTransaction => true;
+        void Init(string cipherId,
+            bool userVerified,
+            Func<bool> hasVaultBeenUnlockedInThisTransaction,
+            string rpId);
+    }
 
-        public Task EnsureUnlockedVaultAsync()
+    public class Fido2GetAssertionUserInterface : Core.Utilities.Fido2.Fido2GetAssertionUserInterface, IFido2AndroidGetAssertionUserInterface
+    {
+        private readonly IStateService _stateService;
+        private readonly IVaultTimeoutService _vaultTimeoutService;
+        private readonly ICipherService _cipherService;
+        private readonly IUserVerificationMediatorService _userVerificationMediatorService;
+
+        public Fido2GetAssertionUserInterface(IStateService stateService, 
+            IVaultTimeoutService vaultTimeoutService,
+            ICipherService cipherService,
+            IUserVerificationMediatorService userVerificationMediatorService)
         {
-            return Task.FromResult(true);
+            _stateService = stateService;
+            _vaultTimeoutService = vaultTimeoutService;
+            _cipherService = cipherService;
+            _userVerificationMediatorService = userVerificationMediatorService;
         }
 
-        public Task<(string CipherId, bool UserVerified)> PickCredentialAsync(Fido2GetAssertionUserInterfaceCredential[] credentials)
+        public void Init(string cipherId,
+            bool userVerified,
+            Func<bool> hasVaultBeenUnlockedInThisTransaction,
+            string rpId)
         {
-            var credential = credentials[0];
-            return Task.FromResult<(string CipherId, bool UserVerified)>((credential.CipherId, true));
+            Init(cipherId, 
+                userVerified, 
+                EnsureAuthenAndVaultUnlockedAsync, 
+                hasVaultBeenUnlockedInThisTransaction, 
+                (cipherId, userVerificationPreference) => VerifyUserAsync(cipherId, userVerificationPreference, rpId, hasVaultBeenUnlockedInThisTransaction()));
+        }
+
+        public async Task EnsureAuthenAndVaultUnlockedAsync()
+        {
+            if (!await _stateService.IsAuthenticatedAsync() || await _vaultTimeoutService.IsLockedAsync())
+            {
+                // this should never happen but just in case.
+                throw new InvalidOperationException("Not authed or vault locked");
+            }
+        }
+
+        private async Task<bool> VerifyUserAsync(string selectedCipherId, Fido2UserVerificationPreference userVerificationPreference, string rpId, bool vaultUnlockedDuringThisTransaction)
+        {
+            try
+            {
+                var encrypted = await _cipherService.GetAsync(selectedCipherId);
+                var cipher = await encrypted.DecryptAsync();
+
+                var userVerification = await _userVerificationMediatorService.VerifyUserForFido2Async(
+                    new Fido2UserVerificationOptions(
+                        cipher?.Reprompt == Core.Enums.CipherRepromptType.Password,
+                        userVerificationPreference,
+                        vaultUnlockedDuringThisTransaction,
+                        rpId)
+                    );
+                return !userVerification.IsCancelled && userVerification.Result;
+            }
+            catch (Exception ex)
+            {
+                LoggerHelper.LogEvenIfCantBeResolved(ex);
+                return false;
+            }
         }
     }
 }

--- a/src/App/Platforms/Android/MainApplication.cs
+++ b/src/App/Platforms/Android/MainApplication.cs
@@ -110,6 +110,13 @@ namespace Bit.Droid
                     userVerificationMediatorService);
                 ServiceContainer.Register<IFido2AuthenticatorService>(fido2AuthenticatorService);
 
+                var fido2GetAssertionUserInterface = new Fido2GetAssertionUserInterface(
+                    ServiceContainer.Resolve<IStateService>(),
+                    ServiceContainer.Resolve<IVaultTimeoutService>(),
+                    ServiceContainer.Resolve<ICipherService>(),
+                    ServiceContainer.Resolve<IUserVerificationMediatorService>());
+                ServiceContainer.Register<IFido2AndroidGetAssertionUserInterface>(fido2GetAssertionUserInterface);                
+
                 var fido2MakeCredentialUserInterface = new Fido2MakeCredentialUserInterface(
                     ServiceContainer.Resolve<IStateService>(),
                     ServiceContainer.Resolve<IVaultTimeoutService>(),
@@ -124,7 +131,7 @@ namespace Bit.Droid
                     ServiceContainer.Resolve<IEnvironmentService>(),
                     ServiceContainer.Resolve<ICryptoFunctionService>(),
                     ServiceContainer.Resolve<IFido2AuthenticatorService>(),
-                    new Fido2GetAssertionUserInterface(),
+                    fido2GetAssertionUserInterface,
                     fido2MakeCredentialUserInterface);
                 ServiceContainer.Register<IFido2ClientService>(fido2ClientService);
 

--- a/src/Core/Utilities/Fido2/Fido2GetAssertionUserInterface.cs
+++ b/src/Core/Utilities/Fido2/Fido2GetAssertionUserInterface.cs
@@ -12,15 +12,28 @@ namespace Bit.Core.Utilities.Fido2
     /// </summary>
     public class Fido2GetAssertionUserInterface : IFido2GetAssertionUserInterface
     {
-        private readonly string _cipherId;
-        private readonly bool _userVerified = false;
-        private readonly Func<Task> _ensureUnlockedVaultCallback;
-        private readonly Func<bool> _hasVaultBeenUnlockedInThisTransaction;
-        private readonly Func<string, Fido2UserVerificationPreference, Task<bool>> _verifyUserCallback;
+        protected string _cipherId;
+        protected bool _userVerified = false;
+        protected Func<Task> _ensureUnlockedVaultCallback;
+        protected Func<bool> _hasVaultBeenUnlockedInThisTransaction;
+        protected Func<string, Fido2UserVerificationPreference, Task<bool>> _verifyUserCallback;
+
+        public Fido2GetAssertionUserInterface()
+        {
+        }
 
         /// <param name="cipherId">The cipherId for the credential that the user has already picker</param>
         /// <param name="userVerified">True if the user has already been verified by the operating system</param>
         public Fido2GetAssertionUserInterface(string cipherId,
+            bool userVerified,
+            Func<Task> ensureUnlockedVaultCallback,
+            Func<bool> hasVaultBeenUnlockedInThisTransaction,
+            Func<string, Fido2UserVerificationPreference, Task<bool>> verifyUserCallback)
+        {
+            Init(cipherId, userVerified, ensureUnlockedVaultCallback, hasVaultBeenUnlockedInThisTransaction, verifyUserCallback);
+        }
+
+        protected void Init(string cipherId,
             bool userVerified,
             Func<Task> ensureUnlockedVaultCallback,
             Func<bool> hasVaultBeenUnlockedInThisTransaction,


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Fix proper implementation of IFido2GetAssertionUserInterface Android


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **Fido2GetAssertionUserInterface:** Implemented this interface correctly, adding an `Init(...)` method to initialize the things in this singleton for every fido2 request. Moved ensure vault unlocked and user verification here as well instead of on the activity.
* **Others:** Updated to use the new interface correctly


## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
