### PR TITLE
[PM-7585] Show error message when Origin is null on Fido2 Android

### DIFF
--- a/src/App/Platforms/Android/Autofill/CredentialHelpers.cs
+++ b/src/App/Platforms/Android/Autofill/CredentialHelpers.cs
@@ -6,7 +6,9 @@ using AndroidX.Credentials;
 using AndroidX.Credentials.Exceptions;
 using AndroidX.Credentials.Provider;
 using AndroidX.Credentials.WebAuthn;
+using Bit.App.Abstractions;
 using Bit.Core.Abstractions;
+using Bit.Core.Resources.Localization;
 using Bit.Core.Utilities;
 using Bit.Core.Utilities.Fido2.Extensions;
 using Bit.Droid;
@@ -77,6 +79,13 @@ namespace Bit.App.Platforms.Android.Autofill
             var callingRequest = getRequest?.CallingRequest as CreatePublicKeyCredentialRequest;
             var origin = callingRequest.Origin;
             var credentialCreationOptions = GetPublicKeyCredentialCreationOptionsFromJson(callingRequest.RequestJson);
+
+            if (origin is null
+                &&
+                ServiceContainer.TryResolve<IDeviceActionService>(out var deviceActionService))
+            {
+                await deviceActionService.DisplayAlertAsync(AppResources.ErrorCreatingPasskey, AppResources.PasskeysNotSupportedForThisApp, AppResources.Ok);
+            }
 
             var rp = new Core.Utilities.Fido2.PublicKeyCredentialRpEntity()
             {

--- a/src/App/Platforms/Android/Autofill/CredentialProviderSelectionActivity.cs
+++ b/src/App/Platforms/Android/Autofill/CredentialProviderSelectionActivity.cs
@@ -70,6 +70,13 @@ namespace Bit.Droid.Autofill
                 var packageName = getRequest?.CallingAppInfo.PackageName;
                 var appInfoOrigin = getRequest?.CallingAppInfo.Origin;
 
+                if (appInfoOrigin is null)
+                {
+                    await _deviceActionService.Value.DisplayAlertAsync(AppResources.ErrorReadingPasskey, AppResources.PasskeysNotSupportedForThisApp, AppResources.Ok);
+                    Finish();
+                    return;
+                }
+
                 var userInterface = new Fido2GetAssertionUserInterface(
                     cipherId: cipherId,
                     userVerified: false,

--- a/src/Core/Resources/Localization/AppResources.Designer.cs
+++ b/src/Core/Resources/Localization/AppResources.Designer.cs
@@ -5282,6 +5282,15 @@ namespace Bit.Core.Resources.Localization {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Passkeys not supported for this app.
+        /// </summary>
+        public static string PasskeysNotSupportedForThisApp {
+            get {
+                return ResourceManager.GetString("PasskeysNotSupportedForThisApp", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Passkey will not be copied.
         /// </summary>
         public static string PasskeyWillNotBeCopied {

--- a/src/Core/Resources/Localization/AppResources.resx
+++ b/src/Core/Resources/Localization/AppResources.resx
@@ -2987,4 +2987,7 @@ Do you want to switch to this account?</value>
   <data name="Notice" xml:space="preserve">
     <value>Notice</value>
   </data>
+  <data name="PasskeysNotSupportedForThisApp" xml:space="preserve">
+    <value>Passkeys not supported for this app</value>
+  </data>
 </root>


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [ ] New feature development
- [X] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Show error message when trying to use/create a fido2 credential on Android from a native app, i.e. origin is `null`


## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
