### PR TITLE
[PM-7631] Handle new FCMv1 format

### DIFF
--- a/src/App/Platforms/Android/Push/FirebaseMessagingService.cs
+++ b/src/App/Platforms/Android/Push/FirebaseMessagingService.cs
@@ -18,7 +18,7 @@ namespace Bit.Droid.Push
     {
         public async override void OnNewToken(string token)
         {
-            try {
+            try { 
                 var stateService = ServiceContainer.Resolve<IStateService>("stateService");
                 var pushNotificationService = ServiceContainer.Resolve<IPushNotificationService>("pushNotificationService");
 


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

Google is deprecating their legacy FCM endpoints (GCM), so migrate to FCMv1 as outlined by Microsoft:

https://learn.microsoft.com/en-us/azure/notification-hubs/notification-hubs-gcm-to-fcm

ref: https://github.com/bitwarden/server/pull/3917

(old) GCM format: 
```
{
  "data": {
    "data": {
      "type": 1,
      "payload": "JSON_Data"
    }
  }
}
```

(new) FCM format:
```
{
  "message": {
    "data": {
      "type": "1",
      "payload": "JSON_Data"
    }
  }
}
```

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **FirebaseMessagingService.cs:** Update remote message parsing to account for GCM and FCM message formats. GCM is detected and kept as-is. FCM is detected and re-constructed into a JObject to match the existing GCM format.


## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
