### PR TITLE
[PM-7553] Implement native app Fido2 credentials

### DIFF
--- a/src/App/Platforms/Android/Utilities/CallingAppInfoExtensions.cs
+++ b/src/App/Platforms/Android/Utilities/CallingAppInfoExtensions.cs
@@ -1,0 +1,23 @@
+using Android.OS;
+using AndroidX.Credentials.Provider;
+using Bit.Core.Utilities;
+using Java.Security;
+
+namespace Bit.App.Droid.Utilities
+{
+    public static class CallingAppInfoExtensions
+    {
+        public static string GetAndroidOrigin(this CallingAppInfo callingAppInfo)
+        {
+            if (Build.VERSION.SdkInt < BuildVersionCodes.P || callingAppInfo?.SigningInfo?.GetApkContentsSigners().Any() != true)
+            {
+                return null;
+            }
+
+            var cert = callingAppInfo.SigningInfo.GetApkContentsSigners()[0].ToByteArray();
+            var md = MessageDigest.GetInstance("SHA-256");
+            var certHash = md.Digest(cert);
+            return $"android:apk-key-hash:{CoreHelpers.Base64UrlEncode(certHash)}";
+        }
+    }
+}

--- a/src/Core/Abstractions/IFido2ClientService.cs
+++ b/src/Core/Abstractions/IFido2ClientService.cs
@@ -20,8 +20,9 @@ namespace Bit.Core.Abstractions
         /// For more information please see: https://www.w3.org/TR/webauthn-3/#sctn-createCredential
         /// </summary>
         /// <param name="createCredentialParams">The parameters for the credential creation operation</param>
+        /// <param name="extraParams">Extra parameters for the credential creation operation</param>
         /// <returns>The new credential</returns>
-        Task<Fido2ClientCreateCredentialResult> CreateCredentialAsync(Fido2ClientCreateCredentialParams createCredentialParams, byte[] clientDataHash);
+        Task<Fido2ClientCreateCredentialResult> CreateCredentialAsync(Fido2ClientCreateCredentialParams createCredentialParams, Fido2ExtraCreateCredentialParams extraParams);
 
         /// <summary>
         /// Allows WebAuthn Relying Party scripts to discover and use an existing public key credential, with the user’s consent.
@@ -29,7 +30,8 @@ namespace Bit.Core.Abstractions
         /// For more information please see: https://www.w3.org/TR/webauthn-3/#sctn-getAssertion
         /// </summary>
         /// <param name="assertCredentialParams">The parameters for the credential assertion operation</param>
+        /// <param name="extraParams">Extra parameters for the credential assertion operation</param>
         /// <returns>The asserted credential</returns>
-        Task<Fido2ClientAssertCredentialResult> AssertCredentialAsync(Fido2ClientAssertCredentialParams assertCredentialParams, byte[] clientDataHash);
+        Task<Fido2ClientAssertCredentialResult> AssertCredentialAsync(Fido2ClientAssertCredentialParams assertCredentialParams, Fido2ExtraAssertCredentialParams extraParams);
     }
 }

--- a/src/Core/Abstractions/IFido2MediatorService.cs
+++ b/src/Core/Abstractions/IFido2MediatorService.cs
@@ -4,8 +4,8 @@ namespace Bit.Core.Abstractions
 {
     public interface IFido2MediatorService
     {
-        Task<Fido2ClientCreateCredentialResult> CreateCredentialAsync(Fido2ClientCreateCredentialParams createCredentialParams, byte[] clientDataHash = null);
-        Task<Fido2ClientAssertCredentialResult> AssertCredentialAsync(Fido2ClientAssertCredentialParams assertCredentialParams, byte[] clientDataHash = null);
+        Task<Fido2ClientCreateCredentialResult> CreateCredentialAsync(Fido2ClientCreateCredentialParams createCredentialParams, Fido2ExtraCreateCredentialParams extraParams);
+        Task<Fido2ClientAssertCredentialResult> AssertCredentialAsync(Fido2ClientAssertCredentialParams assertCredentialParams, Fido2ExtraAssertCredentialParams extraParams);
 
         Task<Fido2AuthenticatorMakeCredentialResult> MakeCredentialAsync(Fido2AuthenticatorMakeCredentialParams makeCredentialParams, IFido2MakeCredentialUserInterface userInterface);
         Task<Fido2AuthenticatorGetAssertionResult> GetAssertionAsync(Fido2AuthenticatorGetAssertionParams assertionParams, IFido2GetAssertionUserInterface userInterface);

--- a/src/Core/Services/Fido2MediatorService.cs
+++ b/src/Core/Services/Fido2MediatorService.cs
@@ -18,9 +18,9 @@ namespace Bit.Core.Services
             _cipherService = cipherService;
         }
 
-        public async Task<Fido2ClientAssertCredentialResult> AssertCredentialAsync(Fido2ClientAssertCredentialParams assertCredentialParams, byte[] clientDataHash = null)
+        public async Task<Fido2ClientAssertCredentialResult> AssertCredentialAsync(Fido2ClientAssertCredentialParams assertCredentialParams, Fido2ExtraAssertCredentialParams extraParams)
         {
-            var result = await _fido2ClientService.AssertCredentialAsync(assertCredentialParams, clientDataHash);
+            var result = await _fido2ClientService.AssertCredentialAsync(assertCredentialParams, extraParams);
 
             if (result?.SelectedCredential?.Cipher != null)
             {
@@ -30,9 +30,9 @@ namespace Bit.Core.Services
             return result;
         }
 
-        public Task<Fido2ClientCreateCredentialResult> CreateCredentialAsync(Fido2ClientCreateCredentialParams createCredentialParams, byte[] clientDataHash = null)
+        public Task<Fido2ClientCreateCredentialResult> CreateCredentialAsync(Fido2ClientCreateCredentialParams createCredentialParams, Fido2ExtraCreateCredentialParams extraParams)
         {
-            return _fido2ClientService.CreateCredentialAsync(createCredentialParams, clientDataHash);
+            return _fido2ClientService.CreateCredentialAsync(createCredentialParams, extraParams);
         }
 
         public async Task<Fido2AuthenticatorGetAssertionResult> GetAssertionAsync(Fido2AuthenticatorGetAssertionParams assertionParams, IFido2GetAssertionUserInterface userInterface)

--- a/src/Core/Utilities/Fido2/Fido2ExtraAssertCredentialParams.cs
+++ b/src/Core/Utilities/Fido2/Fido2ExtraAssertCredentialParams.cs
@@ -1,0 +1,26 @@
+namespace Bit.Core.Utilities.Fido2
+{
+    #nullable enable
+
+    /// <summary>
+    /// Extra parameters for asserting a credential.
+    /// </summary>
+    public class Fido2ExtraAssertCredentialParams
+    {
+        public Fido2ExtraAssertCredentialParams(byte[]? clientDataHash = null, string? androidPackageName = null)
+        {
+            ClientDataHash = clientDataHash;
+            AndroidPackageName = androidPackageName;
+        }
+
+        /// <summary>
+        /// The hash of the serialized client data.
+        /// </summary>
+        public byte[]? ClientDataHash { get; }
+
+        /// <summary>
+        /// The Android package name.
+        /// </summary>
+        public string? AndroidPackageName { get; }
+    }
+}

--- a/src/Core/Utilities/Fido2/Fido2ExtraCreateCredentialParams.cs
+++ b/src/Core/Utilities/Fido2/Fido2ExtraCreateCredentialParams.cs
@@ -1,0 +1,26 @@
+namespace Bit.Core.Utilities.Fido2
+{
+#nullable enable
+
+    /// <summary>
+    /// Extra parameters for creating a new credential.
+    /// </summary>
+    public struct Fido2ExtraCreateCredentialParams
+    {
+        public Fido2ExtraCreateCredentialParams(byte[]? clientDataHash = null, string? androidPackageName = null)
+        {
+            ClientDataHash = clientDataHash;
+            AndroidPackageName = androidPackageName;
+        }
+
+        /// <summary>
+        /// The hash of the serialized client data.
+        /// </summary>
+        public byte[]? ClientDataHash { get; }
+
+        /// <summary>
+        /// The Android package name.
+        /// </summary>
+        public string? AndroidPackageName { get; }
+    }
+}


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Implement Fido2 credentials autofill and creation from native Android apps.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **Fido2ClientService:** Added extra parameters objects to pass additional data like the client data hash and the android package name that is needed for the client data json. Also, added additional logic for the origin validations so they're not performed when the request comes from a native app.
* **CallingAppInfoExtensions:** Extracted the `CallingAppInfo` to Android origin here so it can be reused.
* **CredentialHelpers:** Updated the code with the new needed parameters and improved the code when the flows fails. Also updated `origin` accordingly depending on whether the `Origin` from the RP is `null` or not.
* **CredentialProviderSelectionActivity:** Updated the code with the new needed parameters and improved the code when the flows fails. Also updated `origin` accordingly depending on whether the `Origin` from the RP is `null` or not. Also changed the response build to be done manually given that the object from the Credentials package was giving some errors.


## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
