### PR TITLE
[PM-7690] Unable to decrypt vault with MP after SSO authentication

### DIFF
--- a/src/Core/Pages/Accounts/LoginSsoPage.xaml.cs
+++ b/src/Core/Pages/Accounts/LoginSsoPage.xaml.cs
@@ -125,7 +125,7 @@ namespace Bit.App.Pages
 
         private async Task StartDeviceApprovalOptionsAsync()
         {
-            var page = new LoginApproveDevicePage();
+            var page = new LoginApproveDevicePage(_appOptions);
             await Navigation.PushModalAsync(new NavigationPage(page));
         }
 


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Fix bug where users could not use master password as decryption option method for vault unlock.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->
AppOptions were not set on navigation making the app throw an exception when trying to set `_appOptions.HasJustLoggedInOrUnlocked = true;` on vault unlock in `LockPage`

## Screenshots
<!--Required for any UI changes. Delete if not applicable-->



## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
