### PR TITLE
[PM-7698] Fix crash produced for non-catched exception on iOS Autofill

### DIFF
--- a/src/Core/Utilities/TaskExtensions.cs
+++ b/src/Core/Utilities/TaskExtensions.cs
@@ -37,9 +37,12 @@ namespace Bit.Core.Utilities
             {
                 await task.ConfigureAwait(false);
             }
-            catch (Exception ex) when (shouldLogException(ex))
+            catch (Exception ex)
             {
-                LoggerHelper.LogEvenIfCantBeResolved(ex);
+                if (shouldLogException(ex))
+                {
+                    LoggerHelper.LogEvenIfCantBeResolved(ex);
+                }
             }
         }
     }


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Fix crash produced for non-catched exception on iOS Autofill when opening the combined Password + Passkeys view with no Passkeys to load.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **TaskExtensions:** Moved `shouldLogException` to an internal `if` so all exceptions are catched and then the specific ones logged which was the original intent.


## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
