### PR TITLE
[PM-7886] Show either card number or security code and not both

### DIFF
--- a/src/Core/Pages/Vault/CipherDetailsPageViewModel.cs
+++ b/src/Core/Pages/Vault/CipherDetailsPageViewModel.cs
@@ -334,6 +334,7 @@ namespace Bit.App.Pages
             ShowCardNumber = !ShowCardNumber;
             if (ShowCardNumber)
             {
+                ShowCardCode = false;
                 var task = _eventService.CollectAsync(
                     Core.Enums.EventType.Cipher_ClientToggledCardNumberVisible, CipherId);
             }
@@ -348,6 +349,7 @@ namespace Bit.App.Pages
             ShowCardCode = !ShowCardCode;
             if (ShowCardCode)
             {
+                ShowCardNumber = false;
                 var task = _eventService.CollectAsync(
                     Core.Enums.EventType.Cipher_ClientToggledCardCodeVisible, CipherId);
             }


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
Enhancing security by implementing a feature to hide the CVV (Card Verification Value) when displaying the card number and vice versa. This enhancement aims to mitigate the risk of unauthorized access to sensitive financial information and aligns with industry best practices for safeguarding user data.

## Code changes
[src/Core/Pages/Vault/CipherDetailsPageViewModel.cs](https://github.com/GobinathAL/bitwarden-mobile/blob/e81e411abcc3a53e729a9be0912fb0d5593c0f44/src/Core/Pages/Vault/CipherDetailsPageViewModel.cs)

Modified ToggleCardNumber and ToggleCardCode methods



## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
