### PR TITLE
[PM-7922] Updating labeler.yml to the new format required by V5

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -2,7 +2,7 @@
 name: "Pull Request Labeler"
 
 on:
-- pull_request
+  pull_request_target: {}
 
 jobs:
   labeler:


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

#2895 updated our PR Labeler to V5 which changed the structure of `labeler.yml`, reason why this build step has been failing. This PR fixes that.

While at it, added "Xamarin.AndroidX.Credentials" folder path to the Android label.



## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
