### PR TITLE
[PM-7255] Fix autofill cancelling the request producing inconsistent behavior

### DIFF
--- a/src/iOS.Autofill/CredentialProviderViewController.Passkeys.cs
+++ b/src/iOS.Autofill/CredentialProviderViewController.Passkeys.cs
@@ -328,11 +328,6 @@ namespace Bit.iOS.Autofill
             }
         }
 
-        private bool CanProvideCredentialOnPasskeyRequest(CipherView cipherView)
-        {
-            return _context.PasskeyCredentialRequest != null && !cipherView.Login.HasFido2Credentials;
-        }
-
         private void OnConfirmingNewCredential()
         {
             MainThread.BeginInvokeOnMainThread(() =>

--- a/src/iOS.Autofill/CredentialProviderViewController.cs
+++ b/src/iOS.Autofill/CredentialProviderViewController.cs
@@ -443,13 +443,16 @@ namespace Bit.iOS.Autofill
                     return;
                 }
 
-                var decCipher = await cipher.DecryptAsync();
-
-                if (!CanProvideCredentialOnPasskeyRequest(decCipher))
+                if (_context.IsPasskey)
                 {
+                    // this shouldn't happen but as a safeguard we've set it here:
+                    // if somehow the flow got into here then it's impossible to find the credential identity
+                    // i.e. if on iOS < 17 and somehow there is a PasskeyCredentialRequest that was passed along in the iOS callbacks
                     CancelRequest(ASExtensionErrorCode.CredentialIdentityNotFound);
                     return;
                 }
+
+                var decCipher = await cipher.DecryptAsync();
 
                 if (decCipher.Reprompt != CipherRepromptType.None)
                 {


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Fix autofill cancelling the request producing inconsistent behavior on passwords because of Fido2 check safeguard.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **CredentialProviderViewController:** Changed the safeguard for iOS < 17 to only check if the context is for passkeys/fido2 which previously was wrongly checking the condition.

## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
