### PR TITLE
[PM-7963] Fix vault timeout immediately on Android Fido2 autofill

### DIFF
--- a/src/Core/Utilities/Fido2/CredentialProviderConstants.cs
+++ b/src/Core/Utilities/Fido2/CredentialProviderConstants.cs
@@ -5,6 +5,7 @@
         public const string Fido2CredentialCreate = "fido2CredentialCreate";
         public const string Fido2CredentialGet = "fido2CredentialGet";
         public const string Fido2CredentialAction = "fido2CredentialAction";
+        public const string Fido2CredentialNeedsUnlockingAgainBecauseImmediateTimeout = "fido2CredentialNeedsUnlockingAgainBecauseImmediateTimeout";
         public const string CredentialProviderCipherId = "credentialProviderCipherId";
         public const string CredentialDataIntentExtra = "CREDENTIAL_DATA";
         public const string CredentialIdIntentExtra = "credId";


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Fix vault timeout immediately on Android Fido2 autofill, where it was locking immediately after user unlocks because changing activity


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **CredentialProviderSelectionActivity:** Changed `NoHistory` to `false` so we can launch the `MainActivity` and return to this one. Added the activity launcher so we can launch `MainActivity` to unlock the vault after the user selects the cipher to autofill which confirms unlock on the callback.
* **Fido2GetAssertionUserInterface:** Added `_unlockVaultTcs` so we can await until the user unlocks on immediate timeout vaults to ensure vault is unlocked for the Fido2 flow.
* **DeviceActionService:** Added a new `CredentialProviderConstants.Fido2CredentialNeedsUnlockingAgainBecauseImmediateTimeout` to have a way to know after unlocking that is because of this scenario and then set the result back. Here a caveat is that we set `vaultTimeoutService.DelayLockAndLogoutMs` in order to maintain a time window of the vault unlocked for this flow. Otherwise it'll be immediately locked after the `MainActivity` is finished.


## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
