### PR TITLE
[PM-8051] Fix WebAuthenticator getting the Window properly on iOS Autofill extension 2FA WebAuthn

### DIFF
--- a/src/Core/Pages/Accounts/LoginPage.xaml.cs
+++ b/src/Core/Pages/Accounts/LoginPage.xaml.cs
@@ -25,6 +25,7 @@ namespace Bit.App.Pages
             _broadcasterService = ServiceContainer.Resolve<IBroadcasterService>();
             _vm = BindingContext as LoginPageViewModel;
             _vm.Page = this;
+            _vm.FromIosExtension = _appOptions?.IosExtension ?? false;
             _vm.StartTwoFactorAction = () => MainThread.BeginInvokeOnMainThread(async () => await StartTwoFactorAsync());
             _vm.LogInSuccessAction = () => MainThread.BeginInvokeOnMainThread(async () => await LogInSuccessAsync());
             _vm.LogInWithDeviceAction = () => StartLoginWithDeviceAsync().FireAndForget();

--- a/src/Core/Pages/Accounts/LoginPasswordlessRequestPage.xaml.cs
+++ b/src/Core/Pages/Accounts/LoginPasswordlessRequestPage.xaml.cs
@@ -19,6 +19,7 @@ namespace Bit.App.Pages
             _vm.Email = email;
             _vm.AuthRequestType = authRequestType;
             _vm.AuthingWithSso = authingWithSso;
+            _vm.FromIosExtension = _appOptions?.IosExtension ?? false;
             _vm.StartTwoFactorAction = () => MainThread.BeginInvokeOnMainThread(async () => await StartTwoFactorAsync());
             _vm.LogInSuccessAction = () => MainThread.BeginInvokeOnMainThread(async () => await LogInSuccessAsync());
             _vm.UpdateTempPasswordAction = () => MainThread.BeginInvokeOnMainThread(async () => await UpdateTempPasswordAsync());

--- a/src/Core/Pages/Accounts/RegisterPage.xaml.cs
+++ b/src/Core/Pages/Accounts/RegisterPage.xaml.cs
@@ -1,4 +1,6 @@
-﻿namespace Bit.App.Pages
+﻿using Bit.App.Models;
+
+namespace Bit.App.Pages
 {
     public partial class RegisterPage : BaseContentPage
     {
@@ -6,11 +8,12 @@
 
         private bool _inputFocused;
 
-        public RegisterPage(HomePage homePage)
+        public RegisterPage(HomePage homePage, AppOptions appOptions = null)
         {
             InitializeComponent();
             _vm = BindingContext as RegisterPageViewModel;
             _vm.Page = this;
+            _vm.FromIosExtension = appOptions?.IosExtension ?? false;
             _vm.RegistrationSuccess = () => MainThread.BeginInvokeOnMainThread(async () => await RegistrationSuccessAsync(homePage));
             _vm.CloseAction = async () =>
             {

--- a/src/Core/Pages/Accounts/TwoFactorPage.xaml.cs
+++ b/src/Core/Pages/Accounts/TwoFactorPage.xaml.cs
@@ -28,6 +28,7 @@ namespace Bit.App.Pages
             _vm = BindingContext as TwoFactorPageViewModel;
             _vm.Page = this;
             _vm.AuthingWithSso = authingWithSso ?? false;
+            _vm.FromIosExtension = _appOptions?.IosExtension ?? false;
             _vm.StartSetPasswordAction = () =>
                 MainThread.BeginInvokeOnMainThread(async () => await StartSetPasswordAsync());
             _vm.TwoFactorAuthSuccessAction = () =>

--- a/src/Core/Pages/Accounts/TwoFactorPageViewModel.cs
+++ b/src/Core/Pages/Accounts/TwoFactorPageViewModel.cs
@@ -11,6 +11,13 @@ using Bit.Core.Models.Request;
 using Bit.Core.Resources.Localization;
 using Bit.Core.Utilities;
 using Newtonsoft.Json;
+using Bit.Core.Services;
+
+#if IOS
+using WebAuthenticator = Bit.Core.Utilities.MAUI.WebAuthenticator;
+using WebAuthenticatorResult = Bit.Core.Utilities.MAUI.WebAuthenticatorResult;
+using WebAuthenticatorOptions = Bit.Core.Utilities.MAUI.WebAuthenticatorOptions;
+#endif
 
 namespace Bit.App.Pages
 {
@@ -136,6 +143,7 @@ namespace Bit.App.Pages
                 nameof(ShowTryAgain),
             });
         }
+
         public ICommand SubmitCommand { get; }
         public ICommand MoreCommand { get; }
         public ICommand AuthenticateWithDuoFramelessCommand { get; }
@@ -261,7 +269,11 @@ namespace Bit.App.Pages
                 authResult = await WebAuthenticator.AuthenticateAsync(new WebAuthenticatorOptions
                 {
                     Url = new Uri(url),
-                    CallbackUrl = new Uri(Constants.DuoCallback)
+                    CallbackUrl = new Uri(Constants.DuoCallback),
+#if IOS
+                    ShouldUseSharedApplicationKeyWindow = FromIosExtension
+#endif
+
                 });
             }
             catch (TaskCanceledException)
@@ -348,6 +360,9 @@ namespace Bit.App.Pages
                         Url = new Uri(url),
                         CallbackUrl = new Uri(callbackUri),
                         PrefersEphemeralWebBrowserSession = true,
+#if IOS
+                        ShouldUseSharedApplicationKeyWindow = FromIosExtension
+#endif
                     };
                     authResult = await WebAuthenticator.AuthenticateAsync(options);
                 }

--- a/src/Core/Pages/CaptchaProtectedViewModel.cs
+++ b/src/Core/Pages/CaptchaProtectedViewModel.cs
@@ -6,6 +6,12 @@ using Bit.App.Utilities;
 using Bit.Core.Abstractions;
 using Microsoft.Maui.Authentication;
 
+#if IOS
+using WebAuthenticator = Bit.Core.Utilities.MAUI.WebAuthenticator;
+using WebAuthenticatorResult = Bit.Core.Utilities.MAUI.WebAuthenticatorResult;
+using WebAuthenticatorOptions = Bit.Core.Utilities.MAUI.WebAuthenticatorOptions;
+#endif
+
 namespace Bit.App.Pages
 {
     public abstract class CaptchaProtectedViewModel : BaseViewModel
@@ -15,6 +21,8 @@ namespace Bit.App.Pages
         protected abstract IDeviceActionService deviceActionService { get; }
         protected abstract IPlatformUtilsService platformUtilsService { get; }
         protected string _captchaToken = null;
+
+        public bool FromIosExtension { get; set; }
 
         protected async Task<bool> HandleCaptchaAsync(string captchaSiteKey, bool needsCaptcha, Func<Task> onSuccess)
         {
@@ -61,6 +69,9 @@ namespace Bit.App.Pages
                     Url = new Uri(url),
                     CallbackUrl = new Uri(callbackUri),
                     PrefersEphemeralWebBrowserSession = false,
+#if IOS
+                    ShouldUseSharedApplicationKeyWindow = FromIosExtension
+#endif
                 };
                 authResult = await WebAuthenticator.AuthenticateAsync(options);
             }

--- a/src/iOS.Autofill/CredentialProviderViewController.cs
+++ b/src/iOS.Autofill/CredentialProviderViewController.cs
@@ -617,8 +617,9 @@ namespace Bit.iOS.Autofill
 
         private void LaunchRegisterFlow()
         {
-            var registerPage = new RegisterPage(null);
-            var app = new App.App(new AppOptions { IosExtension = true });
+            var appOptions = new AppOptions { IosExtension = true };
+            var registerPage = new RegisterPage(null, appOptions);
+            var app = new App.App(appOptions);
             ThemeManager.SetTheme(app.Resources);
             ThemeManager.ApplyResourcesTo(registerPage);
             if (registerPage.BindingContext is RegisterPageViewModel vm)
@@ -696,8 +697,9 @@ namespace Bit.iOS.Autofill
 
         private void LaunchTwoFactorFlow(bool authingWithSso)
         {
-            var twoFactorPage = new TwoFactorPage(authingWithSso);
-            var app = new App.App(new AppOptions { IosExtension = true });
+            var appOptions = new AppOptions { IosExtension = true };
+            var twoFactorPage = new TwoFactorPage(authingWithSso, appOptions);
+            var app = new App.App();
             ThemeManager.SetTheme(app.Resources);
             ThemeManager.ApplyResourcesTo(twoFactorPage);
             if (twoFactorPage.BindingContext is TwoFactorPageViewModel vm)


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Fix for WebAuthn 2FA not working on iOS Autofill extension given that the `UIWindow` was not getting properly gotten. This fixes it by using our custom workaround for it.
This affects WebAuthn as well as could affect Captcha views.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **All:** Applied workaround to use `ShouldUseSharedApplicationKeyWindow` when coming from iOS extension and updated callers to properly pass `FromIosExtension` flag to it gets applied correctly.


## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
