### PR TITLE
[PM-950] Cannot save new login if personal ownership is disabled

### DIFF
--- a/src/iOS.Core/Views/FormEntryTableViewCell.cs
+++ b/src/iOS.Core/Views/FormEntryTableViewCell.cs
@@ -22,7 +22,8 @@ namespace Bit.iOS.Core.Views
             nfloat? height = null,
             ButtonsConfig buttonsConfig = ButtonsConfig.None,
             bool useLabelAsPlaceholder = false,
-            float leadingConstant = 15f)
+            float leadingConstant = 15f,
+            bool empty = false)
             : base(UITableViewCellStyle.Default, nameof(FormEntryTableViewCell))
         {
             var descriptor = UIFontDescriptor.PreferredBody;
@@ -86,7 +87,7 @@ namespace Bit.iOS.Core.Views
                     ValueChanged?.Invoke(sender, e);
                 };
             }
-            else
+            else if( !empty )
             {
                 TextField = new UITextField
                 {
@@ -128,16 +129,16 @@ namespace Bit.iOS.Core.Views
                         NSLayoutConstraint.Create(TextField, NSLayoutAttribute.Top, NSLayoutRelation.Equal, ContentView, NSLayoutAttribute.Top, 1f, 10f));
                 }
 
-                if (height.HasValue)
-                {
-                    ContentView.AddConstraint(
-                        NSLayoutConstraint.Create(TextField, NSLayoutAttribute.Height, NSLayoutRelation.Equal, null, NSLayoutAttribute.NoAttribute, 1f, height.Value));
-                }
-
                 TextField.AddTarget((object sender, EventArgs e) =>
                 {
                     ValueChanged?.Invoke(sender, e);
                 }, UIControlEvent.EditingChanged);
+            }
+
+            if (empty && height.HasValue)
+            {
+                ContentView.AddConstraint(
+                    NSLayoutConstraint.Create(TextField, NSLayoutAttribute.Height, NSLayoutRelation.Equal, null, NSLayoutAttribute.NoAttribute, 1f, height.Value));
             }
 
             if (labelName != null && !useLabelAsPlaceholder)


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Fixes https://github.com/bitwarden/mobile-maui/issues/1874

Add the ability to select a collection for the new item if personal ownership is disabled.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **LoginAddViewController.cs:** Refactor how the number of rows and sections are calculated based on the value of the flag `_personalOwnershipPolicyApplies`. Added cells to warn the user the personal ownership is disabled and allow organisation and collection selection.
* **FormEntryTableViewCell.cs:** Allow a form entry empty.

## Screenshots
<!--Required for any UI changes. Delete if not applicable-->
**BEFORE**
<img width="322" alt="image" src="https://github.com/bitwarden/mobile/assets/6855596/1e59f8d3-5a62-4d67-8b97-aa8a7368f913">


**AFTER**
<img width="322" alt="image" src="https://github.com/bitwarden/mobile/assets/6855596/1b0b16f0-9ad7-435a-8b3a-f00bfcd3d584">
<img width="322" alt="image" src="https://github.com/bitwarden/mobile/assets/6855596/952763e8-527b-45ff-823f-6f7ac6f902e8">



## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
