### PR TITLE
[PM-8666] Fix Password Autofill from Quick Type on iOS < 17

### DIFF
--- a/src/iOS.Autofill/CredentialProviderViewController.cs
+++ b/src/iOS.Autofill/CredentialProviderViewController.cs
@@ -152,17 +152,17 @@ namespace Bit.iOS.Autofill
             }
         }
 
-        //public override async void ProvideCredentialWithoutUserInteraction(ASPasswordCredentialIdentity credentialIdentity)
-        //{
-        //    try
-        //    {
-        //        await ProvideCredentialWithoutUserInteractionAsync(credentialIdentity);
-        //    }
-        //    catch (Exception ex)
-        //    {
-        //        OnProvidingCredentialException(ex);
-        //    }
-        //}
+        public override async void ProvideCredentialWithoutUserInteraction(ASPasswordCredentialIdentity credentialIdentity)
+        {
+           try
+           {
+               await ProvideCredentialWithoutUserInteractionAsync(credentialIdentity);
+           }
+           catch (Exception ex)
+           {
+               OnProvidingCredentialException(ex);
+           }
+        }
 
         [Export("prepareInterfaceToProvideCredentialForRequest:")]
         public override async void PrepareInterfaceToProvideCredential(IASCredentialRequest credentialRequest)
@@ -197,17 +197,17 @@ namespace Bit.iOS.Autofill
             }
         }
 
-        //public override async void PrepareInterfaceToProvideCredential(ASPasswordCredentialIdentity credentialIdentity)
-        //{
-        //    try
-        //    {
-        //        await PrepareInterfaceToProvideCredentialAsync(c => c.PasswordCredentialIdentity = credentialIdentity);
-        //    }
-        //    catch (Exception ex)
-        //    {
-        //        OnProvidingCredentialException(ex);
-        //    }
-        //}
+        public override async void PrepareInterfaceToProvideCredential(ASPasswordCredentialIdentity credentialIdentity)
+        {
+           try
+           {
+               await PrepareInterfaceToProvideCredentialAsync(c => c.PasswordCredentialIdentity = credentialIdentity);
+           }
+           catch (Exception ex)
+           {
+               OnProvidingCredentialException(ex);
+           }
+        }
 
         public override async void PrepareInterfaceForExtensionConfiguration()
         {


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Fix Password Autofill from Quick Type on iOS < 17


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **CredentialProviderViewController:** Uncommented old deprecated methods to autofill using the Quick type bar so it works on iOS < 17.


## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
