### PR TITLE
Prepare strings for Android Crowdin sync

### DIFF
--- a/src/Core/Resources/Localization/AppResources.resx
+++ b/src/Core/Resources/Localization/AppResources.resx
@@ -457,6 +457,9 @@
   <data name="Continue" xml:space="preserve">
     <value>Continue</value>
   </data>
+  <data name="ContinueText" xml:space"preserve">
+    <value>Continue</value>
+  </data>
   <data name="CreateAccount" xml:space="preserve">
     <value>Create account</value>
   </data>
@@ -1235,6 +1238,9 @@ Scanning will happen automatically.</value>
     <value>Base domain</value>
   </data>
   <data name="Default" xml:space="preserve">
+    <value>Default</value>
+  </data>
+  <data name="DefaultText" xml:space="preserve">
     <value>Default</value>
   </data>
   <data name="Exact" xml:space="preserve">


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [x] Other

## Objective
String resources, `Continue` and `Default` use key values that are protected keywords in Android XML resource files. In order to prepare the MAUI project for syncing with the native Android project these terms must have their keys replaced. To prevent losing translations for the existing keys we are adding matching resources that do not use protected keywords. Once translations have been migrated in Crowdin the legacy entries will be removed.



## Code changes


* **AppResources.resx** Add terms `ContinueText` and `DefaultText`.

## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
