### PR TITLE
[PM-9483] Fix added Attachment from the Edit Cipher Screen on mobile apps can't be retrieved

### DIFF
--- a/src/Core/Services/CipherService.cs
+++ b/src/Core/Services/CipherService.cs
@@ -114,7 +114,7 @@ namespace Bit.Core.Services
         public async Task<Cipher> EncryptAsync(CipherView model, SymmetricCryptoKey key = null,
             Cipher originalCipher = null)
         {
-            // Adjust password history
+            // Adjust password history and attachments
             if (model.Id != null)
             {
                 if (originalCipher == null)
@@ -169,6 +169,9 @@ namespace Bit.Core.Services
                             }
                         }
                     }
+
+                    //adjust attachments
+                    model.Attachments = existingCipher.Attachments;
                 }
                 if (!model.PasswordHistory?.Any() ?? false)
                 {


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Ensure attachments that are added on edit cipher screen can be retrieved.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **src/Core/Services/CipherService.cs:** Although attachments added on edit cipher screen are updated on server, that state isn't applied to the cipher in memory. This ensures that the current cipher has the updated attachments.

## Screenshots
<!--Required for any UI changes. Delete if not applicable-->



## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
