### PR TITLE
[PM-13677] Disable WatchOS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -687,12 +687,6 @@ jobs:
           EOF
 
       - name: Validate app in App Store
-        if: |
-          (github.ref == 'refs/heads/main'
-            && needs.setup.outputs.rc_branch_exists == 0
-            && needs.setup.outputs.hotfix_branch_exists == 0)
-          || (github.ref == 'refs/heads/rc' && needs.setup.outputs.hotfix_branch_exists == 0)
-          || github.ref == 'refs/heads/hotfix-rc'
         run: |
           xcrun altool \
             --validate-app \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -687,6 +687,12 @@ jobs:
           EOF
 
       - name: Validate app in App Store
+        if: |
+          (github.ref == 'refs/heads/main'
+            && needs.setup.outputs.rc_branch_exists == 0
+            && needs.setup.outputs.hotfix_branch_exists == 0)
+          || (github.ref == 'refs/heads/rc' && needs.setup.outputs.hotfix_branch_exists == 0)
+          || github.ref == 'refs/heads/hotfix-rc'
         run: |
           xcrun altool \
             --validate-app \

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
    <ReleaseCodesignProvision>Automatic:AppStore</ReleaseCodesignProvision>
    <ReleaseCodesignKey>iPhone Distribution</ReleaseCodesignKey>
    <IncludeBitwardeniOSExtensions>True</IncludeBitwardeniOSExtensions>
-   <IncludeBitwardenWatchOSApp>True</IncludeBitwardenWatchOSApp>
+   <IncludeBitwardenWatchOSApp>False</IncludeBitwardenWatchOSApp>
    <Argon2IdLoadMtouchExtraArgs>-gcc_flags "-L$(ProjectDir)../../lib/ios -largon2 -force_load $(ProjectDir)../../lib/ios/libargon2.a"</Argon2IdLoadMtouchExtraArgs>
    <!-- Uncomment this when Unit Testing-->
    <!-- <CustomConstants>UT</CustomConstants> -->


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

Disabling including the watchOS app to fix the AppStoreConnect validation. 

https://github.com/bitwarden/mobile/actions/runs/11354214966/job/31580966938#step:31:30

> 024-10-15 21:22:34.700 *** Error: ERROR: [ContentDelivery.Uploader] Asset validation failed (90949) Invalid bundle. The watchOS app at “Payload/App.app/Watch/Bitwarden.app” must be built as a single-target watchOS app to match the version that’s currently available for distribution.


## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
